### PR TITLE
Add Orca pool stats tool

### DIFF
--- a/src/tools/validate.ts
+++ b/src/tools/validate.ts
@@ -151,6 +151,10 @@ const RaydiumPoolSchema = z.object({
   poolId: z.string().min(1),
 });
 
+const OrcaPoolSchema = z.object({
+  poolId: z.string().min(1),
+});
+
 const SwitchboardPriceSchema = z.object({
   feedId: z.string().min(1),
 });
@@ -176,6 +180,7 @@ export const TOOL_VALIDATORS: Record<string, z.ZodTypeAny> = {
   "market.prediction_markets_list": PredictionMarketsListSchema,
   "market.prediction_market_quote": PredictionMarketQuoteSchema,
   "market.raydium_pool_stats": RaydiumPoolSchema,
+  "market.orca_pool_stats": OrcaPoolSchema,
   "market.switchboard_price": SwitchboardPriceSchema,
   "market.liquidity_by_mint": LiquidityByMintSchema,
   "openclaw.invoke": OpenClawInvokeSchema,

--- a/tests/integration/tools.integration.test.ts
+++ b/tests/integration/tools.integration.test.ts
@@ -256,6 +256,22 @@ integrationTest("market.raydium_pool_stats (integration)", async () => {
   expect(Number.isFinite(result.feeTierBps)).toBe(true);
 });
 
+integrationTest("market.orca_pool_stats (integration)", async () => {
+  if (!process.env.ORCA_POOL_ID) {
+    return;
+  }
+  const { registry, ctx } = setup();
+  const poolId = process.env.ORCA_POOL_ID;
+
+  const result = (await registry.invoke("market.orca_pool_stats", ctx, {
+    poolId,
+  })) as { tvlUsd: string; volume24hUsd: string; feeTierBps: number };
+
+  expect(result.tvlUsd).toBeTruthy();
+  expect(result.volume24hUsd).toBeTruthy();
+  expect(Number.isFinite(result.feeTierBps)).toBe(true);
+});
+
 integrationTest("market.switchboard_price (integration)", async () => {
   if (!process.env.SWITCHBOARD_FEED_ID) {
     return;


### PR DESCRIPTION
## Summary
- add Orca whirlpool fetcher + cache to tool deps
- register market.orca_pool_stats tool with TVL/24h volume/fee tier output
- add validator and optional integration test gated by ORCA_POOL_ID

## Testing
- bun run lint
