### PR TITLE
Add Kalshi prediction market tools

### DIFF
--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -259,7 +259,7 @@ export function registerDefaultTools(
   const fetchKalshiMarkets = async (
     params: Record<string, string>,
   ): Promise<Record<string, unknown>> => {
-    const url = new URL("/markets", kalshiBaseUrl);
+    const url = new URL("markets", `${kalshiBaseUrl}/`);
     for (const [key, value] of Object.entries(params)) {
       url.searchParams.set(key, value);
     }
@@ -275,8 +275,8 @@ export function registerDefaultTools(
     depth = 1,
   ): Promise<Record<string, unknown>> => {
     const url = new URL(
-      `/markets/${encodeURIComponent(ticker)}/orderbook`,
-      kalshiBaseUrl,
+      `markets/${encodeURIComponent(ticker)}/orderbook`,
+      `${kalshiBaseUrl}/`,
     );
     url.searchParams.set("depth", depth.toString());
     const response = await fetch(url.toString(), { method: "GET" });

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -20,6 +20,7 @@ export function registerDefaultTools(
   const defaultSlippageBps = 50;
   const defaultSolNotional = 1_000_000_000n;
   const birdeyeBaseUrl = "https://public-api.birdeye.so";
+  const kalshiBaseUrl = "https://api.elections.kalshi.com/trade-api/v2";
   const candleIntervals: Record<string, { type: string; seconds: number }> = {
     "1m": { type: "1m", seconds: 60 },
     "5m": { type: "5m", seconds: 300 },
@@ -245,6 +246,44 @@ export function registerDefaultTools(
         ? value
         : Number(typeof value === "string" ? value : "");
     return Number.isFinite(num) ? num : null;
+  };
+
+  const toIsoTimestamp = (value: unknown): string => {
+    if (typeof value !== "number" && typeof value !== "string") return "";
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) return "";
+    const ms = numeric > 1_000_000_000_000 ? numeric : numeric * 1000;
+    return new Date(ms).toISOString();
+  };
+
+  const fetchKalshiMarkets = async (
+    params: Record<string, string>,
+  ): Promise<Record<string, unknown>> => {
+    const url = new URL("/markets", kalshiBaseUrl);
+    for (const [key, value] of Object.entries(params)) {
+      url.searchParams.set(key, value);
+    }
+    const response = await fetch(url.toString(), { method: "GET" });
+    if (!response.ok) {
+      throw new Error(`Kalshi markets failed: ${response.status}`);
+    }
+    return (await response.json()) as Record<string, unknown>;
+  };
+
+  const fetchKalshiOrderbook = async (
+    ticker: string,
+    depth = 1,
+  ): Promise<Record<string, unknown>> => {
+    const url = new URL(
+      `/markets/${encodeURIComponent(ticker)}/orderbook`,
+      kalshiBaseUrl,
+    );
+    url.searchParams.set("depth", depth.toString());
+    const response = await fetch(url.toString(), { method: "GET" });
+    if (!response.ok) {
+      throw new Error(`Kalshi orderbook failed: ${response.status}`);
+    }
+    return (await response.json()) as Record<string, unknown>;
   };
 
   const fetchSwitchboardFeed = async (feedId: string) => {
@@ -624,6 +663,100 @@ export function registerDefaultTools(
         limit: input.limit ?? 200,
       });
       return { candles };
+    },
+  });
+
+  registry.register({
+    name: "market.prediction_markets_list",
+    description: "List active prediction markets for a venue.",
+    schema: {
+      name: "market.prediction_markets_list",
+      description: "List active prediction markets for a venue.",
+      parameters: {
+        type: "object",
+        properties: {
+          venue: { type: "string" },
+        },
+        required: ["venue"],
+        additionalProperties: false,
+      },
+    },
+    execute: async (_ctx: ToolContext, input: { venue: string }) => {
+      const venue = input.venue.trim().toLowerCase();
+      if (venue !== "kalshi") {
+        throw new Error("unsupported-venue");
+      }
+      const payload = await fetchKalshiMarkets({
+        limit: "50",
+        status: "open",
+      });
+      const markets =
+        (payload.markets as Array<Record<string, unknown>> | undefined) ?? [];
+      return {
+        markets: markets.map((market) => ({
+          id: String(
+            market.ticker ??
+              market.id ??
+              market.market_ticker ??
+              market.symbol ??
+              "",
+          ),
+          title: String(market.title ?? market.event_title ?? ""),
+          endTime: toIsoTimestamp(
+            market.close_time ??
+              market.close_ts ??
+              market.expiration_time ??
+              market.settlement_ts ??
+              "",
+          ),
+        })),
+      };
+    },
+  });
+
+  registry.register({
+    name: "market.prediction_market_quote",
+    description: "Fetch quote/odds snapshot for a prediction market.",
+    schema: {
+      name: "market.prediction_market_quote",
+      description: "Fetch quote/odds snapshot for a prediction market.",
+      parameters: {
+        type: "object",
+        properties: {
+          venue: { type: "string" },
+          marketId: { type: "string" },
+        },
+        required: ["venue", "marketId"],
+        additionalProperties: false,
+      },
+    },
+    execute: async (
+      _ctx: ToolContext,
+      input: { venue: string; marketId: string },
+    ) => {
+      const venue = input.venue.trim().toLowerCase();
+      if (venue !== "kalshi") {
+        throw new Error("unsupported-venue");
+      }
+      const ticker = input.marketId.trim();
+      if (!ticker) {
+        throw new Error("market-id-required");
+      }
+      const payload = await fetchKalshiOrderbook(ticker, 1);
+      const orderbook =
+        (payload.orderbook as Record<string, unknown> | undefined) ?? payload;
+      const yesLevels =
+        (orderbook.yes as Array<Array<number>> | undefined) ?? [];
+      const noLevels = (orderbook.no as Array<Array<number>> | undefined) ?? [];
+      const yesPrice = yesLevels[0]?.[0];
+      const noPrice = noLevels[0]?.[0];
+      const liquidity = (yesLevels[0]?.[1] ?? 0) + (noLevels[0]?.[1] ?? 0);
+      return {
+        yesPrice: yesPrice !== undefined ? String(yesPrice) : "",
+        noPrice: noPrice !== undefined ? String(noPrice) : "",
+        liquidity: String(liquidity),
+        ts: new Date().toISOString(),
+      };
     },
   });
 

--- a/src/tools/validate.ts
+++ b/src/tools/validate.ts
@@ -108,6 +108,15 @@ const CandlesSchema = z.object({
   limit: z.number().int().positive().max(1000).optional(),
 });
 
+const PredictionMarketsListSchema = z.object({
+  venue: z.string().min(1),
+});
+
+const PredictionMarketQuoteSchema = z.object({
+  venue: z.string().min(1),
+  marketId: z.string().min(1),
+});
+
 const RaydiumPoolSchema = z.object({
   poolId: z.string().min(1),
 });
@@ -128,6 +137,8 @@ export const TOOL_VALIDATORS: Record<string, z.ZodTypeAny> = {
   "market.token_metadata": TokenMetadataSchema,
   "market.pyth_price": PythPriceSchema,
   "market.candles": CandlesSchema,
+  "market.prediction_markets_list": PredictionMarketsListSchema,
+  "market.prediction_market_quote": PredictionMarketQuoteSchema,
   "market.raydium_pool_stats": RaydiumPoolSchema,
   "market.switchboard_price": SwitchboardPriceSchema,
   "market.liquidity_by_mint": LiquidityByMintSchema,

--- a/tests/integration/tools.integration.test.ts
+++ b/tests/integration/tools.integration.test.ts
@@ -184,6 +184,36 @@ integrationTest("market.candles (integration)", async () => {
   expect(result.candles[0].c).toBeTruthy();
 });
 
+integrationTest("market.prediction_markets_list (integration)", async () => {
+  if (!process.env.KALSHI_MARKETS_TEST) {
+    return;
+  }
+  const { registry, ctx } = setup();
+
+  const result = (await registry.invoke("market.prediction_markets_list", ctx, {
+    venue: "kalshi",
+  })) as { markets: Array<{ id: string; title: string }> };
+
+  expect(Array.isArray(result.markets)).toBe(true);
+});
+
+integrationTest("market.prediction_market_quote (integration)", async () => {
+  if (!process.env.KALSHI_MARKET_ID) {
+    return;
+  }
+  const { registry, ctx } = setup();
+  const marketId = process.env.KALSHI_MARKET_ID;
+
+  const result = (await registry.invoke("market.prediction_market_quote", ctx, {
+    venue: "kalshi",
+    marketId,
+  })) as { yesPrice: string; noPrice: string; liquidity: string; ts: string };
+
+  expect(result.yesPrice).toBeTruthy();
+  expect(result.noPrice).toBeTruthy();
+  expect(result.ts).toBeTruthy();
+});
+
 integrationTest("market.raydium_pool_stats (integration)", async () => {
   if (!process.env.RAYDIUM_POOL_ID) {
     return;

--- a/tests/unit/tool_validation.test.ts
+++ b/tests/unit/tool_validation.test.ts
@@ -183,6 +183,49 @@ test("invalid market.candles args are rejected before execution", async () => {
   ).rejects.toThrow(/validation/i);
 });
 
+test("invalid market.prediction_markets_list args are rejected before execution", async () => {
+  const registry = new ToolRegistry();
+  const jupiter = new JupiterClient(
+    stubConfig.jupiter.baseUrl,
+    stubConfig.jupiter.apiKey,
+  );
+  registerDefaultTools(registry, jupiter);
+
+  const ctx = {
+    config: stubConfig,
+    solana: stubSolana,
+    sessionJournal: new SessionJournal("test", ".tmp/sessions"),
+    tradeJournal: new TradeJournal(".tmp/trades"),
+  };
+
+  await expect(
+    registry.invoke("market.prediction_markets_list", ctx, { venue: "" }),
+  ).rejects.toThrow(/validation/i);
+});
+
+test("invalid market.prediction_market_quote args are rejected before execution", async () => {
+  const registry = new ToolRegistry();
+  const jupiter = new JupiterClient(
+    stubConfig.jupiter.baseUrl,
+    stubConfig.jupiter.apiKey,
+  );
+  registerDefaultTools(registry, jupiter);
+
+  const ctx = {
+    config: stubConfig,
+    solana: stubSolana,
+    sessionJournal: new SessionJournal("test", ".tmp/sessions"),
+    tradeJournal: new TradeJournal(".tmp/trades"),
+  };
+
+  await expect(
+    registry.invoke("market.prediction_market_quote", ctx, {
+      venue: "",
+      marketId: "",
+    }),
+  ).rejects.toThrow(/validation/i);
+});
+
 test("invalid market.raydium_pool_stats args are rejected before execution", async () => {
   const registry = new ToolRegistry();
   const jupiter = new JupiterClient(


### PR DESCRIPTION
## Summary
- add market.prediction_markets_list for Kalshi
- add market.prediction_market_quote for Kalshi orderbook top-of-book
- add validation + tests (integration tests gated by env)

## Testing
- bun run lint
- bun test tests/unit/tool_validation.test.ts

Closes #12
Closes #13