### PR TITLE
LA-19: Loop A health + latency telemetry artifacts

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -18,6 +18,7 @@ import {
   LOOP_A_COORDINATOR_NAME,
   LoopACoordinator,
 } from "./loop_a/coordinator";
+import { readLoopAHealthFromKv, recordLoopAHealthTick } from "./loop_a/health";
 import { runLoopATickPipeline } from "./loop_a/pipeline";
 import {
   fetchMacroEtfFlows,
@@ -87,7 +88,17 @@ export default {
     const url = new URL(request.url);
     try {
       if (request.method === "GET" && url.pathname === "/api/health") {
-        return withCors(json({ ok: true }), env);
+        const loopAHealth = await readLoopAHealthFromKv(env);
+        if (!loopAHealth) {
+          return withCors(json({ ok: true }), env);
+        }
+        return withCors(
+          json({
+            ok: loopAHealth.status !== "error",
+            loopA: loopAHealth,
+          }),
+          env,
+        );
       }
 
       if (request.method === "POST" && url.pathname === "/api/waitlist") {
@@ -1432,6 +1443,7 @@ export default {
   },
 
   async scheduled(_event: ScheduledEvent, env: Env, _ctx: ExecutionContext) {
+    const startedAtMs = Date.now();
     const slotSourceEnabled =
       String(env.LOOP_A_SLOT_SOURCE_ENABLED ?? "0").trim() === "1";
     if (!slotSourceEnabled) return;
@@ -1478,8 +1490,29 @@ export default {
     }
 
     try {
-      await runLoopATickPipeline(env);
+      const tickResult = await runLoopATickPipeline(env);
+      await recordLoopAHealthTick(env, {
+        ok: true,
+        trigger: "scheduled",
+        startedAtMs,
+        tickResult,
+      });
     } catch (error) {
+      try {
+        await recordLoopAHealthTick(env, {
+          ok: false,
+          trigger: "scheduled",
+          startedAtMs,
+          error,
+        });
+      } catch (healthError) {
+        console.error("loop_a.health.scheduled.error", {
+          message:
+            healthError instanceof Error
+              ? healthError.message
+              : "unknown-health-error",
+        });
+      }
       console.error("loop_a.scheduled.error", {
         message: error instanceof Error ? error.message : "unknown-error",
         stack: error instanceof Error ? error.stack : undefined,

--- a/apps/worker/src/loop_a/coordinator.ts
+++ b/apps/worker/src/loop_a/coordinator.ts
@@ -1,5 +1,6 @@
 import type { Env } from "../types";
 import { readLoopACursorStateFromKv } from "./cursor_store_kv";
+import { recordLoopAHealthTick } from "./health";
 import { type LoopAPipelineTickResult, runLoopATickPipeline } from "./pipeline";
 import type { LoopACursorHeads, LoopACursorState } from "./types";
 
@@ -131,6 +132,7 @@ export class LoopACoordinator {
   }
 
   private async handleTick(trigger: "fetch" | "alarm"): Promise<Response> {
+    const startedAtMs = Date.now();
     const prevState = await this.loadState();
 
     try {
@@ -152,6 +154,26 @@ export class LoopACoordinator {
 
       await this.persistState(nextState);
       await setBacklogAlarm(this.state, tickResult.backlog);
+      try {
+        await recordLoopAHealthTick(this.env, {
+          ok: true,
+          trigger:
+            trigger === "alarm" ? "coordinator_alarm" : "coordinator_fetch",
+          startedAtMs,
+          tickResult: {
+            ...tickResult,
+            cursorState,
+          },
+        });
+      } catch (healthError) {
+        console.error("loop_a.coordinator.health.error", {
+          trigger,
+          message:
+            healthError instanceof Error
+              ? healthError.message
+              : "unknown-health-error",
+        });
+      }
 
       return new Response(
         JSON.stringify({
@@ -181,6 +203,24 @@ export class LoopACoordinator {
       };
       await this.persistState(nextState);
       await this.state.storage.setAlarm(Date.now() + 60_000);
+      try {
+        await recordLoopAHealthTick(this.env, {
+          ok: false,
+          trigger:
+            trigger === "alarm" ? "coordinator_alarm" : "coordinator_fetch",
+          startedAtMs,
+          cursorStateFallback: prevState.cursorState,
+          error,
+        });
+      } catch (healthError) {
+        console.error("loop_a.coordinator.health.error", {
+          trigger,
+          message:
+            healthError instanceof Error
+              ? healthError.message
+              : "unknown-health-error",
+        });
+      }
       console.error("loop_a.coordinator.tick.error", {
         trigger,
         message,

--- a/apps/worker/src/loop_a/health.ts
+++ b/apps/worker/src/loop_a/health.ts
@@ -1,0 +1,344 @@
+import {
+  type Health,
+  safeParseHealth,
+} from "../../../../src/loops/contracts/loop_a";
+import type { Env } from "../types";
+import type { LoopAPipelineTickResult } from "./pipeline";
+import {
+  LOOP_A_SCHEMA_VERSION,
+  type LoopACursorHeads,
+  type LoopACursorState,
+} from "./types";
+
+export const LOOP_A_HEALTH_KEY = `loopA:${LOOP_A_SCHEMA_VERSION}:health`;
+export const LOOP_A_LATENCY_LATEST_KEY = `loopA:${LOOP_A_SCHEMA_VERSION}:latency:latest`;
+
+type LoopAHealthTickTrigger =
+  | "scheduled"
+  | "coordinator_fetch"
+  | "coordinator_alarm";
+
+export type LoopALatencyTelemetry = {
+  schemaVersion: typeof LOOP_A_SCHEMA_VERSION;
+  generatedAt: string;
+  trigger: LoopAHealthTickTrigger;
+  ok: boolean;
+  tickDurationMs: number;
+  stateCommitment?: "processed" | "confirmed" | "finalized";
+  stateTargetSlot?: number;
+  stateAppliedSlot?: number | null;
+  error?: string;
+};
+
+type RecordLoopAHealthTickInput = {
+  ok: boolean;
+  trigger: LoopAHealthTickTrigger;
+  startedAtMs: number;
+  nowMs?: number;
+  observedAt?: string;
+  tickResult?: LoopAPipelineTickResult;
+  cursorStateFallback?: LoopACursorState;
+  error?: unknown;
+};
+
+const ZERO_HEADS: LoopACursorHeads = {
+  processed: 0,
+  confirmed: 0,
+  finalized: 0,
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function parseLatencyTelemetry(input: unknown): LoopALatencyTelemetry | null {
+  const record = asRecord(input);
+  if (!record) return null;
+  if (record.schemaVersion !== LOOP_A_SCHEMA_VERSION) return null;
+  if (
+    record.generatedAt === undefined ||
+    typeof record.generatedAt !== "string" ||
+    Number.isNaN(Date.parse(record.generatedAt))
+  ) {
+    return null;
+  }
+  if (
+    record.trigger !== "scheduled" &&
+    record.trigger !== "coordinator_fetch" &&
+    record.trigger !== "coordinator_alarm"
+  ) {
+    return null;
+  }
+  if (typeof record.ok !== "boolean") return null;
+  if (
+    typeof record.tickDurationMs !== "number" ||
+    !Number.isFinite(record.tickDurationMs) ||
+    record.tickDurationMs < 0
+  ) {
+    return null;
+  }
+
+  return {
+    schemaVersion: LOOP_A_SCHEMA_VERSION,
+    generatedAt: record.generatedAt,
+    trigger: record.trigger,
+    ok: record.ok,
+    tickDurationMs: Math.floor(record.tickDurationMs),
+    stateCommitment:
+      record.stateCommitment === "processed" ||
+      record.stateCommitment === "confirmed" ||
+      record.stateCommitment === "finalized"
+        ? record.stateCommitment
+        : undefined,
+    stateTargetSlot:
+      typeof record.stateTargetSlot === "number" &&
+      Number.isInteger(record.stateTargetSlot) &&
+      record.stateTargetSlot >= 0
+        ? record.stateTargetSlot
+        : undefined,
+    stateAppliedSlot:
+      typeof record.stateAppliedSlot === "number" &&
+      Number.isInteger(record.stateAppliedSlot) &&
+      record.stateAppliedSlot >= 0
+        ? record.stateAppliedSlot
+        : record.stateAppliedSlot === null
+          ? null
+          : undefined,
+    error: typeof record.error === "string" ? record.error : undefined,
+  };
+}
+
+function sanitizeErrorMessage(error: unknown): string | undefined {
+  if (error instanceof Error) return error.message.slice(0, 300);
+  if (typeof error === "string") return error.slice(0, 300);
+  return undefined;
+}
+
+function resolveHeadsFromState(
+  cursorState: LoopACursorState | undefined,
+  previous: Health | null,
+): LoopACursorHeads {
+  if (cursorState) return cursorState.headCursor;
+  if (!previous) return ZERO_HEADS;
+
+  return {
+    processed: previous.cursors.processed + previous.lagSlots.processedLag,
+    confirmed: previous.cursors.confirmed + previous.lagSlots.confirmedLag,
+    finalized: previous.cursors.finalized + previous.lagSlots.finalizedLag,
+  };
+}
+
+function resolveStateCursor(
+  cursorState: LoopACursorState | undefined,
+  previous: Health | null,
+): LoopACursorHeads {
+  if (cursorState) return cursorState.stateCursor;
+  if (!previous) return ZERO_HEADS;
+  return previous.cursors;
+}
+
+function resolveLagSlots(
+  heads: LoopACursorHeads,
+  cursors: LoopACursorHeads,
+): Health["lagSlots"] {
+  return {
+    processedLag: Math.max(0, heads.processed - cursors.processed),
+    confirmedLag: Math.max(0, heads.confirmed - cursors.confirmed),
+    finalizedLag: Math.max(0, heads.finalized - cursors.finalized),
+  };
+}
+
+function resolveStatus(input: {
+  ok: boolean;
+  lagSlots: Health["lagSlots"];
+  warnings: string[];
+}): Health["status"] {
+  if (!input.ok) return "error";
+  const maxLag = Math.max(
+    input.lagSlots.processedLag,
+    input.lagSlots.confirmedLag,
+    input.lagSlots.finalizedLag,
+  );
+  if (maxLag > 64 || input.warnings.length > 0) return "degraded";
+  return "ok";
+}
+
+function minutePartition(iso: string): string {
+  const date = new Date(iso);
+  const yyyy = date.getUTCFullYear().toString().padStart(4, "0");
+  const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(date.getUTCDate()).padStart(2, "0");
+  const hh = String(date.getUTCHours()).padStart(2, "0");
+  const minute = String(date.getUTCMinutes()).padStart(2, "0");
+  return `date=${yyyy}-${mm}-${dd}/hour=${hh}/minute=${yyyy}-${mm}-${dd}T${hh}:${minute}:00Z`;
+}
+
+function safeR2Token(iso: string): string {
+  return iso.replaceAll(":", "-");
+}
+
+export function loopAHealthR2Key(generatedAt: string): string {
+  return `loopA/${LOOP_A_SCHEMA_VERSION}/health/${minutePartition(generatedAt)}/at=${safeR2Token(generatedAt)}.json`;
+}
+
+export function loopALatencyR2Key(generatedAt: string): string {
+  return `loopA/${LOOP_A_SCHEMA_VERSION}/latency/${minutePartition(generatedAt)}/at=${safeR2Token(generatedAt)}.json`;
+}
+
+export async function readLoopAHealthFromKv(env: Env): Promise<Health | null> {
+  if (!env.CONFIG_KV) return null;
+  const raw = await env.CONFIG_KV.get(LOOP_A_HEALTH_KEY);
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw);
+    const result = safeParseHealth(parsed);
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function readLoopALatencyFromKv(
+  env: Env,
+): Promise<LoopALatencyTelemetry | null> {
+  if (!env.CONFIG_KV) return null;
+  const raw = await env.CONFIG_KV.get(LOOP_A_LATENCY_LATEST_KEY);
+  if (!raw) return null;
+  try {
+    return parseLatencyTelemetry(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+function buildHealthArtifact(input: {
+  previous: Health | null;
+  cursorState: LoopACursorState | undefined;
+  ok: boolean;
+  observedAt: string;
+  tickResult?: LoopAPipelineTickResult;
+  errorMessage?: string;
+}): Health {
+  const heads = resolveHeadsFromState(input.cursorState, input.previous);
+  const cursors = resolveStateCursor(input.cursorState, input.previous);
+  const lagSlots = resolveLagSlots(heads, cursors);
+
+  const warnings: string[] = [];
+  const maxLag = Math.max(
+    lagSlots.processedLag,
+    lagSlots.confirmedLag,
+    lagSlots.finalizedLag,
+  );
+  if (maxLag > 0) {
+    warnings.push(`state-lag-slots=${maxLag}`);
+  }
+  if (input.tickResult?.stateAppliedSlot === null) {
+    warnings.push("state-store-disabled-or-no-snapshot");
+  }
+  if (!input.ok && input.errorMessage) {
+    warnings.push(`last-error=${input.errorMessage}`);
+  }
+
+  const lastSuccessfulSlot = input.ok
+    ? (input.tickResult?.stateAppliedSlot ??
+      cursors[input.tickResult?.stateCommitment ?? "confirmed"])
+    : (input.previous?.lastSuccessfulSlot ?? cursors.confirmed);
+  const lastSuccessfulAt = input.ok
+    ? input.observedAt
+    : (input.previous?.lastSuccessfulAt ?? input.observedAt);
+  const errorCount = input.ok
+    ? (input.previous?.errorCount ?? 0)
+    : (input.previous?.errorCount ?? 0) + 1;
+
+  return {
+    schemaVersion: LOOP_A_SCHEMA_VERSION,
+    generatedAt: input.observedAt,
+    component: "loopA",
+    status: resolveStatus({
+      ok: input.ok,
+      lagSlots,
+      warnings:
+        maxLag > 64 || !input.ok || input.tickResult?.stateAppliedSlot === null
+          ? warnings
+          : [],
+    }),
+    updatedAt: input.observedAt,
+    cursors,
+    lagSlots,
+    lastSuccessfulSlot,
+    lastSuccessfulAt,
+    errorCount,
+    lastError: input.ok ? undefined : input.errorMessage,
+    warnings,
+    version: LOOP_A_SCHEMA_VERSION,
+  };
+}
+
+function buildLatencyTelemetry(input: {
+  observedAt: string;
+  durationMs: number;
+  trigger: LoopAHealthTickTrigger;
+  ok: boolean;
+  tickResult?: LoopAPipelineTickResult;
+  errorMessage?: string;
+}): LoopALatencyTelemetry {
+  return {
+    schemaVersion: LOOP_A_SCHEMA_VERSION,
+    generatedAt: input.observedAt,
+    trigger: input.trigger,
+    ok: input.ok,
+    tickDurationMs: input.durationMs,
+    stateCommitment: input.tickResult?.stateCommitment,
+    stateTargetSlot: input.tickResult?.stateTargetSlot,
+    stateAppliedSlot: input.tickResult?.stateAppliedSlot,
+    error: input.ok ? undefined : input.errorMessage,
+  };
+}
+
+export async function recordLoopAHealthTick(
+  env: Env,
+  input: RecordLoopAHealthTickInput,
+): Promise<{ health: Health; latency: LoopALatencyTelemetry } | null> {
+  if (!env.CONFIG_KV) return null;
+
+  const nowMs = input.nowMs ?? Date.now();
+  const observedAt = input.observedAt ?? new Date(nowMs).toISOString();
+  const durationMs = Math.max(0, Math.floor(nowMs - input.startedAtMs));
+  const previous = await readLoopAHealthFromKv(env);
+  const errorMessage = sanitizeErrorMessage(input.error);
+  const cursorState =
+    input.tickResult?.cursorState ?? input.cursorStateFallback;
+  const health = buildHealthArtifact({
+    previous,
+    cursorState,
+    ok: input.ok,
+    observedAt,
+    tickResult: input.tickResult,
+    errorMessage,
+  });
+  const latency = buildLatencyTelemetry({
+    observedAt,
+    durationMs,
+    trigger: input.trigger,
+    ok: input.ok,
+    tickResult: input.tickResult,
+    errorMessage,
+  });
+
+  await env.CONFIG_KV.put(LOOP_A_HEALTH_KEY, JSON.stringify(health));
+  await env.CONFIG_KV.put(LOOP_A_LATENCY_LATEST_KEY, JSON.stringify(latency));
+
+  if (env.LOGS_BUCKET) {
+    await Promise.all([
+      env.LOGS_BUCKET.put(loopAHealthR2Key(observedAt), JSON.stringify(health)),
+      env.LOGS_BUCKET.put(
+        loopALatencyR2Key(observedAt),
+        JSON.stringify(latency),
+      ),
+    ]);
+  }
+
+  return { health, latency };
+}

--- a/loop-a-loop-b-architecture.md
+++ b/loop-a-loop-b-architecture.md
@@ -30,6 +30,10 @@ It is intentionally written as something you can hand to an implementation agent
 - MarkEngine v1 (current):
   - computes swap-derived marks from decoded batches,
   - publishes hot keys for `loopA:v1:marks:confirmed:latest` and per-pair latest marks in Cloudflare Key-Value store.
+- Health + latency telemetry (current):
+  - writes Loop A health artifacts to `loopA:v1:health` in Cloudflare Key-Value store on every tick (success/failure),
+  - writes latest tick latency telemetry to `loopA:v1:latency:latest`,
+  - persists per-tick health and latency snapshots to Cloudflare R2 object storage when bound.
 
 ### Execution routing already exists (v0)
 

--- a/tests/unit/worker_loop_a_health.test.ts
+++ b/tests/unit/worker_loop_a_health.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, test } from "bun:test";
+import worker from "../../apps/worker/src/index";
+import {
+  LOOP_A_HEALTH_KEY,
+  LOOP_A_LATENCY_LATEST_KEY,
+  loopAHealthR2Key,
+  loopALatencyR2Key,
+  readLoopAHealthFromKv,
+  readLoopALatencyFromKv,
+  recordLoopAHealthTick,
+} from "../../apps/worker/src/loop_a/health";
+import type { LoopAPipelineTickResult } from "../../apps/worker/src/loop_a/pipeline";
+import type { LoopACursorState } from "../../apps/worker/src/loop_a/types";
+import type { Env } from "../../apps/worker/src/types";
+
+function createMockDb() {
+  return {
+    prepare(_sql: string) {
+      return {
+        bind(..._args: unknown[]) {
+          return {
+            run: async () => ({ meta: { changes: 1 } }),
+            all: async () => ({ results: [] }),
+            first: async () => null,
+          };
+        },
+      };
+    },
+  };
+}
+
+function createMockKv() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    kv: {
+      get: async (key: string) => store.get(key) ?? null,
+      put: async (key: string, value: string) => {
+        store.set(key, value);
+      },
+      delete: async (key: string) => {
+        store.delete(key);
+      },
+      list: async () => ({
+        keys: [...store.keys()].map((name) => ({ name })),
+        list_complete: true,
+        cursor: "",
+      }),
+    },
+  };
+}
+
+function createMockR2() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    bucket: {
+      put: async (key: string, value: string) => {
+        store.set(key, value);
+      },
+      get: async (key: string) => {
+        const value = store.get(key);
+        if (!value) return null;
+        return {
+          text: async () => value,
+        };
+      },
+    },
+  };
+}
+
+function createCursorState(input: {
+  head: number;
+  state: number;
+  updatedAt?: string;
+}): LoopACursorState {
+  return {
+    schemaVersion: "v1",
+    updatedAt: input.updatedAt ?? "2026-02-21T12:00:00.000Z",
+    headCursor: {
+      processed: input.head,
+      confirmed: input.head,
+      finalized: input.head,
+    },
+    fetchedCursor: {
+      processed: input.head,
+      confirmed: input.head,
+      finalized: input.head,
+    },
+    ingestionCursor: {
+      processed: input.head,
+      confirmed: input.head,
+      finalized: input.head,
+    },
+    stateCursor: {
+      processed: input.state,
+      confirmed: input.state,
+      finalized: input.state,
+    },
+  };
+}
+
+function createTickResult(
+  cursorState: LoopACursorState,
+  stateAppliedSlot: number | null,
+): LoopAPipelineTickResult {
+  return {
+    cursorState,
+    backlog:
+      cursorState.headCursor.confirmed > cursorState.stateCursor.confirmed,
+    stateCommitment: "confirmed",
+    stateTargetSlot: cursorState.ingestionCursor.confirmed,
+    stateAppliedSlot,
+  };
+}
+
+function createEnv(options?: { withKv?: boolean; withR2?: boolean }): {
+  env: Env;
+  kvStore: Map<string, string>;
+  r2Store: Map<string, string>;
+} {
+  const { kv, store: kvStore } = createMockKv();
+  const { bucket, store: r2Store } = createMockR2();
+  return {
+    env: {
+      WAITLIST_DB: createMockDb() as never,
+      CONFIG_KV: options?.withKv === false ? undefined : (kv as never),
+      LOGS_BUCKET: options?.withR2 === false ? undefined : (bucket as never),
+      ALLOWED_ORIGINS: "*",
+    } as Env,
+    kvStore,
+    r2Store,
+  };
+}
+
+function createExecutionContextStub(): ExecutionContext {
+  return {
+    waitUntil(_promise: Promise<unknown>) {},
+    passThroughOnException() {},
+  } as ExecutionContext;
+}
+
+describe("worker loop A health + latency telemetry", () => {
+  test("records success health and latency artifacts to KV and R2", async () => {
+    const { env, kvStore, r2Store } = createEnv();
+    const cursorState = createCursorState({ head: 125, state: 124 });
+    const observedAt = "2026-02-21T12:01:00.000Z";
+    const startedAtMs = Date.parse("2026-02-21T12:00:59.250Z");
+    const nowMs = Date.parse("2026-02-21T12:01:00.000Z");
+
+    const result = await recordLoopAHealthTick(env, {
+      ok: true,
+      trigger: "scheduled",
+      startedAtMs,
+      nowMs,
+      observedAt,
+      tickResult: createTickResult(cursorState, 124),
+    });
+
+    expect(result).not.toBeNull();
+    expect(kvStore.has(LOOP_A_HEALTH_KEY)).toBe(true);
+    expect(kvStore.has(LOOP_A_LATENCY_LATEST_KEY)).toBe(true);
+
+    const parsedHealth = await readLoopAHealthFromKv(env);
+    expect(parsedHealth?.component).toBe("loopA");
+    expect(parsedHealth?.status).toBe("ok");
+    expect(parsedHealth?.lastSuccessfulSlot).toBe(124);
+    expect(parsedHealth?.errorCount).toBe(0);
+
+    const parsedLatency = await readLoopALatencyFromKv(env);
+    expect(parsedLatency?.ok).toBe(true);
+    expect(parsedLatency?.tickDurationMs).toBe(750);
+    expect(parsedLatency?.trigger).toBe("scheduled");
+
+    expect(r2Store.has(loopAHealthR2Key(observedAt))).toBe(true);
+    expect(r2Store.has(loopALatencyR2Key(observedAt))).toBe(true);
+  });
+
+  test("records failures without losing the last successful checkpoint", async () => {
+    const { env } = createEnv({ withR2: false });
+    const successObservedAt = "2026-02-21T12:10:00.000Z";
+    const cursorState = createCursorState({ head: 420, state: 418 });
+
+    await recordLoopAHealthTick(env, {
+      ok: true,
+      trigger: "coordinator_fetch",
+      startedAtMs: 1000,
+      nowMs: 2000,
+      observedAt: successObservedAt,
+      tickResult: createTickResult(cursorState, 418),
+    });
+
+    await recordLoopAHealthTick(env, {
+      ok: false,
+      trigger: "coordinator_alarm",
+      startedAtMs: 3000,
+      nowMs: 4500,
+      observedAt: "2026-02-21T12:11:00.000Z",
+      cursorStateFallback: createCursorState({ head: 421, state: 418 }),
+      error: new Error("rpc-timeout"),
+    });
+
+    const health = await readLoopAHealthFromKv(env);
+    expect(health?.status).toBe("error");
+    expect(health?.errorCount).toBe(1);
+    expect(health?.lastSuccessfulSlot).toBe(418);
+    expect(health?.lastSuccessfulAt).toBe(successObservedAt);
+    expect(health?.lastError).toBe("rpc-timeout");
+
+    const latency = await readLoopALatencyFromKv(env);
+    expect(latency?.ok).toBe(false);
+    expect(latency?.trigger).toBe("coordinator_alarm");
+    expect(latency?.error).toBe("rpc-timeout");
+  });
+
+  test("returns null for invalid health/latency KV payloads", async () => {
+    const { env, kvStore } = createEnv({ withR2: false });
+    kvStore.set(LOOP_A_HEALTH_KEY, JSON.stringify({ ok: true }));
+    kvStore.set(LOOP_A_LATENCY_LATEST_KEY, JSON.stringify({ ok: true }));
+
+    const health = await readLoopAHealthFromKv(env);
+    const latency = await readLoopALatencyFromKv(env);
+
+    expect(health).toBeNull();
+    expect(latency).toBeNull();
+  });
+
+  test("api health returns loop-a artifact when available", async () => {
+    const { env } = createEnv({ withR2: false });
+    const cursorState = createCursorState({ head: 640, state: 640 });
+    await recordLoopAHealthTick(env, {
+      ok: true,
+      trigger: "scheduled",
+      startedAtMs: 1000,
+      nowMs: 1100,
+      observedAt: "2026-02-21T12:20:00.000Z",
+      tickResult: createTickResult(cursorState, 640),
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/health", { method: "GET" }),
+      env,
+      createExecutionContextStub(),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      loopA: {
+        component: "loopA",
+        status: "ok",
+        lastSuccessfulSlot: 640,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## What changed
- Added `apps/worker/src/loop_a/health.ts` to persist per-tick Loop A health and latency telemetry.
- Wired health telemetry into both execution paths:
  - `LoopACoordinator` success/failure tick handling
  - direct Worker `scheduled()` pipeline fallback when coordinator is disabled
- Updated `GET /api/health` to return the Loop A health artifact when available (while preserving legacy `{ ok: true }` fallback if no health artifact exists).
- Added unit tests in `tests/unit/worker_loop_a_health.test.ts`.
- Updated architecture status notes in `loop-a-loop-b-architecture.md`.

## Why (LA-19 acceptance mapping)
- Health artifact with lag/error/last-successful-slot is now produced once per tick and stored in KV (`loopA:v1:health`).
- Latency telemetry is produced once per tick and stored in KV (`loopA:v1:latency:latest`).
- Both artifacts are also persisted to R2 when `LOGS_BUCKET` is configured.
- `/api/health` can now expose loop health directly from KV without heavy runtime computation.

## Storage keys
- KV:
  - `loopA:v1:health`
  - `loopA:v1:latency:latest`
- R2 (per tick):
  - `loopA/v1/health/date=YYYY-MM-DD/hour=HH/minute=.../at=...json`
  - `loopA/v1/latency/date=YYYY-MM-DD/hour=HH/minute=.../at=...json`

## Test evidence
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit`
- `bun run test:integration` (skip-only in this env)

## Follow-ups
- LA-18/LA-19 dashboard exposure and percentiles can build on the new latency artifacts.
- Loop B health views can mirror this pattern once LB-01 is in place.
