### PR TITLE
Add runtime tool policy and validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ dist/
 .env
 ralph.config.yaml
 sessions/
+runs/
 trades/
 .tmp/

--- a/biome.json
+++ b/biome.json
@@ -26,6 +26,7 @@
       "**/*",
       "!!**/node_modules",
       "!!**/dist",
+      "!!**/runs",
       "!!**/sessions",
       "!!**/trades",
       "!!**/.tmp"

--- a/ralph.config.example.yaml
+++ b/ralph.config.example.yaml
@@ -14,6 +14,7 @@ llm:
   baseUrl: "https://api.deepinfra.com/v1/openai"
   apiKey: "<REPLACE_ME>"
   model: "zai-org/GLM-4.7"
+  # toolMode: "auto" # auto|tools|functions|none
 autopilot:
   enabled: false
   intervalMs: 15000
@@ -37,6 +38,22 @@ openclaw:
   #   sessionKey: ""
   #   messageChannel: ""
   #   accountId: ""
+runtime:
+  sessionsDir: "sessions"
+  runsDir: "runs"
+  lanes:
+    main: 1
+    subagent: 4
+    autopilot: 1
+agents:
+  defaultAgentId: "main"
+  agents:
+    main:
+      # instructions: "You are Serious Trader Ralph, an autonomous Solana trading agent."
+      # model: "zai-org/GLM-4.7"
+      # lane: "main"
+      # toolPolicy:
+      #   deny: ["sessions.*", "runs.*"]
 notify:
   # webhookUrl: "https://example.com/webhook"
 policy:

--- a/src/bin/ralph.ts
+++ b/src/bin/ralph.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 import { Command } from "commander";
-import { AgentController, AgentOrchestrator } from "../agent/index.js";
 import { sendAgentMessage } from "../cli/agent.js";
 import { runCliCommand } from "../cli/client.js";
 import { runDoctor } from "../cli/doctor.js";
@@ -10,6 +9,7 @@ import { loadConfig } from "../config/index.js";
 import { GatewayServer } from "../gateway/server.js";
 import { SessionJournal, TradeJournal } from "../journal/index.js";
 import { JupiterClient } from "../jupiter/client.js";
+import { AgentManager } from "../runtime/agent_manager.js";
 import { createSolanaAdapter } from "../solana/index.js";
 import { loadSkillsFromDir } from "../tools/loader.js";
 import { loadOpenClawPluginsFromDir } from "../tools/openclaw.js";
@@ -47,13 +47,8 @@ program
         tradeJournal: new TradeJournal(),
       };
 
