### PR TITLE
LA-01: Define Loop A contracts + versioning (v1)

### DIFF
--- a/apps/portal/vercel.json
+++ b/apps/portal/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "installCommand": "bun install",
+  "buildCommand": "bun run build"
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:unit": "bun test tests/unit",
     "test:integration": "bun test tests/integration",
     "test:integration:worker:live": "RUN_INTEGRATION_TESTS=1 RUN_WORKER_LIVE_TESTS=1 bun test tests/integration/worker_x402_live.integration.test.ts",
+    "contracts:loop-a:schemas": "bun run scripts/generate_loop_a_schemas.ts",
     "typecheck": "bunx tsc --noEmit",
     "lint": "biome check .",
     "lint:fix": "biome check . --write",

--- a/scripts/generate_loop_a_schemas.ts
+++ b/scripts/generate_loop_a_schemas.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import { LOOP_A_SCHEMA_REGISTRY } from "../src/loops/contracts/loop_a.js";
+
+const OUTPUT_DIR = path.resolve("src/loops/contracts/json");
+
+async function writeSchemaFile(input: {
+  schema: z.ZodType;
+  schemaId: string;
+  outputFile: string;
+}): Promise<void> {
+  const schemaDocument = z.toJSONSchema(input.schema);
+  const finalDocument = {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    $id: input.schemaId,
+    ...schemaDocument,
+  };
+  const outputPath = path.join(OUTPUT_DIR, input.outputFile);
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, `${JSON.stringify(finalDocument, null, 2)}\n`);
+  console.log(`wrote ${outputPath}`);
+}
+
+async function main(): Promise<void> {
+  const entries = Object.values(LOOP_A_SCHEMA_REGISTRY);
+  for (const entry of entries) {
+    await writeSchemaFile(entry);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/generate_loop_a_schemas.ts
+++ b/scripts/generate_loop_a_schemas.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { z } from "zod";
@@ -22,11 +23,38 @@ async function writeSchemaFile(input: {
   console.log(`wrote ${outputPath}`);
 }
 
+async function formatSchemaFiles(filePaths: string[]): Promise<void> {
+  if (filePaths.length === 0) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn("bunx", ["biome", "format", "--write", ...filePaths], {
+      stdio: "inherit",
+    });
+
+    child.on("error", (error) => {
+      reject(error);
+    });
+
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`biome format failed with exit code ${code ?? -1}`));
+    });
+  });
+}
+
 async function main(): Promise<void> {
   const entries = Object.values(LOOP_A_SCHEMA_REGISTRY);
+  const generatedPaths: string[] = [];
   for (const entry of entries) {
     await writeSchemaFile(entry);
+    generatedPaths.push(path.join(OUTPUT_DIR, entry.outputFile));
   }
+  await formatSchemaFiles(generatedPaths);
 }
 
 main().catch((error) => {

--- a/src/loops/contracts/index.ts
+++ b/src/loops/contracts/index.ts
@@ -1,0 +1,1 @@
+export * from "./loop_a.js";

--- a/src/loops/contracts/json/loop_a.health.v1.schema.json
+++ b/src/loops/contracts/json/loop_a.health.v1.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ralph.trade/schemas/loopA/v1/health",
+  "type": "object",
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+    },
+    "component": {
+      "type": "string",
+      "const": "loopA"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["ok", "degraded", "error"]
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+    },
+    "cursors": {
+      "type": "object",
+      "properties": {
+        "processed": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "confirmed": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "finalized": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        }
+      },
+      "required": ["processed", "confirmed", "finalized"],
+      "additionalProperties": false
+    },
+    "lagSlots": {
+      "type": "object",
+      "properties": {
+        "processedLag": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "confirmedLag": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "finalizedLag": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        }
+      },
+      "required": ["processedLag", "confirmedLag", "finalizedLag"],
+      "additionalProperties": false
+    },
+    "lastSuccessfulSlot": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "lastSuccessfulAt": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+    },
+    "errorCount": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "lastError": {
+      "type": "string"
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "version": {
+      "type": "string",
+      "const": "v1"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "generatedAt",
+    "component",
+    "status",
+    "updatedAt",
+    "cursors",
+    "lagSlots",
+    "lastSuccessfulSlot",
+    "lastSuccessfulAt",
+    "errorCount",
+    "warnings",
+    "version"
+  ],
+  "additionalProperties": false
+}

