### PR TITLE
LB-01: Add Loop B minute accumulator durable object

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -20,6 +20,7 @@ import {
 } from "./loop_a/coordinator";
 import { readLoopAHealthFromKv, recordLoopAHealthTick } from "./loop_a/health";
 import { runLoopATickPipeline } from "./loop_a/pipeline";
+import { MinuteAccumulator } from "./loop_b/minute_accumulator";
 import {
   fetchMacroEtfFlows,
   fetchMacroFredIndicators,
@@ -69,7 +70,7 @@ const EXPERIENCE_EVENT_NAMES = new Set<ExperienceEventName>([
   "terminal_opened_from_consumer",
 ]);
 
-export { LoopACoordinator };
+export { LoopACoordinator, MinuteAccumulator };
 
 function resolveX402ReadRpcEndpoint(env: Env): string {
   const balanceRpc = String(env.BALANCE_RPC_ENDPOINT ?? "").trim();

--- a/apps/worker/src/loop_a/mark_engine.ts
+++ b/apps/worker/src/loop_a/mark_engine.ts
@@ -27,6 +27,7 @@ export type LoopAMarkEngineTickResult = {
   latestSlot: number | null;
   latestKey: string | null;
   pairKeysWritten: number;
+  marks: Mark[];
 };
 
 const KNOWN_MINT_DECIMALS: Record<string, number> = {
@@ -253,6 +254,7 @@ export async function runLoopAMarkEngineTick(
       latestSlot: null,
       latestKey: null,
       pairKeysWritten: 0,
+      marks: [],
     };
   }
 
@@ -284,5 +286,6 @@ export async function runLoopAMarkEngineTick(
     latestSlot,
     latestKey,
     pairKeysWritten: marks.length,
+    marks,
   };
 }

--- a/apps/worker/src/loop_a/pipeline.ts
+++ b/apps/worker/src/loop_a/pipeline.ts
@@ -1,3 +1,4 @@
+import { publishMarksToMinuteAccumulator } from "../loop_b/minute_accumulator";
 import type { Env } from "../types";
 import { createDefaultDecoderRegistry } from "./adapters";
 import { runLoopABackfillResolverTick } from "./backfill_resolver";
@@ -171,6 +172,20 @@ export async function runLoopATickPipeline(
       commitment: markCommitment,
     });
     console.log("loop_a.mark_engine.tick", markResult);
