### PR TITLE
Worker: local wrangler dev harness

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -22,6 +22,35 @@ wrangler dev
 Replace the `REPLACE_WITH_*` placeholders in `wrangler.toml` with the IDs
 output by Wrangler (KV namespace IDs and D1 database IDs).
 
+## Local Quickstart (Fast Loop Testing)
+
+This uses `wrangler dev --local` with a persisted local state directory so you
+can iterate on the loop quickly without touching real Cloudflare resources.
+
+```bash
+cd apps/worker
+npm install
+
+# Create the local D1 DB and apply migrations into the persisted state dir.
+npm run db:migrate:local
+
+# Enable the loop in local KV (cron + /__scheduled will no-op if disabled).
+npm run loop:enable:local
+
+# Start the local dev server (includes --test-scheduled).
+npm run dev:local
+```
+
+In another terminal you can force a scheduled tick:
+
+```bash
+cd apps/worker
+npm run loop:tick:local
+```
+
+Or open `http://127.0.0.1:8787/__scheduled` in a browser to trigger the
+scheduled event handler.
+
 ## Notes
 - Cron runs every minute by default. The loop only runs if enabled in KV.
 - The trading loop implementation is stubbed in `src/loop.ts` and is the entry

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -48,8 +48,12 @@ cd apps/worker
 npm run loop:tick:local
 ```
 
-Or open `http://127.0.0.1:8787/__scheduled` in a browser to trigger the
+Or open `http://127.0.0.1:8888/__scheduled` in a browser to trigger the
 scheduled event handler.
+By default this local dev script binds to port `8888` to avoid clashing with
+the local Ralph gateway (which commonly uses `8787`).
+Note: Wrangler local mode uses the preview KV namespace by default, so the
+`loop:*:local` scripts write to the preview namespace to match.
 
 ## Notes
 - Cron runs every minute by default. The loop only runs if enabled in KV.

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -4,6 +4,12 @@
   "private": true,
   "scripts": {
     "dev": "wrangler dev",
+    "dev:local": "wrangler dev --local --persist-to .wrangler/state --test-scheduled --port 8787",
+    "db:migrate:local": "wrangler d1 migrations apply WAITLIST_DB --local --persist-to .wrangler/state",
+    "loop:enable:local": "wrangler kv key put loop:config '{\"enabled\":true}' --binding CONFIG_KV --preview false --local --persist-to .wrangler/state",
+    "loop:disable:local": "wrangler kv key put loop:config '{\"enabled\":false}' --binding CONFIG_KV --preview false --local --persist-to .wrangler/state",
+    "loop:status:local": "curl -sS http://127.0.0.1:8787/api/loop/status | cat",
+    "loop:tick:local": "curl -sS http://127.0.0.1:8787/__scheduled | cat",
     "deploy": "wrangler deploy"
   },
   "dependencies": {

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -4,12 +4,12 @@
   "private": true,
   "scripts": {
     "dev": "wrangler dev",
-    "dev:local": "wrangler dev --local --persist-to .wrangler/state --test-scheduled --port 8787",
+    "dev:local": "wrangler dev --local --persist-to .wrangler/state --test-scheduled --port 8888",
     "db:migrate:local": "wrangler d1 migrations apply WAITLIST_DB --local --persist-to .wrangler/state",
-    "loop:enable:local": "wrangler kv key put loop:config '{\"enabled\":true}' --binding CONFIG_KV --preview false --local --persist-to .wrangler/state",
-    "loop:disable:local": "wrangler kv key put loop:config '{\"enabled\":false}' --binding CONFIG_KV --preview false --local --persist-to .wrangler/state",
-    "loop:status:local": "curl -sS http://127.0.0.1:8787/api/loop/status | cat",
-    "loop:tick:local": "curl -sS http://127.0.0.1:8787/__scheduled | cat",
+    "loop:enable:local": "wrangler kv key put loop:config '{\"enabled\":true}' --binding CONFIG_KV --preview --local --persist-to .wrangler/state",
+    "loop:disable:local": "wrangler kv key put loop:config '{\"enabled\":false}' --binding CONFIG_KV --preview --local --persist-to .wrangler/state",
+    "loop:status:local": "curl -sS http://127.0.0.1:8888/api/loop/status | cat",
+    "loop:tick:local": "curl -sS http://127.0.0.1:8888/__scheduled | cat",
     "deploy": "wrangler deploy"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,13 @@
     "test:integration": "bun test tests/integration",
     "typecheck": "bunx tsc --noEmit",
     "lint": "biome check .",
-    "lint:fix": "biome check . --write"
+    "lint:fix": "biome check . --write",
+    "edge:dev": "cd apps/worker && npm run dev:local",
+    "edge:db:migrate:local": "cd apps/worker && npm run db:migrate:local",
+    "edge:loop:enable:local": "cd apps/worker && npm run loop:enable:local",
+    "edge:loop:disable:local": "cd apps/worker && npm run loop:disable:local",
+    "edge:loop:status:local": "cd apps/worker && npm run loop:status:local",
+    "edge:loop:tick:local": "cd apps/worker && npm run loop:tick:local"
   },
   "dependencies": {
     "@ellipsis-labs/phoenix-sdk": "^2.0.3",


### PR DESCRIPTION
Adds a lightweight local dev harness for the Cloudflare Worker so you can iterate on the loop quickly with wrangler.

- Adds `apps/worker` scripts for `wrangler dev --local` + persisted state and scheduled-event testing.
- Adds root-level convenience scripts (`bun run edge:*`) to avoid cd-ing.
- Updates worker README with a fast local quickstart.

Usage:
- `bun run edge:db:migrate:local`
- `bun run edge:loop:enable:local`
- `bun run edge:dev`
- `bun run edge:loop:tick:local` (or hit `http://127.0.0.1:8888/__scheduled`)