-      const agent = new AgentOrchestrator(registry, {
-        ...ctx,
-        sessionJournal: new SessionJournal("agent"),
-      });
-      const agentControl = new AgentController(agent);
-
-      const gatewayCtx = { ...ctx, agent, agentControl };
+      const runtime = new AgentManager(registry, ctx);
+      const gatewayCtx = { ...ctx, runtime };
 
       const gateway = new GatewayServer(config, registry, gatewayCtx);
       gateway.start();

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -182,6 +182,14 @@ export class GatewayServer {
   private startAutopilot(): void {
     if (this.autopilotTimer) return;
     this.autopilotTimer = setInterval(() => {
+      if (this.ctx.runtime) {
+        try {
+          this.ctx.runtime.submitAutopilotTick("timer");
+        } catch (err) {
+          warn("autopilot tick failed", { err: String(err) });
+        }
+        return;
+      }
       if (this.ctx.agent) {
         this.ctx.agent
           .tick("timer")

--- a/src/llm/openai_chat.ts
+++ b/src/llm/openai_chat.ts
@@ -1,4 +1,6 @@
+import crypto from "node:crypto";
 import type { RalphConfig } from "../config/config.js";
+import { randomId } from "../util/id.js";
 import { OpenAiChatResponseSchema } from "./schema.js";
 import type {
   LlmClient,
@@ -9,26 +11,53 @@ import type {
 } from "./types.js";
 
 export class OpenAiChatClient implements LlmClient {
+  private autoMode?: "tools" | "functions" | "none";
+
   constructor(private readonly config: RalphConfig["llm"]) {}
 
   async generate(
     messages: LlmMessage[],
     tools: ToolSchema[],
   ): Promise<LlmResponse> {
+    const toolNameMap = buildToolNameMap(tools);
+    const mode = this.resolveMode();
+    if (mode === "auto") {
+      return this.generateAuto(messages, toolNameMap);
+    }
+    return this.sendRequest(messages, toolNameMap, mode);
+  }
+
+  private async sendRequest(
+    messages: LlmMessage[],
+    toolNameMap: ToolNameMap,
+    mode: "tools" | "functions" | "none",
+  ): Promise<LlmResponse> {
     const url = `${this.config.baseUrl.replace(/\/$/, "")}/chat/completions`;
-    const payload = {
+    const payload: Record<string, unknown> = {
       model: this.config.model,
       messages,
-      tools: tools.map((tool) => ({
-        type: "function",
-        function: {
+      stream: false,
+    };
+    if (toolNameMap.tools.length > 0 && mode !== "none") {
+      if (mode === "tools") {
+        payload.tools = toolNameMap.tools.map((tool) => ({
+          type: "function",
+          function: {
+            name: tool.name,
+            description: tool.description,
+            parameters: tool.parameters,
+          },
+        }));
+        payload.tool_choice = "auto";
+      } else {
+        payload.functions = toolNameMap.tools.map((tool) => ({
           name: tool.name,
           description: tool.description,
           parameters: tool.parameters,
-        },
-      })),
-      tool_choice: "auto",
-    };
+        }));
+        payload.function_call = "auto";
+      }
+    }
 
     const response = await fetch(url, {
       method: "POST",
@@ -50,13 +79,37 @@ export class OpenAiChatClient implements LlmClient {
       throw new Error("LLM response missing message");
     }
 
-    const toolCalls: LlmToolCall[] | undefined = choice.tool_calls?.map(
+    let toolCalls: LlmToolCall[] | undefined = choice.tool_calls?.map(
       (call) => ({
         id: call.id,
-        name: call.function.name,
+        name:
+          toolNameMap.toOriginal.get(call.function.name) ?? call.function.name,
         arguments: call.function.arguments,
       }),
     );
+    let toolCallPayload = choice.tool_calls;
+    if ((!toolCalls || toolCalls.length === 0) && choice.function_call) {
+      const id = randomId("call");
+      toolCalls = [
+        {
+          id,
+          name:
+            toolNameMap.toOriginal.get(choice.function_call.name) ??
+            choice.function_call.name,
+          arguments: choice.function_call.arguments,
+        },
+      ];
+      toolCallPayload = [
+        {
+          id,
+          type: "function",
+          function: {
+            name: choice.function_call.name,
+            arguments: choice.function_call.arguments,
+          },
+        },
+      ];
+    }
 
     const role =
       choice.role === "system" ||
@@ -70,10 +123,93 @@ export class OpenAiChatClient implements LlmClient {
       message: {
         role,
         content: choice.content ?? null,
-        tool_calls: choice.tool_calls,
+        tool_calls: toolCallPayload,
       },
       text: choice.content ?? null,
       toolCalls,
     };
   }
+
+  private resolveMode(): "auto" | "tools" | "functions" | "none" {
+    if (this.config.toolMode === "auto") return "auto";
+    return this.config.toolMode;
+  }
+
+  private async generateAuto(
+    messages: LlmMessage[],
+    toolNameMap: ToolNameMap,
+  ): Promise<LlmResponse> {
+    const order: Array<"tools" | "functions" | "none"> = this.autoMode
+      ? [this.autoMode]
+      : ["tools", "functions", "none"];
+    let lastError: unknown;
+    for (const mode of order) {
+      try {
+        const result = await this.sendRequest(messages, toolNameMap, mode);
+        this.autoMode = mode;
+        return result;
+      } catch (err) {
+        lastError = err;
+        if (!this.isToolSupportError(err)) {
+          throw err;
+        }
+      }
+    }
+    throw lastError;
+  }
+
+  private isToolSupportError(err: unknown): boolean {
+    const message = err instanceof Error ? err.message : String(err);
+    return (
+      message.includes("Tool type cannot be empty") ||
+      message.includes("Unknown field: tools") ||
+      message.includes("invalid tools") ||
+      message.includes("tool_choice") ||
+      message.includes("functions not supported")
+    );
+  }
+}
+
+type ToolNameMap = {
+  tools: ToolSchema[];
+  toOriginal: Map<string, string>;
+};
+
+function buildToolNameMap(tools: ToolSchema[]): ToolNameMap {
+  const used = new Set<string>();
+  const toOriginal = new Map<string, string>();
+  const mapped: ToolSchema[] = [];
+  for (const tool of tools) {
+    const alias = toSafeToolName(tool.name, used);
+    toOriginal.set(alias, tool.name);
+    mapped.push({ ...tool, name: alias });
+  }
+  return { tools: mapped, toOriginal };
+}
+
+function toSafeToolName(name: string, used: Set<string>): string {
+  const base = name.replace(/[^a-zA-Z0-9_-]/g, "_");
+  const trimmed = base.replace(/^_+|_+$/g, "") || "tool";
+  const hash = crypto.createHash("sha1").update(name).digest("hex").slice(0, 6);
+  let candidate = trimmed;
+  if (candidate.length > 64) {
+    candidate = candidate.slice(0, 64);
+  }
+  if (!/^[a-zA-Z0-9_-]+$/.test(candidate) || candidate.length === 0) {
+    candidate = `tool_${hash}`;
+  }
+  if (used.has(candidate)) {
+    const suffix = `_${hash}`;
+    const maxPrefix = Math.max(1, 64 - suffix.length);
+    candidate = `${trimmed.slice(0, maxPrefix)}${suffix}`;
+    let counter = 1;
+    while (used.has(candidate)) {
+      const extra = `_${hash}${counter}`;
+      const max = Math.max(1, 64 - extra.length);
+      candidate = `${trimmed.slice(0, max)}${extra}`;
+      counter += 1;
+    }
+  }
+  used.add(candidate);
+  return candidate;
 }

--- a/src/llm/schema.ts
+++ b/src/llm/schema.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const OpenAiToolCallSchema = z.object({
   id: z.string(),
+  type: z.string().default("function"),
   function: z.object({
     name: z.string(),
     arguments: z.string().default("{}"),
@@ -13,6 +14,12 @@ export const OpenAiMessageSchema = z
     role: z.string().optional(),
     content: z.union([z.string(), z.null()]).optional(),
     tool_calls: z.array(OpenAiToolCallSchema).optional(),
+    function_call: z
+      .object({
+        name: z.string(),
+        arguments: z.string().default("{}"),
+      })
+      .optional(),
   })
   .passthrough();
 

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -17,6 +17,7 @@ export type LlmMessage = {
   content?: string | null;
   tool_calls?: Array<{
     id: string;
+    type?: string;
     function: { name: string; arguments: string };
   }>;
   tool_call_id?: string;

--- a/src/runtime/agent_manager.ts
+++ b/src/runtime/agent_manager.ts
@@ -1,0 +1,530 @@
+import { SessionJournal } from "../journal/index.js";
+import { createLlmClient } from "../llm/index.js";
+import type {
+  LlmClient,
+  LlmMessage,
+  LlmToolCall,
+  ToolSchema,
+} from "../llm/types.js";
+import type { ToolContext, ToolRegistry } from "../tools/registry.js";
+import { randomId } from "../util/id.js";
+import { warn } from "../util/logger.js";
+import { isRecord } from "../util/types.js";
+import { LaneQueue } from "./queue.js";
+import { RunStore } from "./run_store.js";
+import { SessionStore } from "./session_store.js";
+import { isToolAllowed, mergeToolPolicies } from "./tool_policy.js";
+import type {
+  AgentDefinition,
+  AgentMeta,
+  AgentRunRequest,
+  AgentRuntime,
+  RunAccepted,
+  RunRecord,
+  ToolPolicy,
+} from "./types.js";
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+type RunResult = {
+  actionsTaken: string[];
+  outputText?: string | null;
+};
+
+export class AgentManager implements AgentRuntime {
+  private readonly sessionStore: SessionStore;
+  private readonly runStore: RunStore;
+  private readonly queue: LaneQueue;
+  private readonly defaultAgentId: string;
+  private readonly agents = new Map<string, AgentDefinition>();
+  private readonly llmCache = new Map<string, LlmClient>();
+  private readonly runPromises = new Map<string, Deferred<RunRecord>>();
+
+  constructor(
+    private readonly registry: ToolRegistry,
+    private readonly baseCtx: Omit<ToolContext, "sessionJournal">,
+  ) {
+    const runtimeCfg = baseCtx.config.runtime;
+    this.sessionStore = new SessionStore(runtimeCfg.sessionsDir);
+    this.runStore = new RunStore(runtimeCfg.runsDir);
+    this.queue = new LaneQueue(runtimeCfg.lanes);
+    this.defaultAgentId = baseCtx.config.agents.defaultAgentId;
+    this.loadAgents(baseCtx.config.agents.agents);
+  }
+
+  getDefaultAgentId(): string {
+    return this.defaultAgentId;
+  }
+
+  submitRun(request: AgentRunRequest): RunAccepted {
+    const runId = randomId("run");
+    const acceptedAt = new Date().toISOString();
+    const agentId = request.agentId || this.defaultAgentId;
+    const agent = this.getAgent(agentId);
+    const lane = request.lane ?? agent.lane ?? "main";
+    const record: RunRecord = {
+      runId,
+      agentId,
+      sessionKey: request.sessionKey,
+      status: "accepted",
+      acceptedAt,
+      lane,
+      parentRunId: request.parentRunId,
+      metadata: request.metadata,
+    };
+
+    void this.runStore.write(record).catch((err) => {
+      warn("run.store.write.failed", { err: String(err) });
+    });
+
+    const deferred = this.createDeferred<RunRecord>();
+    this.runPromises.set(runId, deferred);
+
+    this.queue.enqueue({
+      id: randomId("task"),
+      runId,
+      sessionKey: request.sessionKey,
+      lane,
+      execute: async () => {
+        await this.executeRun(request, runId, acceptedAt, agent, lane);
+      },
+    });
+
+    return { runId, acceptedAt };
+  }
+
+  async submitMessage(input: {
+    sessionKey: string;
+    content: string;
+    agentId?: string;
+    triggerRun?: boolean;
+  }): Promise<{ ok: true } | RunAccepted> {
+    if (!input.triggerRun) {
+      const message: LlmMessage = { role: "user", content: input.content };
+      await this.appendMessage(input.sessionKey, message);
+      return { ok: true };
+    }
+    const agentId = input.agentId ?? this.defaultAgentId;
+    return this.submitRun({
+      agentId,
+      sessionKey: input.sessionKey,
+      input: input.content,
+      reason: "operator",
+    });
+  }
+
+  submitAutopilotTick(reason: "timer" | "operator" | "recovery"): RunAccepted {
+    const agentId = this.defaultAgentId;
+    const sessionKey = `autopilot:${agentId}`;
+    const input = `Tick reason: ${reason}. Decide whether to take action. Use tools when needed.`;
+    return this.submitRun({
+      agentId,
+      sessionKey,
+      input,
+      reason,
+      lane: "autopilot",
+    });
+  }
+
+  spawnSubagent(input: {
+    task: string;
+    agentId?: string;
+    label?: string;
+    parentRunId?: string;
+    parentSessionKey?: string;
+  }): RunAccepted & { childSessionKey: string } {
+    const agentId = input.agentId ?? this.defaultAgentId;
+    const childSessionKey = `agent:${agentId}:subagent:${randomId("sub")}`;
+    const accepted = this.submitRun({
+      agentId,
+      sessionKey: childSessionKey,
+      input: input.task,
+      lane: "subagent",
+      parentRunId: input.parentRunId,
+      parentSessionKey: input.parentSessionKey,
+      metadata: input.label ? { label: input.label } : undefined,
+      toolPolicy: {
+        deny: [
+          "sessions.*",
+          "runs.*",
+          "agent.message",
+          "system.autopilot_tick",
+        ],
+      },
+    });
+    return { ...accepted, childSessionKey };
+  }
+
+  async wait(runId: string, timeoutMs?: number): Promise<RunRecord | null> {
+    const pending = this.runPromises.get(runId);
+    if (!pending) {
+      return this.getRun(runId);
+    }
+    if (!timeoutMs || timeoutMs <= 0) {
+      return pending.promise;
+    }
+    return await Promise.race([
+      pending.promise,
+      new Promise<RunRecord | null>((resolve) => {
+        setTimeout(() => {
+          void this.getRun(runId)
+            .then(resolve)
+            .catch(() => resolve(null));
+        }, timeoutMs);
+      }),
+    ]);
+  }
+
+  async getRun(runId: string): Promise<RunRecord | null> {
+    return this.runStore.get(runId);
+  }
+
+  async listSessions() {
+    return this.sessionStore.list();
+  }
+
+  async getSessionHistory(sessionKey: string, limit?: number) {
+    return this.sessionStore.read(sessionKey, limit);
+  }
+
+  async getSessionMessages(sessionKey: string) {
+    return this.sessionStore.getMessages(sessionKey);
+  }
+
+  private createDeferred<T>(): Deferred<T> {
+    let resolveFn: (value: T) => void = () => {};
+    const promise = new Promise<T>((res) => {
+      resolveFn = res;
+    });
+    return { promise, resolve: resolveFn };
+  }
+
+  private loadAgents(defs: Record<string, Omit<AgentDefinition, "id">>): void {
+    for (const [id, def] of Object.entries(defs)) {
+      this.agents.set(id, {
+        id,
+        canSpawnSubagents: def.canSpawnSubagents ?? true,
+        instructions: def.instructions,
+        model: def.model,
+        toolPolicy: def.toolPolicy,
+        lane: def.lane,
+      });
+    }
+  }
+
+  private getAgent(id: string): AgentDefinition {
+    return (
+      this.agents.get(id) ?? {
+        id,
+        canSpawnSubagents: true,
+      }
+    );
+  }
+
+  private async executeRun(
+    request: AgentRunRequest,
+    runId: string,
+    acceptedAt: string,
+    agent: AgentDefinition,
+    lane: string,
+  ): Promise<void> {
+    const startedAt = new Date().toISOString();
+    await this.runStore.update(runId, {
+      status: "running",
+      startedAt,
+      acceptedAt,
+      agentId: agent.id,
+      sessionKey: request.sessionKey,
+      lane,
+      parentRunId: request.parentRunId,
+      metadata: request.metadata,
+    });
+
+    let result: RunResult | undefined;
+    let error: string | undefined;
+    try {
+      result = await this.runAgent(request, runId, agent);
+    } catch (err) {
+      error = String(err);
+      warn("agent.run.failed", { err: error, runId });
+    }
+
+    const completedAt = new Date().toISOString();
+    const record = await this.runStore.update(runId, {
+      status: error ? "failed" : "completed",
+      completedAt,
+      error,
+      output: result
+        ? { text: result.outputText, actionsTaken: result.actionsTaken }
+        : undefined,
+    });
+
+    await this.maybeAnnounceSubagent(request, record);
+
+    const deferred = this.runPromises.get(runId);
+    if (deferred) {
+      deferred.resolve(record);
+      this.runPromises.delete(runId);
+    }
+  }
+
+  private async runAgent(
+    request: AgentRunRequest,
+    runId: string,
+    agent: AgentDefinition,
+  ): Promise<RunResult> {
+    const llm = this.getLlm(agent.model);
+    const messages = await this.sessionStore.getMessages(request.sessionKey);
+    await this.ensureSystemPrompt(messages, agent, request.sessionKey);
+
+    const userMessage: LlmMessage = {
+      role: "user",
+      content: request.input,
+    };
+    messages.push(userMessage);
+    await this.appendMessage(request.sessionKey, userMessage);
+
+    const toolPolicy = this.resolveToolPolicy(agent, request);
+    const tools = this.filterTools(toolPolicy);
+    const ctx = this.buildToolContext(request, runId, agent, toolPolicy);
+
+    const actions: string[] = [];
+    const maxSteps = 4;
+    let lastAssistantText: string | null | undefined;
+
+    for (let step = 0; step < maxSteps; step += 1) {
+      const response = await llm.generate(messages, tools);
+      messages.push(response.message);
+      lastAssistantText = response.text ?? response.message.content ?? null;
+      await this.appendMessage(request.sessionKey, response.message);
+      await ctx.sessionJournal.append({
+        type: "llm",
+        role: "assistant",
+        content: response.text,
+        toolCalls: response.toolCalls?.map((call) => ({
+          id: call.id,
+          name: call.name,
+        })),
+        ts: new Date().toISOString(),
+      });
+
+      if (!response.toolCalls || response.toolCalls.length === 0) {
+        break;
+      }
+
+      const toolResults = await this.executeToolCalls(
+        response.toolCalls,
+        actions,
+        ctx,
+        toolPolicy,
+        request.sessionKey,
+      );
+      messages.push(...toolResults);
+    }
+
+    return { actionsTaken: actions, outputText: lastAssistantText };
+  }
+
+  private buildToolContext(
+    request: AgentRunRequest,
+    runId: string,
+    agent: AgentDefinition,
+    toolPolicy: ToolPolicy | undefined,
+  ): ToolContext {
+    const canSpawnSubagents =
+      request.parentRunId != null ? false : (agent.canSpawnSubagents ?? true);
+    const meta: AgentMeta = {
+      agentId: agent.id,
+      sessionKey: request.sessionKey,
+      runId,
+      parentRunId: request.parentRunId,
+      canSpawnSubagents,
+    };
+    return {
+      ...this.baseCtx,
+      sessionJournal: new SessionJournal(
+        request.sessionKey,
+        this.sessionStore.getBaseDir(),
+      ),
+      runtime: this,
+      agentMeta: meta,
+      toolPolicy,
+    };
+  }
+
+  private getLlm(modelOverride?: string): LlmClient {
+    const model = modelOverride ?? this.baseCtx.config.llm.model;
+    const key = `${this.baseCtx.config.llm.provider}:${model}`;
+    const cached = this.llmCache.get(key);
+    if (cached) return cached;
+    const client = createLlmClient({
+      ...this.baseCtx.config.llm,
+      model,
+    });
+    this.llmCache.set(key, client);
+    return client;
+  }
+
+  private buildSystemPrompt(agent: AgentDefinition): string {
+    const policy = this.baseCtx.config.policy;
+    const plan = this.baseCtx.config.autopilot.plan;
+    const instruction =
+      agent.instructions ??
+      "You are Serious Trader Ralph, an autonomous Solana trading agent.";
+    const lines = [
+      instruction,
+      "Use the available tools to inspect balances, request quotes, check risk, and execute swaps.",
+      "Never ask for private keys or API keys. Assume tools handle signing.",
+      `Policy: killSwitch=${policy.killSwitch}, maxSlippageBps=${policy.maxSlippageBps}, maxPriceImpactPct=${policy.maxPriceImpactPct}, cooldownSeconds=${policy.cooldownSeconds}.`,
+      policy.allowedMints.length > 0
+        ? `Allowed mints: ${policy.allowedMints.join(", ")}`
+        : "Allowed mints: any",
+      plan
+        ? `Preferred plan: inputMint=${plan.inputMint}, outputMint=${plan.outputMint}, amount=${plan.amount}, slippageBps=${plan.slippageBps}.`
+        : "No preferred plan configured; decide dynamically.",
+    ];
+    return lines.join("\n");
+  }
+
+  private async ensureSystemPrompt(
+    messages: LlmMessage[],
+    agent: AgentDefinition,
+    sessionKey: string,
+  ): Promise<void> {
+    if (messages.some((msg) => msg.role === "system")) return;
+    const systemMessage: LlmMessage = {
+      role: "system",
+      content: this.buildSystemPrompt(agent),
+    };
+    messages.unshift(systemMessage);
+    await this.appendMessage(sessionKey, systemMessage);
+  }
+
+  private async appendMessage(
+    sessionKey: string,
+    message: LlmMessage,
+  ): Promise<void> {
+    await this.sessionStore.append(sessionKey, {
+      type: "message",
+      message,
+      ts: new Date().toISOString(),
+    });
+  }
+
+  private resolveToolPolicy(
+    agent: AgentDefinition,
+    request: AgentRunRequest,
+  ): ToolPolicy | undefined {
+    let merged = mergeToolPolicies(agent.toolPolicy, request.toolPolicy);
+    if (request.parentRunId) {
+      merged = mergeToolPolicies(merged, {
+        deny: [
+          "sessions.*",
+          "runs.*",
+          "agent.message",
+          "system.autopilot_tick",
+        ],
+      });
+    }
+    if (agent.canSpawnSubagents === false) {
+      merged = mergeToolPolicies(merged, { deny: ["sessions.spawn"] });
+    }
+    return merged;
+  }
+
+  private filterTools(policy: ToolPolicy | undefined): ToolSchema[] {
+    const tools = this.registry.listSchemas(this.baseCtx.config);
+    if (!policy) return tools;
+    return tools.filter((schema) => isToolAllowed(policy, schema.name));
+  }
+
+  private async executeToolCalls(
+    toolCalls: LlmToolCall[],
+    actions: string[],
+    ctx: ToolContext,
+    policy: ToolPolicy | undefined,
+    sessionKey: string,
+  ): Promise<LlmMessage[]> {
+    const toolResults: LlmMessage[] = [];
+    for (const call of toolCalls) {
+      let args: Record<string, unknown> = {};
+      try {
+        const parsed = JSON.parse(call.arguments || "{}");
+        if (isRecord(parsed)) {
+          args = parsed;
+        }
+      } catch (_err) {
+        await ctx.sessionJournal.append({
+          type: "tool_call",
+          tool: call.name,
+          args: {},
+          ts: new Date().toISOString(),
+          error: "invalid-arguments",
+        });
+      }
+
+      if (!isToolAllowed(policy, call.name)) {
+        const denied = { error: "tool-not-allowed", tool: call.name };
+        const deniedMessage: LlmMessage = {
+          role: "tool",
+          tool_call_id: call.id,
+          content: JSON.stringify(denied),
+        };
+        toolResults.push(deniedMessage);
+        await this.appendMessage(sessionKey, deniedMessage);
+        continue;
+      }
+
+      await ctx.sessionJournal.append({
+        type: "tool_call",
+        tool: call.name,
+        args,
+        ts: new Date().toISOString(),
+      });
+
+      try {
+        const result = await this.registry.invoke(call.name, ctx, args);
+        actions.push(call.name);
+        const content = JSON.stringify(result);
+        const toolMessage: LlmMessage = {
+          role: "tool",
+          tool_call_id: call.id,
+          content,
+        };
+        toolResults.push(toolMessage);
+        await this.appendMessage(sessionKey, toolMessage);
+      } catch (err) {
+        const errorPayload = { error: String(err) };
+        const toolMessage: LlmMessage = {
+          role: "tool",
+          tool_call_id: call.id,
+          content: JSON.stringify(errorPayload),
+        };
+        toolResults.push(toolMessage);
+        await this.appendMessage(sessionKey, toolMessage);
+      }
+    }
+    return toolResults;
+  }
+
+  private async maybeAnnounceSubagent(
+    request: AgentRunRequest,
+    record: RunRecord,
+  ): Promise<void> {
+    if (!request.parentSessionKey) return;
+    const entry = {
+      type: "subagent_announce",
+      ts: new Date().toISOString(),
+      runId: record.runId,
+      agentId: record.agentId,
+      sessionKey: record.sessionKey,
+      status: record.status,
+      output: record.output,
+      error: record.error,
+    };
+    await this.sessionStore.append(request.parentSessionKey, entry);
+  }
+}

--- a/src/runtime/queue.ts
+++ b/src/runtime/queue.ts
@@ -1,0 +1,60 @@
+import { warn } from "../util/logger.js";
+
+export type QueueTask = {
+  id: string;
+  runId: string;
+  sessionKey: string;
+  lane: string;
+  execute: () => Promise<void>;
+};
+
+export class LaneQueue {
+  private readonly laneLimits = new Map<string, number>();
+  private readonly laneActive = new Map<string, number>();
+  private readonly activeSessions = new Set<string>();
+  private readonly queue: QueueTask[] = [];
+
+  constructor(lanes: Record<string, number>) {
+    for (const [lane, limit] of Object.entries(lanes)) {
+      this.laneLimits.set(lane, Math.max(1, limit));
+    }
+  }
+
+  enqueue(task: QueueTask): void {
+    this.queue.push(task);
+    this.schedule();
+  }
+
+  private schedule(): void {
+    if (this.queue.length === 0) return;
+    for (let i = 0; i < this.queue.length; i += 1) {
+      const task = this.queue[i];
+      if (!this.canRun(task)) continue;
+      this.queue.splice(i, 1);
+      i -= 1;
+      this.start(task);
+    }
+  }
+
+  private canRun(task: QueueTask): boolean {
+    if (this.activeSessions.has(task.sessionKey)) return false;
+    const limit = this.laneLimits.get(task.lane) ?? 1;
+    const active = this.laneActive.get(task.lane) ?? 0;
+    return active < limit;
+  }
+
+  private start(task: QueueTask): void {
+    const active = this.laneActive.get(task.lane) ?? 0;
+    this.laneActive.set(task.lane, active + 1);
+    this.activeSessions.add(task.sessionKey);
+    void task
+      .execute()
+      .catch((err) => warn("queue.task.failed", { err: String(err) }))
+      .finally(() => {
+        const current = this.laneActive.get(task.lane) ?? 1;
+        this.laneActive.set(task.lane, Math.max(0, current - 1));
+        this.activeSessions.delete(task.sessionKey);
+        this.schedule();
+      });
+  }
+}

--- a/src/runtime/run_store.ts
+++ b/src/runtime/run_store.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { isErrnoException, isRecord } from "../util/types.js";
+import type { RunRecord } from "./types.js";
+
+export class RunStore {
+  constructor(private readonly baseDir = "runs") {}
+
+  async write(record: RunRecord): Promise<void> {
+    await fs.mkdir(this.baseDir, { recursive: true });
+    const filePath = path.join(this.baseDir, `${record.runId}.json`);
+    await fs.writeFile(filePath, JSON.stringify(record, null, 2), "utf8");
+  }
+
+  async update(runId: string, patch: Partial<RunRecord>): Promise<RunRecord> {
+    const existing = (await this.get(runId)) ?? ({ runId } as RunRecord);
+    const merged = { ...existing, ...patch };
+    await this.write(merged as RunRecord);
+    return merged as RunRecord;
+  }
+
+  async get(runId: string): Promise<RunRecord | null> {
+    const filePath = path.join(this.baseDir, `${runId}.json`);
+    try {
+      const raw = await fs.readFile(filePath, "utf8");
+      const parsed = JSON.parse(raw);
+      return isRecord(parsed) ? (parsed as RunRecord) : null;
+    } catch (err) {
+      if (isErrnoException(err) && err.code === "ENOENT") {
+        return null;
+      }
+      throw err;
+    }
+  }
+}

--- a/src/runtime/session_store.ts
+++ b/src/runtime/session_store.ts
@@ -87,7 +87,11 @@ export class SessionStore {
     if (!sessionKey) {
       throw new Error("Invalid session key.");
     }
-    if (sessionKey.includes("/") || sessionKey.includes("\\") || sessionKey.includes("\0")) {
+    if (
+      sessionKey.includes("/") ||
+      sessionKey.includes("\\") ||
+      sessionKey.includes("\0")
+    ) {
       throw new Error("Invalid session key.");
     }
     const baseDir = path.resolve(this.baseDir);

--- a/src/runtime/session_store.ts
+++ b/src/runtime/session_store.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { LlmMessage } from "../llm/types.js";
+import { appendJsonl } from "../util/jsonl.js";
+import { isErrnoException, isRecord } from "../util/types.js";
+import type { SessionHistoryEntry, SessionSummary } from "./types.js";
+
+export class SessionStore {
+  constructor(private readonly baseDir = "sessions") {}
+
+  async append(sessionKey: string, entry: SessionHistoryEntry): Promise<void> {
+    const filePath = path.join(this.baseDir, `${sessionKey}.jsonl`);
+    await appendJsonl(filePath, entry);
+  }
+
+  async read(
+    sessionKey: string,
+    limit?: number,
+  ): Promise<SessionHistoryEntry[]> {
+    const filePath = path.join(this.baseDir, `${sessionKey}.jsonl`);
+    try {
+      const raw = await fs.readFile(filePath, "utf8");
+      const entries: SessionHistoryEntry[] = [];
+      const lines = raw.split("\n").map((line) => line.trim());
+      for (const line of lines) {
+        if (!line) continue;
+        const parsed = JSON.parse(line);
+        if (isRecord(parsed)) {
+          entries.push(parsed);
+        }
+      }
+      if (limit && limit > 0) {
+        return entries.slice(-limit);
+      }
+      return entries;
+    } catch (err) {
+      if (isErrnoException(err) && err.code === "ENOENT") {
+        return [];
+      }
+      throw err;
+    }
+  }
+
+  async list(): Promise<SessionSummary[]> {
+    try {
+      const entries = await fs.readdir(this.baseDir);
+      const summaries: SessionSummary[] = [];
+      for (const entry of entries) {
+        if (!entry.endsWith(".jsonl")) continue;
+        const sessionKey = entry.slice(0, -".jsonl".length);
+        const stat = await fs.stat(path.join(this.baseDir, entry));
+        summaries.push({
+          sessionKey,
+          updatedAt: stat.mtime.toISOString(),
+        });
+      }
+      summaries.sort((a, b) =>
+        (b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""),
+      );
+      return summaries;
+    } catch (err) {
+      if (isErrnoException(err) && err.code === "ENOENT") {
+        return [];
+      }
+      throw err;
+    }
+  }
+
+  async getMessages(sessionKey: string): Promise<LlmMessage[]> {
+    const entries = await this.read(sessionKey);
+    const messages: LlmMessage[] = [];
+    for (const entry of entries) {
+      if (entry.type !== "message") continue;
+      const message = entry.message;
+      if (isRecord(message) && typeof message.role === "string") {
+        messages.push(normalizeToolCalls(message as LlmMessage));
+      }
+    }
+    return messages;
+  }
+
+  getBaseDir(): string {
+    return this.baseDir;
+  }
+}
+
+function normalizeToolCalls(message: LlmMessage): LlmMessage {
+  if (!message.tool_calls) return message;
+  const tool_calls = message.tool_calls.map((call) => ({
+    ...call,
+    type: call.type ?? "function",
+  }));
+  return { ...message, tool_calls };
+}

--- a/src/runtime/tool_policy.ts
+++ b/src/runtime/tool_policy.ts
@@ -1,0 +1,40 @@
+import type { ToolPolicy } from "./types.js";
+
+function matchesPattern(pattern: string, name: string): boolean {
+  if (pattern === "*") return true;
+  if (pattern.endsWith("*")) {
+    const prefix = pattern.slice(0, -1);
+    return name.startsWith(prefix);
+  }
+  return pattern === name;
+}
+
+export function isToolAllowed(
+  policy: ToolPolicy | undefined,
+  name: string,
+): boolean {
+  if (!policy) return true;
+  const allow = policy.allow;
+  const deny = policy.deny;
+  let allowed = policy.allowAll ?? (!allow || allow.length === 0);
+  if (allow && allow.length > 0) {
+    allowed = allow.some((pattern) => matchesPattern(pattern, name));
+  }
+  if (!allowed) return false;
+  if (deny?.some((pattern) => matchesPattern(pattern, name))) {
+    return false;
+  }
+  return true;
+}
+
+export function mergeToolPolicies(
+  base: ToolPolicy | undefined,
+  override: ToolPolicy | undefined,
+): ToolPolicy | undefined {
+  if (!base && !override) return undefined;
+  return {
+    allowAll: override?.allowAll ?? base?.allowAll,
+    allow: [...(base?.allow ?? []), ...(override?.allow ?? [])],
+    deny: [...(base?.deny ?? []), ...(override?.deny ?? [])],
+  };
+}

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,0 +1,97 @@
+import type { LlmMessage } from "../llm/types.js";
+
+export type ToolPolicy = {
+  allow?: string[];
+  deny?: string[];
+  allowAll?: boolean;
+};
+
+export type AgentDefinition = {
+  id: string;
+  instructions?: string;
+  model?: string;
+  toolPolicy?: ToolPolicy;
+  lane?: string;
+  canSpawnSubagents?: boolean;
+};
+
+export type AgentMeta = {
+  agentId: string;
+  sessionKey: string;
+  runId: string;
+  parentRunId?: string;
+  canSpawnSubagents: boolean;
+};
+
+export type RunStatus = "accepted" | "running" | "completed" | "failed";
+
+export type RunRecord = {
+  runId: string;
+  agentId: string;
+  sessionKey: string;
+  status: RunStatus;
+  acceptedAt: string;
+  startedAt?: string;
+  completedAt?: string;
+  error?: string;
+  lane?: string;
+  parentRunId?: string;
+  metadata?: Record<string, unknown>;
+  output?: {
+    text?: string | null;
+    actionsTaken?: string[];
+  };
+};
+
+export type RunAccepted = {
+  runId: string;
+  acceptedAt: string;
+};
+
+export type SessionSummary = {
+  sessionKey: string;
+  updatedAt?: string;
+};
+
+export type SessionHistoryEntry = Record<string, unknown>;
+
+export type AgentRunRequest = {
+  agentId: string;
+  sessionKey: string;
+  input: string;
+  reason?: "timer" | "operator" | "recovery";
+  parentRunId?: string;
+  parentSessionKey?: string;
+  lane?: string;
+  toolPolicy?: ToolPolicy;
+  metadata?: Record<string, unknown>;
+};
+
+export type AgentRuntime = {
+  submitRun: (request: AgentRunRequest) => RunAccepted;
+  submitMessage: (input: {
+    sessionKey: string;
+    content: string;
+    agentId?: string;
+    triggerRun?: boolean;
+  }) => Promise<{ ok: true } | RunAccepted>;
+  submitAutopilotTick: (
+    reason: "timer" | "operator" | "recovery",
+  ) => RunAccepted;
+  spawnSubagent: (input: {
+    task: string;
+    agentId?: string;
+    label?: string;
+    parentRunId?: string;
+    parentSessionKey?: string;
+  }) => RunAccepted & { childSessionKey: string };
+  wait: (runId: string, timeoutMs?: number) => Promise<RunRecord | null>;
+  getRun: (runId: string) => Promise<RunRecord | null>;
+  listSessions: () => Promise<SessionSummary[]>;
+  getSessionHistory: (
+    sessionKey: string,
+    limit?: number,
+  ) => Promise<SessionHistoryEntry[]>;
+  getSessionMessages: (sessionKey: string) => Promise<LlmMessage[]>;
+  getDefaultAgentId: () => string;
+};

--- a/src/tools/runtime_tools.ts
+++ b/src/tools/runtime_tools.ts
@@ -1,0 +1,168 @@
+import type { ToolContext, ToolRegistry } from "./registry.js";
+
+export function registerRuntimeTools(registry: ToolRegistry): void {
+  registry.register({
+    name: "sessions.list",
+    description: "List known agent sessions.",
+    schema: {
+      name: "sessions.list",
+      description: "List known agent sessions.",
+      parameters: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+    },
+    execute: async (ctx: ToolContext) => {
+      if (!ctx.runtime) return [];
+      return ctx.runtime.listSessions();
+    },
+  });
+
+  registry.register({
+    name: "sessions.history",
+    description: "Fetch session history entries.",
+    schema: {
+      name: "sessions.history",
+      description: "Fetch session history entries.",
+      parameters: {
+        type: "object",
+        properties: {
+          sessionKey: { type: "string" },
+          limit: { type: "number" },
+        },
+        required: ["sessionKey"],
+        additionalProperties: false,
+      },
+    },
+    execute: async (
+      ctx: ToolContext,
+      input: { sessionKey: string; limit?: number },
+    ) => {
+      if (!ctx.runtime) return [];
+      return ctx.runtime.getSessionHistory(input.sessionKey, input.limit);
+    },
+  });
+
+  registry.register({
+    name: "sessions.send",
+    description: "Send a message into a session.",
+    schema: {
+      name: "sessions.send",
+      description: "Send a message into a session.",
+      parameters: {
+        type: "object",
+        properties: {
+          sessionKey: { type: "string" },
+          content: { type: "string" },
+          agentId: { type: "string" },
+          triggerRun: { type: "boolean" },
+        },
+        required: ["sessionKey", "content"],
+        additionalProperties: false,
+      },
+    },
+    execute: async (
+      ctx: ToolContext,
+      input: {
+        sessionKey: string;
+        content: string;
+        agentId?: string;
+        triggerRun?: boolean;
+      },
+    ) => {
+      if (!ctx.runtime) {
+        return { ok: false, error: "runtime-missing" };
+      }
+      return ctx.runtime.submitMessage({
+        sessionKey: input.sessionKey,
+        content: input.content,
+        agentId: input.agentId,
+        triggerRun: input.triggerRun,
+      });
+    },
+  });
+
+  registry.register({
+    name: "sessions.spawn",
+    description: "Spawn a subagent run in a new session.",
+    schema: {
+      name: "sessions.spawn",
+      description: "Spawn a subagent run in a new session.",
+      parameters: {
+        type: "object",
+        properties: {
+          task: { type: "string" },
+          label: { type: "string" },
+          agentId: { type: "string" },
+        },
+        required: ["task"],
+        additionalProperties: false,
+      },
+    },
+    execute: async (
+      ctx: ToolContext,
+      input: { task: string; label?: string; agentId?: string },
+    ) => {
+      if (!ctx.runtime) {
+        return { ok: false, error: "runtime-missing" };
+      }
+      if (ctx.agentMeta && !ctx.agentMeta.canSpawnSubagents) {
+        return { ok: false, error: "subagent-spawn-forbidden" };
+      }
+      return ctx.runtime.spawnSubagent({
+        task: input.task,
+        label: input.label,
+        agentId: input.agentId,
+        parentRunId: ctx.agentMeta?.runId,
+        parentSessionKey: ctx.agentMeta?.sessionKey,
+      });
+    },
+  });
+
+  registry.register({
+    name: "runs.status",
+    description: "Fetch run status by runId.",
+    schema: {
+      name: "runs.status",
+      description: "Fetch run status by runId.",
+      parameters: {
+        type: "object",
+        properties: {
+          runId: { type: "string" },
+        },
+        required: ["runId"],
+        additionalProperties: false,
+      },
+    },
+    execute: async (ctx: ToolContext, input: { runId: string }) => {
+      if (!ctx.runtime) return null;
+      return ctx.runtime.getRun(input.runId);
+    },
+  });
+
+  registry.register({
+    name: "runs.wait",
+    description: "Wait for a run to complete.",
+    schema: {
+      name: "runs.wait",
+      description: "Wait for a run to complete.",
+      parameters: {
+        type: "object",
+        properties: {
+          runId: { type: "string" },
+          timeoutMs: { type: "number" },
+        },
+        required: ["runId"],
+        additionalProperties: false,
+      },
+    },
+    execute: async (
+      ctx: ToolContext,
+      input: { runId: string; timeoutMs?: number },
+    ) => {
+      if (!ctx.runtime) return null;
+      return ctx.runtime.wait(input.runId, input.timeoutMs);
+    },
+  });
+}

--- a/src/tools/system_tools.ts
+++ b/src/tools/system_tools.ts
@@ -22,6 +22,9 @@ export function registerSystemTools(registry: ToolRegistry): void {
       input: { reason: "timer" | "operator" | "recovery" },
     ) => {
       info("autopilot tick", { reason: input.reason });
+      if (ctx.runtime) {
+        return ctx.runtime.submitAutopilotTick(input.reason);
+      }
       if (ctx.agent) {
         return ctx.agent.tick(input.reason);
       }
@@ -43,6 +46,7 @@ export function registerSystemTools(registry: ToolRegistry): void {
         properties: {
           content: { type: "string" },
           triggerTick: { type: "boolean" },
+          sessionKey: { type: "string" },
         },
         required: ["content"],
         additionalProperties: false,
@@ -50,8 +54,15 @@ export function registerSystemTools(registry: ToolRegistry): void {
     },
     execute: async (
       ctx: ToolContext,
-      input: { content: string; triggerTick?: boolean },
+      input: { content: string; triggerTick?: boolean; sessionKey?: string },
     ) => {
+      if (ctx.runtime) {
+        return ctx.runtime.submitMessage({
+          sessionKey: input.sessionKey ?? "operator",
+          content: input.content,
+          triggerRun: input.triggerTick,
+        });
+      }
       if (!ctx.agentControl) {
         return { ok: false, error: "agent-control-missing" };
       }

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -3,6 +3,7 @@ import { registerMarketTools } from "./market_tools.js";
 import { registerOpenClawTools } from "./openclaw_tools.js";
 import type { ToolRegistry } from "./registry.js";
 import { registerRiskTools } from "./risk_tools.js";
+import { registerRuntimeTools } from "./runtime_tools.js";
 import { registerSystemTools } from "./system_tools.js";
 import { createToolDeps } from "./tool_deps.js";
 import { registerTradeTools } from "./trade_tools.js";
@@ -19,4 +20,5 @@ export function registerDefaultTools(
   registerRiskTools(registry, deps);
   registerTradeTools(registry, deps);
   registerSystemTools(registry);
+  registerRuntimeTools(registry);
 }

--- a/src/tools/validate.ts
+++ b/src/tools/validate.ts
@@ -81,6 +81,36 @@ const TickSchema = z.object({
 const AgentMessageSchema = z.object({
   content: z.string().min(1),
   triggerTick: z.boolean().optional(),
+  sessionKey: z.string().optional(),
+});
+
+const SessionsListSchema = z.object({});
+
+const SessionsHistorySchema = z.object({
+  sessionKey: z.string().min(1),
+  limit: z.number().int().positive().optional(),
+});
+
+const SessionsSendSchema = z.object({
+  sessionKey: z.string().min(1),
+  content: z.string().min(1),
+  agentId: z.string().optional(),
+  triggerRun: z.boolean().optional(),
+});
+
+const SessionsSpawnSchema = z.object({
+  task: z.string().min(1),
+  label: z.string().optional(),
+  agentId: z.string().optional(),
+});
+
+const RunsStatusSchema = z.object({
+  runId: z.string().min(1),
+});
+
+const RunsWaitSchema = z.object({
+  runId: z.string().min(1),
+  timeoutMs: z.number().int().positive().optional(),
 });
 
 const PricesSchema = z.object({
@@ -156,4 +186,10 @@ export const TOOL_VALIDATORS: Record<string, z.ZodTypeAny> = {
   "notify.emit": NotifySchema,
   "system.autopilot_tick": TickSchema,
   "agent.message": AgentMessageSchema,
+  "sessions.list": SessionsListSchema,
+  "sessions.history": SessionsHistorySchema,
+  "sessions.send": SessionsSendSchema,
+  "sessions.spawn": SessionsSpawnSchema,
+  "runs.status": RunsStatusSchema,
+  "runs.wait": RunsWaitSchema,
 };

--- a/tests/unit/session_store.test.ts
+++ b/tests/unit/session_store.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { SessionStore } from "../../src/runtime/session_store.js";
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "ralph-session-store-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("session store writes and reads valid session key", async () => {
+  await withTempDir(async (dir) => {
+    const store = new SessionStore(dir);
+    await store.append("session-1", {
+      type: "message",
+      message: { role: "user", content: "hi" },
+      ts: new Date().toISOString(),
+    });
+    const entries = await store.read("session-1");
+    expect(entries.length).toBe(1);
+  });
+});
+
+test("session store rejects traversal session key", async () => {
+  await withTempDir(async (dir) => {
+    const store = new SessionStore(dir);
+    await expect(
+      store.append("../evil", { type: "message", ts: "now" }),
+    ).rejects.toThrow();
+    await expect(
+      store.append("..\\evil", { type: "message", ts: "now" }),
+    ).rejects.toThrow();
+    await expect(
+      store.append("/etc/passwd", { type: "message", ts: "now" }),
+    ).rejects.toThrow();
+  });
+});

--- a/tests/unit/tool_validation.test.ts
+++ b/tests/unit/tool_validation.test.ts
@@ -22,6 +22,15 @@ const stubConfig: RalphConfig = {
   tools: { skillsDir: "skills" },
   openclaw: {},
   notify: {},
+  runtime: {
+    sessionsDir: "sessions",
+    runsDir: "runs",
+    lanes: { main: 1, subagent: 4, autopilot: 1 },
+  },
+  agents: {
+    defaultAgentId: "main",
+    agents: {},
+  },
   policy: {
     killSwitch: false,
     allowedMints: [],

--- a/tests/unit/tools_install.test.ts
+++ b/tests/unit/tools_install.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { RalphConfig } from "../../src/config/config.js";
 import { installToolFromRegistry } from "../../src/cli/tools.js";
+import type { RalphConfig } from "../../src/config/config.js";
 
 const tmpRoot = path.resolve(".tmp/test-tools-install");
 const registryUrl = "https://registry.example.com/tools.json";
@@ -24,6 +24,15 @@ const baseConfig: RalphConfig = {
   tools: { skillsDir: "skills" },
   openclaw: {},
   notify: {},
+  runtime: {
+    sessionsDir: "sessions",
+    runsDir: "runs",
+    lanes: { main: 1, subagent: 4, autopilot: 1 },
+  },
+  agents: {
+    defaultAgentId: "main",
+    agents: {},
+  },
   policy: {
     killSwitch: false,
     allowedMints: [],
@@ -90,8 +99,9 @@ test("rejects registry entries with path traversal", async () => {
     [downloadUrl]: { body: "console.log('x')" },
   });
 
-  await expect(installToolFromRegistry(configWithRegistry(), "bad")).rejects
-    .toThrow(/unsafe filename/i);
+  await expect(
+    installToolFromRegistry(configWithRegistry(), "bad"),
+  ).rejects.toThrow(/unsafe filename/i);
 });
 
 test("rejects registry entries with absolute paths", async () => {
@@ -106,8 +116,9 @@ test("rejects registry entries with absolute paths", async () => {
     [downloadUrl]: { body: "console.log('x')" },
   });
 
-  await expect(installToolFromRegistry(configWithRegistry(), "bad")).rejects
-    .toThrow(/unsafe filename/i);
+  await expect(
+    installToolFromRegistry(configWithRegistry(), "bad"),
+  ).rejects.toThrow(/unsafe filename/i);
 });
 
 test("installs tool with a safe filename", async () => {

--- a/tests/unit/tools_install.test.ts
+++ b/tests/unit/tools_install.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { RalphConfig } from "../../src/config/config.js";
+import { installToolFromRegistry } from "../../src/cli/tools.js";
+
+const tmpRoot = path.resolve(".tmp/test-tools-install");
+const registryUrl = "https://registry.example.com/tools.json";
+const downloadUrl = "https://registry.example.com/tool.js";
+
+const baseConfig: RalphConfig = {
+  rpc: { endpoint: "http://localhost:8899" },
+  wallet: {},
+  jupiter: { apiKey: "test", baseUrl: "https://api.jup.ag" },
+  solana: { sdkMode: "web3" },
+  llm: {
+    provider: "openai_chat",
+    baseUrl: "https://api.z.ai/api/paas/v4",
+    apiKey: "test",
+    model: "glm-4.7",
+  },
+  autopilot: { enabled: false, intervalMs: 15000 },
+  gateway: { bind: "127.0.0.1", port: 8787, authToken: "test" },
+  tools: { skillsDir: "skills" },
+  openclaw: {},
+  notify: {},
+  policy: {
+    killSwitch: false,
+    allowedMints: [],
+    maxTradeAmountLamports: "0",
+    maxSlippageBps: 50,
+    maxPriceImpactPct: 1,
+    cooldownSeconds: 30,
+  },
+};
+
+let originalFetch: typeof fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(async () => {
+  globalThis.fetch = originalFetch;
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+function mockFetch(
+  responses: Record<
+    string,
+    { status?: number; body: unknown; headers?: HeadersInit }
+  >,
+): void {
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const match = responses[url];
+    if (!match) {
+      throw new Error(`unexpected fetch: ${url}`);
+    }
+    const body =
+      typeof match.body === "string" ? match.body : JSON.stringify(match.body);
+    return new Response(body, {
+      status: match.status ?? 200,
+      headers: match.headers,
+    });
+  }) as typeof fetch;
+}
+
+function configWithRegistry(): RalphConfig {
+  return {
+    ...baseConfig,
+    tools: { skillsDir: path.join(tmpRoot, "skills") },
+    openclaw: {
+      ...baseConfig.openclaw,
+      registryUrl,
+      pluginsDir: path.join(tmpRoot, "plugins"),
+    },
+  };
+}
+
+test("rejects registry entries with path traversal", async () => {
+  mockFetch({
+    [registryUrl]: {
+      body: {
+        tools: {
+          bad: { url: downloadUrl, filename: "../evil.js" },
+        },
+      },
+    },
+    [downloadUrl]: { body: "console.log('x')" },
+  });
+
+  await expect(installToolFromRegistry(configWithRegistry(), "bad")).rejects
+    .toThrow(/unsafe filename/i);
+});
+
+test("rejects registry entries with absolute paths", async () => {
+  mockFetch({
+    [registryUrl]: {
+      body: {
+        tools: {
+          bad: { url: downloadUrl, filename: "/etc/passwd" },
+        },
+      },
+    },
+    [downloadUrl]: { body: "console.log('x')" },
+  });
+
+  await expect(installToolFromRegistry(configWithRegistry(), "bad")).rejects
+    .toThrow(/unsafe filename/i);
+});
+
+test("installs tool with a safe filename", async () => {
+  mockFetch({
+    [registryUrl]: {
+      body: {
+        tools: {
+          ok: { url: downloadUrl, filename: "tool.js" },
+        },
+      },
+    },
+    [downloadUrl]: { body: "console.log('ok')" },
+  });
+
+  const dest = await installToolFromRegistry(configWithRegistry(), "ok");
+  const content = await fs.readFile(dest, "utf8");
+
+  expect(dest).toBe(path.resolve(path.join(tmpRoot, "plugins"), "tool.js"));
+  expect(content).toBe("console.log('ok')");
+});
+
+test("installs tool into a nested subdirectory", async () => {
+  mockFetch({
+    [registryUrl]: {
+      body: {
+        tools: {
+          ok: { url: downloadUrl, filename: "nested/tool.js" },
+        },
+      },
+    },
+    [downloadUrl]: { body: "console.log('nested')" },
+  });
+
+  const dest = await installToolFromRegistry(configWithRegistry(), "ok");
+  const content = await fs.readFile(dest, "utf8");
+
+  expect(dest).toBe(
+    path.resolve(path.join(tmpRoot, "plugins"), "nested", "tool.js"),
+  );
+  expect(content).toBe("console.log('nested')");
+});
+
+test("refuses to overwrite existing tool without --force", async () => {
+  mockFetch({
+    [registryUrl]: {
+      body: {
+        tools: {
+          ok: { url: downloadUrl, filename: "tool.js" },
+        },
+      },
+    },
+    [downloadUrl]: { body: "console.log('new')" },
+  });
+
+  const config = configWithRegistry();
+  const destDir = path.join(tmpRoot, "plugins");
+  await fs.mkdir(destDir, { recursive: true });
+  const existingPath = path.join(destDir, "tool.js");
+  await fs.writeFile(existingPath, "console.log('old')", "utf8");
+
+  await expect(installToolFromRegistry(config, "ok")).rejects.toThrow(
+    /already installed/i,
+  );
+
+  const content = await fs.readFile(existingPath, "utf8");
+  expect(content).toBe("console.log('old')");
+});


### PR DESCRIPTION
## Summary
- add runtime agent manager, stores, and tool policy types
- introduce runtime tools and validation for tool policy
- expand OpenAI chat/tool registry wiring for runtime support
- update config and tests for runtime tool validation

## Testing
- not run (not requested)
