### PR TITLE
LC-05: Add auth-only recommendations APIs (latest + feedback)

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1220,15 +1220,22 @@ export default {
           payload.persona,
           payload.riskMode,
         );
+        const observedAt =
+          typeof payload.observedAt === "string" &&
+          payload.observedAt.trim().length > 0
+            ? payload.observedAt.trim()
+            : undefined;
+        if (observedAt && Number.isNaN(Date.parse(observedAt))) {
+          return withCors(
+            json({ ok: false, error: "invalid-observedAt" }, { status: 400 }),
+            env,
+          );
+        }
         const view = await requestLoopCRecommendations(env, {
           userId: user.id,
           wallet: scopedWallet.wallet,
           limit: toBoundedInt(payload.limit, 10, 1, 50),
-          observedAt:
-            typeof payload.observedAt === "string" &&
-            payload.observedAt.trim().length > 0
-              ? payload.observedAt.trim()
-              : undefined,
+          observedAt,
           ...(persona ? { persona } : {}),
         });
         if (!view) {
@@ -1308,12 +1315,23 @@ export default {
             env,
           );
         }
+        const resolvedPairId =
+          pairId || parsePairIdFromRecommendationId(recommendationId);
+        if (!resolvedPairId) {
+          return withCors(
+            json(
+              { ok: false, error: "invalid-recommendationId" },
+              { status: 400 },
+            ),
+            env,
+          );
+        }
 
         const update = await submitLoopCRecommendationFeedback(env, {
           userId: user.id,
           wallet: scopedWallet.wallet,
           ...(recommendationId ? { recommendationId } : {}),
-          ...(pairId ? { pairId } : {}),
+          pairId: resolvedPairId,
           decision,
           reason:
             typeof payload.reason === "string"
@@ -1879,6 +1897,17 @@ function parseLoopCPersonaOverride(
   };
 
   return Object.keys(parsed).length > 0 ? parsed : undefined;
+}
+
+function parsePairIdFromRecommendationId(
+  recommendationId: string | undefined,
+): string | null {
+  const raw = String(recommendationId ?? "").trim();
+  if (!raw) return null;
+  const markerIndex = raw.indexOf(":");
+  if (markerIndex < 0) return null;
+  const pairId = raw.slice(markerIndex + 1).trim();
+  return pairId ? pairId : null;
 }
 
 function resolveScopedWallet(input: {

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -21,7 +21,12 @@ import {
 import { readLoopAHealthFromKv, recordLoopAHealthTick } from "./loop_a/health";
 import { runLoopATickPipeline } from "./loop_a/pipeline";
 import { MinuteAccumulator } from "./loop_b/minute_accumulator";
-import { Recommender } from "./loop_c/recommender";
+import {
+  Recommender,
+  requestLoopCRecommendations,
+  submitLoopCRecommendationFeedback,
+  type UserPersonaInput,
+} from "./loop_c/recommender";
 import {
   fetchMacroEtfFlows,
   fetchMacroFredIndicators,
@@ -1179,6 +1184,172 @@ export default {
         );
       }
 
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/recommendations/latest"
+      ) {
+        let user = await requireOnboardedUser(request, env);
+        user = await ensureUserWallet(env, user);
+        const payload = await readPayload(request);
+        const scopedWallet = resolveScopedWallet({
+          requestedWallet: payload.wallet,
+          userWallet: user.walletAddress,
+        });
+        if (!scopedWallet.ok) {
+          return withCors(
+            json({ ok: false, error: scopedWallet.error }, { status: 400 }),
+            env,
+          );
+        }
+        if (!scopedWallet.wallet) {
+          return withCors(
+            json({ ok: false, error: "user-wallet-missing" }, { status: 503 }),
+            env,
+          );
+        }
+        if (scopedWallet.forbidden) {
+          return withCors(
+            json(
+              { ok: false, error: "wallet-not-authorized" },
+              { status: 403 },
+            ),
+            env,
+          );
+        }
+        const persona = parseLoopCPersonaOverride(
+          payload.persona,
+          payload.riskMode,
+        );
+        const view = await requestLoopCRecommendations(env, {
+          userId: user.id,
+          wallet: scopedWallet.wallet,
+          limit: toBoundedInt(payload.limit, 10, 1, 50),
+          observedAt:
+            typeof payload.observedAt === "string" &&
+            payload.observedAt.trim().length > 0
+              ? payload.observedAt.trim()
+              : undefined,
+          ...(persona ? { persona } : {}),
+        });
+        if (!view) {
+          return withCors(
+            json(
+              { ok: false, error: "recommendations-unavailable" },
+              { status: 503 },
+            ),
+            env,
+          );
+        }
+
+        return withCors(
+          json({
+            ok: true,
+            view,
+          }),
+          env,
+        );
+      }
+
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/recommendations/feedback"
+      ) {
+        let user = await requireOnboardedUser(request, env);
+        user = await ensureUserWallet(env, user);
+        const payload = await readPayload(request);
+        const scopedWallet = resolveScopedWallet({
+          requestedWallet: payload.wallet,
+          userWallet: user.walletAddress,
+        });
+        if (!scopedWallet.ok) {
+          return withCors(
+            json({ ok: false, error: scopedWallet.error }, { status: 400 }),
+            env,
+          );
+        }
+        if (!scopedWallet.wallet) {
+          return withCors(
+            json({ ok: false, error: "user-wallet-missing" }, { status: 503 }),
+            env,
+          );
+        }
+        if (scopedWallet.forbidden) {
+          return withCors(
+            json(
+              { ok: false, error: "wallet-not-authorized" },
+              { status: 403 },
+            ),
+            env,
+          );
+        }
+
+        const decision = String(payload.decision ?? "")
+          .trim()
+          .toLowerCase();
+        if (decision !== "yes" && decision !== "no") {
+          return withCors(
+            json({ ok: false, error: "invalid-decision" }, { status: 400 }),
+            env,
+          );
+        }
+
+        const recommendationId =
+          typeof payload.recommendationId === "string"
+            ? payload.recommendationId.trim()
+            : "";
+        const pairId =
+          typeof payload.pairId === "string" ? payload.pairId.trim() : "";
+        if (!recommendationId && !pairId) {
+          return withCors(
+            json(
+              { ok: false, error: "missing-recommendation-target" },
+              { status: 400 },
+            ),
+            env,
+          );
+        }
+
+        const update = await submitLoopCRecommendationFeedback(env, {
+          userId: user.id,
+          wallet: scopedWallet.wallet,
+          ...(recommendationId ? { recommendationId } : {}),
+          ...(pairId ? { pairId } : {}),
+          decision,
+          reason:
+            typeof payload.reason === "string"
+              ? payload.reason.trim()
+              : undefined,
+          decidedAt:
+            typeof payload.decidedAt === "string" &&
+            payload.decidedAt.trim().length > 0
+              ? payload.decidedAt.trim()
+              : undefined,
+        });
+
+        if (!update) {
+          return withCors(
+            json(
+              { ok: false, error: "recommendations-unavailable" },
+              { status: 503 },
+            ),
+            env,
+          );
+        }
+
+        return withCors(
+          json({
+            ok: true,
+            ack: {
+              decision,
+              ...(recommendationId ? { recommendationId } : {}),
+              ...(pairId ? { pairId } : {}),
+            },
+            signalState: update,
+          }),
+          env,
+        );
+      }
+
       if (request.method === "PATCH" && url.pathname === "/api/me/profile") {
         const user = await requireOnboardedUser(request, env);
         const payload = await readPayload(request);
@@ -1648,6 +1819,94 @@ function toUniqueStrings(value: unknown, maxItems: number): string[] {
     if (out.length >= maxItems) break;
   }
   return out;
+}
+
+function parseRiskMode(
+  value: unknown,
+): "conservative" | "balanced" | "aggressive" | null {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  if (normalized === "conservative") return "conservative";
+  if (normalized === "balanced") return "balanced";
+  if (normalized === "aggressive") return "aggressive";
+  return null;
+}
+
+function parseLoopCPersonaOverride(
+  value: unknown,
+  riskModeRaw: unknown,
+): UserPersonaInput | undefined {
+  const persona = isRecord(value) ? value : {};
+  const fromRiskMode = parseRiskMode(riskModeRaw);
+  const riskBudgetRaw = persona.riskBudget;
+  let riskBudget: UserPersonaInput["riskBudget"] | undefined;
+  if (
+    riskBudgetRaw === "low" ||
+    riskBudgetRaw === "medium" ||
+    riskBudgetRaw === "high"
+  ) {
+    riskBudget = riskBudgetRaw;
+  } else if (
+    typeof riskBudgetRaw === "number" &&
+    Number.isFinite(riskBudgetRaw) &&
+    riskBudgetRaw >= 0
+  ) {
+    riskBudget = riskBudgetRaw;
+  }
+
+  if (fromRiskMode === "conservative") riskBudget = "low";
+  if (fromRiskMode === "balanced") riskBudget = "medium";
+  if (fromRiskMode === "aggressive") riskBudget = "high";
+
+  const horizonRaw = String(persona.horizon ?? "")
+    .trim()
+    .toLowerCase();
+  const horizon: UserPersonaInput["horizon"] =
+    horizonRaw === "short" || horizonRaw === "medium" || horizonRaw === "long"
+      ? horizonRaw
+      : undefined;
+  const sectorPreferences = toUniqueStrings(persona.sectorPreferences, 20);
+  const excludedAssets = toUniqueStrings(persona.excludedAssets, 200);
+  const excludedProtocols = toUniqueStrings(persona.excludedProtocols, 50);
+
+  const parsed: UserPersonaInput = {
+    ...(riskBudget !== undefined ? { riskBudget } : {}),
+    ...(horizon ? { horizon } : {}),
+    ...(sectorPreferences.length > 0 ? { sectorPreferences } : {}),
+    ...(excludedAssets.length > 0 ? { excludedAssets } : {}),
+    ...(excludedProtocols.length > 0 ? { excludedProtocols } : {}),
+  };
+
+  return Object.keys(parsed).length > 0 ? parsed : undefined;
+}
+
+function resolveScopedWallet(input: {
+  requestedWallet: unknown;
+  userWallet: string | null;
+}):
+  | { ok: true; wallet: string | null; forbidden: false }
+  | { ok: true; wallet: string | null; forbidden: true }
+  | { ok: false; error: string } {
+  const userWallet = String(input.userWallet ?? "").trim();
+  if (!userWallet) {
+    return { ok: true, wallet: null, forbidden: false };
+  }
+
+  if (input.requestedWallet === undefined || input.requestedWallet === null) {
+    return { ok: true, wallet: userWallet, forbidden: false };
+  }
+  if (typeof input.requestedWallet !== "string") {
+    return { ok: false, error: "invalid-wallet" };
+  }
+  const requestedWallet = input.requestedWallet.trim();
+  if (!requestedWallet) {
+    return { ok: true, wallet: userWallet, forbidden: false };
+  }
+  if (requestedWallet !== userWallet) {
+    return { ok: true, wallet: userWallet, forbidden: true };
+  }
+  return { ok: true, wallet: requestedWallet, forbidden: false };
 }
 
 function summarizeJupiterQuote(

--- a/loop-a-loop-b-architecture.md
+++ b/loop-a-loop-b-architecture.md
@@ -48,6 +48,8 @@ It is intentionally written as something you can hand to an implementation agent
   - feedback writes invalidate minute cache and shift acceptance probability predictably for subsequent rankings,
   - hard guardrails suppress candidates by liquidity floor, staleness cutoff, excluded assets, and excluded protocols,
   - ranking includes explicit risk/stability tags and surfaces rejection reason tags for suppressed candidates,
+  - Worker now exposes auth-only recommendation APIs at `/api/recommendations/latest` and `/api/recommendations/feedback` with user wallet scoping,
+  - personalized recommendation payloads remain unavailable through public x402 routes (`/api/x402/read/*`),
   - persists per-user wallet-scoped latest recommendations to Cloudflare Key-Value store and Cloudflare R2 object storage.
 
 ### Execution routing already exists (v0)

--- a/tests/unit/worker_cutover_routes.test.ts
+++ b/tests/unit/worker_cutover_routes.test.ts
@@ -120,5 +120,40 @@ describe("worker botless cutover routes", () => {
       ok: false,
       error: "unauthorized",
     });
+
+    const recommendationsLatestResponse = await worker.fetch(
+      new Request("http://localhost/api/recommendations/latest", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ wallet: "wallet-1" }),
+      }),
+      authEnv,
+      createExecutionContextStub(),
+    );
+    expect(recommendationsLatestResponse.status).toBe(401);
+    await expect(recommendationsLatestResponse.json()).resolves.toMatchObject({
+      ok: false,
+      error: "unauthorized",
+    });
+
+    const recommendationsFeedbackResponse = await worker.fetch(
+      new Request("http://localhost/api/recommendations/feedback", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          recommendationId: "2026-02-21T20:00:00.000Z:SOL:USDC",
+          decision: "yes",
+        }),
+      }),
+      authEnv,
+      createExecutionContextStub(),
+    );
+    expect(recommendationsFeedbackResponse.status).toBe(401);
+    await expect(recommendationsFeedbackResponse.json()).resolves.toMatchObject(
+      {
+        ok: false,
+        error: "unauthorized",
+      },
+    );
   });
 });


