### PR TITLE
Add OpenClaw tool compatibility

### DIFF
--- a/ralph.config.example.yaml
+++ b/ralph.config.example.yaml
@@ -28,6 +28,14 @@ gateway:
   authToken: "<REPLACE_ME>"
 tools:
   skillsDir: "skills"
+openclaw:
+  # pluginsDir: "openclaw-plugins"
+  # gateway:
+  #   baseUrl: "http://127.0.0.1:18789"
+  #   token: "<REPLACE_ME>"
+  #   sessionKey: ""
+  #   messageChannel: ""
+  #   accountId: ""
 notify:
   # webhookUrl: "https://example.com/webhook"
 policy:

--- a/src/bin/ralph.ts
+++ b/src/bin/ralph.ts
@@ -11,6 +11,7 @@ import { SessionJournal, TradeJournal } from "../journal/index.js";
 import { JupiterClient } from "../jupiter/client.js";
 import { createSolanaAdapter } from "../solana/index.js";
 import { loadSkillsFromDir } from "../tools/loader.js";
+import { loadOpenClawPluginsFromDir } from "../tools/openclaw.js";
 import { ToolRegistry } from "../tools/registry.js";
 import { registerDefaultTools } from "../tools/tools.js";
 import { isRecord } from "../util/types.js";
@@ -36,6 +37,7 @@ program
       );
       registerDefaultTools(registry, jupiter);
       await loadSkillsFromDir(registry, config.tools.skillsDir);
