### PR TITLE
LB-04: Add anomaly feed + freshness metadata views

### DIFF
--- a/apps/worker/src/loop_b/minute_accumulator.ts
+++ b/apps/worker/src/loop_b/minute_accumulator.ts
@@ -13,6 +13,7 @@ export const LOOP_B_MINUTE_ACCUMULATOR_NAME = "loop-b-minute-accumulator-v1";
 export const LOOP_B_TOP_MOVERS_KEY = "loopB:v1:views:top_movers:latest";
 export const LOOP_B_LIQUIDITY_STRESS_KEY =
   "loopB:v1:views:liquidity_stress:latest";
+export const LOOP_B_ANOMALY_FEED_KEY = "loopB:v1:views:anomaly_feed:latest";
 export const LOOP_B_FEATURES_LATEST_KEY = "loopB:v1:features:latest";
 export const LOOP_B_SCORES_LATEST_KEY = "loopB:v1:scores:latest";
 export const LOOP_B_HEALTH_KEY = "loopB:v1:health";
@@ -71,6 +72,7 @@ type LoopBTopMoversView = {
   schemaVersion: typeof LOOP_B_SCHEMA_VERSION;
   generatedAt: string;
   minute: MinuteId;
+  freshnessMs: number;
   count: number;
   movers: PairAggregate[];
 };
@@ -79,10 +81,25 @@ type LoopBLiquidityStressView = {
   schemaVersion: typeof LOOP_B_SCHEMA_VERSION;
   generatedAt: string;
   minute: MinuteId;
+  freshnessMs: number;
   count: number;
   pairs: Array<
     PairAggregate & {
       stressScore: number;
+    }
+  >;
+};
+
+type LoopBAnomalyFeedView = {
+  schemaVersion: typeof LOOP_B_SCHEMA_VERSION;
+  generatedAt: string;
+  minute: MinuteId;
+  freshnessMs: number;
+  count: number;
+  anomalies: Array<
+    PairAggregate & {
+      anomalyScore: number;
+      reasonTags: string[];
     }
   >;
 };