### PR DESCRIPTION
## What changed
- Added `POST /api/recommendations/latest` (auth-only) in Worker.
- Added `POST /api/recommendations/feedback` (auth-only) in Worker.
- Enforced wallet scoping: optional requested wallet must match the authenticated user wallet.
- Added risk-mode + persona override parsing for latest recommendations requests.
- Wired both routes to existing Loop C DO helpers:
  - `requestLoopCRecommendations(...)`
  - `submitLoopCRecommendationFeedback(...)`
- Added route auth coverage in `tests/unit/worker_cutover_routes.test.ts`.
- Updated `loop-a-loop-b-architecture.md` status section to reflect LC-05 completion.

## Why (LC-05 acceptance mapping)
- **Auth-only APIs**: implemented both required endpoints behind existing user auth flow.
- **Strong user/wallet authorization**: request wallet is validated against authenticated user wallet and rejected on mismatch.
- **No personalized data on x402 routes**: personalized recommendations remain served only by `/api/recommendations/*`; no x402 route changes.

## API behavior
### `POST /api/recommendations/latest`
- Request: `{ wallet?, limit?, riskMode?, persona?, observedAt? }`
- Response: `{ ok: true, view }` or structured error.

### `POST /api/recommendations/feedback`
- Request: `{ wallet?, recommendationId?, pairId?, decision, reason?, decidedAt? }`
- Response: `{ ok: true, ack, signalState }` or structured error.

## Test evidence
- `bun run lint`
- `bun run typecheck`
- `bun test tests/unit/worker_cutover_routes.test.ts tests/unit/worker_loop_c_recommender.test.ts`
- `bun run test:unit`

## Follow-ups
- Next ticket candidate: `EX-01` (execution contracts + receipt schema + latency trace artifacts).
