### PR TITLE
LC-01: Add Loop C recommender durable object + minute cache

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -21,6 +21,7 @@ import {
 import { readLoopAHealthFromKv, recordLoopAHealthTick } from "./loop_a/health";
 import { runLoopATickPipeline } from "./loop_a/pipeline";
 import { MinuteAccumulator } from "./loop_b/minute_accumulator";
+import { Recommender } from "./loop_c/recommender";
 import {
   fetchMacroEtfFlows,
   fetchMacroFredIndicators,
@@ -70,7 +71,7 @@ const EXPERIENCE_EVENT_NAMES = new Set<ExperienceEventName>([
   "terminal_opened_from_consumer",
 ]);
 
-export { LoopACoordinator, MinuteAccumulator };
+export { LoopACoordinator, MinuteAccumulator, Recommender };
 
 function resolveX402ReadRpcEndpoint(env: Env): string {
   const balanceRpc = String(env.BALANCE_RPC_ENDPOINT ?? "").trim();

--- a/apps/worker/src/loop_c/recommender.ts
+++ b/apps/worker/src/loop_c/recommender.ts
@@ -52,6 +52,7 @@ type RecommenderState = {
   schemaVersion: typeof LOOP_C_SCHEMA_VERSION;
   updatedAt: string;
   lastMinute: string | null;
+  lastRequestKey: string | null;
   cachedView: RecommendationView | null;
 };
 
@@ -156,6 +157,37 @@ function normalizeSet(input: string[] | undefined): Set<string> {
   );
 }
 
+function normalizePersona(input: UserPersonaInput | undefined): {
+  riskBudget: UserPersonaInput["riskBudget"] | null;
+  horizon: UserPersonaInput["horizon"] | null;
+  sectorPreferences: string[];
+  excludedAssets: string[];
+} {
+  const sectorPreferences = [...normalizeSet(input?.sectorPreferences)].sort();
+  const excludedAssets = [...normalizeSet(input?.excludedAssets)].sort();
+
+  return {
+    riskBudget: input?.riskBudget ?? null,
+    horizon: input?.horizon ?? null,
+    sectorPreferences,
+    excludedAssets,
+  };
+}
+
+function buildRequestKey(input: {
+  userId: string;
+  wallet: string;
+  limit: number;
+  persona?: UserPersonaInput;
+}): string {
+  return JSON.stringify({
+    userId: input.userId,
+    wallet: input.wallet,
+    limit: input.limit,
+    persona: normalizePersona(input.persona),
+  });
+}
+
 function recommendationKey(userId: string, wallet: string): string {
   return `loopC:${LOOP_C_SCHEMA_VERSION}:recs:latest:user:${userId}:wallet:${wallet}`;
 }
@@ -248,6 +280,7 @@ function parseState(input: unknown): RecommenderState {
       schemaVersion: LOOP_C_SCHEMA_VERSION,
       updatedAt: new Date().toISOString(),
       lastMinute: null,
+      lastRequestKey: null,
       cachedView: null,
     };
   }
@@ -322,6 +355,8 @@ function parseState(input: unknown): RecommenderState {
         : new Date().toISOString(),
     lastMinute:
       typeof record.lastMinute === "string" ? record.lastMinute : null,
+    lastRequestKey:
+      typeof record.lastRequestKey === "string" ? record.lastRequestKey : null,
     cachedView,
   };
 }