@@ -409,10 +426,15 @@ function buildTopMoversView(input: {
   pairs: PairAggregate[];
   limit: number;
 }): LoopBTopMoversView {
+  const freshnessMs = Math.max(
+    0,
+    Date.parse(input.generatedAt) - Date.parse(input.minute),
+  );
   return {
     schemaVersion: LOOP_B_SCHEMA_VERSION,
     generatedAt: input.generatedAt,
     minute: input.minute,
+    freshnessMs,
     count: Math.min(input.limit, input.pairs.length),
     movers: input.pairs.slice(0, input.limit),
   };
@@ -424,6 +446,10 @@ function buildLiquidityStressView(input: {
   pairs: PairAggregate[];
   limit: number;
 }): LoopBLiquidityStressView {
+  const freshnessMs = Math.max(
+    0,
+    Date.parse(input.generatedAt) - Date.parse(input.minute),
+  );
   const stressed = input.pairs
     .map((pair) => ({
       ...pair,
@@ -437,8 +463,48 @@ function buildLiquidityStressView(input: {
     schemaVersion: LOOP_B_SCHEMA_VERSION,
     generatedAt: input.generatedAt,
     minute: input.minute,
+    freshnessMs,
     count: Math.min(input.limit, stressed.length),
     pairs: stressed.slice(0, input.limit),
+  };
+}
+
+function buildAnomalyFeedView(input: {
+  minute: MinuteId;
+  generatedAt: string;
+  pairs: PairAggregate[];
+  limit: number;
+}): LoopBAnomalyFeedView {
+  const freshnessMs = Math.max(
+    0,
+    Date.parse(input.generatedAt) - Date.parse(input.minute),
+  );
+  const anomalies = input.pairs
+    .map((pair) => {
+      const reasons: string[] = [];
+      if (Math.abs(pair.pctChange) >= 5) reasons.push("large_move");
+      if (pair.avgConfidence <= 0.75) reasons.push("low_confidence");
+      if (pair.volatility >= 3) reasons.push("high_volatility");
+      if (pair.markCount <= 1) reasons.push("thin_sample");
+      const anomalyScore =
+        Math.abs(pair.pctChange) * (1 + (1 - pair.avgConfidence)) +
+        pair.volatility * 0.75 +
+        (pair.markCount <= 1 ? 3 : 0);
+      return {
+        ...pair,
+        anomalyScore: round(anomalyScore, 8),
+        reasonTags: reasons,
+      };
+    })
+    .sort((a, b) => b.anomalyScore - a.anomalyScore);
+
+  return {
+    schemaVersion: LOOP_B_SCHEMA_VERSION,
+    generatedAt: input.generatedAt,
+    minute: input.minute,
+    freshnessMs,
+    count: Math.min(input.limit, anomalies.length),
+    anomalies: anomalies.slice(0, input.limit),
   };
 }
 
@@ -644,9 +710,16 @@ async function publishFinalizedMinute(input: {
     pairs,
     limit: input.topLimit,
   });
+  const anomalyFeed = buildAnomalyFeedView({
+    minute: input.minute,
+    generatedAt: input.generatedAt,
+    pairs,
+    limit: input.topLimit,
+  });
 
   await putKvJson(input.env, LOOP_B_TOP_MOVERS_KEY, topMovers);
   await putKvJson(input.env, LOOP_B_LIQUIDITY_STRESS_KEY, liquidityStress);
+  await putKvJson(input.env, LOOP_B_ANOMALY_FEED_KEY, anomalyFeed);
   await putKvJson(input.env, LOOP_B_FEATURES_LATEST_KEY, featureSet);
   await putKvJson(input.env, LOOP_B_SCORES_LATEST_KEY, scoreSet);
   const featureRowsByPair = new Map(

--- a/loop-a-loop-b-architecture.md
+++ b/loop-a-loop-b-architecture.md
@@ -38,7 +38,7 @@ It is intentionally written as something you can hand to an implementation agent
   - Durable Object ingests Loop A marks incrementally and tracks per-minute revisions in stateful storage,
   - finalizes deterministic minute feature rows with provenance (slot range + input refs) and publishes them to hot Cloudflare Key-Value store,
   - finalizes deterministic, explainable score rows (`loopB:v1:scores:latest` + per-pair score keys) using weighted contribution components,
-  - finalizes minute snapshots to hot Cloudflare Key-Value store views (`top_movers`, `liquidity_stress`, per-pair latest scores, health),
+  - finalizes minute snapshots to hot Cloudflare Key-Value store views (`top_movers`, `liquidity_stress`, `anomaly_feed`, per-pair latest scores, health) with freshness metadata,
   - re-finalizes corrected minutes when late/corrected marks arrive, and writes minute snapshots to Cloudflare R2 object storage.
 
 ### Execution routing already exists (v0)

--- a/tests/unit/worker_loop_b_minute_accumulator.test.ts
+++ b/tests/unit/worker_loop_b_minute_accumulator.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  LOOP_B_ANOMALY_FEED_KEY,
   LOOP_B_FEATURES_LATEST_KEY,
   LOOP_B_HEALTH_KEY,
   LOOP_B_LIQUIDITY_STRESS_KEY,
@@ -190,6 +191,7 @@ describe("worker loop B minute accumulator", () => {
 
     expect(kvStore.has(LOOP_B_TOP_MOVERS_KEY)).toBe(true);
     expect(kvStore.has(LOOP_B_LIQUIDITY_STRESS_KEY)).toBe(true);
+    expect(kvStore.has(LOOP_B_ANOMALY_FEED_KEY)).toBe(true);
     expect(kvStore.has(LOOP_B_FEATURES_LATEST_KEY)).toBe(true);
     expect(kvStore.has(LOOP_B_SCORES_LATEST_KEY)).toBe(true);
     expect(kvStore.has(LOOP_B_HEALTH_KEY)).toBe(true);
@@ -247,6 +249,30 @@ describe("worker loop B minute accumulator", () => {
     expect(scoreSet.rows[0]?.finalScore).toBeGreaterThan(0);
     expect(scoreSet.rows[0]?.contributions.confidence).toBeGreaterThan(0);
     expect(scoreSet.rows[0]?.explain[0]).toContain("score=momentum");
+    const topMoversView = JSON.parse(
+      kvStore.get(LOOP_B_TOP_MOVERS_KEY) ?? "{}",
+    ) as {
+      freshnessMs: number;
+    };
+    const liquidityStressView = JSON.parse(
+      kvStore.get(LOOP_B_LIQUIDITY_STRESS_KEY) ?? "{}",
+    ) as {
+      freshnessMs: number;
+    };
+    const anomalyFeedView = JSON.parse(
+      kvStore.get(LOOP_B_ANOMALY_FEED_KEY) ?? "{}",
+    ) as {
+      freshnessMs: number;
+      anomalies: Array<{
+        anomalyScore: number;
+        reasonTags: string[];
+      }>;
+    };
+    expect(topMoversView.freshnessMs).toBe(60000);
+    expect(liquidityStressView.freshnessMs).toBe(60000);
+    expect(anomalyFeedView.freshnessMs).toBe(60000);
+    expect(anomalyFeedView.anomalies[0]?.anomalyScore).toBeGreaterThan(0);
+    expect(anomalyFeedView.anomalies[0]?.reasonTags.length).toBeGreaterThan(0);
 
     expect(r2Store.size).toBeGreaterThan(0);
   });


### PR DESCRIPTION
## What changed
- Extended Loop B view materialization with a dedicated anomaly view:
  - `loopB:v1:views:anomaly_feed:latest`
- Added explicit freshness metadata (`freshnessMs`) to all Loop B hot views:
  - `top_movers`
  - `liquidity_stress`
  - `anomaly_feed`
- Added deterministic anomaly scoring + reason tags per pair (`large_move`, `low_confidence`, `high_volatility`, `thin_sample`).
- Updated unit tests to validate anomaly output and freshness metadata.
- Updated architecture status doc for LB-04.

## Why (LB-04 acceptance mapping)
- Loop B now publishes additive, KV-optimized read views including anomaly feed.
- Views expose freshness metadata directly for low-latency serving and client-side staleness handling.

## Test evidence
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit`
- `bun run test:integration` (skip-only in this env)

## Follow-ups
- LB-05 can archive these finalized views/minute packs in richer R2 partitions for backtests.
