### PR TITLE
LA-16: Move Loop A event history to R2 (KV hot-only)

### DIFF
--- a/apps/worker/src/loop_a/canonical_state.ts
+++ b/apps/worker/src/loop_a/canonical_state.ts
@@ -73,6 +73,7 @@ export type CanonicalStateTickResult = {
 
 const DEFAULT_STATE_COMMITMENT: SlotCommitment = "confirmed";
 const DEFAULT_SNAPSHOT_EVERY_SLOTS = 100;
+const LOOP_A_EVENT_BATCH_R2_PREFIX = `loopA/${LOOP_A_SCHEMA_VERSION}/events`;
 
 function asRecord(value: unknown): JsonRecord | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
@@ -279,6 +280,13 @@ export function loopAEventBatchKey(
   return `loopA:${LOOP_A_SCHEMA_VERSION}:events:${commitment}:slot:${slot}`;
 }
 
+export function loopAEventBatchR2Key(
+  commitment: SlotCommitment,
+  slot: number,
+): string {
+  return `${LOOP_A_EVENT_BATCH_R2_PREFIX}/commitment=${commitment}/slot=${slot}.json`;
+}
+
 export function loopAStateLatestKey(commitment: SlotCommitment): string {
   return `loopA:${LOOP_A_SCHEMA_VERSION}:state:latest:${commitment}`;
 }
@@ -450,11 +458,45 @@ async function readJson(env: Env, key: string): Promise<unknown | null> {
   }
 }
 
