### PR TITLE
EX-01: Add execution contracts and content-addressed receipts

### DIFF
--- a/apps/worker/src/execution/contracts.ts
+++ b/apps/worker/src/execution/contracts.ts
@@ -1,0 +1,344 @@
+import type { JupiterQuoteResponse } from "../jupiter";
+import type { Env, ExecutionConfig } from "../types";
+import type { ExecuteSwapResult } from "./types";
+
+export const EXECUTION_SCHEMA_VERSION = "v1" as const;
+
+export type ExecutionIntent = {
+  schemaVersion: typeof EXECUTION_SCHEMA_VERSION;
+  intentId: string;
+  receivedAt: string;
+  userId: string;
+  wallet: string;
+  inputMint: string;
+  outputMint: string;
+  amountAtomic: string;
+  slippageBps: number;
+  source: string;
+  reason: string | null;
+  execution: {
+    adapter: string;
+    params: Record<string, unknown> | null;
+  };
+};
+
+export type ExecutionDecision = {
+  schemaVersion: typeof EXECUTION_SCHEMA_VERSION;
+  decisionId: string;
+  intentId: string;
+  decidedAt: string;
+  route: string;
+  simulateOnly: boolean;
+  dryRun: boolean;
+  commitment: "processed" | "confirmed" | "finalized";
+};
+
+export type ExecutionLatencyTrace = {
+  schemaVersion: typeof EXECUTION_SCHEMA_VERSION;
+  receivedAt: string;
+  validatedAt: string | null;
+  decisionAt: string | null;
+  txBuiltAt: string | null;
+  simulatedAt: string | null;
+  sentAt: string | null;
+  landedAt: string | null;
+  confirmedAt: string | null;
+  finalizedAt: string | null;
+  failedAt: string | null;
+};
+
+export type ExecutionOutcome = {
+  status: ExecuteSwapResult["status"] | "error" | "rejected" | "not_executed";
+  signature: string | null;
+  refreshed: boolean;
+  lastValidBlockHeight: number | null;
+  error: string | null;
+};
+
+export type ExecutionReceipt = {
+  schemaVersion: typeof EXECUTION_SCHEMA_VERSION;
+  generatedAt: string;
+  receiptId: string;
+  intent: ExecutionIntent;
+  decision: ExecutionDecision;
+  trace: ExecutionLatencyTrace;
+  outcome: ExecutionOutcome;
+  quote: {
+    inputMint: string;
+    outputMint: string;
+    inAmount: string;
+    outAmount: string;
+    priceImpactPct: number;
+    routeHopCount: number;
+  };
+  storage: {
+    contentSha256: string;
+    key: string;
+  };
+};
+
+function toIsoOrFallback(value: string, fallback: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return fallback;
+  return parsed.toISOString();
+}
+
+function summarizeQuote(
+  input: JupiterQuoteResponse,
+): ExecutionReceipt["quote"] {
+  const hopCount = Array.isArray(input.routePlan) ? input.routePlan.length : 0;
+  return {
+    inputMint: String(input.inputMint ?? ""),
+    outputMint: String(input.outputMint ?? ""),
+    inAmount: String(input.inAmount ?? ""),
+    outAmount: String(input.outAmount ?? ""),
+    priceImpactPct:
+      typeof input.priceImpactPct === "number" &&
+      Number.isFinite(input.priceImpactPct)
+        ? input.priceImpactPct
+        : Number(input.priceImpactPct ?? 0) || 0,
+    routeHopCount: hopCount,
+  };
+}
+
+function stableOrder(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => stableOrder(item));
+  }
+  if (!value || typeof value !== "object") return value;
+  const record = value as Record<string, unknown>;
+  const ordered: Record<string, unknown> = {};
+  for (const key of Object.keys(record).sort()) {
+    ordered[key] = stableOrder(record[key]);
+  }
+  return ordered;
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(stableOrder(value));
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const bytes = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  const view = new Uint8Array(digest);
+  return Array.from(view, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  );
+}
+
+function normalizeError(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Error) {
+    return value.message.slice(0, 2_000);
+  }
+  if (typeof value === "string") {
+    return value.slice(0, 2_000);
+  }
+  try {
+    return JSON.stringify(value).slice(0, 2_000);
+  } catch {
+    return String(value).slice(0, 2_000);
+  }
+}
+
+function receiptStorageKey(hash: string): string {
+  return `exec/${EXECUTION_SCHEMA_VERSION}/receipts/sha256=${hash}.json`;
+}
+
+export function createExecutionIntent(input: {
+  receivedAt: string;
+  userId: string;
+  wallet: string;
+  inputMint: string;
+  outputMint: string;
+  amountAtomic: string;
+  slippageBps: number;
+  source: string;
+  reason?: string;
+  execution?: ExecutionConfig;
+}): ExecutionIntent {
+  return {
+    schemaVersion: EXECUTION_SCHEMA_VERSION,
+    intentId: crypto.randomUUID(),
+    receivedAt: toIsoOrFallback(input.receivedAt, new Date().toISOString()),
+    userId: input.userId,
+    wallet: input.wallet,
+    inputMint: input.inputMint,
+    outputMint: input.outputMint,
+    amountAtomic: input.amountAtomic,
+    slippageBps: input.slippageBps,
+    source: input.source.trim() || "TERMINAL",
+    reason:
+      typeof input.reason === "string" && input.reason.trim().length > 0
+        ? input.reason.trim()
+        : null,
+    execution: {
+      adapter:
+        String(input.execution?.adapter ?? "jupiter").trim() || "jupiter",
+      params:
+        input.execution?.params &&
+        typeof input.execution.params === "object" &&
+        !Array.isArray(input.execution.params)
+          ? { ...input.execution.params }
+          : null,
+    },
+  };
+}
+
+export function createExecutionDecision(input: {
+  intentId: string;
+  decidedAt: string;
+  route: string;
+  simulateOnly: boolean;
+  dryRun: boolean;
+  commitment: "processed" | "confirmed" | "finalized";
+}): ExecutionDecision {
+  return {
+    schemaVersion: EXECUTION_SCHEMA_VERSION,
+    decisionId: crypto.randomUUID(),
+    intentId: input.intentId,
+    decidedAt: toIsoOrFallback(input.decidedAt, new Date().toISOString()),
+    route: input.route.trim() || "jupiter",
+    simulateOnly: input.simulateOnly,
+    dryRun: input.dryRun,
+    commitment: input.commitment,
+  };
+}
+
+export function newExecutionLatencyTrace(
+  receivedAt: string,
+): ExecutionLatencyTrace {
+  return {
+    schemaVersion: EXECUTION_SCHEMA_VERSION,
+    receivedAt: toIsoOrFallback(receivedAt, new Date().toISOString()),
+    validatedAt: null,
+    decisionAt: null,
+    txBuiltAt: null,
+    simulatedAt: null,
+    sentAt: null,
+    landedAt: null,
+    confirmedAt: null,
+    finalizedAt: null,
+    failedAt: null,
+  };
+}
+
+export function buildExecutionOutcomeFromResult(
+  result: ExecuteSwapResult,
+): ExecutionOutcome {
+  return {
+    status: result.status,
+    signature: result.signature ?? null,
+    refreshed: Boolean(result.refreshed),
+    lastValidBlockHeight:
+      typeof result.lastValidBlockHeight === "number"
+        ? result.lastValidBlockHeight
+        : null,
+    error: normalizeError(result.err),
+  };
+}
+
+export function buildExecutionOutcomeFromError(
+  error: unknown,
+): ExecutionOutcome {
+  return {
+    status: "error",
+    signature: null,
+    refreshed: false,
+    lastValidBlockHeight: null,
+    error: normalizeError(error) ?? "unknown-error",
+  };
+}
+
+export function applyExecutionResultToTrace(input: {
+  trace: ExecutionLatencyTrace;
+  result: ExecuteSwapResult;
+  settledAt: string;
+}): ExecutionLatencyTrace {
+  const settledAt = toIsoOrFallback(input.settledAt, new Date().toISOString());
+  const next: ExecutionLatencyTrace = {
+    ...input.trace,
+    ...(input.result.signature
+      ? { sentAt: input.trace.sentAt ?? settledAt }
+      : {}),
+  };
+
+  if (
+    input.result.status === "simulated" ||
+    input.result.status === "simulate_error"
+  ) {
+    next.simulatedAt = settledAt;
+  }
+  if (input.result.status === "processed") {
+    next.landedAt = next.landedAt ?? settledAt;
+  }
+  if (input.result.status === "confirmed") {
+    next.landedAt = next.landedAt ?? settledAt;
+    next.confirmedAt = settledAt;
+  }
+  if (input.result.status === "finalized") {
+    next.landedAt = next.landedAt ?? settledAt;
+    next.confirmedAt = next.confirmedAt ?? settledAt;
+    next.finalizedAt = settledAt;
+  }
+  if (
+    input.result.status === "simulate_error" ||
+    input.result.status === "error"
+  ) {
+    next.failedAt = settledAt;
+  }
+
+  return next;
+}
+
+export async function buildExecutionReceipt(input: {
+  generatedAt?: string;
+  intent: ExecutionIntent;
+  decision: ExecutionDecision;
+  trace: ExecutionLatencyTrace;
+  outcome: ExecutionOutcome;
+  quote: JupiterQuoteResponse;
+}): Promise<ExecutionReceipt> {
+  const generatedAt = toIsoOrFallback(
+    input.generatedAt ?? new Date().toISOString(),
+    new Date().toISOString(),
+  );
+  const base = {
+    schemaVersion: EXECUTION_SCHEMA_VERSION,
+    generatedAt,
+    intent: input.intent,
+    decision: input.decision,
+    trace: input.trace,
+    outcome: input.outcome,
+    quote: summarizeQuote(input.quote),
+  } as const;
+  const contentSha256 = await sha256Hex(stableStringify(base));
+
+  return {
+    ...base,
+    receiptId: `exec_${contentSha256.slice(0, 16)}`,
+    storage: {
+      contentSha256,
+      key: receiptStorageKey(contentSha256),
+    },
+  };
+}
+
+export async function recordExecutionReceipt(
+  env: Env,
+  input: {
+    generatedAt?: string;
+    intent: ExecutionIntent;
+    decision: ExecutionDecision;
+    trace: ExecutionLatencyTrace;
+    outcome: ExecutionOutcome;
+    quote: JupiterQuoteResponse;
+  },
+): Promise<ExecutionReceipt> {
+  const receipt = await buildExecutionReceipt(input);
+  if (env.LOGS_BUCKET) {
+    await env.LOGS_BUCKET.put(receipt.storage.key, JSON.stringify(receipt));
+  }
+  return receipt;
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -2,6 +2,15 @@ import { requireUser } from "./auth";
 
 import { getUserSubscription, toSubscriptionView } from "./billing";
 import { USDC_MINT } from "./defaults";
+import {
+  applyExecutionResultToTrace,
+  buildExecutionOutcomeFromError,
+  buildExecutionOutcomeFromResult,
+  createExecutionDecision,
+  createExecutionIntent,
+  newExecutionLatencyTrace,
+  recordExecutionReceipt,
+} from "./execution/contracts";
 import { executeSwapViaRouter } from "./execution/router";
 import {
   type ExperienceLevel,
@@ -40,7 +49,7 @@ import { createPrivySolanaWallet } from "./privy";
 import { gatherMarketSnapshot } from "./research";
 import { json, okCors, withCors } from "./response";
 import { SolanaRpc } from "./solana_rpc";
-import type { Env } from "./types";
+import type { Env, ExecutionConfig } from "./types";
 import type { UserRow } from "./users_db";
 import {
   findUserByPrivyUserId,
@@ -914,6 +923,7 @@ export default {
       }
 
       if (request.method === "POST" && url.pathname === "/api/trade/swap") {
+        const requestReceivedAt = new Date().toISOString();
         let user = await requireOnboardedUser(request, env);
         user = await ensureUserWallet(env, user);
         if (!user.walletAddress || !user.privyWalletId) {
@@ -924,6 +934,7 @@ export default {
         }
 
         const payload = await readPayload(request);
+        const execution = parseExecutionConfig(payload.execution);
         const inputMint = String(payload.inputMint ?? "").trim();
         const outputMint = String(payload.outputMint ?? "").trim();
         const amount = String(payload.amount ?? "").trim();
@@ -1047,28 +1058,111 @@ export default {
         });
         enforcePolicy(policy, quoteResponse);
 
-        const result = await executeSwapViaRouter({
-          env,
-          policy,
-          rpc,
-          jupiter,
-          quoteResponse,
-          userPublicKey: walletAddress,
-          privyWalletId: user.privyWalletId,
-          log(level, message, meta) {
-            console[level]("trade.swap", {
-              userId: user.id,
-              inputMint,
-              outputMint,
-              amount,
-              slippageBps: policy.slippageBps,
-              source: source || "TERMINAL",
-              reason: reason || undefined,
-              message,
-              ...(meta ?? {}),
-            });
-          },
+        const trace = newExecutionLatencyTrace(requestReceivedAt);
+        trace.validatedAt = new Date().toISOString();
+        trace.decisionAt = new Date().toISOString();
+
+        const intent = createExecutionIntent({
+          receivedAt: requestReceivedAt,
+          userId: user.id,
+          wallet: walletAddress,
+          inputMint,
+          outputMint,
+          amountAtomic: amount,
+          slippageBps: policy.slippageBps,
+          source: source || "TERMINAL",
+          reason: reason || undefined,
+          execution,
         });
+        const executionRoute =
+          String(execution?.adapter ?? "jupiter").trim() || "jupiter";
+        const decision = createExecutionDecision({
+          intentId: intent.intentId,
+          decidedAt: trace.decisionAt,
+          route: executionRoute,
+          simulateOnly: policy.simulateOnly,
+          dryRun: policy.dryRun,
+          commitment: policy.commitment,
+        });
+
+        let result: Awaited<ReturnType<typeof executeSwapViaRouter>>;
+        try {
+          result = await executeSwapViaRouter({
+            env,
+            execution,
+            policy,
+            rpc,
+            jupiter,
+            quoteResponse,
+            userPublicKey: walletAddress,
+            privyWalletId: user.privyWalletId,
+            log(level, message, meta) {
+              console[level]("trade.swap", {
+                userId: user.id,
+                inputMint,
+                outputMint,
+                amount,
+                slippageBps: policy.slippageBps,
+                source: source || "TERMINAL",
+                reason: reason || undefined,
+                executionRoute,
+                message,
+                ...(meta ?? {}),
+              });
+            },
+          });
+        } catch (error) {
+          trace.failedAt = new Date().toISOString();
+          try {
+            await recordExecutionReceipt(env, {
+              generatedAt: trace.failedAt,
+              intent,
+              decision,
+              trace,
+              outcome: buildExecutionOutcomeFromError(error),
+              quote: quoteResponse,
+            });
+          } catch (receiptError) {
+            console.error("trade.swap.receipt.error", {
+              userId: user.id,
+              route: executionRoute,
+              message:
+                receiptError instanceof Error
+                  ? receiptError.message
+                  : String(receiptError),
+            });
+          }
+          throw error;
+        }
+
+        const settledAt = new Date().toISOString();
+        const traceSettled = applyExecutionResultToTrace({
+          trace,
+          result,
+          settledAt,
+        });
+        let executionReceipt: Awaited<
+          ReturnType<typeof recordExecutionReceipt>
+        > | null = null;
+        try {
+          executionReceipt = await recordExecutionReceipt(env, {
+            generatedAt: settledAt,
+            intent,
+            decision,
+            trace: traceSettled,
+            outcome: buildExecutionOutcomeFromResult(result),
+            quote: result.usedQuote,
+          });
+        } catch (receiptError) {
+          console.error("trade.swap.receipt.error", {
+            userId: user.id,
+            route: executionRoute,
+            message:
+              receiptError instanceof Error
+                ? receiptError.message
+                : String(receiptError),
+          });
+        }
 
         return withCors(
           json({
@@ -1082,6 +1176,13 @@ export default {
             ),
             source: source || "TERMINAL",
             err: result.err ?? null,
+            executionReceipt:
+              executionReceipt === null
+                ? null
+                : {
+                    receiptId: executionReceipt.receiptId,
+                    key: executionReceipt.storage.key,
+                  },
           }),
           env,
         );
@@ -1837,6 +1938,18 @@ function toUniqueStrings(value: unknown, maxItems: number): string[] {
     if (out.length >= maxItems) break;
   }
   return out;
+}
+
+function parseExecutionConfig(value: unknown): ExecutionConfig | undefined {
+  if (!isRecord(value)) return undefined;
+  const adapter = String(value.adapter ?? "").trim();
+  const params =
+    value.params && isRecord(value.params) ? { ...value.params } : undefined;
+  if (!adapter && !params) return undefined;
+  return {
+    ...(adapter ? { adapter } : {}),
+    ...(params ? { params } : {}),
+  };
 }
 
 function parseRiskMode(

--- a/loop-a-loop-b-architecture.md
+++ b/loop-a-loop-b-architecture.md
@@ -58,6 +58,7 @@ There is already an execution router with adapters for:
 
 - "Jupiter"
 - "Jito bundle" ([GitHub][6])
+- execution contract artifacts now include versioned `ExecutionIntent`, `ExecutionDecision`, `ExecutionLatencyTrace`, and `ExecutionReceipt` records persisted to content-addressed keys in Cloudflare R2 object storage during swap attempts.
 
 ---
 

--- a/tests/unit/worker_execution_contracts.test.ts
+++ b/tests/unit/worker_execution_contracts.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from "bun:test";
+import {
+  applyExecutionResultToTrace,
+  buildExecutionOutcomeFromError,
+  buildExecutionOutcomeFromResult,
+  buildExecutionReceipt,
+  createExecutionDecision,
+  createExecutionIntent,
+  newExecutionLatencyTrace,
+  recordExecutionReceipt,
+} from "../../apps/worker/src/execution/contracts";
+import type { ExecuteSwapResult } from "../../apps/worker/src/execution/types";
+import type { Env } from "../../apps/worker/src/types";
+
+const BASE_QUOTE = {
+  inputMint: "So11111111111111111111111111111111111111112",
+  outputMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  inAmount: "100000000",
+  outAmount: "18000000",
+  priceImpactPct: "0.0012",
+  routePlan: [{ swapInfo: { label: "Jupiter" } }],
+};
+
+describe("worker execution contracts", () => {
+  test("builds deterministic content hash for same receipt payload", async () => {
+    const intent = createExecutionIntent({
+      receivedAt: "2026-02-21T20:00:00.000Z",
+      userId: "user-1",
+      wallet: "wallet-1",
+      inputMint: BASE_QUOTE.inputMint,
+      outputMint: BASE_QUOTE.outputMint,
+      amountAtomic: "100000000",
+      slippageBps: 50,
+      source: "TERMINAL",
+      execution: { adapter: "jupiter" },
+    });
+    const decision = createExecutionDecision({
+      intentId: intent.intentId,
+      decidedAt: "2026-02-21T20:00:01.000Z",
+      route: "jupiter",
+      simulateOnly: false,
+      dryRun: false,
+      commitment: "confirmed",
+    });
+    const trace = newExecutionLatencyTrace("2026-02-21T20:00:00.000Z");
+    trace.validatedAt = "2026-02-21T20:00:00.500Z";
+    trace.decisionAt = "2026-02-21T20:00:01.000Z";
+    trace.sentAt = "2026-02-21T20:00:02.000Z";
+    trace.confirmedAt = "2026-02-21T20:00:03.000Z";
+
+    const outcome = {
+      status: "confirmed" as const,
+      signature: "sig-1",
+      refreshed: false,
+      lastValidBlockHeight: 123,
+      error: null,
+    };
+
+    const first = await buildExecutionReceipt({
+      generatedAt: "2026-02-21T20:00:03.000Z",
+      intent,
+      decision,
+      trace,
+      outcome,
+      quote: BASE_QUOTE,
+    });
+    const second = await buildExecutionReceipt({
+      generatedAt: "2026-02-21T20:00:03.000Z",
+      intent,
+      decision,
+      trace,
+      outcome,
+      quote: BASE_QUOTE,
+    });
+
+    expect(first.storage.contentSha256).toBe(second.storage.contentSha256);
+    expect(first.storage.key).toBe(second.storage.key);
+    expect(first.receiptId).toBe(second.receiptId);
+  });
+
+  test("records receipt to content-addressed R2 key", async () => {
+    const r2Writes = new Map<string, string>();
+    const env = {
+      LOGS_BUCKET: {
+        put: async (key: string, value: string) => {
+          r2Writes.set(key, value);
+        },
+      },
+    } as Env;
+    const intent = createExecutionIntent({
+      receivedAt: "2026-02-21T20:10:00.000Z",
+      userId: "user-2",
+      wallet: "wallet-2",
+      inputMint: BASE_QUOTE.inputMint,
+      outputMint: BASE_QUOTE.outputMint,
+      amountAtomic: "25000000",
+      slippageBps: 25,
+      source: "TERMINAL",
+      execution: { adapter: "jupiter" },
+    });
+    const decision = createExecutionDecision({
+      intentId: intent.intentId,
+      decidedAt: "2026-02-21T20:10:01.000Z",
+      route: "jupiter",
+      simulateOnly: false,
+      dryRun: false,
+      commitment: "confirmed",
+    });
+    const trace = newExecutionLatencyTrace("2026-02-21T20:10:00.000Z");
+    trace.validatedAt = "2026-02-21T20:10:00.400Z";
+    trace.decisionAt = "2026-02-21T20:10:01.000Z";
+    trace.sentAt = "2026-02-21T20:10:01.800Z";
+    trace.confirmedAt = "2026-02-21T20:10:02.300Z";
+
+    const receipt = await recordExecutionReceipt(env, {
+      generatedAt: "2026-02-21T20:10:02.300Z",
+      intent,
+      decision,
+      trace,
+      outcome: {
+        status: "confirmed",
+        signature: "sig-2",
+        refreshed: true,
+        lastValidBlockHeight: 456,
+        error: null,
+      },
+      quote: BASE_QUOTE,
+    });
+
+    expect(receipt.storage.key).toContain("exec/v1/receipts/sha256=");
+    expect(r2Writes.has(receipt.storage.key)).toBe(true);
+    const persisted = JSON.parse(
+      r2Writes.get(receipt.storage.key) ?? "{}",
+    ) as Record<string, unknown>;
+    expect(persisted.receiptId).toBe(receipt.receiptId);
+    expect(
+      (
+        persisted.storage as
+          | { contentSha256?: string; key?: string }
+          | undefined
+      )?.contentSha256,
+    ).toBe(receipt.storage.contentSha256);
+  });
+
+  test("maps execution status to latency stages", () => {
+    const trace = newExecutionLatencyTrace("2026-02-21T20:20:00.000Z");
+    const result = {
+      status: "finalized",
+      signature: "sig-3",
+      usedQuote: BASE_QUOTE,
+      refreshed: false,
+      lastValidBlockHeight: 999,
+      err: null,
+    } satisfies ExecuteSwapResult;
+
+    const next = applyExecutionResultToTrace({
+      trace,
+      result,
+      settledAt: "2026-02-21T20:20:02.000Z",
+    });
+    expect(next.sentAt).toBe("2026-02-21T20:20:02.000Z");
+    expect(next.landedAt).toBe("2026-02-21T20:20:02.000Z");
+    expect(next.confirmedAt).toBe("2026-02-21T20:20:02.000Z");
+    expect(next.finalizedAt).toBe("2026-02-21T20:20:02.000Z");
+    expect(next.failedAt).toBeNull();
+  });
+
+  test("normalizes execution outcomes from result and thrown errors", () => {
+    const fromResult = buildExecutionOutcomeFromResult({
+      status: "simulate_error",
+      signature: null,
+      usedQuote: BASE_QUOTE,
+      refreshed: false,
+      lastValidBlockHeight: null,
+      err: { code: "sim-failed" },
+    });
+    expect(fromResult.status).toBe("simulate_error");
+    expect(fromResult.error).toContain("sim-failed");
+
+    const fromError = buildExecutionOutcomeFromError(
+      new Error("send-transaction-failed"),
+    );
+    expect(fromError.status).toBe("error");
+    expect(fromError.error).toBe("send-transaction-failed");
+  });
+});


### PR DESCRIPTION
## What changed
- Added new versioned execution contract module: `apps/worker/src/execution/contracts.ts`
  - `ExecutionIntent`
  - `ExecutionDecision`
  - `ExecutionLatencyTrace`
  - `ExecutionOutcome`
  - `ExecutionReceipt`
- Added deterministic content-address logic:
  - stable JSON ordering
  - SHA-256 hashing
  - receipt key format `exec/v1/receipts/sha256=<hash>.json`
- Added receipt helpers:
  - `createExecutionIntent`
  - `createExecutionDecision`
  - `newExecutionLatencyTrace`
  - `applyExecutionResultToTrace`
  - `buildExecutionOutcomeFromResult`
  - `buildExecutionOutcomeFromError`
  - `buildExecutionReceipt`
  - `recordExecutionReceipt`
- Wired `/api/trade/swap` to emit receipts for both success and execution-failure paths.
  - Adds optional `executionReceipt` metadata to successful swap responses.
  - Accepts optional `payload.execution` routing config.
- Added tests in `tests/unit/worker_execution_contracts.test.ts` for deterministic hashing, trace mapping, outcome normalization, and R2 persistence.
- Updated architecture doc status in `loop-a-loop-b-architecture.md` for EX-01 completion.

## Why (EX-01 acceptance mapping)
- **Versioned contracts**: implemented all EX-01 contract artifacts in code.
- **Every execution attempt yields a receipt**: swap route records receipts for success and caught execution errors.
- **Immutable content-addressed receipt**: receipt storage key is derived from SHA-256 of stable payload content and persisted to R2 when bound.

## Test evidence
- `bun run lint`
- `bun run typecheck`
- `bun test tests/unit/worker_execution_contracts.test.ts tests/unit/worker_execution_router.test.ts tests/unit/worker_cutover_routes.test.ts`
- `bun run test:unit`

## Follow-ups
- EX-02: Durable Object `ExecutionCoordinator` orchestration layer.
- EX-03: Jito execution adapter hardening + staged latency telemetry.
