### PR TITLE
LB-05: Persist finalized Loop B view bundles to R2

### DIFF
--- a/apps/worker/src/loop_b/minute_accumulator.ts
+++ b/apps/worker/src/loop_b/minute_accumulator.ts
@@ -667,6 +667,21 @@ function scoreSnapshotR2Key(input: {
   return `loopB/${LOOP_B_SCHEMA_VERSION}/scores/date=${yyyy}-${mm}-${dd}/hour=${hh}/minute=${yyyy}-${mm}-${dd}T${hh}:${minute}:00Z/revision=${input.revision}/at=${token}.json`;
 }
 
+function viewSnapshotR2Key(input: {
+  minute: MinuteId;
+  generatedAt: string;
+  revision: number;
+}): string {
+  const date = new Date(input.minute);
+  const yyyy = date.getUTCFullYear().toString().padStart(4, "0");
+  const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(date.getUTCDate()).padStart(2, "0");
+  const hh = String(date.getUTCHours()).padStart(2, "0");
+  const minute = String(date.getUTCMinutes()).padStart(2, "0");
+  const token = input.generatedAt.replaceAll(":", "-");
+  return `loopB/${LOOP_B_SCHEMA_VERSION}/views/date=${yyyy}-${mm}-${dd}/hour=${hh}/minute=${yyyy}-${mm}-${dd}T${hh}:${minute}:00Z/revision=${input.revision}/at=${token}.json`;
+}
+
 async function putKvJson(
   env: Env,
   key: string,
@@ -772,6 +787,24 @@ async function publishFinalizedMinute(input: {
           revision: input.minuteRecord.revision,
         }),
         JSON.stringify(scoreSet),
+      ),
+      input.env.LOGS_BUCKET.put(
+        viewSnapshotR2Key({
+          minute: input.minute,
+          generatedAt: input.generatedAt,
+          revision: input.minuteRecord.revision,
+        }),
+        JSON.stringify({
+          schemaVersion: LOOP_B_SCHEMA_VERSION,
+          generatedAt: input.generatedAt,
+          minute: input.minute,
+          revision: input.minuteRecord.revision,
+          views: {
+            topMovers,
+            liquidityStress,
+            anomalyFeed,
+          },
+        }),
       ),
     ]);
   }

--- a/loop-a-loop-b-architecture.md
+++ b/loop-a-loop-b-architecture.md
@@ -39,7 +39,7 @@ It is intentionally written as something you can hand to an implementation agent
   - finalizes deterministic minute feature rows with provenance (slot range + input refs) and publishes them to hot Cloudflare Key-Value store,
   - finalizes deterministic, explainable score rows (`loopB:v1:scores:latest` + per-pair score keys) using weighted contribution components,
   - finalizes minute snapshots to hot Cloudflare Key-Value store views (`top_movers`, `liquidity_stress`, `anomaly_feed`, per-pair latest scores, health) with freshness metadata,
-  - re-finalizes corrected minutes when late/corrected marks arrive, and writes minute snapshots to Cloudflare R2 object storage.
+  - re-finalizes corrected minutes when late/corrected marks arrive, and writes minute/features/scores/view bundles to Cloudflare R2 object storage.
 
 ### Execution routing already exists (v0)
 

--- a/tests/unit/worker_loop_b_minute_accumulator.test.ts
+++ b/tests/unit/worker_loop_b_minute_accumulator.test.ts
@@ -275,6 +275,9 @@ describe("worker loop B minute accumulator", () => {
     expect(anomalyFeedView.anomalies[0]?.reasonTags.length).toBeGreaterThan(0);
 
     expect(r2Store.size).toBeGreaterThan(0);
+    expect(
+      [...r2Store.keys()].some((key) => key.includes("/views/date=")),
+    ).toBe(true);
   });
 
   test("late correction re-finalizes the minute with updated scores", async () => {


### PR DESCRIPTION
## What changed
- Added R2 persistence for finalized Loop B view bundles (`top_movers`, `liquidity_stress`, `anomaly_feed`) in minute-partitioned paths.
- New R2 partition path pattern:
  - `loopB/v1/views/date=YYYY-MM-DD/hour=HH/minute=.../revision=.../at=...json`
- Extended unit coverage to assert `/views/` artifacts are written in R2.
- Updated architecture status doc for LB-05 completion.

## Why (LB-05 acceptance mapping)
- Finalized minute views are now stored immutably in R2, enabling historical replay/backtest inputs without relying on hot KV snapshots.

## Test evidence
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit`
- `bun run test:integration` (skip-only in this env)