+async function writeJsonToR2(
+  env: Env,
+  key: string,
+  value: unknown,
+): Promise<boolean> {
+  if (!env.LOGS_BUCKET) return false;
+  await env.LOGS_BUCKET.put(key, JSON.stringify(value), {
+    httpMetadata: {
+      contentType: "application/json",
+    },
+  });
+  return true;
+}
+
+async function readJsonFromR2(env: Env, key: string): Promise<unknown | null> {
+  if (!env.LOGS_BUCKET) return null;
+  const object = await env.LOGS_BUCKET.get(key);
+  if (!object) return null;
+  try {
+    return JSON.parse(await object.text());
+  } catch {
+    return null;
+  }
+}
+
 export async function writeLoopAEventBatchToKv(
   env: Env,
   batch: LoopAEventBatch,
 ): Promise<void> {
-  await writeJson(env, loopAEventBatchKey(batch.commitment, batch.slot), batch);
+  const r2Key = loopAEventBatchR2Key(batch.commitment, batch.slot);
+  const wroteToR2 = await writeJsonToR2(env, r2Key, batch);
+  if (!wroteToR2) {
+    // Legacy fallback when R2 binding is unavailable.
+    await writeJson(
+      env,
+      loopAEventBatchKey(batch.commitment, batch.slot),
+      batch,
+    );
+  }
 }
 
 export function createEmptyMarkerBatch(input: {
@@ -491,8 +533,21 @@ export async function readLoopAEventBatchFromKv(
   commitment: SlotCommitment,
   slot: number,
 ): Promise<LoopAEventBatch | null> {
-  const parsed = await readJson(env, loopAEventBatchKey(commitment, slot));
-  return parseLoopAEventBatch(parsed);
+  const r2Key = loopAEventBatchR2Key(commitment, slot);
+  const parsedFromR2 = await readJsonFromR2(env, r2Key);
+  const batchFromR2 = parseLoopAEventBatch(parsedFromR2);
+  if (batchFromR2) return batchFromR2;
+
+  const parsedFromKv = await readJson(
+    env,
+    loopAEventBatchKey(commitment, slot),
+  );
+  const batchFromKv = parseLoopAEventBatch(parsedFromKv);
+  if (!batchFromKv) return null;
+
+  // Opportunistic migration path so old KV-only rows become available in R2.
+  await writeJsonToR2(env, r2Key, batchFromKv);
+  return batchFromKv;
 }
 
 export async function resolveContiguousIngestionSlot(input: {
@@ -657,7 +712,7 @@ export async function runLoopACanonicalStateTick(
     appliedEvents += batch.events.length;
     replayedSlots += 1;
     currentSlot = slot;
-    eventRefs.push(loopAEventBatchKey(input.commitment, slot));
+    eventRefs.push(loopAEventBatchR2Key(input.commitment, slot));
   }
 
   const snapshotAfter = buildSnapshot({

--- a/apps/worker/src/loop_a/canonical_state.ts
+++ b/apps/worker/src/loop_a/canonical_state.ts
@@ -71,6 +71,11 @@ export type CanonicalStateTickResult = {
   checkpointsWritten: number;
 };
 
+type LoopAEventBatchRead = {
+  batch: LoopAEventBatch;
+  ref: string;
+};
+
 const DEFAULT_STATE_COMMITMENT: SlotCommitment = "confirmed";
 const DEFAULT_SNAPSHOT_EVERY_SLOTS = 100;
 const LOOP_A_EVENT_BATCH_R2_PREFIX = `loopA/${LOOP_A_SCHEMA_VERSION}/events`;
@@ -486,17 +491,16 @@ async function readJsonFromR2(env: Env, key: string): Promise<unknown | null> {
 export async function writeLoopAEventBatchToKv(
   env: Env,
   batch: LoopAEventBatch,
-): Promise<void> {
+): Promise<string> {
   const r2Key = loopAEventBatchR2Key(batch.commitment, batch.slot);
   const wroteToR2 = await writeJsonToR2(env, r2Key, batch);
   if (!wroteToR2) {
     // Legacy fallback when R2 binding is unavailable.
-    await writeJson(
-      env,
-      loopAEventBatchKey(batch.commitment, batch.slot),
-      batch,
-    );
+    const kvKey = loopAEventBatchKey(batch.commitment, batch.slot);
+    await writeJson(env, kvKey, batch);
+    return kvKey;
   }
+  return r2Key;
 }
 
 export function createEmptyMarkerBatch(input: {
@@ -528,26 +532,52 @@ export async function readLoopAStateSnapshotFromKv(
   return parseLoopAStateSnapshot(parsed);
 }
 
+async function readLoopAEventBatchWithRef(
+  env: Env,
+  commitment: SlotCommitment,
+  slot: number,
+): Promise<LoopAEventBatchRead | null> {
+  const r2Key = loopAEventBatchR2Key(commitment, slot);
+  const parsedFromR2 = await readJsonFromR2(env, r2Key);
+  const batchFromR2 = parseLoopAEventBatch(parsedFromR2);
+  if (batchFromR2) {
+    return {
+      batch: batchFromR2,
+      ref: r2Key,
+    };
+  }
+
+  const kvKey = loopAEventBatchKey(commitment, slot);
+  const parsedFromKv = await readJson(env, kvKey);
+  const batchFromKv = parseLoopAEventBatch(parsedFromKv);
+  if (!batchFromKv) return null;
+
+  // Opportunistic migration path so old KV-only rows become available in R2.
+  try {
+    const migrated = await writeJsonToR2(env, r2Key, batchFromKv);
+    if (migrated) {
+      return {
+        batch: batchFromKv,
+        ref: r2Key,
+      };
+    }
+  } catch {
+    // Best-effort migration should never block loop progression.
+  }
+
+  return {
+    batch: batchFromKv,
+    ref: kvKey,
+  };
+}
+
 export async function readLoopAEventBatchFromKv(
   env: Env,
   commitment: SlotCommitment,
   slot: number,
 ): Promise<LoopAEventBatch | null> {
-  const r2Key = loopAEventBatchR2Key(commitment, slot);
-  const parsedFromR2 = await readJsonFromR2(env, r2Key);
-  const batchFromR2 = parseLoopAEventBatch(parsedFromR2);
-  if (batchFromR2) return batchFromR2;
-
-  const parsedFromKv = await readJson(
-    env,
-    loopAEventBatchKey(commitment, slot),
-  );
-  const batchFromKv = parseLoopAEventBatch(parsedFromKv);
-  if (!batchFromKv) return null;
-
-  // Opportunistic migration path so old KV-only rows become available in R2.
-  await writeJsonToR2(env, r2Key, batchFromKv);
-  return batchFromKv;
+  const read = await readLoopAEventBatchWithRef(env, commitment, slot);
+  return read?.batch ?? null;
 }
 
 export async function resolveContiguousIngestionSlot(input: {
@@ -581,17 +611,22 @@ export async function resolveContiguousIngestionSlot(input: {
 export async function persistLoopAEventBatchesToKv(
   env: Env,
   batches: LoopAEventBatch[],
-): Promise<number> {
+): Promise<{ count: number; refsBySlot: Map<string, string> }> {
   const deduped = dedupeByKey(
     batches,
     (entry) => `${entry.commitment}:${entry.slot}`,
   );
+  const refsBySlot = new Map<string, string>();
 
   for (const batch of deduped) {
-    await writeLoopAEventBatchToKv(env, batch);
+    const ref = await writeLoopAEventBatchToKv(env, batch);
+    refsBySlot.set(`${batch.commitment}:${batch.slot}`, ref);
   }
 
-  return deduped.length;
+  return {
+    count: deduped.length,
+    refsBySlot,
+  };
 }
 
 function determineBootstrapSlot(
@@ -667,10 +702,11 @@ export async function runLoopACanonicalStateTick(
       ? input.cursorAfter[input.commitment]
       : Math.min(input.targetSlot, input.cursorAfter[input.commitment]);
 
-  const persistedBatches = await persistLoopAEventBatchesToKv(
+  const persisted = await persistLoopAEventBatchesToKv(
     env,
     input.decodedBatches,
   );
+  const persistedBatches = persisted.count;
 
   const snapshotBefore = await readLoopAStateSnapshotFromKv(
     env,
@@ -699,8 +735,15 @@ export async function runLoopACanonicalStateTick(
 
   for (let slot = currentSlot + 1; slot <= targetSlot; slot += 1) {
     let batch = decodedBySlot.get(slot) ?? null;
+    let eventRef = persisted.refsBySlot.get(`${input.commitment}:${slot}`);
     if (!batch) {
-      batch = await readLoopAEventBatchFromKv(env, input.commitment, slot);
+      const read = await readLoopAEventBatchWithRef(
+        env,
+        input.commitment,
+        slot,
+      );
+      batch = read?.batch ?? null;
+      eventRef = read?.ref;
     }
 
     if (!batch) {
@@ -712,7 +755,9 @@ export async function runLoopACanonicalStateTick(
     appliedEvents += batch.events.length;
     replayedSlots += 1;
     currentSlot = slot;
-    eventRefs.push(loopAEventBatchR2Key(input.commitment, slot));
+    if (eventRef) {
+      eventRefs.push(eventRef);
+    }
   }
 
   const snapshotAfter = buildSnapshot({

--- a/loop-a-loop-b-architecture.md
+++ b/loop-a-loop-b-architecture.md
@@ -25,7 +25,7 @@ It is intentionally written as something you can hand to an implementation agent
   - fetches blocks with bounded concurrency + retry,
   - emits "block missing" tasks into Cloudflare Key-Value store. ([GitHub][4])
 - CanonicalState (current):
-  - persists decoded batches to Cloudflare Key-Value store,
+  - persists decoded batches to Cloudflare R2 object storage (with legacy Cloudflare Key-Value store fallback reads during migration),
   - attempts to replay slot-by-slot until it hits a missing slot (then stops). ([GitHub][5])
 
 ### Execution routing already exists (v0)
@@ -170,7 +170,7 @@ Loop A currently runs in the Worker `scheduled()` handler with this sequence:
 1. SlotSource tick updates cursor and emits backfill tasks. ([GitHub][1])
 2. BlockFetcher tick fetches blocks between cursorBefore and cursorAfter, with bounded concurrency/retries, emitting missing tasks. ([GitHub][1])
 3. DecoderRegistry decodes events (SPL token transfer adapter, Jupiter swap adapter). ([GitHub][9])
-4. Canonical state tick persists batches to Cloudflare Key-Value store and replays contiguously until missing slot. ([GitHub][1])
+4. Canonical state tick persists batches to Cloudflare R2 object storage and replays contiguously until missing slot. ([GitHub][1])
 
 ## Loop A v0 latency/reliability bottlenecks (fix list)
 

--- a/tests/unit/worker_loop_a_backfill_resolver.test.ts
+++ b/tests/unit/worker_loop_a_backfill_resolver.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { runLoopABackfillResolverTick } from "../../apps/worker/src/loop_a/backfill_resolver";
 import {
   loopAEventBatchKey,
+  loopAEventBatchR2Key,
   parseLoopAEventBatch,
 } from "../../apps/worker/src/loop_a/canonical_state";
 import type { Env } from "../../apps/worker/src/types";
@@ -51,21 +52,48 @@ function createMockKv() {
   };
 }
 
-function createEnv(): { env: Env; store: Map<string, string> } {
+function createMockR2() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    bucket: {
+      put: async (key: string, value: string) => {
+        store.set(key, value);
+      },
+      get: async (key: string) => {
+        const value = store.get(key);
+        if (!value) return null;
+        return {
+          text: async () => value,
+        };
+      },
+      head: async (key: string) => (store.has(key) ? { key } : null),
+    },
+  };
+}
+
+function createEnv(): {
+  env: Env;
+  store: Map<string, string>;
+  r2Store: Map<string, string>;
+} {
   const { kv, store } = createMockKv();
+  const { bucket, store: r2Store } = createMockR2();
   return {
     env: {
       WAITLIST_DB: createMockDb() as never,
       CONFIG_KV: kv as never,
+      LOGS_BUCKET: bucket as never,
       RPC_ENDPOINT: "https://rpc.example",
     } as Env,
     store,
+    r2Store,
   };
 }
 
 describe("worker loop A backfill resolver", () => {
   test("resolves range backfill tasks and persists empty marker batches", async () => {
-    const { env, store } = createEnv();
+    const { env, store, r2Store } = createEnv();
     store.set(
       "loopA:v1:backfill:pending:confirmed:100-101",
       JSON.stringify({
@@ -102,10 +130,10 @@ describe("worker loop A backfill resolver", () => {
     );
 
     const batch100 = parseLoopAEventBatch(
-      JSON.parse(store.get(loopAEventBatchKey("confirmed", 100)) ?? "null"),
+      JSON.parse(r2Store.get(loopAEventBatchR2Key("confirmed", 100)) ?? "null"),
     );
     const batch101 = parseLoopAEventBatch(
-      JSON.parse(store.get(loopAEventBatchKey("confirmed", 101)) ?? "null"),
+      JSON.parse(r2Store.get(loopAEventBatchR2Key("confirmed", 101)) ?? "null"),
     );
 
     expect(batch100?.events.length).toBe(0);
@@ -115,7 +143,7 @@ describe("worker loop A backfill resolver", () => {
   });
 
   test("converts rpc-missing task into empty marker and clears task", async () => {
-    const { env, store } = createEnv();
+    const { env, store, r2Store } = createEnv();
     store.set(
       "loopA:v1:block_missing:pending:confirmed:222",
       JSON.stringify({
@@ -148,13 +176,13 @@ describe("worker loop A backfill resolver", () => {
     );
 
     const batch = parseLoopAEventBatch(
-      JSON.parse(store.get(loopAEventBatchKey("confirmed", 222)) ?? "null"),
+      JSON.parse(r2Store.get(loopAEventBatchR2Key("confirmed", 222)) ?? "null"),
     );
     expect(batch?.marker?.reason).toBe("missing_in_storage");
   });
 
   test("retains unresolved task on hard rpc failure", async () => {
-    const { env, store } = createEnv();
+    const { env, store, r2Store } = createEnv();
     const taskKey = "loopA:v1:backfill:pending:confirmed:333-333";
     store.set(
       taskKey,
@@ -186,5 +214,6 @@ describe("worker loop A backfill resolver", () => {
     expect(result.hardFailures).toBe(1);
     expect(store.has(taskKey)).toBe(true);
     expect(store.has(loopAEventBatchKey("confirmed", 333))).toBe(false);
+    expect(r2Store.has(loopAEventBatchR2Key("confirmed", 333))).toBe(false);
   });
 });

--- a/tests/unit/worker_loop_a_canonical_state.test.ts
+++ b/tests/unit/worker_loop_a_canonical_state.test.ts
@@ -5,6 +5,7 @@ import {
   type LoopAEventBatch,
   type LoopAStateSnapshot,
   loopAEventBatchKey,
+  loopAEventBatchR2Key,
   loopAStateLatestKey,
   loopAStateSnapshotKey,
   resolveContiguousIngestionSlot,
@@ -46,14 +47,40 @@ function createMockKv() {
   };
 }
 
-function createEnv(): { env: Env; store: Map<string, string> } {
+function createMockR2() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    bucket: {
+      put: async (key: string, value: string) => {
+        store.set(key, value);
+      },
+      get: async (key: string) => {
+        const value = store.get(key);
+        if (!value) return null;
+        return {
+          text: async () => value,
+        };
+      },
+      head: async (key: string) => (store.has(key) ? { key } : null),
+    },
+  };
+}
+
+function createEnv(): {
+  env: Env;
+  store: Map<string, string>;
+  r2Store: Map<string, string>;
+} {
   const { kv, store } = createMockKv();
+  const { bucket, store: r2Store } = createMockR2();
   const env = {
     WAITLIST_DB: createMockDb() as never,
     CONFIG_KV: kv as never,
+    LOGS_BUCKET: bucket as never,
     RPC_ENDPOINT: "https://rpc.example",
   } as Env;
-  return { env, store };
+  return { env, store, r2Store };
 }
 
 function cursor(
@@ -128,7 +155,7 @@ function readSnapshot(
 
 describe("worker loop A canonical state", () => {
   test("bootstraps from decoded batches and persists latest snapshot", async () => {
-    const { env, store } = createEnv();
+    const { env, store, r2Store } = createEnv();
 
     const result = await runLoopACanonicalStateTick(env, {
       cursorAfter: cursor(102, 102, 100),
@@ -155,12 +182,14 @@ describe("worker loop A canonical state", () => {
     expect(snapshot?.trackedState.byProtocol.spl_token).toBe(1);
     expect(snapshot?.trackedState.byProtocol.jupiter).toBe(1);
 
-    expect(store.has(loopAEventBatchKey("confirmed", 101))).toBe(true);
-    expect(store.has(loopAEventBatchKey("confirmed", 102))).toBe(true);
+    expect(r2Store.has(loopAEventBatchR2Key("confirmed", 101))).toBe(true);
+    expect(r2Store.has(loopAEventBatchR2Key("confirmed", 102))).toBe(true);
+    expect(store.has(loopAEventBatchKey("confirmed", 101))).toBe(false);
+    expect(store.has(loopAEventBatchKey("confirmed", 102))).toBe(false);
   });
 
   test("replays persisted batches after restart to recover forward", async () => {
-    const { env, store } = createEnv();
+    const { env, store, r2Store } = createEnv();
 
     await runLoopACanonicalStateTick(env, {
       cursorAfter: cursor(201, 201, 200),
@@ -170,12 +199,12 @@ describe("worker loop A canonical state", () => {
       observedAt: "2026-02-21T04:32:00.000Z",
     });
 
-    store.set(
-      loopAEventBatchKey("confirmed", 202),
+    r2Store.set(
+      loopAEventBatchR2Key("confirmed", 202),
       JSON.stringify(batch(202, [swapEvent(202, "sig-202")], "confirmed")),
     );
-    store.set(
-      loopAEventBatchKey("confirmed", 203),
+    r2Store.set(
+      loopAEventBatchR2Key("confirmed", 203),
       JSON.stringify(batch(203, [transferEvent(203, "sig-203")], "confirmed")),
     );
 
@@ -247,7 +276,7 @@ describe("worker loop A canonical state", () => {
   });
 
   test("continues replay through explicit empty-batch markers", async () => {
-    const { env, store } = createEnv();
+    const { env, r2Store } = createEnv();
 
     await runLoopACanonicalStateTick(env, {
       cursorAfter: cursor(300, 300, 299),
@@ -257,8 +286,8 @@ describe("worker loop A canonical state", () => {
       observedAt: "2026-02-21T04:37:00.000Z",
     });
 
-    store.set(
-      loopAEventBatchKey("confirmed", 301),
+    r2Store.set(
+      loopAEventBatchR2Key("confirmed", 301),
       JSON.stringify(
         createEmptyMarkerBatch({
           commitment: "confirmed",
@@ -269,8 +298,8 @@ describe("worker loop A canonical state", () => {
         }),
       ),
     );
-    store.set(
-      loopAEventBatchKey("confirmed", 302),
+    r2Store.set(
+      loopAEventBatchR2Key("confirmed", 302),
       JSON.stringify(batch(302, [swapEvent(302, "sig-302")], "confirmed")),
     );
 
@@ -294,5 +323,25 @@ describe("worker loop A canonical state", () => {
     });
     expect(contiguous.ingestionSlot).toBe(302);
     expect(contiguous.missingSlot).toBeNull();
+  });
+
+  test("migrates legacy KV-only event batches into R2 on read", async () => {
+    const { env, store, r2Store } = createEnv();
+
+    store.set(
+      loopAEventBatchKey("confirmed", 451),
+      JSON.stringify(batch(451, [transferEvent(451, "sig-451")], "confirmed")),
+    );
+
+    const contiguous = await resolveContiguousIngestionSlot({
+      env,
+      commitment: "confirmed",
+      fromSlot: 450,
+      targetSlot: 451,
+    });
+
+    expect(contiguous.ingestionSlot).toBe(451);
+    expect(contiguous.missingSlot).toBeNull();
+    expect(r2Store.has(loopAEventBatchR2Key("confirmed", 451))).toBe(true);
   });
 });

--- a/tests/unit/worker_loop_a_canonical_state.test.ts
+++ b/tests/unit/worker_loop_a_canonical_state.test.ts
@@ -83,6 +83,16 @@ function createEnv(): {
   return { env, store, r2Store };
 }
 
+function createEnvWithoutR2(): { env: Env; store: Map<string, string> } {
+  const { kv, store } = createMockKv();
+  const env = {
+    WAITLIST_DB: createMockDb() as never,
+    CONFIG_KV: kv as never,
+    RPC_ENDPOINT: "https://rpc.example",
+  } as Env;
+  return { env, store };
+}
+
 function cursor(
   processed: number,
   confirmed: number,
@@ -343,5 +353,53 @@ describe("worker loop A canonical state", () => {
     expect(contiguous.ingestionSlot).toBe(451);
     expect(contiguous.missingSlot).toBeNull();
     expect(r2Store.has(loopAEventBatchR2Key("confirmed", 451))).toBe(true);
+  });
+
+  test("continues replay when KV-to-R2 migration write fails", async () => {
+    const { kv, store } = createMockKv();
+    const env = {
+      WAITLIST_DB: createMockDb() as never,
+      CONFIG_KV: kv as never,
+      LOGS_BUCKET: {
+        put: async () => {
+          throw new Error("r2-put-failed");
+        },
+        get: async () => null,
+      } as never,
+      RPC_ENDPOINT: "https://rpc.example",
+    } as Env;
+
+    store.set(
+      loopAEventBatchKey("confirmed", 552),
+      JSON.stringify(batch(552, [transferEvent(552, "sig-552")], "confirmed")),
+    );
+
+    const contiguous = await resolveContiguousIngestionSlot({
+      env,
+      commitment: "confirmed",
+      fromSlot: 551,
+      targetSlot: 552,
+    });
+
+    expect(contiguous.ingestionSlot).toBe(552);
+    expect(contiguous.missingSlot).toBeNull();
+  });
+
+  test("records KV event refs when R2 is unavailable", async () => {
+    const { env, store } = createEnvWithoutR2();
+
+    await runLoopACanonicalStateTick(env, {
+      cursorAfter: cursor(701, 701, 700),
+      decodedBatches: [batch(701, [transferEvent(701, "sig-701")])],
+      commitment: "confirmed",
+      snapshotEverySlots: 100,
+      observedAt: "2026-02-21T04:45:00.000Z",
+    });
+
+    const snapshot = readSnapshot(store, loopAStateLatestKey("confirmed"));
+    expect(snapshot?.inputs.eventRefs).toEqual([
+      loopAEventBatchKey("confirmed", 701),
+    ]);
+    expect(store.has(loopAEventBatchKey("confirmed", 701))).toBe(true);
   });
 });


### PR DESCRIPTION
## What changed
- Moved Loop A event-batch persistence from KV-first to R2-first in `apps/worker/src/loop_a/canonical_state.ts`.
- Added deterministic R2 event keys via `loopAEventBatchR2Key(commitment, slot)`.
- Updated canonical replay reads to:
  - read from R2 first,
  - fallback to legacy KV event keys,
  - opportunistically migrate KV-only batches into R2.
- Updated snapshot `inputs.eventRefs` to point to R2 event object keys.
- Updated unit tests for canonical state + backfill resolver to assert R2-backed storage behavior.
- Synced architecture doc wording to match current implementation status for Loop A canonical batch persistence.

## Why (LA-16 acceptance mapping)
- "Move event batch history to Cloudflare R2, keep KV hot-only":
  - satisfied by writing new Loop A event batches to R2 by default.
  - KV full event-batch storage is now legacy fallback only (for missing R2 binding or migration reads).
- "Loop A does not permanently store all batches in KV":
  - satisfied by R2-first persistence path and R2-backed replay lookups.
- "Worker read endpoints never need to scan R2":
  - unchanged endpoint behavior; this change is internal loop storage/replay only.

## Storage model (implemented)
- R2 keys:
  - `loopA/v1/events/commitment=<commitment>/slot=<slot>.json`
- Legacy compatibility:
  - reads still accept old KV keys `loopA:v1:events:<commitment>:slot:<slot>` and migrate them to R2.

## Test evidence
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit`
- `bun run test:integration` (suite currently skip-only in this environment; no failures)

## Follow-ups
- LA-17 MarkEngine v1 (swap-derived marks + hot caches).
- LA-19 Loop A health + latency telemetry artifacts.