+      await loadOpenClawPluginsFromDir(registry, config.openclaw.pluginsDir);
 
       const ctx = {
         config,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -130,6 +130,19 @@ export function loadConfig(configPath?: string): RalphConfig {
   const parsedConfig = parseConfigFile(resolvedPath);
   const fileConfig = isRecord(parsedConfig) ? parsedConfig : {};
 
+  const openclawGatewayBaseUrl = process.env.OPENCLAW_GATEWAY_URL;
+  const openclawGatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+  const openclawGatewayOverrides =
+    openclawGatewayBaseUrl || openclawGatewayToken
+      ? {
+          baseUrl: openclawGatewayBaseUrl,
+          token: openclawGatewayToken,
+          sessionKey: process.env.OPENCLAW_GATEWAY_SESSION,
+          messageChannel: process.env.OPENCLAW_MESSAGE_CHANNEL,
+          accountId: process.env.OPENCLAW_ACCOUNT_ID,
+        }
+      : undefined;
+
   const envOverrides: Record<string, unknown> = {
     rpc: {
       endpoint: process.env.RPC_ENDPOINT,
@@ -168,13 +181,9 @@ export function loadConfig(configPath?: string): RalphConfig {
     },
     openclaw: {
       pluginsDir: process.env.OPENCLAW_PLUGINS_DIR,
-      gateway: {
-        baseUrl: process.env.OPENCLAW_GATEWAY_URL,
-        token: process.env.OPENCLAW_GATEWAY_TOKEN,
-        sessionKey: process.env.OPENCLAW_GATEWAY_SESSION,
-        messageChannel: process.env.OPENCLAW_MESSAGE_CHANNEL,
-        accountId: process.env.OPENCLAW_ACCOUNT_ID,
-      },
+      ...(openclawGatewayOverrides
+        ? { gateway: openclawGatewayOverrides }
+        : {}),
     },
   };
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -59,6 +59,20 @@ const ConfigSchema = z.object({
       skillsDir: z.string().default("skills"),
     })
     .default({}),
+  openclaw: z
+    .object({
+      pluginsDir: z.string().optional(),
+      gateway: z
+        .object({
+          baseUrl: z.string().min(1),
+          token: z.string().min(1),
+          sessionKey: z.string().optional(),
+          messageChannel: z.string().optional(),
+          accountId: z.string().optional(),
+        })
+        .optional(),
+    })
+    .default({}),
   notify: z
     .object({
       webhookUrl: z.string().optional(),
@@ -151,6 +165,16 @@ export function loadConfig(configPath?: string): RalphConfig {
     },
     tools: {
       skillsDir: process.env.SKILLS_DIR,
+    },
+    openclaw: {
+      pluginsDir: process.env.OPENCLAW_PLUGINS_DIR,
+      gateway: {
+        baseUrl: process.env.OPENCLAW_GATEWAY_URL,
+        token: process.env.OPENCLAW_GATEWAY_TOKEN,
+        sessionKey: process.env.OPENCLAW_GATEWAY_SESSION,
+        messageChannel: process.env.OPENCLAW_MESSAGE_CHANNEL,
+        accountId: process.env.OPENCLAW_ACCOUNT_ID,
+      },
     },
   };
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -130,19 +130,6 @@ export function loadConfig(configPath?: string): RalphConfig {
   const parsedConfig = parseConfigFile(resolvedPath);
   const fileConfig = isRecord(parsedConfig) ? parsedConfig : {};
 
-  const openclawGatewayBaseUrl = process.env.OPENCLAW_GATEWAY_URL;
-  const openclawGatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN;
-  const openclawGatewayOverrides =
-    openclawGatewayBaseUrl || openclawGatewayToken
-      ? {
-          baseUrl: openclawGatewayBaseUrl,
-          token: openclawGatewayToken,
-          sessionKey: process.env.OPENCLAW_GATEWAY_SESSION,
-          messageChannel: process.env.OPENCLAW_MESSAGE_CHANNEL,
-          accountId: process.env.OPENCLAW_ACCOUNT_ID,
-        }
-      : undefined;
-
   const envOverrides: Record<string, unknown> = {
     rpc: {
       endpoint: process.env.RPC_ENDPOINT,
@@ -178,12 +165,6 @@ export function loadConfig(configPath?: string): RalphConfig {
     },
     tools: {
       skillsDir: process.env.SKILLS_DIR,
-    },
-    openclaw: {
-      pluginsDir: process.env.OPENCLAW_PLUGINS_DIR,
-      ...(openclawGatewayOverrides
-        ? { gateway: openclawGatewayOverrides }
-        : {}),
     },
   };
 

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -1,12 +1,9 @@
+export type JsonSchema = Record<string, unknown>;
+
 export type ToolSchema = {
   name: string;
   description: string;
-  parameters: {
-    type: "object";
-    properties?: Record<string, unknown>;
-    required?: string[];
-    additionalProperties?: boolean;
-  };
+  parameters: JsonSchema;
 };
 
 export type LlmToolCall = {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,4 +1,16 @@
 export { loadSkillsFromDir } from "./loader.js";
+export type {
+  OpenClawApiShim,
+  OpenClawContentPart,
+  OpenClawToolDef,
+  OpenClawToolResult,
+} from "./openclaw.js";
+export {
+  createOpenClawApiShim,
+  loadOpenClawPluginIntoRegistry,
+  loadOpenClawPluginsFromDir,
+  normalizeOpenClawResult,
+} from "./openclaw.js";
 export type { ToolContext, ToolDefinition } from "./registry.js";
 export { ToolRegistry } from "./registry.js";
 export { registerDefaultTools } from "./tools.js";

--- a/src/tools/openclaw.ts
+++ b/src/tools/openclaw.ts
@@ -1,0 +1,253 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import type { ToolSchema } from "../llm/types.js";
+import { randomId } from "../util/id.js";
+import { error, info, warn } from "../util/logger.js";
+import { isRecord } from "../util/types.js";
+import type { ToolContext, ToolRegistry } from "./registry.js";
+
+export type OpenClawJsonSchema = Record<string, unknown>;
+
+export type OpenClawContentPart =
+  | { type: "text"; text: string }
+  | { type: "image"; url?: string; data?: string; mimeType?: string }
+  | { type: "file"; path: string; mimeType?: string }
+  | { type: string; [key: string]: unknown };
+
+export type OpenClawToolResult =
+  | { content: OpenClawContentPart[]; [key: string]: unknown }
+  | string
+  | unknown;
+
+export type OpenClawToolContext = {
+  callId: string;
+  toolContext: ToolContext;
+  logger?: OpenClawLogger;
+  runtime?: unknown;
+};
+
+export type OpenClawToolDef<P = Record<string, unknown>> = {
+  name: string;
+  description?: string;
+  parameters: OpenClawJsonSchema;
+  execute: (
+    id: string,
+    params: P,
+    ctx?: OpenClawToolContext,
+  ) => Promise<OpenClawToolResult>;
+};
+
+export type OpenClawRegisterOpts = {
+  optional?: boolean;
+};
+
+export type OpenClawLogger = {
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+};
+
+export type OpenClawApiShim = {
+  registerTool: (tool: OpenClawToolDef, opts?: OpenClawRegisterOpts) => void;
+  logger?: OpenClawLogger;
+  runtime?: unknown;
+};
+
+type OpenClawPluginFunction = (api: OpenClawApiShim) => void | Promise<void>;
+
+type OpenClawPluginObject = {
+  id?: string;
+  name?: string;
+  configSchema?: OpenClawJsonSchema;
+  register: OpenClawPluginFunction;
+};
+
+type OpenClawPluginExport = OpenClawPluginFunction | OpenClawPluginObject;
+
+const SUPPORTED_EXTS = new Set([".ts", ".js", ".mjs"]);
+
+export function normalizeOpenClawResult(result: OpenClawToolResult): {
+  content: OpenClawContentPart[];
+} {
+  if (typeof result === "string") {
+    return { content: [{ type: "text", text: result }] };
+  }
+  if (isRecord(result) && Array.isArray(result.content)) {
+    return result as { content: OpenClawContentPart[] };
+  }
+  if (result === undefined) {
+    return { content: [{ type: "text", text: "" }] };
+  }
+  return {
+    content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+  };
+}
+
+export function createOpenClawApiShim(
+  registry: ToolRegistry,
+  options: {
+    logger?: OpenClawLogger;
+    runtime?: unknown;
+    namePrefix?: string;
+    onRegister?: (name: string) => void;
+  } = {},
+): OpenClawApiShim {
+  const logger: OpenClawLogger =
+    options.logger ??
+    ({
+      info: (...args) => info("openclaw", { args }),
+      warn: (...args) => warn("openclaw", { args }),
+      error: (...args) => error("openclaw.error", { args }),
+    } satisfies OpenClawLogger);
+
+  return {
+    logger,
+    runtime: options.runtime,
+    registerTool: (tool, opts) => {
+      if (!tool || typeof tool.name !== "string") {
+        throw new Error("openclaw tool missing name");
+      }
+      if (!isRecord(tool.parameters)) {
+        throw new Error(`openclaw tool ${tool.name} missing parameters`);
+      }
+      const name = options.namePrefix
+        ? `${options.namePrefix}${tool.name}`
+        : tool.name;
+      const description = tool.description ?? "";
+      const schema: ToolSchema = {
+        name,
+        description,
+        parameters: isObjectSchema(tool.parameters)
+          ? tool.parameters
+          : { type: "object", properties: {}, additionalProperties: true },
+      };
+      registry.register({
+        name,
+        description,
+        schema,
+        execute: async (ctx: ToolContext, input: Record<string, unknown>) => {
+          const callId = randomId("openclaw");
+          const result = await tool.execute(callId, input as never, {
+            callId,
+            toolContext: ctx,
+            logger,
+            runtime: options.runtime,
+          });
+          return normalizeOpenClawResult(result);
+        },
+      });
+      options.onRegister?.(name);
+      if (opts?.optional) {
+        logger.info("openclaw optional tool registered", name);
+      }
+    },
+  };
+}
+
+export async function loadOpenClawPluginIntoRegistry(
+  registry: ToolRegistry,
+  pluginModule: unknown,
+  options: {
+    pluginId?: string;
+    logger?: OpenClawLogger;
+    runtime?: unknown;
+    namePrefix?: string;
+  } = {},
+): Promise<string[]> {
+  const registered: string[] = [];
+  const api = createOpenClawApiShim(registry, {
+    ...options,
+    onRegister: (name) => registered.push(name),
+  });
+  const plugin = resolveOpenClawPlugin(pluginModule);
+  if (!plugin) {
+    const id = options.pluginId ? ` (${options.pluginId})` : "";
+    throw new Error(`Unsupported OpenClaw plugin export${id}`);
+  }
+  await pluginRegister(plugin, api);
+  return registered;
+}
+
+export async function loadOpenClawPluginsFromDir(
+  registry: ToolRegistry,
+  dir?: string,
+): Promise<void> {
+  if (!dir) return;
+  const resolved = path.resolve(dir);
+  let entries: string[] = [];
+  try {
+    entries = await fs.readdir(resolved);
+  } catch (err) {
+    warn("openclaw plugins directory missing or unreadable", {
+      dir: resolved,
+      err: String(err),
+    });
+    return;
+  }
+
+  for (const entry of entries) {
+    const ext = path.extname(entry);
+    if (!SUPPORTED_EXTS.has(ext)) continue;
+    const fullPath = path.join(resolved, entry);
+    try {
+      const mod = await import(pathToFileURL(fullPath).href);
+      const before = registry.list().length;
+      await loadOpenClawPluginIntoRegistry(registry, mod, {
+        pluginId: entry,
+      });
+      const after = registry.list().length;
+      info("openclaw plugin loaded", {
+        file: fullPath,
+        tools: after - before,
+      });
+    } catch (err) {
+      warn("failed to load openclaw plugin", {
+        file: fullPath,
+        err: String(err),
+      });
+    }
+  }
+}
+
+function isObjectSchema(schema: OpenClawJsonSchema): boolean {
+  const type = schema.type;
+  return typeof type === "string" && type.toLowerCase() === "object";
+}
+
+function resolveOpenClawPlugin(
+  moduleValue: unknown,
+): OpenClawPluginExport | null {
+  const candidate =
+    isRecord(moduleValue) && "default" in moduleValue
+      ? moduleValue.default
+      : moduleValue;
+  if (isOpenClawPluginFunction(candidate)) {
+    return candidate;
+  }
+  if (isOpenClawPluginObject(candidate)) {
+    return candidate;
+  }
+  return null;
+}
+
+function isOpenClawPluginObject(value: unknown): value is OpenClawPluginObject {
+  return isRecord(value) && typeof value.register === "function";
+}
+
+function isOpenClawPluginFunction(
+  value: unknown,
+): value is OpenClawPluginFunction {
+  return typeof value === "function";
+}
+
+async function pluginRegister(
+  plugin: OpenClawPluginExport,
+  api: OpenClawApiShim,
+): Promise<void> {
+  if (typeof plugin === "function") {
+    await plugin(api);
+    return;
+  }
+  await plugin.register(api);
+}

--- a/src/tools/openclaw_gateway.ts
+++ b/src/tools/openclaw_gateway.ts
@@ -1,0 +1,76 @@
+import { isRecord } from "../util/types.js";
+
+export type OpenClawGatewayClientOpts = {
+  baseUrl: string;
+  token: string;
+  sessionKey?: string;
+  messageChannel?: string;
+  accountId?: string;
+};
+
+type OpenClawGatewayError = {
+  type?: string;
+  message?: string;
+};
+
+type OpenClawGatewayResponse = {
+  ok?: boolean;
+  result?: unknown;
+  error?: OpenClawGatewayError;
+};
+
+export async function openClawInvokeTool(
+  cfg: OpenClawGatewayClientOpts,
+  tool: string,
+  args: Record<string, unknown>,
+  action?: string,
+): Promise<unknown> {
+  const url = `${cfg.baseUrl.replace(/\/+$/, "")}/tools/invoke`;
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    authorization: `Bearer ${cfg.token}`,
+  };
+  if (cfg.messageChannel) {
+    headers["x-openclaw-message-channel"] = cfg.messageChannel;
+  }
+  if (cfg.accountId) {
+    headers["x-openclaw-account-id"] = cfg.accountId;
+  }
+
+  const body = {
+    tool,
+    args,
+    ...(action ? { action } : {}),
+    ...(cfg.sessionKey ? { sessionKey: cfg.sessionKey } : {}),
+    dryRun: false,
+  };
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  if (res.status === 404) {
+    throw new Error(`openclaw tool not available: ${tool}`);
+  }
+  if (res.status === 401) {
+    throw new Error("openclaw unauthorized");
+  }
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`openclaw request failed: ${res.status} ${body}`);
+  }
+
+  const payload = (await res.json()) as unknown;
+  if (!isRecord(payload)) {
+    throw new Error("openclaw invalid response");
+  }
+  const response = payload as OpenClawGatewayResponse;
+  if (!response.ok) {
+    const message = response.error?.message ?? "unknown";
+    const type = response.error?.type ?? "error";
+    throw new Error(`openclaw tool error: ${type}: ${message}`);
+  }
+  return response.result;
+}

--- a/src/tools/openclaw_tools.ts
+++ b/src/tools/openclaw_tools.ts
@@ -1,0 +1,47 @@
+import { openClawInvokeTool } from "./openclaw_gateway.js";
+import type { ToolContext, ToolRegistry } from "./registry.js";
+
+export function registerOpenClawTools(registry: ToolRegistry): void {
+  registry.register({
+    name: "openclaw.invoke",
+    description: "Invoke a tool on an OpenClaw gateway.",
+    schema: {
+      name: "openclaw.invoke",
+      description: "Invoke a tool on an OpenClaw gateway.",
+      parameters: {
+        type: "object",
+        properties: {
+          tool: { type: "string" },
+          args: { type: "object" },
+          action: { type: "string" },
+        },
+        required: ["tool"],
+        additionalProperties: false,
+      },
+    },
+    requires: {
+      config: ["openclaw.gateway.baseUrl", "openclaw.gateway.token"],
+    },
+    execute: async (
+      ctx: ToolContext,
+      input: { tool: string; args?: Record<string, unknown>; action?: string },
+    ) => {
+      const cfg = ctx.config.openclaw?.gateway;
+      if (!cfg) {
+        throw new Error("openclaw gateway not configured");
+      }
+      return openClawInvokeTool(
+        {
+          baseUrl: cfg.baseUrl,
+          token: cfg.token,
+          sessionKey: cfg.sessionKey,
+          messageChannel: cfg.messageChannel,
+          accountId: cfg.accountId,
+        },
+        input.tool,
+        input.args ?? {},
+        input.action,
+      );
+    },
+  });
+}

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -1,5 +1,6 @@
 import type { JupiterClient } from "../jupiter/client.js";
 import { registerMarketTools } from "./market_tools.js";
+import { registerOpenClawTools } from "./openclaw_tools.js";
 import type { ToolRegistry } from "./registry.js";
 import { registerRiskTools } from "./risk_tools.js";
 import { registerSystemTools } from "./system_tools.js";
@@ -14,6 +15,7 @@ export function registerDefaultTools(
   const deps = createToolDeps(jupiter);
   registerWalletTools(registry);
   registerMarketTools(registry, deps);
+  registerOpenClawTools(registry);
   registerRiskTools(registry, deps);
   registerTradeTools(registry, deps);
   registerSystemTools(registry);

--- a/src/tools/validate.ts
+++ b/src/tools/validate.ts
@@ -129,6 +129,12 @@ const LiquidityByMintSchema = z.object({
   mint: z.string().min(1),
 });
 
+const OpenClawInvokeSchema = z.object({
+  tool: z.string().min(1),
+  args: z.record(z.unknown()).optional(),
+  action: z.string().optional(),
+});
+
 export const TOOL_VALIDATORS: Record<string, z.ZodTypeAny> = {
   "wallet.get_balances": BalancesSchema,
   "market.jupiter_quote": QuoteSchema,
@@ -142,6 +148,7 @@ export const TOOL_VALIDATORS: Record<string, z.ZodTypeAny> = {
   "market.raydium_pool_stats": RaydiumPoolSchema,
   "market.switchboard_price": SwitchboardPriceSchema,
   "market.liquidity_by_mint": LiquidityByMintSchema,
+  "openclaw.invoke": OpenClawInvokeSchema,
   "risk.max_position_check": MaxPositionSchema,
   "risk.daily_pnl_snapshot": DailyPnlSchema,
   "risk.check_trade": RiskSchema,

--- a/tests/integration/tools.integration.test.ts
+++ b/tests/integration/tools.integration.test.ts
@@ -61,6 +61,7 @@ function buildConfig(): RalphConfig {
     tools: {
       skillsDir: "skills",
     },
+    openclaw: {},
     notify: {},
     policy: {
       killSwitch: false,

--- a/tests/unit/tool_validation.test.ts
+++ b/tests/unit/tool_validation.test.ts
@@ -20,6 +20,7 @@ const stubConfig: RalphConfig = {
   autopilot: { enabled: false, intervalMs: 15000 },
   gateway: { bind: "127.0.0.1", port: 8787, authToken: "test" },
   tools: { skillsDir: "skills" },
+  openclaw: {},
   notify: {},
   policy: {
     killSwitch: false,


### PR DESCRIPTION
## Summary
- add OpenClaw plugin shim + loader to register OpenClaw tools in the registry
- add OpenClaw gateway proxy tool with config/env support
- widen tool schema JSON support and wire registration/validation updates

## Testing
- bun run lint
- bun run typecheck
- bun run test:unit