### PR TITLE
LB-03: Add deterministic explainable Loop B scoring

### DIFF
--- a/apps/worker/src/loop_b/minute_accumulator.ts
+++ b/apps/worker/src/loop_b/minute_accumulator.ts
@@ -14,6 +14,7 @@ export const LOOP_B_TOP_MOVERS_KEY = "loopB:v1:views:top_movers:latest";
 export const LOOP_B_LIQUIDITY_STRESS_KEY =
   "loopB:v1:views:liquidity_stress:latest";
 export const LOOP_B_FEATURES_LATEST_KEY = "loopB:v1:features:latest";
+export const LOOP_B_SCORES_LATEST_KEY = "loopB:v1:scores:latest";
 export const LOOP_B_HEALTH_KEY = "loopB:v1:health";
 
 type MinuteId = `${string}T${string}:00Z`;
@@ -86,10 +87,33 @@ type LoopBLiquidityStressView = {
   >;
 };
 
-type LoopBPairScoreRow = PairAggregate & {
+type LoopBScoreContributions = {
+  momentum: number;
+  confidence: number;
+  stabilityPenalty: number;
+  activity: number;
+};
+
+export type LoopBScoreRow = {
   schemaVersion: typeof LOOP_B_SCHEMA_VERSION;
   generatedAt: string;
   minute: MinuteId;
+  pairId: string;
+  baseMint: string;
+  quoteMint: string;
+  finalScore: number;
+  contributions: LoopBScoreContributions;
+  featuresRef: string;
+  revision: number;
+  explain: string[];
+};
+
+type LoopBScoreSet = {
+  schemaVersion: typeof LOOP_B_SCHEMA_VERSION;
+  generatedAt: string;
+  minute: MinuteId;
+  count: number;
+  rows: LoopBScoreRow[];
 };
 
 type LoopBHealth = {
@@ -456,6 +480,62 @@ function buildFeatureSet(input: {
   };
 }
 
+function round(value: number, digits = 6): number {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+function buildScoreSet(input: { featureSet: LoopBFeatureSet }): LoopBScoreSet {
+  const rows = input.featureSet.rows
+    .map((row) => {
+      const momentum = row.returnPct * 0.55;
+      const confidence = row.confidenceAvg * 100 * 0.25;
+      const stabilityPenalty = row.volatilityPct * 0.2;
+      const activity = Math.log10(row.markCount + 1) * 2.5;
+      const finalScore = momentum + confidence + activity - stabilityPenalty;
+
+      const scoreRow: LoopBScoreRow = {
+        schemaVersion: LOOP_B_SCHEMA_VERSION,
+        generatedAt: row.generatedAt,
+        minute: row.minute,
+        pairId: row.pairId,
+        baseMint: row.baseMint,
+        quoteMint: row.quoteMint,
+        finalScore: round(finalScore, 8),
+        contributions: {
+          momentum: round(momentum, 8),
+          confidence: round(confidence, 8),
+          stabilityPenalty: round(stabilityPenalty, 8),
+          activity: round(activity, 8),
+        },
+        featuresRef: `${LOOP_B_FEATURES_LATEST_KEY}:pair:${row.pairId}`,
+        revision: row.revision,
+        explain: [
+          `score=momentum+confidence+activity-stability`,
+          `momentum=${round(momentum, 4)}`,
+          `confidence=${round(confidence, 4)}`,
+          `stability_penalty=${round(stabilityPenalty, 4)}`,
+          `activity=${round(activity, 4)}`,
+        ],
+      };
+      return scoreRow;
+    })
+    .sort((a, b) => {
+      if (a.finalScore !== b.finalScore) return b.finalScore - a.finalScore;
+      if (a.pairId < b.pairId) return -1;
+      if (a.pairId > b.pairId) return 1;
+      return 0;
+    });
+
+  return {
+    schemaVersion: LOOP_B_SCHEMA_VERSION,
+    generatedAt: input.featureSet.generatedAt,
+    minute: input.featureSet.minute,
+    count: rows.length,
+    rows,
+  };
+}
+
 function buildHealthArtifact(input: {
   state: MinuteAccumulatorState;
   generatedAt: string;
@@ -506,6 +586,21 @@ function featureSnapshotR2Key(input: {
   return `loopB/${LOOP_B_SCHEMA_VERSION}/features/date=${yyyy}-${mm}-${dd}/hour=${hh}/minute=${yyyy}-${mm}-${dd}T${hh}:${minute}:00Z/revision=${input.revision}/at=${token}.json`;
 }
 
+function scoreSnapshotR2Key(input: {
+  minute: MinuteId;
+  generatedAt: string;
+  revision: number;
+}): string {
+  const date = new Date(input.minute);
+  const yyyy = date.getUTCFullYear().toString().padStart(4, "0");
+  const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(date.getUTCDate()).padStart(2, "0");
+  const hh = String(date.getUTCHours()).padStart(2, "0");
+  const minute = String(date.getUTCMinutes()).padStart(2, "0");
+  const token = input.generatedAt.replaceAll(":", "-");
+  return `loopB/${LOOP_B_SCHEMA_VERSION}/scores/date=${yyyy}-${mm}-${dd}/hour=${hh}/minute=${yyyy}-${mm}-${dd}T${hh}:${minute}:00Z/revision=${input.revision}/at=${token}.json`;
+}
+
 async function putKvJson(
   env: Env,
   key: string,
@@ -515,8 +610,8 @@ async function putKvJson(
   await env.CONFIG_KV.put(key, JSON.stringify(payload));
 }
 
-function pairScoreKey(pair: PairAggregate): string {
-  return `loopB:v1:scores:latest:pair:${pair.pairId}`;
+function pairScoreKey(pairIdValue: string): string {
+  return `loopB:v1:scores:latest:pair:${pairIdValue}`;
 }
 
 function featureRowKey(pairIdValue: string): string {
@@ -536,6 +631,7 @@ async function publishFinalizedMinute(input: {
     generatedAt: input.generatedAt,
     pairs,
   });
+  const scoreSet = buildScoreSet({ featureSet });
   const topMovers = buildTopMoversView({
     minute: input.minute,
     generatedAt: input.generatedAt,
@@ -552,18 +648,19 @@ async function publishFinalizedMinute(input: {
   await putKvJson(input.env, LOOP_B_TOP_MOVERS_KEY, topMovers);
   await putKvJson(input.env, LOOP_B_LIQUIDITY_STRESS_KEY, liquidityStress);
   await putKvJson(input.env, LOOP_B_FEATURES_LATEST_KEY, featureSet);
+  await putKvJson(input.env, LOOP_B_SCORES_LATEST_KEY, scoreSet);
   const featureRowsByPair = new Map(
     featureSet.rows.map((row) => [row.pairId, row] as const),
   );
+  const scoreRowsByPair = new Map(
+    scoreSet.rows.map((row) => [row.pairId, row] as const),
+  );
 
   for (const pair of pairs) {
-    const row: LoopBPairScoreRow = {
-      schemaVersion: LOOP_B_SCHEMA_VERSION,
-      generatedAt: input.generatedAt,
-      minute: input.minute,
-      ...pair,
-    };
-    await putKvJson(input.env, pairScoreKey(pair), row);
+    const scoreRow = scoreRowsByPair.get(pair.pairId) ?? null;
+    if (scoreRow) {
+      await putKvJson(input.env, pairScoreKey(pair.pairId), scoreRow);
+    }
     const featureRow = featureRowsByPair.get(pair.pairId) ?? null;
     if (featureRow) {
       await putKvJson(input.env, featureRowKey(pair.pairId), featureRow);
@@ -594,6 +691,14 @@ async function publishFinalizedMinute(input: {
           revision: input.minuteRecord.revision,
         }),
         JSON.stringify(featureSet),
+      ),
+      input.env.LOGS_BUCKET.put(
+        scoreSnapshotR2Key({
+          minute: input.minute,
+          generatedAt: input.generatedAt,
+          revision: input.minuteRecord.revision,
+        }),
+        JSON.stringify(scoreSet),
       ),
     ]);
   }

--- a/loop-a-loop-b-architecture.md
+++ b/loop-a-loop-b-architecture.md
@@ -37,6 +37,7 @@ It is intentionally written as something you can hand to an implementation agent
 - Loop B MinuteAccumulator (current):
   - Durable Object ingests Loop A marks incrementally and tracks per-minute revisions in stateful storage,
   - finalizes deterministic minute feature rows with provenance (slot range + input refs) and publishes them to hot Cloudflare Key-Value store,
+  - finalizes deterministic, explainable score rows (`loopB:v1:scores:latest` + per-pair score keys) using weighted contribution components,
   - finalizes minute snapshots to hot Cloudflare Key-Value store views (`top_movers`, `liquidity_stress`, per-pair latest scores, health),
   - re-finalizes corrected minutes when late/corrected marks arrive, and writes minute snapshots to Cloudflare R2 object storage.
 

--- a/tests/unit/worker_loop_b_minute_accumulator.test.ts
+++ b/tests/unit/worker_loop_b_minute_accumulator.test.ts
@@ -4,6 +4,7 @@ import {
   LOOP_B_HEALTH_KEY,
   LOOP_B_LIQUIDITY_STRESS_KEY,
   LOOP_B_MINUTE_ACCUMULATOR_NAME,
+  LOOP_B_SCORES_LATEST_KEY,
   LOOP_B_TOP_MOVERS_KEY,
   MinuteAccumulator,
   publishMarksToMinuteAccumulator,
@@ -190,6 +191,7 @@ describe("worker loop B minute accumulator", () => {
     expect(kvStore.has(LOOP_B_TOP_MOVERS_KEY)).toBe(true);
     expect(kvStore.has(LOOP_B_LIQUIDITY_STRESS_KEY)).toBe(true);
     expect(kvStore.has(LOOP_B_FEATURES_LATEST_KEY)).toBe(true);
+    expect(kvStore.has(LOOP_B_SCORES_LATEST_KEY)).toBe(true);
     expect(kvStore.has(LOOP_B_HEALTH_KEY)).toBe(true);
     expect(
       kvStore.has(
@@ -226,6 +228,25 @@ describe("worker loop B minute accumulator", () => {
       "loopA/v1/events/slot=700",
       "loopA/v1/events/slot=701",
     ]);
+    const scoreSet = JSON.parse(
+      kvStore.get(LOOP_B_SCORES_LATEST_KEY) ?? "{}",
+    ) as {
+      rows: Array<{
+        pairId: string;
+        finalScore: number;
+        contributions: {
+          momentum: number;
+          confidence: number;
+          stabilityPenalty: number;
+          activity: number;
+        };
+        explain: string[];
+      }>;
+    };
+    expect(scoreSet.rows.length).toBe(2);
+    expect(scoreSet.rows[0]?.finalScore).toBeGreaterThan(0);
+    expect(scoreSet.rows[0]?.contributions.confidence).toBeGreaterThan(0);
+    expect(scoreSet.rows[0]?.explain[0]).toContain("score=momentum");
 
     expect(r2Store.size).toBeGreaterThan(0);
   });
@@ -278,6 +299,17 @@ describe("worker loop B minute accumulator", () => {
       returnPct: number;
       revision: number;
     };
+    const firstScoreRow = JSON.parse(
+      kvStore.get(
+        "loopB:v1:scores:latest:pair:So11111111111111111111111111111111111111112:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      ) ?? "{}",
+    ) as {
+      finalScore: number;
+      revision: number;
+      contributions: {
+        momentum: number;
+      };
+    };
 
     await accumulator.fetch(
       new Request("https://internal/loop-b/ingest", {
@@ -313,6 +345,17 @@ describe("worker loop B minute accumulator", () => {
       returnPct: number;
       revision: number;
     };
+    const secondScoreRow = JSON.parse(
+      kvStore.get(
+        "loopB:v1:scores:latest:pair:So11111111111111111111111111111111111111112:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      ) ?? "{}",
+    ) as {
+      finalScore: number;
+      revision: number;
+      contributions: {
+        momentum: number;
+      };
+    };
 
     expect(secondTopMovers.minute).toBe("2026-02-21T18:02:00.000Z");
     expect(secondChange).toBeGreaterThan(firstChange);
@@ -321,6 +364,11 @@ describe("worker loop B minute accumulator", () => {
       firstFeatureRow.returnPct,
     );
     expect(secondFeatureRow.revision).toBeGreaterThan(firstFeatureRow.revision);
+    expect(secondScoreRow.finalScore).toBeGreaterThan(firstScoreRow.finalScore);
+    expect(secondScoreRow.revision).toBeGreaterThan(firstScoreRow.revision);
+    expect(secondScoreRow.contributions.momentum).toBeGreaterThan(
+      firstScoreRow.contributions.momentum,
+    );
   });
 
   test("publish helper sends marks into minute accumulator durable object", async () => {


### PR DESCRIPTION
## What changed
- Added explicit Loop B scoring materialization on minute finalization.
- New hot score view key:
  - `loopB:v1:scores:latest`
- Existing per-pair score keys are now structured explainable score rows derived from feature rows.
- Added deterministic weighted contribution model per row:
  - `momentum`
  - `confidence`
  - `stabilityPenalty`
  - `activity`
- Added human-readable `explain[]` contribution traces.
- Persisted score snapshots to R2 alongside minute and feature snapshots.
- Extended unit tests to validate score publication and re-finalization behavior after corrected marks.
- Updated architecture status section for LB-03.

## Why (LB-03 acceptance mapping)
- Scoring is deterministic for identical feature inputs.
- Each score row now includes explicit “why” via contribution components and explanation tags.
- Scoring output is reproducible and stable under minute re-finalization.

## Test evidence
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit`
- `bun run test:integration` (skip-only in this env)

## Follow-ups
- LB-04 can consume `scores:latest` and `features:latest` to build final top views.