--- a/src/loops/contracts/json/loop_a.mark.v1.schema.json
+++ b/src/loops/contracts/json/loop_a.mark.v1.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ralph.trade/schemas/loopA/v1/mark",
+  "type": "object",
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+    },
+    "slot": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "ts": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+    },
+    "baseMint": {
+      "type": "string",
+      "minLength": 32,
+      "maxLength": 64
+    },
+    "quoteMint": {
+      "type": "string",
+      "minLength": 32,
+      "maxLength": 64
+    },
+    "px": {
+      "type": "string",
+      "pattern": "^\\d+(?:\\.\\d+)?$"
+    },
+    "bid": {
+      "type": "string",
+      "pattern": "^\\d+(?:\\.\\d+)?$"
+    },
+    "ask": {
+      "type": "string",
+      "pattern": "^\\d+(?:\\.\\d+)?$"
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "venue": {
+      "type": "string",
+      "minLength": 1
+    },
+    "liquidityUsd": {
+      "type": "string",
+      "pattern": "^\\d+(?:\\.\\d+)?$"
+    },
+    "evidence": {
+      "type": "object",
+      "properties": {
+        "sigs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "pools": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 32,
+            "maxLength": 64
+          }
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "version": {
+      "type": "string",
+      "const": "v1"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "generatedAt",
+    "slot",
+    "ts",
+    "baseMint",
+    "quoteMint",
+    "px",
+    "confidence",
+    "venue",
+    "version"
+  ],
+  "additionalProperties": false
+}

--- a/src/loops/contracts/json/loop_a.protocol_event.v1.schema.json
+++ b/src/loops/contracts/json/loop_a.protocol_event.v1.schema.json
@@ -1,0 +1,775 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ralph.trade/schemas/loopA/v1/protocol_event",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "schemaVersion": {
+          "type": "string",
+          "const": "v1"
+        },
+        "generatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "protocol": {
+          "type": "string",
+          "minLength": 1
+        },
+        "slot": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "sig": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ts": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "user": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "venue": {
+          "type": "string",
+          "minLength": 1
+        },
+        "meta": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "kind": {
+          "type": "string",
+          "const": "swap"
+        },
+        "inMint": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "outMint": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "inAmount": {
+          "type": "string",
+          "pattern": "^-?\\d+(?:\\.\\d+)?$"
+        },
+        "outAmount": {
+          "type": "string",
+          "pattern": "^-?\\d+(?:\\.\\d+)?$"
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "generatedAt",
+        "protocol",
+        "slot",
+        "sig",
+        "ts",
+        "kind",
+        "inMint",
+        "outMint",
+        "inAmount",
+        "outAmount"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "schemaVersion": {
+          "type": "string",
+          "const": "v1"
+        },
+        "generatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "protocol": {
+          "type": "string",
+          "minLength": 1
+        },
+        "slot": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "sig": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ts": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "user": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "venue": {
+          "type": "string",
+          "minLength": 1
+        },
+        "meta": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "kind": {
+          "type": "string",
+          "const": "liquidity_add"
+        },
+        "pool": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "mint": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "amount": {
+          "type": "string",
+          "pattern": "^-?\\d+(?:\\.\\d+)?$"
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "generatedAt",
+        "protocol",
+        "slot",
+        "sig",
+        "ts",
+        "kind",
+        "pool",
+        "mint",
+        "amount"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "schemaVersion": {
+          "type": "string",
+          "const": "v1"
+        },
+        "generatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "protocol": {
+          "type": "string",
+          "minLength": 1
+        },
+        "slot": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "sig": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ts": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "user": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "venue": {
+          "type": "string",
+          "minLength": 1
+        },
+        "meta": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "kind": {
+          "type": "string",
+          "const": "liquidity_remove"
+        },
+        "pool": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "mint": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "amount": {
+          "type": "string",
+          "pattern": "^-?\\d+(?:\\.\\d+)?$"
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "generatedAt",
+        "protocol",
+        "slot",
+        "sig",
+        "ts",
+        "kind",
+        "pool",
+        "mint",
+        "amount"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "schemaVersion": {
+          "type": "string",
+          "const": "v1"
+        },
+        "generatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "protocol": {
+          "type": "string",
+          "minLength": 1
+        },
+        "slot": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "sig": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ts": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "user": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "venue": {
+          "type": "string",
+          "minLength": 1
+        },
+        "meta": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "kind": {
+          "type": "string",
+          "const": "borrow"
+        },
+        "market": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "mint": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "amount": {
+          "type": "string",
+          "pattern": "^-?\\d+(?:\\.\\d+)?$"
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "generatedAt",
+        "protocol",
+        "slot",
+        "sig",
+        "ts",
+        "kind",
+        "market",
+        "mint",
+        "amount"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "schemaVersion": {
+          "type": "string",
+          "const": "v1"
+        },
+        "generatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "protocol": {
+          "type": "string",
+          "minLength": 1
+        },
+        "slot": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "sig": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ts": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "user": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "venue": {
+          "type": "string",
+          "minLength": 1
+        },
+        "meta": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "kind": {
+          "type": "string",
+          "const": "repay"
+        },
+        "market": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "mint": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "amount": {
+          "type": "string",
+          "pattern": "^-?\\d+(?:\\.\\d+)?$"
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "generatedAt",
+        "protocol",
+        "slot",
+        "sig",
+        "ts",
+        "kind",
+        "market",
+        "mint",
+        "amount"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "schemaVersion": {
+          "type": "string",
+          "const": "v1"
+        },
+        "generatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "protocol": {
+          "type": "string",
+          "minLength": 1
+        },
+        "slot": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "sig": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ts": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "user": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "venue": {
+          "type": "string",
+          "minLength": 1
+        },
+        "meta": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "kind": {
+          "type": "string",
+          "const": "liquidation"
+        },
+        "market": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "mint": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "amount": {
+          "type": "string",
+          "pattern": "^-?\\d+(?:\\.\\d+)?$"
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "generatedAt",
+        "protocol",
+        "slot",
+        "sig",
+        "ts",
+        "kind",
+        "market",
+        "mint",
+        "amount"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "schemaVersion": {
+          "type": "string",
+          "const": "v1"
+        },
+        "generatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "protocol": {
+          "type": "string",
+          "minLength": 1
+        },
+        "slot": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "sig": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ts": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "user": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "venue": {
+          "type": "string",
+          "minLength": 1
+        },
+        "meta": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "kind": {
+          "type": "string",
+          "const": "mint"
+        },
+        "mint": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "amount": {
+          "type": "string",
+          "pattern": "^-?\\d+(?:\\.\\d+)?$"
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "generatedAt",
+        "protocol",
+        "slot",
+        "sig",
+        "ts",
+        "kind",
+        "mint",
+        "amount"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "schemaVersion": {
+          "type": "string",
+          "const": "v1"
+        },
+        "generatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "protocol": {
+          "type": "string",
+          "minLength": 1
+        },
+        "slot": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "sig": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ts": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "user": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "venue": {
+          "type": "string",
+          "minLength": 1
+        },
+        "meta": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "kind": {
+          "type": "string",
+          "const": "burn"
+        },
+        "mint": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "amount": {
+          "type": "string",
+          "pattern": "^-?\\d+(?:\\.\\d+)?$"
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "generatedAt",
+        "protocol",
+        "slot",
+        "sig",
+        "ts",
+        "kind",
+        "mint",
+        "amount"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "schemaVersion": {
+          "type": "string",
+          "const": "v1"
+        },
+        "generatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "protocol": {
+          "type": "string",
+          "minLength": 1
+        },
+        "slot": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "sig": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ts": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "user": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "venue": {
+          "type": "string",
+          "minLength": 1
+        },
+        "meta": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "kind": {
+          "type": "string",
+          "const": "fee_transfer"
+        },
+        "mint": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "amount": {
+          "type": "string",
+          "pattern": "^-?\\d+(?:\\.\\d+)?$"
+        },
+        "to": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "generatedAt",
+        "protocol",
+        "slot",
+        "sig",
+        "ts",
+        "kind",
+        "mint",
+        "amount"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "schemaVersion": {
+          "type": "string",
+          "const": "v1"
+        },
+        "generatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "protocol": {
+          "type": "string",
+          "minLength": 1
+        },
+        "slot": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "sig": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ts": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "user": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "venue": {
+          "type": "string",
+          "minLength": 1
+        },
+        "meta": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "kind": {
+          "type": "string",
+          "const": "unknown"
+        },
+        "rawKind": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "generatedAt",
+        "protocol",
+        "slot",
+        "sig",
+        "ts",
+        "kind"
+      ],
+      "additionalProperties": false
+    }
+  ]
+}

