### PR TITLE
Add market.candles tool

### DIFF
--- a/src/tools/validate.ts
+++ b/src/tools/validate.ts
@@ -101,6 +101,13 @@ const PythPriceSchema = z
     message: "symbol-or-feedId-required",
   });
 
+const CandlesSchema = z.object({
+  inputMint: z.string().min(1),
+  outputMint: z.string().min(1),
+  interval: z.string().min(1),
+  limit: z.number().int().positive().max(1000).optional(),
+});
+
 export const TOOL_VALIDATORS: Record<string, z.ZodTypeAny> = {
   "wallet.get_balances": BalancesSchema,
   "market.jupiter_quote": QuoteSchema,
@@ -108,6 +115,7 @@ export const TOOL_VALIDATORS: Record<string, z.ZodTypeAny> = {
   "market.get_prices": PricesSchema,
   "market.token_metadata": TokenMetadataSchema,
   "market.pyth_price": PythPriceSchema,
+  "market.candles": CandlesSchema,
   "risk.max_position_check": MaxPositionSchema,
   "risk.daily_pnl_snapshot": DailyPnlSchema,
   "risk.check_trade": RiskSchema,

--- a/tests/integration/tools.integration.test.ts
+++ b/tests/integration/tools.integration.test.ts
@@ -153,6 +153,31 @@ integrationTest("market.pyth_price (integration)", async () => {
   expect(result.publishTime).toBeTruthy();
 });
 
+integrationTest("market.candles (integration)", async () => {
+  if (!process.env.BIRDEYE_API_KEY) {
+    return;
+  }
+  const { registry, ctx } = setup();
+  const inputMint =
+    process.env.CANDLES_INPUT_MINT ||
+    "So11111111111111111111111111111111111111112";
+  const outputMint =
+    process.env.CANDLES_OUTPUT_MINT ||
+    "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+  const result = (await registry.invoke("market.candles", ctx, {
+    inputMint,
+    outputMint,
+    interval: process.env.CANDLES_INTERVAL || "1m",
+    limit: Number(process.env.CANDLES_LIMIT || "5"),
+  })) as { candles: Array<{ t: number; o: string; c: string }> };
+
+  expect(result.candles.length).toBeGreaterThan(0);
+  expect(result.candles[0].t).toBeTruthy();
+  expect(result.candles[0].o).toBeTruthy();
+  expect(result.candles[0].c).toBeTruthy();
+});
+
 integrationTest("risk.daily_pnl_snapshot (integration)", async () => {
   const { registry, ctx } = setup();
   const date = new Date().toISOString().slice(0, 10);

--- a/tests/unit/tool_validation.test.ts
+++ b/tests/unit/tool_validation.test.ts
@@ -157,6 +157,32 @@ test("invalid risk.daily_pnl_snapshot args are rejected before execution", async
   ).rejects.toThrow(/validation/i);
 });
 
+test("invalid market.candles args are rejected before execution", async () => {
+  process.env.BIRDEYE_API_KEY = "test";
+  const registry = new ToolRegistry();
+  const jupiter = new JupiterClient(
+    stubConfig.jupiter.baseUrl,
+    stubConfig.jupiter.apiKey,
+  );
+  registerDefaultTools(registry, jupiter);
+
+  const ctx = {
+    config: stubConfig,
+    solana: stubSolana,
+    sessionJournal: new SessionJournal("test", ".tmp/sessions"),
+    tradeJournal: new TradeJournal(".tmp/trades"),
+  };
+
+  await expect(
+    registry.invoke("market.candles", ctx, {
+      inputMint: "",
+      outputMint: "",
+      interval: "",
+      limit: -1,
+    }),
+  ).rejects.toThrow(/validation/i);
+});
+
 test("invalid market.get_prices args are rejected before execution", async () => {
   const registry = new ToolRegistry();
   const jupiter = new JupiterClient(


### PR DESCRIPTION
## Summary
- add market.candles tool backed by Birdeye OHLCV for input/output mints
- add validation + tests (integration test skips without BIRDEYE_API_KEY)

## Testing
- bun run lint
- bun test tests/unit/tool_validation.test.ts

Closes #8