@@ -379,10 +414,17 @@ export class Recommender {
     const limit = Number.isFinite(payload.limit)
       ? Math.max(1, Math.min(50, Math.floor(payload.limit ?? DEFAULT_LIMIT)))
       : parseDefaultLimit(this.env.LOOP_C_RECOMMENDER_DEFAULT_LIMIT);
+    const requestKey = buildRequestKey({
+      userId,
+      wallet,
+      limit,
+      persona: payload.persona,
+    });
 
     const state = await this.readState();
     if (
       state.lastMinute === minute &&
+      state.lastRequestKey === requestKey &&
       state.cachedView &&
       state.cachedView.userId === userId &&
       state.cachedView.wallet === wallet
@@ -415,6 +457,7 @@ export class Recommender {
       schemaVersion: LOOP_C_SCHEMA_VERSION,
       updatedAt: observedAt,
       lastMinute: minute,
+      lastRequestKey: requestKey,
       cachedView: view,
     };
     await this.writeState(nextState);

--- a/apps/worker/src/loop_c/recommender.ts
+++ b/apps/worker/src/loop_c/recommender.ts
@@ -1,0 +1,508 @@
+import {
+  LOOP_B_SCORES_LATEST_KEY,
+  type LoopBScoreRow,
+} from "../loop_b/minute_accumulator";
+import type { Env } from "../types";
+
+const LOOP_C_SCHEMA_VERSION = "v1" as const;
+const STATE_KEY = "loop_c:recommender_state:v1";
+const DEFAULT_LIMIT = 10;
+
+export const LOOP_C_RECOMMENDER_NAME = "loop-c-recommender-v1";
+
+export type UserPersonaInput = {
+  riskBudget?: "low" | "medium" | "high" | number;
+  horizon?: "short" | "medium" | "long";
+  sectorPreferences?: string[];
+  excludedAssets?: string[];
+};
+
+export type RecommendationRow = {
+  recommendationId: string;
+  pairId: string;
+  baseMint: string;
+  quoteMint: string;
+  finalScore: number;
+  baseSignal: number;
+  riskPenalty: number;
+  personaBoost: number;
+  modelVersion: typeof LOOP_C_SCHEMA_VERSION;
+  explain: string[];
+};
+
+export type RecommendationView = {
+  schemaVersion: typeof LOOP_C_SCHEMA_VERSION;
+  generatedAt: string;
+  minute: string;
+  userId: string;
+  wallet: string;
+  freshnessMs: number;
+  recommendations: RecommendationRow[];
+};
+
+type RecommendationRequest = {
+  userId?: string;
+  wallet?: string;
+  limit?: number;
+  observedAt?: string;
+  persona?: UserPersonaInput;
+};
+
+type RecommenderState = {
+  schemaVersion: typeof LOOP_C_SCHEMA_VERSION;
+  updatedAt: string;
+  lastMinute: string | null;
+  cachedView: RecommendationView | null;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function parseDefaultLimit(raw: string | undefined): number {
+  const parsed = Number.parseInt(String(raw ?? "").trim(), 10);
+  if (Number.isFinite(parsed) && parsed > 0 && parsed <= 100) return parsed;
+  return DEFAULT_LIMIT;
+}
+
+function toMinuteId(input: string): string | null {
+  const parsed = new Date(input);
+  if (Number.isNaN(parsed.getTime())) return null;
+  parsed.setUTCSeconds(0, 0);
+  return parsed.toISOString();
+}
+
+function parseScoreRow(raw: unknown): LoopBScoreRow | null {
+  const row = asRecord(raw);
+  if (!row) return null;
+  if (row.schemaVersion !== "v1") return null;
+  if (typeof row.pairId !== "string" || !row.pairId) return null;
+  if (typeof row.baseMint !== "string" || typeof row.quoteMint !== "string") {
+    return null;
+  }
+  if (typeof row.finalScore !== "number" || !Number.isFinite(row.finalScore)) {
+    return null;
+  }
+  const contributions = asRecord(row.contributions);
+  if (!contributions) return null;
+  if (
+    typeof contributions.momentum !== "number" ||
+    typeof contributions.confidence !== "number" ||
+    typeof contributions.stabilityPenalty !== "number" ||
+    typeof contributions.activity !== "number"
+  ) {
+    return null;
+  }
+
+  return {
+    schemaVersion: "v1",
+    generatedAt:
+      typeof row.generatedAt === "string"
+        ? row.generatedAt
+        : new Date().toISOString(),
+    minute:
+      typeof row.minute === "string" ? row.minute : new Date().toISOString(),
+    pairId: row.pairId,
+    baseMint: row.baseMint,
+    quoteMint: row.quoteMint,
+    finalScore: row.finalScore,
+    contributions: {
+      momentum: contributions.momentum,
+      confidence: contributions.confidence,
+      stabilityPenalty: contributions.stabilityPenalty,
+      activity: contributions.activity,
+    },
+    featuresRef: typeof row.featuresRef === "string" ? row.featuresRef : "",
+    revision:
+      typeof row.revision === "number" && Number.isInteger(row.revision)
+        ? row.revision
+        : 0,
+    explain: Array.isArray(row.explain)
+      ? row.explain.filter((item): item is string => typeof item === "string")
+      : [],
+  };
+}
+
+function parseScoreRows(raw: string | null): LoopBScoreRow[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as { rows?: unknown[] };
+    if (!Array.isArray(parsed.rows)) return [];
+    const rows: LoopBScoreRow[] = [];
+    for (const row of parsed.rows) {
+      const parsedRow = parseScoreRow(row);
+      if (parsedRow) rows.push(parsedRow);
+    }
+    return rows;
+  } catch {
+    return [];
+  }
+}
+
+function riskMultiplier(input: UserPersonaInput | undefined): number {
+  const budget = input?.riskBudget;
+  if (budget === "low") return 1.4;
+  if (budget === "high") return 0.6;
+  if (typeof budget === "number" && Number.isFinite(budget)) {
+    return Math.max(0.3, Math.min(2, budget));
+  }
+  return 1;
+}
+
+function normalizeSet(input: string[] | undefined): Set<string> {
+  return new Set(
+    (input ?? []).map((item) => item.trim()).filter((item) => item.length > 0),
+  );
+}
+
+function recommendationKey(userId: string, wallet: string): string {
+  return `loopC:${LOOP_C_SCHEMA_VERSION}:recs:latest:user:${userId}:wallet:${wallet}`;
+}
+
+function sanitizeToken(raw: string): string {
+  return raw.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+function recommendationR2Key(input: {
+  minute: string;
+  generatedAt: string;
+  userId: string;
+  wallet: string;
+}): string {
+  const date = new Date(input.minute);
+  const yyyy = date.getUTCFullYear().toString().padStart(4, "0");
+  const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(date.getUTCDate()).padStart(2, "0");
+  const hh = String(date.getUTCHours()).padStart(2, "0");
+  const minute = String(date.getUTCMinutes()).padStart(2, "0");
+  const at = input.generatedAt.replaceAll(":", "-");
+  return `loopC/${LOOP_C_SCHEMA_VERSION}/recommendations/date=${yyyy}-${mm}-${dd}/hour=${hh}/minute=${yyyy}-${mm}-${dd}T${hh}:${minute}:00Z/user=${sanitizeToken(input.userId)}/wallet=${sanitizeToken(input.wallet)}/at=${at}.json`;
+}
+
+function buildRecommendations(input: {
+  rows: LoopBScoreRow[];
+  userId: string;
+  wallet: string;
+  limit: number;
+  minute: string;
+  generatedAt: string;
+  persona?: UserPersonaInput;
+}): RecommendationView {
+  const preferred = normalizeSet(input.persona?.sectorPreferences);
+  const excluded = normalizeSet(input.persona?.excludedAssets);
+  const risk = riskMultiplier(input.persona);
+
+  const recommendations: RecommendationRow[] = [];
+  for (const row of input.rows) {
+    if (excluded.has(row.baseMint) || excluded.has(row.quoteMint)) continue;
+
+    const personaBoost =
+      preferred.has(row.baseMint) || preferred.has(row.quoteMint) ? 2.5 : 0;
+    const riskPenalty = row.contributions.stabilityPenalty * risk;
+    const finalScore = row.finalScore + personaBoost - riskPenalty;
+
+    recommendations.push({
+      recommendationId: `${input.minute}:${row.pairId}`,
+      pairId: row.pairId,
+      baseMint: row.baseMint,
+      quoteMint: row.quoteMint,
+      finalScore: Math.round(finalScore * 1e8) / 1e8,
+      baseSignal: row.finalScore,
+      riskPenalty: Math.round(riskPenalty * 1e8) / 1e8,
+      personaBoost,
+      modelVersion: LOOP_C_SCHEMA_VERSION,
+      explain: [
+        `base_signal=${row.finalScore.toFixed(4)}`,
+        `persona_boost=${personaBoost.toFixed(4)}`,
+        `risk_penalty=${riskPenalty.toFixed(4)}`,
+      ],
+    });
+  }
+
+  recommendations.sort((a, b) => {
+    if (a.finalScore !== b.finalScore) return b.finalScore - a.finalScore;
+    if (a.pairId < b.pairId) return -1;
+    if (a.pairId > b.pairId) return 1;
+    return 0;
+  });
+
+  return {
+    schemaVersion: LOOP_C_SCHEMA_VERSION,
+    generatedAt: input.generatedAt,
+    minute: input.minute,
+    userId: input.userId,
+    wallet: input.wallet,
+    freshnessMs: Math.max(
+      0,
+      Date.parse(input.generatedAt) - Date.parse(input.minute),
+    ),
+    recommendations: recommendations.slice(0, input.limit),
+  };
+}
+
+function parseState(input: unknown): RecommenderState {
+  const record = asRecord(input);
+  if (!record || record.schemaVersion !== LOOP_C_SCHEMA_VERSION) {
+    return {
+      schemaVersion: LOOP_C_SCHEMA_VERSION,
+      updatedAt: new Date().toISOString(),
+      lastMinute: null,
+      cachedView: null,
+    };
+  }
+
+  const cachedViewRecord = asRecord(record.cachedView);
+  let cachedView: RecommendationView | null = null;
+  if (cachedViewRecord) {
+    const recommendationsRaw = Array.isArray(cachedViewRecord.recommendations)
+      ? cachedViewRecord.recommendations
+      : [];
+    const recommendations: RecommendationRow[] = [];
+    for (const item of recommendationsRaw) {
+      const row = asRecord(item);
+      if (!row) continue;
+      if (
+        typeof row.recommendationId !== "string" ||
+        typeof row.pairId !== "string" ||
+        typeof row.baseMint !== "string" ||
+        typeof row.quoteMint !== "string" ||
+        typeof row.finalScore !== "number" ||
+        typeof row.baseSignal !== "number" ||
+        typeof row.riskPenalty !== "number" ||
+        typeof row.personaBoost !== "number"
+      ) {
+        continue;
+      }
+      recommendations.push({
+        recommendationId: row.recommendationId,
+        pairId: row.pairId,
+        baseMint: row.baseMint,
+        quoteMint: row.quoteMint,
+        finalScore: row.finalScore,
+        baseSignal: row.baseSignal,
+        riskPenalty: row.riskPenalty,
+        personaBoost: row.personaBoost,
+        modelVersion:
+          row.modelVersion === LOOP_C_SCHEMA_VERSION
+            ? LOOP_C_SCHEMA_VERSION
+            : "v1",
+        explain: Array.isArray(row.explain)
+          ? row.explain.filter(
+              (entry): entry is string => typeof entry === "string",
+            )
+          : [],
+      });
+    }
+
+    if (
+      typeof cachedViewRecord.generatedAt === "string" &&
+      typeof cachedViewRecord.minute === "string" &&
+      typeof cachedViewRecord.userId === "string" &&
+      typeof cachedViewRecord.wallet === "string" &&
+      typeof cachedViewRecord.freshnessMs === "number"
+    ) {
+      cachedView = {
+        schemaVersion: LOOP_C_SCHEMA_VERSION,
+        generatedAt: cachedViewRecord.generatedAt,
+        minute: cachedViewRecord.minute,
+        userId: cachedViewRecord.userId,
+        wallet: cachedViewRecord.wallet,
+        freshnessMs: cachedViewRecord.freshnessMs,
+        recommendations,
+      };
+    }
+  }
+
+  return {
+    schemaVersion: LOOP_C_SCHEMA_VERSION,
+    updatedAt:
+      typeof record.updatedAt === "string"
+        ? record.updatedAt
+        : new Date().toISOString(),
+    lastMinute:
+      typeof record.lastMinute === "string" ? record.lastMinute : null,
+    cachedView,
+  };
+}
+
+type RecommenderDeps = {
+  now?: () => string;
+};
+
+export class Recommender {
+  private readonly now: () => string;
+
+  constructor(
+    private readonly state: DurableObjectState,
+    private readonly env: Env,
+    deps: RecommenderDeps = {},
+  ) {
+    this.now = deps.now ?? (() => new Date().toISOString());
+  }
+
+  private async readState(): Promise<RecommenderState> {
+    const raw = await this.state.storage.get(STATE_KEY);
+    return parseState(raw);
+  }
+
+  private async writeState(next: RecommenderState): Promise<void> {
+    await this.state.storage.put(STATE_KEY, next);
+  }
+
+  private async handleRecommend(request: Request): Promise<Response> {
+    const payload = (await request.json()) as RecommendationRequest;
+    const userId = String(payload.userId ?? "").trim();
+    const wallet = String(payload.wallet ?? "").trim();
+    if (!userId || !wallet) {
+      return new Response(
+        JSON.stringify({ ok: false, error: "missing-user-or-wallet" }),
+        {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+
+    const observedAt = payload.observedAt ?? this.now();
+    const minute = toMinuteId(observedAt);
+    if (!minute) {
+      return new Response(
+        JSON.stringify({ ok: false, error: "invalid-observedAt" }),
+        {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+
+    const limit = Number.isFinite(payload.limit)
+      ? Math.max(1, Math.min(50, Math.floor(payload.limit ?? DEFAULT_LIMIT)))
+      : parseDefaultLimit(this.env.LOOP_C_RECOMMENDER_DEFAULT_LIMIT);
+
+    const state = await this.readState();
+    if (
+      state.lastMinute === minute &&
+      state.cachedView &&
+      state.cachedView.userId === userId &&
+      state.cachedView.wallet === wallet
+    ) {
+      return new Response(
+        JSON.stringify({ ok: true, cacheHit: true, view: state.cachedView }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+
+    const scoreRows = parseScoreRows(
+      this.env.CONFIG_KV
+        ? await this.env.CONFIG_KV.get(LOOP_B_SCORES_LATEST_KEY)
+        : null,
+    );
+    const view = buildRecommendations({
+      rows: scoreRows,
+      userId,
+      wallet,
+      limit,
+      minute,
+      generatedAt: observedAt,
+      persona: payload.persona,
+    });
+
+    const nextState: RecommenderState = {
+      schemaVersion: LOOP_C_SCHEMA_VERSION,
+      updatedAt: observedAt,
+      lastMinute: minute,
+      cachedView: view,
+    };
+    await this.writeState(nextState);
+
+    if (this.env.CONFIG_KV) {
+      await this.env.CONFIG_KV.put(
+        recommendationKey(userId, wallet),
+        JSON.stringify(view),
+      );
+    }
+    if (this.env.LOGS_BUCKET) {
+      await this.env.LOGS_BUCKET.put(
+        recommendationR2Key({
+          minute,
+          generatedAt: observedAt,
+          userId,
+          wallet,
+        }),
+        JSON.stringify(view),
+      );
+    }
+
+    return new Response(JSON.stringify({ ok: true, cacheHit: false, view }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (
+      request.method === "POST" &&
+      (url.pathname === "/loop-c/recommend" ||
+        url.pathname === "/internal/loop-c/recommend")
+    ) {
+      return await this.handleRecommend(request);
+    }
+
+    if (
+      request.method === "GET" &&
+      (url.pathname === "/loop-c/state" ||
+        url.pathname === "/internal/loop-c/state")
+    ) {
+      const state = await this.readState();
+      return new Response(JSON.stringify({ ok: true, state }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify({ ok: false, error: "not-found" }), {
+      status: 404,
+      headers: { "content-type": "application/json" },
+    });
+  }
+}
+
+export async function requestLoopCRecommendations(
+  env: Env,
+  input: {
+    userId: string;
+    wallet: string;
+    limit?: number;
+    observedAt?: string;
+    persona?: UserPersonaInput;
+  },
+): Promise<RecommendationView | null> {
+  if (!env.LOOP_C_RECOMMENDER_DO) return null;
+  const enabled = String(env.LOOP_C_RECOMMENDER_ENABLED ?? "0").trim() === "1";
+  if (!enabled) return null;
+
+  const id = env.LOOP_C_RECOMMENDER_DO.idFromName(
+    `${input.userId.trim()}:${input.wallet.trim()}`,
+  );
+  const stub = env.LOOP_C_RECOMMENDER_DO.get(id);
+  const response = await stub.fetch("https://internal/loop-c/recommend", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(input),
+  });
+  if (!response.ok) {
+    throw new Error(`loop-c-recommendation-request-failed:${response.status}`);
+  }
+  const payload = (await response.json()) as {
+    ok: boolean;
+    view?: RecommendationView;
+  };
+  return payload.ok && payload.view ? payload.view : null;
+}

--- a/apps/worker/src/types.ts
+++ b/apps/worker/src/types.ts
@@ -51,6 +51,7 @@ export type Env = {
   LOGS_BUCKET?: R2Bucket;
   LOOP_A_COORDINATOR_DO?: DurableObjectNamespace;
   LOOP_B_MINUTE_ACCUMULATOR_DO?: DurableObjectNamespace;
+  LOOP_C_RECOMMENDER_DO?: DurableObjectNamespace;
   ALLOWED_ORIGINS?: string;
   ADMIN_TOKEN?: string;
   PRIVY_APP_ID?: string;
@@ -108,4 +109,6 @@ export type Env = {
   LOOP_A_COORDINATOR_ENABLED?: string;
   LOOP_B_MINUTE_ACCUMULATOR_ENABLED?: string;
   LOOP_B_TOP_MOVERS_LIMIT?: string;
+  LOOP_C_RECOMMENDER_ENABLED?: string;
+  LOOP_C_RECOMMENDER_DEFAULT_LIMIT?: string;
 };

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -46,6 +46,8 @@ LOOP_A_MARK_COMMITMENT = "confirmed"
 LOOP_A_COORDINATOR_ENABLED = "0"
 LOOP_B_MINUTE_ACCUMULATOR_ENABLED = "0"
 LOOP_B_TOP_MOVERS_LIMIT = "20"
+LOOP_C_RECOMMENDER_ENABLED = "0"
+LOOP_C_RECOMMENDER_DEFAULT_LIMIT = "10"
 
 [[durable_objects.bindings]]
 name = "LOOP_A_COORDINATOR_DO"
@@ -54,6 +56,10 @@ class_name = "LoopACoordinator"
 [[durable_objects.bindings]]
 name = "LOOP_B_MINUTE_ACCUMULATOR_DO"
 class_name = "MinuteAccumulator"
+
+[[durable_objects.bindings]]
+name = "LOOP_C_RECOMMENDER_DO"
+class_name = "Recommender"
 
 [[kv_namespaces]]
 binding = "CONFIG_KV"
@@ -119,6 +125,8 @@ LOOP_A_MARK_COMMITMENT = "confirmed"
 LOOP_A_COORDINATOR_ENABLED = "0"
 LOOP_B_MINUTE_ACCUMULATOR_ENABLED = "0"
 LOOP_B_TOP_MOVERS_LIMIT = "20"
+LOOP_C_RECOMMENDER_ENABLED = "0"
+LOOP_C_RECOMMENDER_DEFAULT_LIMIT = "10"
 
 [[env.staging.kv_namespaces]]
 binding = "CONFIG_KV"
@@ -184,6 +192,8 @@ LOOP_A_MARK_COMMITMENT = "confirmed"
 LOOP_A_COORDINATOR_ENABLED = "0"
 LOOP_B_MINUTE_ACCUMULATOR_ENABLED = "0"
 LOOP_B_TOP_MOVERS_LIMIT = "20"
+LOOP_C_RECOMMENDER_ENABLED = "0"
+LOOP_C_RECOMMENDER_DEFAULT_LIMIT = "10"
 
 [[migrations]]
 tag = "v2-loop-a-coordinator"
@@ -192,6 +202,10 @@ new_sqlite_classes = ["LoopACoordinator"]
 [[migrations]]
 tag = "v3-loop-b-minute-accumulator"
 new_sqlite_classes = ["MinuteAccumulator"]
+
+[[migrations]]
+tag = "v4-loop-c-recommender"
+new_sqlite_classes = ["Recommender"]
 
 [[env.production.kv_namespaces]]
 binding = "CONFIG_KV"

--- a/loop-a-loop-b-architecture.md
+++ b/loop-a-loop-b-architecture.md
@@ -40,6 +40,10 @@ It is intentionally written as something you can hand to an implementation agent
   - finalizes deterministic, explainable score rows (`loopB:v1:scores:latest` + per-pair score keys) using weighted contribution components,
   - finalizes minute snapshots to hot Cloudflare Key-Value store views (`top_movers`, `liquidity_stress`, `anomaly_feed`, per-pair latest scores, health) with freshness metadata,
   - re-finalizes corrected minutes when late/corrected marks arrive, and writes minute/features/scores/view bundles to Cloudflare R2 object storage.
+- Loop C Recommender (current):
+  - Durable Object provides request-time personalized ranking with per-minute cache hits for repeated requests,
+  - reads Loop B score candidates, applies deterministic persona/risk adjustments, and returns ranked recommendation views,
+  - persists per-user wallet-scoped latest recommendations to Cloudflare Key-Value store and Cloudflare R2 object storage.
 
 ### Execution routing already exists (v0)
 

--- a/tests/unit/worker_loop_c_recommender.test.ts
+++ b/tests/unit/worker_loop_c_recommender.test.ts
@@ -195,6 +195,9 @@ describe("worker loop C recommender durable object", () => {
           wallet: "wallet-1",
           observedAt: "2026-02-21T20:01:30.000Z",
           limit: 2,
+          persona: {
+            riskBudget: "low",
+          },
         }),
       }),
     );
@@ -218,8 +221,11 @@ describe("worker loop C recommender durable object", () => {
         body: JSON.stringify({
           userId: "user-1",
           wallet: "wallet-1",
-          observedAt: "2026-02-21T20:02:00.000Z",
+          observedAt: "2026-02-21T20:01:45.000Z",
           limit: 2,
+          persona: {
+            riskBudget: "high",
+          },
         }),
       }),
     );
@@ -232,7 +238,29 @@ describe("worker loop C recommender durable object", () => {
     };
     expect(thirdPayload.ok).toBe(true);
     expect(thirdPayload.cacheHit).toBe(false);
-    expect(thirdPayload.view.recommendations[0]?.finalScore).toBeGreaterThan(
+
+    const fourthResponse = await recommender.fetch(
+      new Request("https://internal/loop-c/recommend", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          userId: "user-1",
+          wallet: "wallet-1",
+          observedAt: "2026-02-21T20:02:00.000Z",
+          limit: 2,
+        }),
+      }),
+    );
+    const fourthPayload = (await fourthResponse.json()) as {
+      ok: boolean;
+      cacheHit: boolean;
+      view: {
+        recommendations: Array<{ finalScore: number }>;
+      };
+    };
+    expect(fourthPayload.ok).toBe(true);
+    expect(fourthPayload.cacheHit).toBe(false);
+    expect(fourthPayload.view.recommendations[0]?.finalScore).toBeGreaterThan(
       10,
     );
 

--- a/tests/unit/worker_loop_c_recommender.test.ts
+++ b/tests/unit/worker_loop_c_recommender.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, test } from "bun:test";
+import { LOOP_B_SCORES_LATEST_KEY } from "../../apps/worker/src/loop_b/minute_accumulator";
+import {
+  Recommender,
+  requestLoopCRecommendations,
+} from "../../apps/worker/src/loop_c/recommender";
+import type { Env } from "../../apps/worker/src/types";
+
+function createMockDb() {
+  return {
+    prepare(_sql: string) {
+      return {
+        bind(..._args: unknown[]) {
+          return {
+            run: async () => ({ meta: { changes: 1 } }),
+            all: async () => ({ results: [] }),
+            first: async () => null,
+          };
+        },
+      };
+    },
+  };
+}
+
+function createMockKv() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    kv: {
+      get: async (key: string) => store.get(key) ?? null,
+      put: async (key: string, value: string) => {
+        store.set(key, value);
+      },
+      delete: async (key: string) => {
+        store.delete(key);
+      },
+    },
+  };
+}
+
+function createMockR2() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    bucket: {
+      put: async (key: string, value: string) => {
+        store.set(key, value);
+      },
+      get: async (key: string) => {
+        const value = store.get(key);
+        if (!value) return null;
+        return {
+          text: async () => value,
+        };
+      },
+    },
+  };
+}
+
+function createMockDoState() {
+  const store = new Map<string, unknown>();
+  return {
+    state: {
+      storage: {
+        get: async (key: string) => store.get(key),
+        put: async (key: string, value: unknown) => {
+          store.set(key, value);
+        },
+      },
+      blockConcurrencyWhile: async <T>(fn: () => Promise<T>) => await fn(),
+    } as unknown as DurableObjectState,
+    store,
+  };
+}
+
+function createEnv(): {
+  env: Env;
+  kvStore: Map<string, string>;
+  r2Store: Map<string, string>;
+} {
+  const { kv, store: kvStore } = createMockKv();
+  const { bucket, store: r2Store } = createMockR2();
+  return {
+    env: {
+      WAITLIST_DB: createMockDb() as never,
+      CONFIG_KV: kv as never,
+      LOGS_BUCKET: bucket as never,
+      LOOP_C_RECOMMENDER_ENABLED: "1",
+      LOOP_C_RECOMMENDER_DEFAULT_LIMIT: "5",
+    } as Env,
+    kvStore,
+    r2Store,
+  };
+}
+
+function setScores(store: Map<string, string>, rowFinalScore: number): void {
+  store.set(
+    LOOP_B_SCORES_LATEST_KEY,
+    JSON.stringify({
+      schemaVersion: "v1",
+      generatedAt: "2026-02-21T20:00:00.000Z",
+      minute: "2026-02-21T20:00:00.000Z",
+      count: 2,
+      rows: [
+        {
+          schemaVersion: "v1",
+          generatedAt: "2026-02-21T20:00:00.000Z",
+          minute: "2026-02-21T20:00:00.000Z",
+          pairId:
+            "So11111111111111111111111111111111111111112:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          baseMint: "So11111111111111111111111111111111111111112",
+          quoteMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          finalScore: rowFinalScore,
+          contributions: {
+            momentum: 2.1,
+            confidence: 10.1,
+            stabilityPenalty: 1.3,
+            activity: 1.2,
+          },
+          featuresRef:
+            "loopB:v1:features:latest:pair:So11111111111111111111111111111111111111112:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          revision: 1,
+          explain: ["score=momentum+confidence+activity-stability"],
+        },
+        {
+          schemaVersion: "v1",
+          generatedAt: "2026-02-21T20:00:00.000Z",
+          minute: "2026-02-21T20:00:00.000Z",
+          pairId:
+            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v:So11111111111111111111111111111111111111112",
+          baseMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          quoteMint: "So11111111111111111111111111111111111111112",
+          finalScore: 4.5,
+          contributions: {
+            momentum: 1.1,
+            confidence: 5.5,
+            stabilityPenalty: 0.9,
+            activity: 0.6,
+          },
+          featuresRef:
+            "loopB:v1:features:latest:pair:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v:So11111111111111111111111111111111111111112",
+          revision: 1,
+          explain: ["score=momentum+confidence+activity-stability"],
+        },
+      ],
+    }),
+  );
+}
+
+describe("worker loop C recommender durable object", () => {
+  test("builds recommendations and caches per minute", async () => {
+    const { env, kvStore, r2Store } = createEnv();
+    setScores(kvStore, 8.2);
+
+    const mock = createMockDoState();
+    const recommender = new Recommender(mock.state, env, {
+      now: () => "2026-02-21T20:01:00.000Z",
+    });
+
+    const firstResponse = await recommender.fetch(
+      new Request("https://internal/loop-c/recommend", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          userId: "user-1",
+          wallet: "wallet-1",
+          observedAt: "2026-02-21T20:01:00.000Z",
+          limit: 2,
+          persona: {
+            riskBudget: "low",
+          },
+        }),
+      }),
+    );
+
+    expect(firstResponse.status).toBe(200);
+    const firstPayload = (await firstResponse.json()) as {
+      ok: boolean;
+      cacheHit: boolean;
+      view: {
+        recommendations: Array<{ pairId: string }>;
+      };
+    };
+    expect(firstPayload.ok).toBe(true);
+    expect(firstPayload.cacheHit).toBe(false);
+    expect(firstPayload.view.recommendations.length).toBe(2);
+
+    setScores(kvStore, 15.6);
+    const secondResponse = await recommender.fetch(
+      new Request("https://internal/loop-c/recommend", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          userId: "user-1",
+          wallet: "wallet-1",
+          observedAt: "2026-02-21T20:01:30.000Z",
+          limit: 2,
+        }),
+      }),
+    );
+    const secondPayload = (await secondResponse.json()) as {
+      ok: boolean;
+      cacheHit: boolean;
+      view: {
+        recommendations: Array<{ pairId: string; finalScore: number }>;
+      };
+    };
+    expect(secondPayload.ok).toBe(true);
+    expect(secondPayload.cacheHit).toBe(true);
+    expect(secondPayload.view.recommendations[0]?.finalScore).toBeLessThan(
+      15.6,
+    );
+
+    const thirdResponse = await recommender.fetch(
+      new Request("https://internal/loop-c/recommend", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          userId: "user-1",
+          wallet: "wallet-1",
+          observedAt: "2026-02-21T20:02:00.000Z",
+          limit: 2,
+        }),
+      }),
+    );
+    const thirdPayload = (await thirdResponse.json()) as {
+      ok: boolean;
+      cacheHit: boolean;
+      view: {
+        recommendations: Array<{ finalScore: number }>;
+      };
+    };
+    expect(thirdPayload.ok).toBe(true);
+    expect(thirdPayload.cacheHit).toBe(false);
+    expect(thirdPayload.view.recommendations[0]?.finalScore).toBeGreaterThan(
+      10,
+    );
+
+    expect(
+      kvStore.has("loopC:v1:recs:latest:user:user-1:wallet:wallet-1"),
+    ).toBe(true);
+    expect(r2Store.size).toBeGreaterThan(0);
+  });
+
+  test("helper routes recommendation request via loop-c durable object namespace", async () => {
+    const { env } = createEnv();
+    let called = false;
+
+    env.LOOP_C_RECOMMENDER_DO = {
+      idFromName: (name: string) => {
+        expect(name).toBe("user-x:wallet-y");
+        return { toString: () => "loop-c-id" } as never;
+      },
+      get: (_id: DurableObjectId) =>
+        ({
+          fetch: async (url: string, init?: RequestInit) => {
+            called = true;
+            expect(url).toContain("/loop-c/recommend");
+            expect(init?.method).toBe("POST");
+            return new Response(
+              JSON.stringify({
+                ok: true,
+                cacheHit: false,
+                view: {
+                  schemaVersion: "v1",
+                  generatedAt: "2026-02-21T20:10:00.000Z",
+                  minute: "2026-02-21T20:10:00.000Z",
+                  userId: "user-x",
+                  wallet: "wallet-y",
+                  freshnessMs: 0,
+                  recommendations: [],
+                },
+              }),
+              {
+                status: 200,
+                headers: { "content-type": "application/json" },
+              },
+            );
+          },
+        }) as never,
+    } as DurableObjectNamespace;
+
+    const view = await requestLoopCRecommendations(env, {
+      userId: "user-x",
+      wallet: "wallet-y",
+      limit: 3,
+    });
+    expect(called).toBe(true);
+    expect(view?.schemaVersion).toBe("v1");
+    expect(view?.wallet).toBe("wallet-y");
+  });
+});


