### PR TITLE
Add market.token_metadata tool

### DIFF
--- a/src/jupiter/client.ts
+++ b/src/jupiter/client.ts
@@ -30,6 +30,7 @@ export type TokenInfo = {
   id: string;
   name?: string;
   symbol?: string;
+  icon?: string | null;
   decimals: number;
   usdPrice?: number | null;
 };

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -335,6 +335,41 @@ export function registerDefaultTools(
   });
 
   registry.register({
+    name: "market.token_metadata",
+    description: "Fetch token metadata (name, symbol, decimals, logo).",
+    schema: {
+      name: "market.token_metadata",
+      description: "Fetch token metadata (name, symbol, decimals, logo).",
+      parameters: {
+        type: "object",
+        properties: {
+          mint: { type: "string" },
+        },
+        required: ["mint"],
+        additionalProperties: false,
+      },
+    },
+    requires: { config: ["jupiter.apiKey"] },
+    execute: async (_ctx: ToolContext, input: { mint: string }) => {
+      const mint = input.mint.trim();
+      if (!mint) {
+        throw new Error("mint-required");
+      }
+      const tokenInfoMap = await getTokenInfoMap([mint]);
+      const token = tokenInfoMap.get(mint);
+      if (!token) {
+        throw new Error("token-not-found");
+      }
+      return {
+        name: token.name ?? "",
+        symbol: token.symbol ?? "",
+        decimals: token.decimals,
+        logoUrl: token.icon ?? null,
+      };
+    },
+  });
+
+  registry.register({
     name: "risk.check_trade",
     description: "Deterministic allow/deny with policy constraints.",
     schema: {

--- a/src/tools/validate.ts
+++ b/src/tools/validate.ts
@@ -70,10 +70,15 @@ const PricesSchema = z.object({
   venue: z.string().optional(),
 });
 
+const TokenMetadataSchema = z.object({
+  mint: z.string().min(1),
+});
+
 export const TOOL_VALIDATORS: Record<string, z.ZodTypeAny> = {
   "wallet.get_balances": BalancesSchema,
   "market.jupiter_quote": QuoteSchema,
   "market.get_prices": PricesSchema,
+  "market.token_metadata": TokenMetadataSchema,
   "risk.check_trade": RiskSchema,
   "trade.jupiter_swap": TradeSchema,
   "notify.emit": NotifySchema,

--- a/tests/integration/tools.integration.test.ts
+++ b/tests/integration/tools.integration.test.ts
@@ -135,6 +135,19 @@ integrationTest("market.get_prices (integration)", async () => {
   expect(result.prices[0].mint).toBe(priceMint);
 });
 
+integrationTest("market.token_metadata (integration)", async () => {
+  const { registry, ctx } = setup();
+  const mint =
+    process.env.METADATA_MINT || "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+  const result = (await registry.invoke("market.token_metadata", ctx, {
+    mint,
+  })) as { symbol: string; decimals: number };
+
+  expect(result.symbol).toBeTruthy();
+  expect(Number.isFinite(result.decimals)).toBe(true);
+});
+
 swapTest("swap simulation (build + sign + simulate)", async () => {
   const { registry, ctx, jupiter, config } = setup();
   if (!config.wallet.privateKey && !config.wallet.keyfilePath) {

--- a/tests/unit/tool_validation.test.ts
+++ b/tests/unit/tool_validation.test.ts
@@ -87,3 +87,23 @@ test("invalid market.get_prices args are rejected before execution", async () =>
     registry.invoke("market.get_prices", ctx, { mints: [] }),
   ).rejects.toThrow(/validation/i);
 });
+
+test("invalid market.token_metadata args are rejected before execution", async () => {
+  const registry = new ToolRegistry();
+  const jupiter = new JupiterClient(
+    stubConfig.jupiter.baseUrl,
+    stubConfig.jupiter.apiKey,
+  );
+  registerDefaultTools(registry, jupiter);
+
+  const ctx = {
+    config: stubConfig,
+    solana: stubSolana,
+    sessionJournal: new SessionJournal("test", ".tmp/sessions"),
+    tradeJournal: new TradeJournal(".tmp/trades"),
+  };
+
+  await expect(
+    registry.invoke("market.token_metadata", ctx, { mint: "" }),
+  ).rejects.toThrow(/validation/i);
+});


### PR DESCRIPTION
## Summary
- add market.token_metadata tool to fetch name/symbol/decimals/logo for a mint
- extend Jupiter token info type for logo
- add validation + tests

## Testing
- bun run lint
- bun test tests/unit/tool_validation.test.ts

Closes #9