### PR TITLE
Cloudflare CI/CD: dev auto deploy, staging/prod manual

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,13 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,37 @@
+name: Deploy (dev)
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: deploy-dev
+  cancel-in-progress: true
+
+jobs:
+  deploy-dev:
+    runs-on: ubuntu-latest
+    environment: dev
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install worker deps
+        working-directory: apps/worker
+        run: npm install
+
+      - name: Apply D1 migrations (dev)
+        working-directory: apps/worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: npx wrangler d1 migrations apply ralph_waitlist_dev --remote
+
+      - name: Deploy worker (dev)
+        working-directory: apps/worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: npx wrangler deploy
+

--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -1,0 +1,53 @@
+name: Deploy (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Which environment to deploy"
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+
+concurrency:
+  group: deploy-manual-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install worker deps
+        working-directory: apps/worker
+        run: npm install
+
+      - name: Apply D1 migrations
+        working-directory: apps/worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.environment }}" = "staging" ]; then
+            npx wrangler d1 migrations apply ralph_waitlist_staging --remote --env staging
+          elif [ "${{ inputs.environment }}" = "production" ]; then
+            npx wrangler d1 migrations apply ralph_waitlist --remote --env production
+          else
+            echo "Unknown environment: ${{ inputs.environment }}"
+            exit 1
+          fi
+
+      - name: Deploy worker
+        working-directory: apps/worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: npx wrangler deploy --env ${{ inputs.environment }}
+

--- a/apps/worker/src/logs.ts
+++ b/apps/worker/src/logs.ts
@@ -1,6 +1,10 @@
 import type { Env } from "./types";
 
 export async function appendLog(env: Env, key: string, line: string) {
+  if (!env.LOGS_BUCKET) {
+    // R2 not configured/enabled yet; still allow the Worker to run.
+    return;
+  }
   const existing = await env.LOGS_BUCKET.get(key);
   const prefix = existing ? await existing.text() : "";
   const body = prefix ? `${prefix}\n${line}` : line;

--- a/apps/worker/src/types.ts
+++ b/apps/worker/src/types.ts
@@ -7,7 +7,8 @@ export type LoopConfig = {
 export type Env = {
   WAITLIST_DB: D1Database;
   CONFIG_KV: KVNamespace;
-  LOGS_BUCKET: R2Bucket;
+  // Optional while R2 is not enabled on the account; logs will fall back to console only.
+  LOGS_BUCKET?: R2Bucket;
   ADMIN_TOKEN?: string;
   PRIVY_APP_ID?: string;
   PRIVY_APP_SECRET?: string;

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -1,6 +1,7 @@
-name = "ralph-edge"
+name = "ralph-edge-dev"
 main = "src/index.ts"
 compatibility_date = "2026-02-03"
+account_id = "4e3939d5df701303b59ffbe4472184de"
 
 [vars]
 LOOP_ENABLED_DEFAULT = "false"
@@ -8,19 +9,71 @@ ALLOWED_ORIGINS = "*"
 
 [[kv_namespaces]]
 binding = "CONFIG_KV"
-id = "REPLACE_WITH_KV_ID"
-preview_id = "REPLACE_WITH_KV_PREVIEW_ID"
+id = "516c7df512df4b8d86b8784c0001da59"
+preview_id = "485beadbf21442dea022939bb1a6894e"
 
 [[d1_databases]]
 binding = "WAITLIST_DB"
-database_name = "ralph_waitlist"
-database_id = "REPLACE_WITH_D1_ID"
-preview_database_id = "REPLACE_WITH_D1_PREVIEW_ID"
+database_name = "ralph_waitlist_dev"
+database_id = "47ccd126-2dfe-47b3-a643-ee2999c435cc"
+preview_database_id = "47ccd126-2dfe-47b3-a643-ee2999c435cc"
 migrations_dir = "migrations"
 
 [[r2_buckets]]
 binding = "LOGS_BUCKET"
-bucket_name = "ralph-logs"
+bucket_name = "ralph-logs-dev"
 
 [triggers]
+crons = ["*/1 * * * *"]
+
+[env.staging]
+name = "ralph-edge-staging"
+
+[env.staging.vars]
+LOOP_ENABLED_DEFAULT = "false"
+ALLOWED_ORIGINS = "*"
+
+[[env.staging.kv_namespaces]]
+binding = "CONFIG_KV"
+id = "24b7fb70e0d6490fb6405c158f397160"
+preview_id = "f06ed95e8c6c4413aeea2dae4b208250"
+
+[[env.staging.d1_databases]]
+binding = "WAITLIST_DB"
+database_name = "ralph_waitlist_staging"
+database_id = "1be9b953-6f4f-4d9b-9941-a42fdc574159"
+preview_database_id = "1be9b953-6f4f-4d9b-9941-a42fdc574159"
+migrations_dir = "migrations"
+
+[[env.staging.r2_buckets]]
+binding = "LOGS_BUCKET"
+bucket_name = "ralph-logs-staging"
+
+[env.staging.triggers]
+crons = ["*/1 * * * *"]
+
+[env.production]
+name = "ralph-edge"
+
+[env.production.vars]
+LOOP_ENABLED_DEFAULT = "false"
+ALLOWED_ORIGINS = "*"
+
+[[env.production.kv_namespaces]]
+binding = "CONFIG_KV"
+id = "3b9a43b162814678a999a6c2540f800d"
+preview_id = "5fc12fba238f4f289ec4cd0aea7c2f47"
+
+[[env.production.d1_databases]]
+binding = "WAITLIST_DB"
+database_name = "ralph_waitlist"
+database_id = "5af86222-a9ca-4227-bf25-4084cbeaeeca"
+preview_database_id = "5af86222-a9ca-4227-bf25-4084cbeaeeca"
+migrations_dir = "migrations"
+
+[[env.production.r2_buckets]]
+binding = "LOGS_BUCKET"
+bucket_name = "ralph-logs"
+
+[env.production.triggers]
 crons = ["*/1 * * * *"]


### PR DESCRIPTION
Implements CI/CD for Cloudflare Worker deployments:

- Dev deploys automatically on every push to main (Worker: ralph-edge-dev).
- Staging and production deploy via manual workflow dispatch.
- Adds a real dev environment (separate KV/D1/R2) and updates apps/worker/wrangler.toml env blocks for dev/staging/prod.

Notes:
- Requires GitHub Actions secret CLOUDFLARE_API_TOKEN (set at repo level or in GitHub Environments: dev, staging, production).
- Workflows apply D1 migrations before deploying.