--- a/src/loops/contracts/json/loop_a.state_snapshot.v1.schema.json
+++ b/src/loops/contracts/json/loop_a.state_snapshot.v1.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ralph.trade/schemas/loopA/v1/state_snapshot",
+  "type": "object",
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+    },
+    "slot": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "commitment": {
+      "type": "string",
+      "enum": ["processed", "confirmed", "finalized"]
+    },
+    "cursor": {
+      "type": "object",
+      "properties": {
+        "processed": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "confirmed": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "finalized": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        }
+      },
+      "required": ["processed", "confirmed", "finalized"],
+      "additionalProperties": false
+    },
+    "stateHash": {
+      "type": "string",
+      "minLength": 1
+    },
+    "trackedState": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {}
+    },
+    "parentSlot": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "appliedEventCount": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "inputs": {
+      "type": "object",
+      "properties": {
+        "eventRefs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "snapshotRef": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["eventRefs"],
+      "additionalProperties": false
+    },
+    "version": {
+      "type": "string",
+      "const": "v1"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "generatedAt",
+    "slot",
+    "commitment",
+    "cursor",
+    "stateHash",
+    "trackedState",
+    "appliedEventCount",
+    "inputs",
+    "version"
+  ],
+  "additionalProperties": false
+}

--- a/src/loops/contracts/loop_a.ts
+++ b/src/loops/contracts/loop_a.ts
@@ -1,0 +1,243 @@
+import { z } from "zod";
+
+export const LOOP_A_SCHEMA_FAMILY = "loopA" as const;
+export const LOOP_A_SCHEMA_VERSION = "v1" as const;
+
+const ISO_DATETIME_SCHEMA = z.string().datetime({ offset: true });
+const NON_EMPTY_STRING_SCHEMA = z.string().min(1);
+const PUBKEY_SCHEMA = z.string().min(32).max(64);
+const DECIMAL_STRING_SCHEMA = z
+  .string()
+  .regex(/^\d+(?:\.\d+)?$/, "invalid-decimal-string");
+const NUMERIC_STRING_SCHEMA = z
+  .string()
+  .regex(/^-?\d+(?:\.\d+)?$/, "invalid-numeric-string");
+
+export const ArtifactMetaSchema = z
+  .object({
+    schemaVersion: z.literal(LOOP_A_SCHEMA_VERSION),
+    generatedAt: ISO_DATETIME_SCHEMA,
+  })
+  .strict();
+
+const ProtocolEventBaseSchema = ArtifactMetaSchema.extend({
+  protocol: NON_EMPTY_STRING_SCHEMA,
+  slot: z.number().int().nonnegative(),
+  sig: NON_EMPTY_STRING_SCHEMA,
+  ts: ISO_DATETIME_SCHEMA,
+  user: PUBKEY_SCHEMA.optional(),
+  venue: NON_EMPTY_STRING_SCHEMA.optional(),
+  meta: z.record(z.string(), z.unknown()).optional(),
+}).strict();
+
+const SwapProtocolEventSchema = ProtocolEventBaseSchema.extend({
+  kind: z.literal("swap"),
+  inMint: PUBKEY_SCHEMA,
+  outMint: PUBKEY_SCHEMA,
+  inAmount: NUMERIC_STRING_SCHEMA,
+  outAmount: NUMERIC_STRING_SCHEMA,
+}).strict();
+
+const LiquidityAddProtocolEventSchema = ProtocolEventBaseSchema.extend({
+  kind: z.literal("liquidity_add"),
+  pool: PUBKEY_SCHEMA,
+  mint: PUBKEY_SCHEMA,
+  amount: NUMERIC_STRING_SCHEMA,
+}).strict();
+
+const LiquidityRemoveProtocolEventSchema = ProtocolEventBaseSchema.extend({
+  kind: z.literal("liquidity_remove"),
+  pool: PUBKEY_SCHEMA,
+  mint: PUBKEY_SCHEMA,
+  amount: NUMERIC_STRING_SCHEMA,
+}).strict();
+
+const BorrowProtocolEventSchema = ProtocolEventBaseSchema.extend({
+  kind: z.literal("borrow"),
+  market: PUBKEY_SCHEMA,
+  mint: PUBKEY_SCHEMA,
+  amount: NUMERIC_STRING_SCHEMA,
+}).strict();
+
+const RepayProtocolEventSchema = ProtocolEventBaseSchema.extend({
+  kind: z.literal("repay"),
+  market: PUBKEY_SCHEMA,
+  mint: PUBKEY_SCHEMA,
+  amount: NUMERIC_STRING_SCHEMA,
+}).strict();
+
+const LiquidationProtocolEventSchema = ProtocolEventBaseSchema.extend({
+  kind: z.literal("liquidation"),
+  market: PUBKEY_SCHEMA,
+  mint: PUBKEY_SCHEMA,
+  amount: NUMERIC_STRING_SCHEMA,
+}).strict();
+
+const MintProtocolEventSchema = ProtocolEventBaseSchema.extend({
+  kind: z.literal("mint"),
+  mint: PUBKEY_SCHEMA,
+  amount: NUMERIC_STRING_SCHEMA,
+}).strict();
+
+const BurnProtocolEventSchema = ProtocolEventBaseSchema.extend({
+  kind: z.literal("burn"),
+  mint: PUBKEY_SCHEMA,
+  amount: NUMERIC_STRING_SCHEMA,
+}).strict();
+
+const FeeTransferProtocolEventSchema = ProtocolEventBaseSchema.extend({
+  kind: z.literal("fee_transfer"),
+  mint: PUBKEY_SCHEMA,
+  amount: NUMERIC_STRING_SCHEMA,
+  to: PUBKEY_SCHEMA.optional(),
+}).strict();
+
+const UnknownProtocolEventSchema = ProtocolEventBaseSchema.extend({
+  kind: z.literal("unknown"),
+  rawKind: NON_EMPTY_STRING_SCHEMA.optional(),
+}).strict();
+
+export const ProtocolEventSchema = z.discriminatedUnion("kind", [
+  SwapProtocolEventSchema,
+  LiquidityAddProtocolEventSchema,
+  LiquidityRemoveProtocolEventSchema,
+  BorrowProtocolEventSchema,
+  RepayProtocolEventSchema,
+  LiquidationProtocolEventSchema,
+  MintProtocolEventSchema,
+  BurnProtocolEventSchema,
+  FeeTransferProtocolEventSchema,
+  UnknownProtocolEventSchema,
+]);
+
+export const MarkSchema = ArtifactMetaSchema.extend({
+  slot: z.number().int().nonnegative(),
+  ts: ISO_DATETIME_SCHEMA,
+  baseMint: PUBKEY_SCHEMA,
+  quoteMint: PUBKEY_SCHEMA,
+  px: DECIMAL_STRING_SCHEMA,
+  bid: DECIMAL_STRING_SCHEMA.optional(),
+  ask: DECIMAL_STRING_SCHEMA.optional(),
+  confidence: z.number().min(0).max(1),
+  venue: NON_EMPTY_STRING_SCHEMA,
+  liquidityUsd: DECIMAL_STRING_SCHEMA.optional(),
+  evidence: z
+    .object({
+      sigs: z.array(NON_EMPTY_STRING_SCHEMA).optional(),
+      pools: z.array(PUBKEY_SCHEMA).optional(),
+      inputs: z.array(NON_EMPTY_STRING_SCHEMA).optional(),
+    })
+    .strict()
+    .optional(),
+  version: z.literal(LOOP_A_SCHEMA_VERSION),
+}).strict();
+
+export const StateSnapshotSchema = ArtifactMetaSchema.extend({
+  slot: z.number().int().nonnegative(),
+  commitment: z.enum(["processed", "confirmed", "finalized"]),
+  cursor: z
+    .object({
+      processed: z.number().int().nonnegative(),
+      confirmed: z.number().int().nonnegative(),
+      finalized: z.number().int().nonnegative(),
+    })
+    .strict(),
+  stateHash: NON_EMPTY_STRING_SCHEMA,
+  trackedState: z.record(z.string(), z.unknown()),
+  parentSlot: z.number().int().nonnegative().optional(),
+  appliedEventCount: z.number().int().nonnegative(),
+  inputs: z
+    .object({
+      eventRefs: z.array(NON_EMPTY_STRING_SCHEMA),
+      snapshotRef: NON_EMPTY_STRING_SCHEMA.optional(),
+    })
+    .strict(),
+  version: z.literal(LOOP_A_SCHEMA_VERSION),
+}).strict();
+
+export const HealthSchema = ArtifactMetaSchema.extend({
+  component: z.literal("loopA"),
+  status: z.enum(["ok", "degraded", "error"]),
+  updatedAt: ISO_DATETIME_SCHEMA,
+  cursors: z
+    .object({
+      processed: z.number().int().nonnegative(),
+      confirmed: z.number().int().nonnegative(),
+      finalized: z.number().int().nonnegative(),
+    })
+    .strict(),
+  lagSlots: z
+    .object({
+      processedLag: z.number().int().nonnegative(),
+      confirmedLag: z.number().int().nonnegative(),
+      finalizedLag: z.number().int().nonnegative(),
+    })
+    .strict(),
+  lastSuccessfulSlot: z.number().int().nonnegative(),
+  lastSuccessfulAt: ISO_DATETIME_SCHEMA,
+  errorCount: z.number().int().nonnegative(),
+  lastError: z.string().optional(),
+  warnings: z.array(z.string()),
+  version: z.literal(LOOP_A_SCHEMA_VERSION),
+}).strict();
+
+export type ArtifactMeta = z.infer<typeof ArtifactMetaSchema>;
+export type ProtocolEvent = z.infer<typeof ProtocolEventSchema>;
+export type Mark = z.infer<typeof MarkSchema>;
+export type StateSnapshot = z.infer<typeof StateSnapshotSchema>;
+export type Health = z.infer<typeof HealthSchema>;
+
+export const LOOP_A_SCHEMA_REGISTRY = {
+  protocolEvent: {
+    schema: ProtocolEventSchema,
+    schemaId: "https://ralph.trade/schemas/loopA/v1/protocol_event",
+    outputFile: "loop_a.protocol_event.v1.schema.json",
+  },
+  mark: {
+    schema: MarkSchema,
+    schemaId: "https://ralph.trade/schemas/loopA/v1/mark",
+    outputFile: "loop_a.mark.v1.schema.json",
+  },
+  stateSnapshot: {
+    schema: StateSnapshotSchema,
+    schemaId: "https://ralph.trade/schemas/loopA/v1/state_snapshot",
+    outputFile: "loop_a.state_snapshot.v1.schema.json",
+  },
+  health: {
+    schema: HealthSchema,
+    schemaId: "https://ralph.trade/schemas/loopA/v1/health",
+    outputFile: "loop_a.health.v1.schema.json",
+  },
+} as const;
+
+export function parseProtocolEvent(input: unknown): ProtocolEvent {
+  return ProtocolEventSchema.parse(input);
+}
+
+export function parseMark(input: unknown): Mark {
+  return MarkSchema.parse(input);
+}
+
+export function parseStateSnapshot(input: unknown): StateSnapshot {
+  return StateSnapshotSchema.parse(input);
+}
+
+export function parseHealth(input: unknown): Health {
+  return HealthSchema.parse(input);
+}
+
+export function safeParseProtocolEvent(input: unknown) {
+  return ProtocolEventSchema.safeParse(input);
+}
+
+export function safeParseMark(input: unknown) {
+  return MarkSchema.safeParse(input);
+}
+
+export function safeParseStateSnapshot(input: unknown) {
+  return StateSnapshotSchema.safeParse(input);
+}
+
+export function safeParseHealth(input: unknown) {
+  return HealthSchema.safeParse(input);
+}