### PR DESCRIPTION
## What changed
- Added `apps/worker/src/loop_c/recommender.ts` with new `Recommender` Durable Object.
- Added recommendation request endpoint in DO:
  - `POST /internal/loop-c/recommend`
- Added DO state endpoint:
  - `GET /internal/loop-c/state`
- Implemented deterministic request-time ranking using Loop B score candidates (`loopB:v1:scores:latest`) plus persona/risk adjustments.
- Added per-minute caching inside the DO to avoid recomputing repeated requests in the same minute.
- Added persistence:
  - KV latest per-user-wallet recommendation view
  - R2 immutable recommendation snapshots
- Added helper `requestLoopCRecommendations(...)` for Worker-side invocation.
- Added env/binding wiring:
  - `LOOP_C_RECOMMENDER_DO`
  - `LOOP_C_RECOMMENDER_ENABLED`
  - `LOOP_C_RECOMMENDER_DEFAULT_LIMIT`
  - migration tag `v4-loop-c-recommender`
- Added unit tests for caching behavior and helper routing.
- Updated architecture status doc for LC-01.

## Why (LC-01 acceptance mapping)
- Loop C now supports on-demand ranking with deterministic logic.
- Per-minute cache is in place for repeated requests, reducing recompute cost.
- Outputs are user+wallet scoped and persisted to private storage surfaces.

## Test evidence
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit`
- `bun run test:integration` (skip-only in this env)

## Follow-ups
- LC-02 candidate pool producer can transition from Loop B scores snapshot to dedicated candidate key.
- LC-05 auth API endpoints can call `requestLoopCRecommendations(...)` directly.