+
+    try {
+      const loopBIngestResult = await publishMarksToMinuteAccumulator(env, {
+        marks: markResult.marks,
+      });
+      if (loopBIngestResult) {
+        console.log("loop_b.minute_accumulator.ingest", loopBIngestResult);
+      }
+    } catch (error) {
+      console.error("loop_b.minute_accumulator.ingest.error", {
+        message: error instanceof Error ? error.message : "unknown-error",
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+    }
   }
 
   const stateCommitment = resolveStateCommitment(env.LOOP_A_STATE_COMMITMENT);

--- a/apps/worker/src/loop_b/minute_accumulator.ts
+++ b/apps/worker/src/loop_b/minute_accumulator.ts
@@ -1,0 +1,746 @@
+import {
+  type Mark,
+  safeParseMark,
+} from "../../../../src/loops/contracts/loop_a";
+import type { Env } from "../types";
+
+export const LOOP_B_SCHEMA_VERSION = "v1" as const;
+const STATE_KEY = "loop_b:minute_accumulator_state:v1";
+const DEFAULT_TOP_LIMIT = 20;
+const MAX_MINUTES_TRACKED = 180;
+
+export const LOOP_B_MINUTE_ACCUMULATOR_NAME = "loop-b-minute-accumulator-v1";
+export const LOOP_B_TOP_MOVERS_KEY = "loopB:v1:views:top_movers:latest";
+export const LOOP_B_LIQUIDITY_STRESS_KEY =
+  "loopB:v1:views:liquidity_stress:latest";
+export const LOOP_B_HEALTH_KEY = "loopB:v1:health";
+
+type MinuteId = `${string}T${string}:00Z`;
+
+type PairAggregate = {
+  pairId: string;
+  baseMint: string;
+  quoteMint: string;
+  firstPx: string;
+  lastPx: string;
+  pctChange: number;
+  volatility: number;
+  avgConfidence: number;
+  markCount: number;
+  firstSlot: number;
+  lastSlot: number;
+  lastTs: string;
+  revision: number;
+  explain: string[];
+};
+
+type LoopBTopMoversView = {
+  schemaVersion: typeof LOOP_B_SCHEMA_VERSION;
+  generatedAt: string;
+  minute: MinuteId;
+  count: number;
+  movers: PairAggregate[];
+};
+
+type LoopBLiquidityStressView = {
+  schemaVersion: typeof LOOP_B_SCHEMA_VERSION;
+  generatedAt: string;
+  minute: MinuteId;
+  count: number;
+  pairs: Array<
+    PairAggregate & {
+      stressScore: number;
+    }
+  >;
+};
+
+type LoopBPairScoreRow = PairAggregate & {
+  schemaVersion: typeof LOOP_B_SCHEMA_VERSION;
+  generatedAt: string;
+  minute: MinuteId;
+};
+
+type LoopBHealth = {
+  schemaVersion: typeof LOOP_B_SCHEMA_VERSION;
+  generatedAt: string;
+  component: "loopB";
+  status: "ok" | "degraded" | "error";
+  currentMinute: MinuteId | null;
+  lastFinalizedMinute: MinuteId | null;
+  activeMinutes: number;
+  pendingMinutes: number;
+};
+
+type MinuteRecord = {
+  minute: MinuteId;
+  revision: number;
+  finalizedRevision: number;
+  marksById: Record<string, Mark>;
+  updatedAt: string;
+};
+
+type MinuteAccumulatorState = {
+  schemaVersion: typeof LOOP_B_SCHEMA_VERSION;
+  updatedAt: string;
+  currentMinute: MinuteId | null;
+  lastFinalizedMinute: MinuteId | null;
+  minutes: Record<string, MinuteRecord>;
+};
+
+type IngestRequest = {
+  marks: unknown[];
+  observedAt?: string;
+};
+
+type FinalizeRequest = {
+  upToMinute?: string;
+  observedAt?: string;
+};
+
+export type MinuteAccumulatorIngestResult = {
+  marksReceived: number;
+  marksAccepted: number;
+  minutesTouched: number;
+  finalizedMinutes: number;
+};
+
+export type MinuteAccumulatorFinalizeResult = {
+  finalizedMinutes: number;
+  minutesConsidered: number;
+  lastFinalizedMinute: MinuteId | null;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function toMinuteId(input: string): MinuteId | null {
+  const parsed = new Date(input);
+  if (Number.isNaN(parsed.getTime())) return null;
+  parsed.setUTCSeconds(0, 0);
+  return parsed.toISOString() as MinuteId;
+}
+
+function previousMinute(input: string): MinuteId {
+  const parsed = new Date(input);
+  parsed.setUTCSeconds(0, 0);
+  parsed.setUTCMinutes(parsed.getUTCMinutes() - 1);
+  return parsed.toISOString() as MinuteId;
+}
+
+function pairId(mark: Mark): string {
+  return `${mark.baseMint}:${mark.quoteMint}`;
+}
+
+function markEventId(mark: Mark): string {
+  const sig = mark.evidence?.sigs?.[0] ?? "no_sig";
+  return `${pairId(mark)}:${mark.slot}:${sig}`;
+}
+
+function asFiniteNumber(value: string): number | null {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function loadState(input: unknown): MinuteAccumulatorState {
+  const record = asRecord(input);
+  if (!record || record.schemaVersion !== LOOP_B_SCHEMA_VERSION) {
+    return {
+      schemaVersion: LOOP_B_SCHEMA_VERSION,
+      updatedAt: new Date().toISOString(),
+      currentMinute: null,
+      lastFinalizedMinute: null,
+      minutes: {},
+    };
+  }
+
+  const minutes = asRecord(record.minutes);
+  const outMinutes: Record<string, MinuteRecord> = {};
+  if (minutes) {
+    for (const [key, raw] of Object.entries(minutes)) {
+      const minute = toMinuteId(key);
+      const rawRecord = asRecord(raw);
+      if (!minute || !rawRecord) continue;
+
+      const revision =
+        typeof rawRecord.revision === "number" &&
+        Number.isInteger(rawRecord.revision) &&
+        rawRecord.revision >= 0
+          ? rawRecord.revision
+          : 0;
+      const finalizedRevision =
+        typeof rawRecord.finalizedRevision === "number" &&
+        Number.isInteger(rawRecord.finalizedRevision) &&
+        rawRecord.finalizedRevision >= 0
+          ? rawRecord.finalizedRevision
+          : 0;
+      const marksByIdRecord = asRecord(rawRecord.marksById);
+      const marksById: Record<string, Mark> = {};
+      if (marksByIdRecord) {
+        for (const [markKey, rawMark] of Object.entries(marksByIdRecord)) {
+          const parsed = safeParseMark(rawMark);
+          if (!parsed.success) continue;
+          marksById[markKey] = parsed.data;
+        }
+      }
+
+      outMinutes[minute] = {
+        minute,
+        revision,
+        finalizedRevision,
+        marksById,
+        updatedAt:
+          typeof rawRecord.updatedAt === "string"
+            ? rawRecord.updatedAt
+            : new Date().toISOString(),
+      };
+    }
+  }
+
+  return {
+    schemaVersion: LOOP_B_SCHEMA_VERSION,
+    updatedAt:
+      typeof record.updatedAt === "string"
+        ? record.updatedAt
+        : new Date().toISOString(),
+    currentMinute:
+      typeof record.currentMinute === "string"
+        ? (toMinuteId(record.currentMinute) ?? null)
+        : null,
+    lastFinalizedMinute:
+      typeof record.lastFinalizedMinute === "string"
+        ? (toMinuteId(record.lastFinalizedMinute) ?? null)
+        : null,
+    minutes: outMinutes,
+  };
+}
+
+function createMinuteRecord(
+  minute: MinuteId,
+  observedAt: string,
+): MinuteRecord {
+  return {
+    minute,
+    revision: 0,
+    finalizedRevision: 0,
+    marksById: {},
+    updatedAt: observedAt,
+  };
+}
+
+function compareMinutes(a: MinuteId, b: MinuteId): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function capTrackedMinutes(state: MinuteAccumulatorState): void {
+  const minuteIds = Object.keys(state.minutes)
+    .map((id) => toMinuteId(id))
+    .filter((id): id is MinuteId => id !== null)
+    .sort(compareMinutes);
+
+  const overflow = minuteIds.length - MAX_MINUTES_TRACKED;
+  if (overflow <= 0) return;
+
+  for (let i = 0; i < overflow; i += 1) {
+    const minute = minuteIds[i];
+    if (!minute) continue;
+    delete state.minutes[minute];
+  }
+}
+
+function aggregateMinutePairs(minuteRecord: MinuteRecord): PairAggregate[] {
+  const grouped = new Map<string, Mark[]>();
+  for (const mark of Object.values(minuteRecord.marksById)) {
+    const key = pairId(mark);
+    const existing = grouped.get(key);
+    if (existing) {
+      existing.push(mark);
+    } else {
+      grouped.set(key, [mark]);
+    }
+  }
+
+  const pairs: PairAggregate[] = [];
+  for (const marks of grouped.values()) {
+    if (marks.length === 0) continue;
+    marks.sort((a, b) => {
+      if (a.slot !== b.slot) return a.slot - b.slot;
+      if (a.ts < b.ts) return -1;
+      if (a.ts > b.ts) return 1;
+      return 0;
+    });
+
+    const first = marks[0];
+    const last = marks[marks.length - 1];
+    if (!first || !last) continue;
+
+    const firstPx = asFiniteNumber(first.px);
+    const lastPx = asFiniteNumber(last.px);
+    if (!firstPx || !lastPx) continue;
+
+    let minPx = firstPx;
+    let maxPx = firstPx;
+    let confidenceSum = 0;
+    for (const mark of marks) {
+      const px = asFiniteNumber(mark.px);
+      if (px !== null) {
+        if (px < minPx) minPx = px;
+        if (px > maxPx) maxPx = px;
+      }
+      confidenceSum += mark.confidence;
+    }
+    const pctChange = ((lastPx - firstPx) / firstPx) * 100;
+    const volatility = ((maxPx - minPx) / firstPx) * 100;
+    const avgConfidence = confidenceSum / marks.length;
+
+    pairs.push({
+      pairId: pairId(first),
+      baseMint: first.baseMint,
+      quoteMint: first.quoteMint,
+      firstPx: first.px,
+      lastPx: last.px,
+      pctChange,
+      volatility,
+      avgConfidence,
+      markCount: marks.length,
+      firstSlot: first.slot,
+      lastSlot: last.slot,
+      lastTs: last.ts,
+      revision: minuteRecord.revision,
+      explain: [
+        `minute=${minuteRecord.minute}`,
+        `mark_count=${marks.length}`,
+        `avg_confidence=${avgConfidence.toFixed(4)}`,
+      ],
+    });
+  }
+
+  pairs.sort((a, b) => {
+    const absA = Math.abs(a.pctChange);
+    const absB = Math.abs(b.pctChange);
+    if (absA !== absB) return absB - absA;
+    return b.lastSlot - a.lastSlot;
+  });
+
+  return pairs;
+}
+
+function buildTopMoversView(input: {
+  minute: MinuteId;
+  generatedAt: string;
+  pairs: PairAggregate[];
+  limit: number;
+}): LoopBTopMoversView {
+  return {
+    schemaVersion: LOOP_B_SCHEMA_VERSION,
+    generatedAt: input.generatedAt,
+    minute: input.minute,
+    count: Math.min(input.limit, input.pairs.length),
+    movers: input.pairs.slice(0, input.limit),
+  };
+}
+
+function buildLiquidityStressView(input: {
+  minute: MinuteId;
+  generatedAt: string;
+  pairs: PairAggregate[];
+  limit: number;
+}): LoopBLiquidityStressView {
+  const stressed = input.pairs
+    .map((pair) => ({
+      ...pair,
+      stressScore:
+        Math.abs(pair.volatility) * (1 + (1 - pair.avgConfidence)) +
+        (1 / Math.max(1, pair.markCount)) * 10,
+    }))
+    .sort((a, b) => b.stressScore - a.stressScore);
+
+  return {
+    schemaVersion: LOOP_B_SCHEMA_VERSION,
+    generatedAt: input.generatedAt,
+    minute: input.minute,
+    count: Math.min(input.limit, stressed.length),
+    pairs: stressed.slice(0, input.limit),
+  };
+}
+
+function buildHealthArtifact(input: {
+  state: MinuteAccumulatorState;
+  generatedAt: string;
+}): LoopBHealth {
+  const pendingMinutes = Object.values(input.state.minutes).filter(
+    (minute) => minute.revision > minute.finalizedRevision,
+  ).length;
+
+  return {
+    schemaVersion: LOOP_B_SCHEMA_VERSION,
+    generatedAt: input.generatedAt,
+    component: "loopB",
+    status: pendingMinutes > 5 ? "degraded" : "ok",
+    currentMinute: input.state.currentMinute,
+    lastFinalizedMinute: input.state.lastFinalizedMinute,
+    activeMinutes: Object.keys(input.state.minutes).length,
+    pendingMinutes,
+  };
+}
+
+function minuteSnapshotR2Key(input: {
+  minute: MinuteId;
+  generatedAt: string;
+  revision: number;
+}): string {
+  const date = new Date(input.minute);
+  const yyyy = date.getUTCFullYear().toString().padStart(4, "0");
+  const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(date.getUTCDate()).padStart(2, "0");
+  const hh = String(date.getUTCHours()).padStart(2, "0");
+  const minute = String(date.getUTCMinutes()).padStart(2, "0");
+  const token = input.generatedAt.replaceAll(":", "-");
+  return `loopB/${LOOP_B_SCHEMA_VERSION}/minutes/date=${yyyy}-${mm}-${dd}/hour=${hh}/minute=${yyyy}-${mm}-${dd}T${hh}:${minute}:00Z/revision=${input.revision}/at=${token}.json`;
+}
+
+async function putKvJson(
+  env: Env,
+  key: string,
+  payload: unknown,
+): Promise<void> {
+  if (!env.CONFIG_KV) return;
+  await env.CONFIG_KV.put(key, JSON.stringify(payload));
+}
+
+function pairScoreKey(pair: PairAggregate): string {
+  return `loopB:v1:scores:latest:pair:${pair.pairId}`;
+}
+
+async function publishFinalizedMinute(input: {
+  env: Env;
+  minute: MinuteId;
+  minuteRecord: MinuteRecord;
+  generatedAt: string;
+  topLimit: number;
+}): Promise<void> {
+  const pairs = aggregateMinutePairs(input.minuteRecord);
+  const topMovers = buildTopMoversView({
+    minute: input.minute,
+    generatedAt: input.generatedAt,
+    pairs,
+    limit: input.topLimit,
+  });
+  const liquidityStress = buildLiquidityStressView({
+    minute: input.minute,
+    generatedAt: input.generatedAt,
+    pairs,
+    limit: input.topLimit,
+  });
+
+  await putKvJson(input.env, LOOP_B_TOP_MOVERS_KEY, topMovers);
+  await putKvJson(input.env, LOOP_B_LIQUIDITY_STRESS_KEY, liquidityStress);
+
+  for (const pair of pairs) {
+    const row: LoopBPairScoreRow = {
+      schemaVersion: LOOP_B_SCHEMA_VERSION,
+      generatedAt: input.generatedAt,
+      minute: input.minute,
+      ...pair,
+    };
+    await putKvJson(input.env, pairScoreKey(pair), row);
+  }
+
+  if (input.env.LOGS_BUCKET) {
+    await input.env.LOGS_BUCKET.put(
+      minuteSnapshotR2Key({
+        minute: input.minute,
+        generatedAt: input.generatedAt,
+        revision: input.minuteRecord.revision,
+      }),
+      JSON.stringify({
+        schemaVersion: LOOP_B_SCHEMA_VERSION,
+        generatedAt: input.generatedAt,
+        minute: input.minute,
+        revision: input.minuteRecord.revision,
+        pairCount: pairs.length,
+        pairs,
+      }),
+    );
+  }
+}
+
+function parseTopLimit(raw: string | undefined): number {
+  const parsed = Number.parseInt(String(raw ?? "").trim(), 10);
+  if (Number.isFinite(parsed) && parsed > 0 && parsed <= 200) return parsed;
+  return DEFAULT_TOP_LIMIT;
+}
+
+type MinuteAccumulatorDeps = {
+  now?: () => string;
+};
+
+export class MinuteAccumulator {
+  private readonly now: () => string;
+
+  constructor(
+    private readonly state: DurableObjectState,
+    private readonly env: Env,
+    deps: MinuteAccumulatorDeps = {},
+  ) {
+    this.now = deps.now ?? (() => new Date().toISOString());
+  }
+
+  private async readState(): Promise<MinuteAccumulatorState> {
+    const raw = await this.state.storage.get(STATE_KEY);
+    return loadState(raw);
+  }
+
+  private async writeState(next: MinuteAccumulatorState): Promise<void> {
+    await this.state.storage.put(STATE_KEY, next);
+  }
+
+  private applyMarks(input: {
+    state: MinuteAccumulatorState;
+    marks: Mark[];
+    observedAt: string;
+  }): { marksAccepted: number; minutesTouched: Set<MinuteId> } {
+    const minutesTouched = new Set<MinuteId>();
+    let marksAccepted = 0;
+
+    for (const mark of input.marks) {
+      const minute = toMinuteId(mark.ts);
+      if (!minute) continue;
+
+      let minuteRecord = input.state.minutes[minute];
+      if (!minuteRecord) {
+        minuteRecord = createMinuteRecord(minute, input.observedAt);
+        input.state.minutes[minute] = minuteRecord;
+      }
+
+      const eventId = markEventId(mark);
+      const prev = minuteRecord.marksById[eventId];
+      const changed = !prev || JSON.stringify(prev) !== JSON.stringify(mark);
+      if (!changed) continue;
+
+      minuteRecord.marksById[eventId] = mark;
+      minuteRecord.revision += 1;
+      minuteRecord.updatedAt = input.observedAt;
+      marksAccepted += 1;
+      minutesTouched.add(minute);
+    }
+
+    if (minutesTouched.size > 0) {
+      const latest = [...minutesTouched].sort(compareMinutes).at(-1) ?? null;
+      input.state.currentMinute = latest;
+      input.state.updatedAt = input.observedAt;
+    }
+
+    capTrackedMinutes(input.state);
+    return { marksAccepted, minutesTouched };
+  }
+
+  private async finalizeMinutes(input: {
+    state: MinuteAccumulatorState;
+    upToMinute: MinuteId;
+    observedAt: string;
+  }): Promise<MinuteAccumulatorFinalizeResult> {
+    const minuteIds = Object.keys(input.state.minutes)
+      .map((minute) => toMinuteId(minute))
+      .filter((minute): minute is MinuteId => minute !== null)
+      .sort(compareMinutes);
+    const topLimit = parseTopLimit(this.env.LOOP_B_TOP_MOVERS_LIMIT);
+
+    let finalizedMinutes = 0;
+    let lastFinalized: MinuteId | null = input.state.lastFinalizedMinute;
+
+    for (const minuteId of minuteIds) {
+      if (compareMinutes(minuteId, input.upToMinute) > 0) break;
+
+      const minuteRecord = input.state.minutes[minuteId];
+      if (!minuteRecord) continue;
+      if (minuteRecord.revision === minuteRecord.finalizedRevision) continue;
+
+      await publishFinalizedMinute({
+        env: this.env,
+        minute: minuteId,
+        minuteRecord,
+        generatedAt: input.observedAt,
+        topLimit,
+      });
+      minuteRecord.finalizedRevision = minuteRecord.revision;
+      minuteRecord.updatedAt = input.observedAt;
+      finalizedMinutes += 1;
+      lastFinalized = minuteId;
+    }
+
+    input.state.lastFinalizedMinute = lastFinalized;
+    input.state.updatedAt = input.observedAt;
+    await putKvJson(
+      this.env,
+      LOOP_B_HEALTH_KEY,
+      buildHealthArtifact({
+        state: input.state,
+        generatedAt: input.observedAt,
+      }),
+    );
+
+    return {
+      finalizedMinutes,
+      minutesConsidered: minuteIds.length,
+      lastFinalizedMinute: input.state.lastFinalizedMinute,
+    };
+  }
+
+  private async setNextMinuteAlarm(observedAt: string): Promise<void> {
+    const next = new Date(observedAt);
+    next.setUTCSeconds(0, 0);
+    next.setUTCMinutes(next.getUTCMinutes() + 1);
+    await this.state.storage.setAlarm(next.getTime() + 1000);
+  }
+
+  private async handleIngest(request: Request): Promise<Response> {
+    const body = (await request.json()) as IngestRequest;
+    const rawMarks = Array.isArray(body.marks) ? body.marks : [];
+    const observedAt = body.observedAt ?? this.now();
+
+    const marks: Mark[] = [];
+    for (const rawMark of rawMarks) {
+      const parsed = safeParseMark(rawMark);
+      if (!parsed.success) continue;
+      marks.push(parsed.data);
+    }
+
+    const state = await this.readState();
+    const applied = this.applyMarks({
+      state,
+      marks,
+      observedAt,
+    });
+    const finalizeResult = await this.finalizeMinutes({
+      state,
+      upToMinute: previousMinute(observedAt),
+      observedAt,
+    });
+    await this.writeState(state);
+    await this.setNextMinuteAlarm(observedAt);
+
+    const result: MinuteAccumulatorIngestResult = {
+      marksReceived: rawMarks.length,
+      marksAccepted: applied.marksAccepted,
+      minutesTouched: applied.minutesTouched.size,
+      finalizedMinutes: finalizeResult.finalizedMinutes,
+    };
+
+    return new Response(JSON.stringify({ ok: true, result }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  private async handleFinalize(request: Request): Promise<Response> {
+    const body = (await request.json()) as FinalizeRequest;
+    const observedAt = body.observedAt ?? this.now();
+    const upToMinute =
+      toMinuteId(body.upToMinute ?? "") ?? previousMinute(observedAt);
+
+    const state = await this.readState();
+    const result = await this.finalizeMinutes({
+      state,
+      upToMinute,
+      observedAt,
+    });
+    await this.writeState(state);
+
+    return new Response(JSON.stringify({ ok: true, result }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (
+      request.method === "POST" &&
+      (url.pathname === "/loop-b/ingest" ||
+        url.pathname === "/internal/loop-b/ingest")
+    ) {
+      return await this.handleIngest(request);
+    }
+
+    if (
+      request.method === "POST" &&
+      (url.pathname === "/loop-b/finalize" ||
+        url.pathname === "/internal/loop-b/finalize")
+    ) {
+      return await this.handleFinalize(request);
+    }
+
+    if (
+      request.method === "GET" &&
+      (url.pathname === "/loop-b/state" ||
+        url.pathname === "/internal/loop-b/state")
+    ) {
+      const state = await this.readState();
+      return new Response(JSON.stringify({ ok: true, state }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify({ ok: false, error: "not-found" }), {
+      status: 404,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  async alarm(): Promise<void> {
+    const observedAt = this.now();
+    const state = await this.readState();
+    await this.finalizeMinutes({
+      state,
+      upToMinute: previousMinute(observedAt),
+      observedAt,
+    });
+    await this.writeState(state);
+  }
+}
+
+export async function publishMarksToMinuteAccumulator(
+  env: Env,
+  input: {
+    marks: Mark[];
+    observedAt?: string;
+  },
+): Promise<MinuteAccumulatorIngestResult | null> {
+  if (!env.LOOP_B_MINUTE_ACCUMULATOR_DO || input.marks.length === 0)
+    return null;
+  const enabled =
+    String(env.LOOP_B_MINUTE_ACCUMULATOR_ENABLED ?? "0").trim() === "1";
+  if (!enabled) return null;
+
+  const id = env.LOOP_B_MINUTE_ACCUMULATOR_DO.idFromName(
+    LOOP_B_MINUTE_ACCUMULATOR_NAME,
+  );
+  const stub = env.LOOP_B_MINUTE_ACCUMULATOR_DO.get(id);
+  const response = await stub.fetch("https://internal/loop-b/ingest", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      marks: input.marks,
+      observedAt: input.observedAt,
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `loop-b-minute-accumulator-ingest-failed:${response.status}`,
+    );
+  }
+
+  const payload = (await response.json()) as {
+    ok: boolean;
+    result?: MinuteAccumulatorIngestResult;
+  };
+  return payload.ok && payload.result ? payload.result : null;
+}

--- a/apps/worker/src/types.ts
+++ b/apps/worker/src/types.ts
@@ -50,6 +50,7 @@ export type Env = {
   CONFIG_KV?: KVNamespace;
   LOGS_BUCKET?: R2Bucket;
   LOOP_A_COORDINATOR_DO?: DurableObjectNamespace;
+  LOOP_B_MINUTE_ACCUMULATOR_DO?: DurableObjectNamespace;
   ALLOWED_ORIGINS?: string;
   ADMIN_TOKEN?: string;
   PRIVY_APP_ID?: string;
@@ -105,4 +106,6 @@ export type Env = {
   LOOP_A_MARK_ENGINE_ENABLED?: string;
   LOOP_A_MARK_COMMITMENT?: string;
   LOOP_A_COORDINATOR_ENABLED?: string;
+  LOOP_B_MINUTE_ACCUMULATOR_ENABLED?: string;
+  LOOP_B_TOP_MOVERS_LIMIT?: string;
 };

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -44,10 +44,16 @@ LOOP_A_BACKFILL_MAX_TOTAL_SLOTS_PER_TICK = "128"
 LOOP_A_MARK_ENGINE_ENABLED = "0"
 LOOP_A_MARK_COMMITMENT = "confirmed"
 LOOP_A_COORDINATOR_ENABLED = "0"
+LOOP_B_MINUTE_ACCUMULATOR_ENABLED = "0"
+LOOP_B_TOP_MOVERS_LIMIT = "20"
 
 [[durable_objects.bindings]]
 name = "LOOP_A_COORDINATOR_DO"
 class_name = "LoopACoordinator"
+
+[[durable_objects.bindings]]
+name = "LOOP_B_MINUTE_ACCUMULATOR_DO"
+class_name = "MinuteAccumulator"
 
 [[kv_namespaces]]
 binding = "CONFIG_KV"
@@ -111,6 +117,8 @@ LOOP_A_BACKFILL_MAX_TOTAL_SLOTS_PER_TICK = "128"
 LOOP_A_MARK_ENGINE_ENABLED = "0"
 LOOP_A_MARK_COMMITMENT = "confirmed"
 LOOP_A_COORDINATOR_ENABLED = "0"
+LOOP_B_MINUTE_ACCUMULATOR_ENABLED = "0"
+LOOP_B_TOP_MOVERS_LIMIT = "20"
 
 [[env.staging.kv_namespaces]]
 binding = "CONFIG_KV"
@@ -174,10 +182,16 @@ LOOP_A_BACKFILL_MAX_TOTAL_SLOTS_PER_TICK = "128"
 LOOP_A_MARK_ENGINE_ENABLED = "0"
 LOOP_A_MARK_COMMITMENT = "confirmed"
 LOOP_A_COORDINATOR_ENABLED = "0"
+LOOP_B_MINUTE_ACCUMULATOR_ENABLED = "0"
+LOOP_B_TOP_MOVERS_LIMIT = "20"
 
 [[migrations]]
 tag = "v2-loop-a-coordinator"
 new_sqlite_classes = ["LoopACoordinator"]
+
+[[migrations]]
+tag = "v3-loop-b-minute-accumulator"
+new_sqlite_classes = ["MinuteAccumulator"]
 
 [[env.production.kv_namespaces]]
 binding = "CONFIG_KV"

--- a/loop-a-loop-b-architecture.md
+++ b/loop-a-loop-b-architecture.md
@@ -34,6 +34,10 @@ It is intentionally written as something you can hand to an implementation agent
   - writes Loop A health artifacts to `loopA:v1:health` in Cloudflare Key-Value store on every tick (success/failure),
   - writes latest tick latency telemetry to `loopA:v1:latency:latest`,
   - persists per-tick health and latency snapshots to Cloudflare R2 object storage when bound.
+- Loop B MinuteAccumulator (current):
+  - Durable Object ingests Loop A marks incrementally and tracks per-minute revisions in stateful storage,
+  - finalizes minute snapshots to hot Cloudflare Key-Value store views (`top_movers`, `liquidity_stress`, per-pair latest scores, health),
+  - re-finalizes corrected minutes when late/corrected marks arrive, and writes minute snapshots to Cloudflare R2 object storage.
 
 ### Execution routing already exists (v0)
 

--- a/tests/unit/worker_loop_b_minute_accumulator.test.ts
+++ b/tests/unit/worker_loop_b_minute_accumulator.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, test } from "bun:test";
+import {
+  LOOP_B_HEALTH_KEY,
+  LOOP_B_LIQUIDITY_STRESS_KEY,
+  LOOP_B_MINUTE_ACCUMULATOR_NAME,
+  LOOP_B_TOP_MOVERS_KEY,
+  MinuteAccumulator,
+  publishMarksToMinuteAccumulator,
+} from "../../apps/worker/src/loop_b/minute_accumulator";
+import type { Env } from "../../apps/worker/src/types";
+import type { Mark } from "../../src/loops/contracts/loop_a";
+
+function createMockDb() {
+  return {
+    prepare(_sql: string) {
+      return {
+        bind(..._args: unknown[]) {
+          return {
+            run: async () => ({ meta: { changes: 1 } }),
+            all: async () => ({ results: [] }),
+            first: async () => null,
+          };
+        },
+      };
+    },
+  };
+}
+
+function createMockKv() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    kv: {
+      get: async (key: string) => store.get(key) ?? null,
+      put: async (key: string, value: string) => {
+        store.set(key, value);
+      },
+      delete: async (key: string) => {
+        store.delete(key);
+      },
+    },
+  };
+}
+
+function createMockR2() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    bucket: {
+      put: async (key: string, value: string) => {
+        store.set(key, value);
+      },
+      get: async (key: string) => {
+        const value = store.get(key);
+        if (!value) return null;
+        return {
+          text: async () => value,
+        };
+      },
+    },
+  };
+}
+
+function createMockDoState() {
+  const store = new Map<string, unknown>();
+  let alarmAt: number | null = null;
+  return {
+    state: {
+      storage: {
+        get: async (key: string) => store.get(key),
+        put: async (key: string, value: unknown) => {
+          store.set(key, value);
+        },
+        setAlarm: async (time: number | Date) => {
+          alarmAt = typeof time === "number" ? time : time.getTime();
+        },
+        getAlarm: async () => alarmAt,
+      },
+      blockConcurrencyWhile: async <T>(fn: () => Promise<T>) => await fn(),
+    } as unknown as DurableObjectState,
+    store,
+    getAlarm: () => alarmAt,
+  };
+}
+
+function createMark(input: {
+  slot: number;
+  ts: string;
+  px: string;
+  sig: string;
+}): Mark {
+  return {
+    schemaVersion: "v1",
+    generatedAt: "2026-02-21T18:00:00.000Z",
+    slot: input.slot,
+    ts: input.ts,
+    baseMint: "So11111111111111111111111111111111111111112",
+    quoteMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    px: input.px,
+    confidence: 0.8,
+    venue: "jupiter",
+    evidence: {
+      sigs: [input.sig],
+      inputs: [`loopA/v1/events/slot=${input.slot}`],
+    },
+    version: "v1",
+  };
+}
+
+function createEnv(options?: { withR2?: boolean }): {
+  env: Env;
+  kvStore: Map<string, string>;
+  r2Store: Map<string, string>;
+} {
+  const { kv, store: kvStore } = createMockKv();
+  const { bucket, store: r2Store } = createMockR2();
+  return {
+    env: {
+      WAITLIST_DB: createMockDb() as never,
+      CONFIG_KV: kv as never,
+      LOGS_BUCKET: options?.withR2 === false ? undefined : (bucket as never),
+      LOOP_B_MINUTE_ACCUMULATOR_ENABLED: "1",
+    } as Env,
+    kvStore,
+    r2Store,
+  };
+}
+
+describe("worker loop B minute accumulator", () => {
+  test("ingests marks and publishes finalized views", async () => {
+    const { env, kvStore, r2Store } = createEnv();
+    const mock = createMockDoState();
+    const accumulator = new MinuteAccumulator(mock.state, env, {
+      now: () => "2026-02-21T18:02:00.000Z",
+    });
+
+    const response = await accumulator.fetch(
+      new Request("https://internal/loop-b/ingest", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          observedAt: "2026-02-21T18:02:00.000Z",
+          marks: [
+            createMark({
+              slot: 700,
+              ts: "2026-02-21T18:01:20.000Z",
+              px: "5.0",
+              sig: "sig-a",
+            }),
+            createMark({
+              slot: 701,
+              ts: "2026-02-21T18:01:40.000Z",
+              px: "5.2",
+              sig: "sig-b",
+            }),
+          ],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as {
+      ok: boolean;
+      result: {
+        marksAccepted: number;
+        finalizedMinutes: number;
+      };
+    };
+    expect(payload.ok).toBe(true);
+    expect(payload.result.marksAccepted).toBe(2);
+    expect(payload.result.finalizedMinutes).toBe(1);
+    expect(mock.getAlarm()).not.toBeNull();
+
+    expect(kvStore.has(LOOP_B_TOP_MOVERS_KEY)).toBe(true);
+    expect(kvStore.has(LOOP_B_LIQUIDITY_STRESS_KEY)).toBe(true);
+    expect(kvStore.has(LOOP_B_HEALTH_KEY)).toBe(true);
+    expect(
+      kvStore.has(
+        "loopB:v1:scores:latest:pair:So11111111111111111111111111111111111111112:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      ),
+    ).toBe(true);
+
+    expect(r2Store.size).toBeGreaterThan(0);
+  });
+
+  test("late correction re-finalizes the minute with updated scores", async () => {
+    const { env, kvStore } = createEnv({ withR2: false });
+    const mock = createMockDoState();
+    const accumulator = new MinuteAccumulator(mock.state, env, {
+      now: () => "2026-02-21T18:03:00.000Z",
+    });
+
+    await accumulator.fetch(
+      new Request("https://internal/loop-b/ingest", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          observedAt: "2026-02-21T18:03:00.000Z",
+          marks: [
+            createMark({
+              slot: 800,
+              ts: "2026-02-21T18:02:10.000Z",
+              px: "10",
+              sig: "sig-c",
+            }),
+            createMark({
+              slot: 801,
+              ts: "2026-02-21T18:02:20.000Z",
+              px: "11",
+              sig: "sig-d",
+            }),
+          ],
+        }),
+      }),
+    );
+
+    const firstTopMovers = JSON.parse(
+      kvStore.get(LOOP_B_TOP_MOVERS_KEY) ?? "{}",
+    ) as {
+      minute: string;
+      movers: Array<{ pctChange: number; revision: number }>;
+    };
+    expect(firstTopMovers.minute).toBe("2026-02-21T18:02:00.000Z");
+    const firstChange = firstTopMovers.movers[0]?.pctChange ?? 0;
+    const firstRevision = firstTopMovers.movers[0]?.revision ?? 0;
+
+    await accumulator.fetch(
+      new Request("https://internal/loop-b/ingest", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          observedAt: "2026-02-21T18:04:00.000Z",
+          marks: [
+            createMark({
+              slot: 801,
+              ts: "2026-02-21T18:02:20.000Z",
+              px: "12",
+              sig: "sig-d",
+            }),
+          ],
+        }),
+      }),
+    );
+
+    const secondTopMovers = JSON.parse(
+      kvStore.get(LOOP_B_TOP_MOVERS_KEY) ?? "{}",
+    ) as {
+      minute: string;
+      movers: Array<{ pctChange: number; revision: number }>;
+    };
+    const secondChange = secondTopMovers.movers[0]?.pctChange ?? 0;
+    const secondRevision = secondTopMovers.movers[0]?.revision ?? 0;
+
+    expect(secondTopMovers.minute).toBe("2026-02-21T18:02:00.000Z");
+    expect(secondChange).toBeGreaterThan(firstChange);
+    expect(secondRevision).toBeGreaterThan(firstRevision);
+  });
+
+  test("publish helper sends marks into minute accumulator durable object", async () => {
+    const { env } = createEnv({ withR2: false });
+    let called = false;
+
+    env.LOOP_B_MINUTE_ACCUMULATOR_DO = {
+      idFromName: (name: string) => {
+        expect(name).toBe(LOOP_B_MINUTE_ACCUMULATOR_NAME);
+        return { toString: () => "loop-b-do-id" } as never;
+      },
+      get: (_id: DurableObjectId) =>
+        ({
+          fetch: async (url: string, init?: RequestInit) => {
+            called = true;
+            expect(url).toContain("/loop-b/ingest");
+            expect(init?.method).toBe("POST");
+            return new Response(
+              JSON.stringify({
+                ok: true,
+                result: {
+                  marksReceived: 1,
+                  marksAccepted: 1,
+                  minutesTouched: 1,
+                  finalizedMinutes: 0,
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            );
+          },
+        }) as never,
+    } as DurableObjectNamespace;
+
+    const result = await publishMarksToMinuteAccumulator(env, {
+      marks: [
+        createMark({
+          slot: 900,
+          ts: "2026-02-21T18:05:01.000Z",
+          px: "15",
+          sig: "sig-e",
+        }),
+      ],
+      observedAt: "2026-02-21T18:05:10.000Z",
+    });
+
+    expect(called).toBe(true);
+    expect(result?.marksAccepted).toBe(1);
+  });
+});


### PR DESCRIPTION
## What changed
- Added `apps/worker/src/loop_b/minute_accumulator.ts` with a new `MinuteAccumulator` Durable Object for incremental minute aggregation.
- Added DO endpoints:
  - `POST /internal/loop-b/ingest` (mark ingestion)
  - `POST /internal/loop-b/finalize` (manual finalize)
  - `GET /internal/loop-b/state` (state inspection)
- Added Loop B hot-view publishing in finalize:
  - `loopB:v1:views:top_movers:latest`
  - `loopB:v1:views:liquidity_stress:latest`
  - `loopB:v1:scores:latest:pair:<pairId>`
  - `loopB:v1:health`
- Added R2 minute snapshot persistence for finalized minutes.
- Wired Loop A → Loop B ingestion:
  - `runLoopAMarkEngineTick` now returns computed marks in result payload.
  - Loop A pipeline now pushes marks into MinuteAccumulator via `publishMarksToMinuteAccumulator(...)` (flag-gated).
- Added wrangler bindings/vars and Durable Object migration for `MinuteAccumulator`.
- Added unit tests for ingestion/finalization/re-finalization/helper dispatch.
- Updated architecture status section to reflect LB-01 implementation state.

## Why (LB-01 acceptance mapping)
- Loop B now ingests marks incrementally in a stateful Durable Object (no storage scans required for minute computation).
- Loop B maintains minute-local revisioned state and re-finalizes corrected minutes when late/corrected marks arrive.
- Finalized minute outputs are materialized to KV hot views for low-latency serving.

## Cloudflare wiring
- Added exported Worker class: `MinuteAccumulator`.
- Added env binding: `LOOP_B_MINUTE_ACCUMULATOR_DO`.
- Added flags:
  - `LOOP_B_MINUTE_ACCUMULATOR_ENABLED` (default `0`)
  - `LOOP_B_TOP_MOVERS_LIMIT` (default `20`)
- Added DO migration tag:
  - `v3-loop-b-minute-accumulator`.

## Test evidence
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit`
- `bun run test:integration` (skip-only in this env)

## Follow-ups
- LB-02 can layer incremental feature rows on top of existing per-minute revision model.
- LB-03 can consume per-pair rows for deterministic explainable scoring outputs.