--- a/tests/unit/loop_a_contracts.test.ts
+++ b/tests/unit/loop_a_contracts.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, test } from "bun:test";
+import { z } from "zod";
 import {
+  LOOP_A_SCHEMA_REGISTRY,
   parseHealth,
   parseMark,
   parseProtocolEvent,
   parseStateSnapshot,
+  safeParseHealth,
   safeParseMark,
   safeParseProtocolEvent,
+  safeParseStateSnapshot,
 } from "../../src/loops/contracts/loop_a.js";
 
 const SOL_MINT = "So11111111111111111111111111111111111111112";
@@ -119,6 +123,33 @@ describe("loop A contracts", () => {
     ).toThrow();
   });
 
+  test("rejects state snapshot when generatedAt is missing", () => {
+    const result = safeParseStateSnapshot({
+      schemaVersion: "v1",
+      slot: 220,
+      commitment: "confirmed",
+      cursor: {
+        processed: 222,
+        confirmed: 220,
+        finalized: 218,
+      },
+      stateHash: "state_abc123",
+      trackedState: {
+        [POOL]: {
+          liquidityUsd: "1240000",
+        },
+      },
+      appliedEventCount: 42,
+      inputs: {
+        eventRefs: [
+          "loopA/v1/events/date=2026-02-21/hour=00/slot=220.jsonl.gz",
+        ],
+      },
+      version: "v1",
+    });
+    expect(result.success).toBe(false);
+  });
+
   test("parses valid state snapshot", () => {
     const snapshot = parseStateSnapshot({
       ...META,
@@ -147,6 +178,31 @@ describe("loop A contracts", () => {
     expect(snapshot.cursor.confirmed).toBe(220);
   });
 
+  test("rejects health payload when schemaVersion is missing", () => {
+    const result = safeParseHealth({
+      generatedAt: "2026-02-21T00:04:00Z",
+      component: "loopA",
+      status: "ok",
+      updatedAt: "2026-02-21T00:04:00Z",
+      cursors: {
+        processed: 300,
+        confirmed: 298,
+        finalized: 296,
+      },
+      lagSlots: {
+        processedLag: 0,
+        confirmedLag: 2,
+        finalizedLag: 4,
+      },
+      lastSuccessfulSlot: 298,
+      lastSuccessfulAt: "2026-02-21T00:04:00Z",
+      errorCount: 0,
+      warnings: [],
+      version: "v1",
+    });
+    expect(result.success).toBe(false);
+  });
+
   test("parses valid health payload", () => {
     const health = parseHealth({
       ...META,
@@ -171,5 +227,13 @@ describe("loop A contracts", () => {
     });
 
     expect(health.status).toBe("ok");
+  });
+
+  test("generates deterministic JSON schema documents", () => {
+    for (const entry of Object.values(LOOP_A_SCHEMA_REGISTRY)) {
+      const schemaA = z.toJSONSchema(entry.schema);
+      const schemaB = z.toJSONSchema(entry.schema);
+      expect(schemaA).toEqual(schemaB);
+    }
   });
 });

--- a/tests/unit/loop_a_contracts.test.ts
+++ b/tests/unit/loop_a_contracts.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseHealth,
+  parseMark,
+  parseProtocolEvent,
+  parseStateSnapshot,
+  safeParseMark,
+  safeParseProtocolEvent,
+} from "../../src/loops/contracts/loop_a.js";
+
+const SOL_MINT = "So11111111111111111111111111111111111111112";
+const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const POOL = "Czfq3xZZD7f7mUXGQ95M5x7TQYtjY1fM6bMpiKFF9s8s";
+const SIG =
+  "4QWQY8hJCF3zz7X9Y7NfKGh6y3ysK4Wi2fFx9kqvF5mkmowMrAkxAuE4L73p5udjXKSzkYsbk1XnX4QgxQeM4QVD";
+
+const META = {
+  schemaVersion: "v1" as const,
+  generatedAt: "2026-02-21T00:00:00Z",
+};
+
+describe("loop A contracts", () => {
+  test("parses valid swap protocol event", () => {
+    const event = parseProtocolEvent({
+      ...META,
+      kind: "swap",
+      protocol: "jupiter",
+      slot: 123,
+      sig: SIG,
+      ts: "2026-02-21T00:00:01Z",
+      inMint: SOL_MINT,
+      outMint: USDC_MINT,
+      inAmount: "1.25",
+      outAmount: "240.5",
+      venue: "jupiter",
+    });
+
+    expect(event.kind).toBe("swap");
+    expect(event.inMint).toBe(SOL_MINT);
+  });
+
+  test("enforces kind-specific swap fields", () => {
+    expect(() =>
+      parseProtocolEvent({
+        ...META,
+        kind: "swap",
+        protocol: "jupiter",
+        slot: 124,
+        sig: SIG,
+        ts: "2026-02-21T00:00:02Z",
+        outMint: USDC_MINT,
+        inAmount: "1",
+        outAmount: "200",
+      }),
+    ).toThrow();
+  });
+
+  test("rejects protocol event when metadata is missing", () => {
+    const result = safeParseProtocolEvent({
+      kind: "unknown",
+      protocol: "test",
+      slot: 1,
+      sig: SIG,
+      ts: "2026-02-21T00:00:03Z",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("parses valid mark payload", () => {
+    const mark = parseMark({
+      ...META,
+      slot: 200,
+      ts: "2026-02-21T00:01:00Z",
+      baseMint: SOL_MINT,
+      quoteMint: USDC_MINT,
+      px: "192.44",
+      confidence: 0.78,
+      venue: "orca",
+      version: "v1",
+      evidence: {
+        sigs: [SIG],
+        pools: [POOL],
+      },
+    });
+
+    expect(mark.confidence).toBe(0.78);
+  });
+
+  test("rejects mark when confidence is out of range", () => {
+    const result = safeParseMark({
+      ...META,
+      slot: 201,
+      ts: "2026-02-21T00:02:00Z",
+      baseMint: SOL_MINT,
+      quoteMint: USDC_MINT,
+      px: "192.44",
+      confidence: 1.01,
+      venue: "orca",
+      version: "v1",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects mark with invalid generatedAt", () => {
+    expect(() =>
+      parseMark({
+        ...META,
+        generatedAt: "not-a-date",
+        slot: 202,
+        ts: "2026-02-21T00:03:00Z",
+        baseMint: SOL_MINT,
+        quoteMint: USDC_MINT,
+        px: "192.44",
+        confidence: 0.6,
+        venue: "orca",
+        version: "v1",
+      }),
+    ).toThrow();
+  });
+
+  test("parses valid state snapshot", () => {
+    const snapshot = parseStateSnapshot({
+      ...META,
+      slot: 220,
+      commitment: "confirmed",
+      cursor: {
+        processed: 222,
+        confirmed: 220,
+        finalized: 218,
+      },
+      stateHash: "state_abc123",
+      trackedState: {
+        [POOL]: {
+          liquidityUsd: "1240000",
+        },
+      },
+      appliedEventCount: 42,
+      inputs: {
+        eventRefs: [
+          "loopA/v1/events/date=2026-02-21/hour=00/slot=220.jsonl.gz",
+        ],
+      },
+      version: "v1",
+    });
+
+    expect(snapshot.cursor.confirmed).toBe(220);
+  });
+
+  test("parses valid health payload", () => {
+    const health = parseHealth({
+      ...META,
+      component: "loopA",
+      status: "ok",
+      updatedAt: "2026-02-21T00:04:00Z",
+      cursors: {
+        processed: 300,
+        confirmed: 298,
+        finalized: 296,
+      },
+      lagSlots: {
+        processedLag: 0,
+        confirmedLag: 2,
+        finalizedLag: 4,
+      },
+      lastSuccessfulSlot: 298,
+      lastSuccessfulAt: "2026-02-21T00:04:00Z",
+      errorCount: 0,
+      warnings: [],
+      version: "v1",
+    });
+
+    expect(health.status).toBe("ok");
+  });
+});


### PR DESCRIPTION
## What changed
- Added Loop A runtime contracts and parse helpers in `src/loops/contracts/loop_a.ts` for `ProtocolEvent`, `Mark`, `StateSnapshot`, and `Health`.
- Added contract barrel export in `src/loops/contracts/index.ts`.
- Added JSON schema generation script in `scripts/generate_loop_a_schemas.ts`.
- Added/committed generated JSON schema artifacts in `src/loops/contracts/json/`:
  - `loop_a.protocol_event.v1.schema.json`
  - `loop_a.mark.v1.schema.json`
  - `loop_a.state_snapshot.v1.schema.json`
  - `loop_a.health.v1.schema.json`
- Added unit coverage in `tests/unit/loop_a_contracts.test.ts`.
- Added package script: `contracts:loop-a:schemas`.

## Why (LA-01 acceptance criteria mapping)
- Serialize/deserialize contracts with runtime validation:
  - Implemented zod runtime schemas plus `parse*` and `safeParse*` helpers for all 4 artifacts.
  - Added tests covering valid payloads and invalid payload rejection paths.
- Each artifact includes `schemaVersion` and `generatedAt`:
  - Introduced shared metadata schema and enforced it across all artifact schemas.
  - Added tests for missing metadata and invalid datetime.

## Schema versioning policy
- Current version is locked to `v1` for Loop A contracts.
- `schemaVersion` is a required literal in every artifact.
- JSON schema artifact filenames are versioned (`*.v1.schema.json`) and include stable schema IDs under `https://ralph.trade/schemas/loopA/v1/...`.

## Test evidence
Commands run successfully on branch:
- `bun run contracts:loop-a:schemas`
- `bun run test:unit -- tests/unit/loop_a_contracts.test.ts`
- `bun run typecheck`
- `bun run lint`

Additional coverage added:
- Missing `generatedAt` rejection (`StateSnapshot`).
- Missing `schemaVersion` rejection (`Health`).
- Deterministic schema generation check via repeated `z.toJSONSchema` equality.

## Follow-ups (LA-02 integration points)
- Wire Loop A ingestion/reducer runtime to emit/consume these contracts.
- Add endpoint/service boundaries using the schema artifacts for validation at IO edges.

## Checklist
- [x] Runtime validation added for all 4 artifacts
- [x] `schemaVersion` + `generatedAt` required everywhere
- [x] JSON schemas generated and committed
- [x] Unit tests added and passing
- [x] Typecheck and lint passing
