### PR TITLE
EX-02: Add execution coordinator durable object and worker routing

### DIFF
--- a/apps/worker/src/execution/contracts.ts
+++ b/apps/worker/src/execution/contracts.ts
@@ -20,6 +20,11 @@ export type ExecutionIntent = {
     adapter: string;
     params: Record<string, unknown> | null;
   };
+  policy: {
+    simulateOnly: boolean;
+    dryRun: boolean;
+    commitment: "processed" | "confirmed" | "finalized";
+  };
 };
 
 export type ExecutionDecision = {
@@ -157,6 +162,9 @@ export function createExecutionIntent(input: {
   source: string;
   reason?: string;
   execution?: ExecutionConfig;
+  simulateOnly: boolean;
+  dryRun: boolean;
+  commitment: "processed" | "confirmed" | "finalized";
 }): ExecutionIntent {
   return {
     schemaVersion: EXECUTION_SCHEMA_VERSION,
@@ -182,6 +190,11 @@ export function createExecutionIntent(input: {
         !Array.isArray(input.execution.params)
           ? { ...input.execution.params }
           : null,
+    },
+    policy: {
+      simulateOnly: input.simulateOnly,
+      dryRun: input.dryRun,
+      commitment: input.commitment,
     },
   };
 }

--- a/apps/worker/src/execution/coordinator.ts
+++ b/apps/worker/src/execution/coordinator.ts
@@ -1,0 +1,470 @@
+import type { Env } from "../types";
+import {
+  createExecutionDecision,
+  type ExecutionDecision,
+  type ExecutionIntent,
+} from "./contracts";
+
+const STATE_KEY = "execution:coordinator_state:v1";
+const SCHEMA_VERSION = "v1" as const;
+const DEFAULT_AUCTION_WINDOW_MS = 250;
+const MAX_QUEUE_SIZE = 1024;
+
+export const EXECUTION_COORDINATOR_NAME = "execution-coordinator-v1";
+
+const ALLOWED_ROUTES = new Set([
+  "jupiter",
+  "jito_bundle",
+  "magicblock_ephemeral_rollup",
+]);
+
+type PendingIntent = {
+  intent: ExecutionIntent;
+  enqueuedAt: string;
+};
+
+type ExecutionCoordinatorState = {
+  schemaVersion: typeof SCHEMA_VERSION;
+  updatedAt: string;
+  decisionCount: number;
+  rejectionCount: number;
+  queue: PendingIntent[];
+};
+
+type SubmitRequest = {
+  intent?: unknown;
+  mode?: "inline" | "enqueue";
+  auctionWindowMs?: unknown;
+};
+
+type TickRequest = {
+  auctionWindowMs?: unknown;
+};
+
+export type ExecutionCoordinatorDecisionResult = {
+  accepted: boolean;
+  reason: string | null;
+  queueDepth: number;
+  queuePosition: number;
+  decision?: ExecutionDecision;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function parseAuctionWindowMs(raw: unknown): number {
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_AUCTION_WINDOW_MS;
+  return Math.max(0, Math.floor(parsed));
+}
+
+function parseIso(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toISOString();
+}
+
+function parseCommitment(
+  raw: unknown,
+): "processed" | "confirmed" | "finalized" | null {
+  const value = String(raw ?? "")
+    .trim()
+    .toLowerCase();
+  if (value === "processed" || value === "confirmed" || value === "finalized") {
+    return value;
+  }
+  return null;
+}
+
+function parseExecutionIntent(input: unknown): ExecutionIntent | null {
+  const record = asRecord(input);
+  if (!record || record.schemaVersion !== SCHEMA_VERSION) return null;
+
+  const receivedAt = parseIso(record.receivedAt);
+  if (!receivedAt) return null;
+
+  const execution = asRecord(record.execution);
+  if (!execution) return null;
+  const policy = asRecord(record.policy);
+  if (!policy) return null;
+  const commitment = parseCommitment(policy.commitment);
+  if (!commitment) return null;
+
+  const intentId = String(record.intentId ?? "").trim();
+  const userId = String(record.userId ?? "").trim();
+  const wallet = String(record.wallet ?? "").trim();
+  const inputMint = String(record.inputMint ?? "").trim();
+  const outputMint = String(record.outputMint ?? "").trim();
+  const amountAtomic = String(record.amountAtomic ?? "").trim();
+  const source = String(record.source ?? "").trim();
+  const adapter = String(execution.adapter ?? "").trim();
+  const slippageBps = Number(record.slippageBps);
+  const simulateOnly = policy.simulateOnly === true;
+  const dryRun = policy.dryRun === true;
+
+  if (
+    !intentId ||
+    !userId ||
+    !wallet ||
+    !inputMint ||
+    !outputMint ||
+    !amountAtomic ||
+    !source ||
+    !adapter ||
+    !Number.isFinite(slippageBps)
+  ) {
+    return null;
+  }
+
+  const params = asRecord(execution.params);
+  const reasonRaw = record.reason;
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    intentId,
+    receivedAt,
+    userId,
+    wallet,
+    inputMint,
+    outputMint,
+    amountAtomic,
+    slippageBps,
+    source,
+    reason:
+      typeof reasonRaw === "string" && reasonRaw.trim() ? reasonRaw : null,
+    execution: {
+      adapter,
+      params: params ? { ...params } : null,
+    },
+    policy: {
+      simulateOnly,
+      dryRun,
+      commitment,
+    },
+  };
+}
+
+function parseState(input: unknown, now: string): ExecutionCoordinatorState {
+  const record = asRecord(input);
+  if (!record || record.schemaVersion !== SCHEMA_VERSION) {
+    return {
+      schemaVersion: SCHEMA_VERSION,
+      updatedAt: now,
+      decisionCount: 0,
+      rejectionCount: 0,
+      queue: [],
+    };
+  }
+
+  const queueRaw = Array.isArray(record.queue) ? record.queue : [];
+  const queue: PendingIntent[] = [];
+  for (const item of queueRaw) {
+    const parsed = asRecord(item);
+    if (!parsed) continue;
+    const intent = parseExecutionIntent(parsed.intent);
+    const enqueuedAt = parseIso(parsed.enqueuedAt);
+    if (!intent || !enqueuedAt) continue;
+    queue.push({ intent, enqueuedAt });
+  }
+
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    updatedAt: parseIso(record.updatedAt) ?? now,
+    decisionCount:
+      typeof record.decisionCount === "number" && record.decisionCount >= 0
+        ? Math.floor(record.decisionCount)
+        : 0,
+    rejectionCount:
+      typeof record.rejectionCount === "number" && record.rejectionCount >= 0
+        ? Math.floor(record.rejectionCount)
+        : 0,
+    queue,
+  };
+}
+
+function sortQueue(queue: PendingIntent[]): void {
+  queue.sort((a, b) => {
+    const aTs = Date.parse(a.intent.receivedAt);
+    const bTs = Date.parse(b.intent.receivedAt);
+    if (aTs !== bTs) return aTs - bTs;
+    return a.intent.intentId.localeCompare(b.intent.intentId);
+  });
+}
+
+function resolveRoute(adapterRaw: string): string {
+  const normalized = adapterRaw.trim().toLowerCase();
+  return normalized || "jupiter";
+}
+
+function enqueueIntent(
+  state: ExecutionCoordinatorState,
+  intent: ExecutionIntent,
+  now: string,
+): { position: number } | { error: "queue-full" } {
+  const existingIndex = state.queue.findIndex(
+    (item) => item.intent.intentId === intent.intentId,
+  );
+  if (existingIndex >= 0) {
+    sortQueue(state.queue);
+    const queuePosition =
+      state.queue.findIndex(
+        (item) => item.intent.intentId === intent.intentId,
+      ) + 1;
+    return { position: queuePosition };
+  }
+
+  if (state.queue.length >= MAX_QUEUE_SIZE) {
+    return { error: "queue-full" };
+  }
+  state.queue.push({ intent, enqueuedAt: now });
+  sortQueue(state.queue);
+  const queuePosition =
+    state.queue.findIndex((item) => item.intent.intentId === intent.intentId) +
+    1;
+  return { position: queuePosition };
+}
+
+function makeDecisionFromHead(input: {
+  state: ExecutionCoordinatorState;
+  now: string;
+}): ExecutionCoordinatorDecisionResult {
+  if (input.state.queue.length === 0) {
+    return {
+      accepted: false,
+      reason: "queue-empty",
+      queueDepth: 0,
+      queuePosition: 0,
+    };
+  }
+
+  const [head] = input.state.queue.splice(0, 1);
+  const route = resolveRoute(head.intent.execution.adapter);
+  if (!ALLOWED_ROUTES.has(route)) {
+    input.state.rejectionCount += 1;
+    return {
+      accepted: false,
+      reason: `unsupported-route:${route}`,
+      queueDepth: input.state.queue.length,
+      queuePosition: 0,
+    };
+  }
+
+  const decision = createExecutionDecision({
+    intentId: head.intent.intentId,
+    decidedAt: input.now,
+    route,
+    simulateOnly: head.intent.policy.simulateOnly,
+    dryRun: head.intent.policy.dryRun,
+    commitment: head.intent.policy.commitment,
+  });
+  input.state.decisionCount += 1;
+  return {
+    accepted: true,
+    reason: null,
+    queueDepth: input.state.queue.length,
+    queuePosition: 0,
+    decision,
+  };
+}
+
+function maybeSetAlarm(
+  state: DurableObjectState,
+  queueDepth: number,
+  auctionWindowMs: number,
+): Promise<void> {
+  if (queueDepth > 0) {
+    return state.storage.setAlarm(Date.now() + Math.max(250, auctionWindowMs));
+  }
+  return state.storage.deleteAlarm();
+}
+
+type CoordinatorDeps = {
+  now?: () => string;
+};
+
+export class ExecutionCoordinator {
+  private readonly now: () => string;
+
+  constructor(
+    private readonly state: DurableObjectState,
+    private readonly env: Env,
+    deps: CoordinatorDeps = {},
+  ) {
+    this.now = deps.now ?? (() => new Date().toISOString());
+  }
+
+  private async loadState(): Promise<ExecutionCoordinatorState> {
+    const now = this.now();
+    const raw = await this.state.storage.get(STATE_KEY);
+    return parseState(raw, now);
+  }
+
+  private async persistState(next: ExecutionCoordinatorState): Promise<void> {
+    await this.state.storage.put(STATE_KEY, next);
+  }
+
+  private async handleSubmit(request: Request): Promise<Response> {
+    const payload = (await request.json()) as SubmitRequest;
+    const now = this.now();
+    const mode = payload.mode === "enqueue" ? "enqueue" : "inline";
+    const intent = parseExecutionIntent(payload.intent);
+    if (!intent) {
+      return new Response(
+        JSON.stringify({ ok: false, error: "invalid-intent" }),
+        {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+    const auctionWindowMs = parseAuctionWindowMs(
+      payload.auctionWindowMs ?? this.env.EXECUTION_AUCTION_WINDOW_MS,
+    );
+
+    const state = await this.loadState();
+    const enqueue = enqueueIntent(state, intent, now);
+    if ("error" in enqueue) {
+      return new Response(JSON.stringify({ ok: false, error: enqueue.error }), {
+        status: 429,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    let result: ExecutionCoordinatorDecisionResult;
+    if (mode === "enqueue") {
+      result = {
+        accepted: false,
+        reason: "queued",
+        queueDepth: state.queue.length,
+        queuePosition: enqueue.position,
+      };
+    } else if (enqueue.position > 1) {
+      state.rejectionCount += 1;
+      result = {
+        accepted: false,
+        reason: "queued-behind-priority",
+        queueDepth: state.queue.length,
+        queuePosition: enqueue.position,
+      };
+    } else {
+      result = makeDecisionFromHead({ state, now });
+    }
+
+    state.updatedAt = now;
+    await this.persistState(state);
+    await maybeSetAlarm(this.state, state.queue.length, auctionWindowMs);
+    return new Response(JSON.stringify({ ok: true, result }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  private async handleTick(request: Request, trigger: "fetch" | "alarm") {
+    const now = this.now();
+    const payload =
+      trigger === "fetch" ? ((await request.json()) as TickRequest) : {};
+    const auctionWindowMs = parseAuctionWindowMs(
+      payload.auctionWindowMs ?? this.env.EXECUTION_AUCTION_WINDOW_MS,
+    );
+    const state = await this.loadState();
+    const result = makeDecisionFromHead({ state, now });
+    state.updatedAt = now;
+    await this.persistState(state);
+    await maybeSetAlarm(this.state, state.queue.length, auctionWindowMs);
+
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        trigger,
+        result,
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (
+      request.method === "POST" &&
+      (url.pathname === "/execution/intent" ||
+        url.pathname === "/internal/execution/intent")
+    ) {
+      return await this.handleSubmit(request);
+    }
+
+    if (
+      request.method === "POST" &&
+      (url.pathname === "/execution/auction/tick" ||
+        url.pathname === "/internal/execution/auction/tick")
+    ) {
+      return await this.handleTick(request, "fetch");
+    }
+
+    if (
+      request.method === "GET" &&
+      (url.pathname === "/execution/state" ||
+        url.pathname === "/internal/execution/state")
+    ) {
+      const state = await this.loadState();
+      return new Response(JSON.stringify({ ok: true, state }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify({ ok: false, error: "not-found" }), {
+      status: 404,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  async alarm(): Promise<void> {
+    await this.handleTick(
+      new Request("https://internal/execution/auction/tick"),
+      "alarm",
+    );
+  }
+}
+
+export async function requestExecutionCoordinatorDecision(
+  env: Env,
+  input: {
+    intent: ExecutionIntent;
+    mode?: "inline" | "enqueue";
+    auctionWindowMs?: number;
+  },
+): Promise<ExecutionCoordinatorDecisionResult | null> {
+  if (!env.EXECUTION_COORDINATOR_DO) return null;
+  const enabled =
+    String(env.EXECUTION_COORDINATOR_ENABLED ?? "0").trim() === "1";
+  if (!enabled) return null;
+
+  const id = env.EXECUTION_COORDINATOR_DO.idFromName(
+    EXECUTION_COORDINATOR_NAME,
+  );
+  const stub = env.EXECUTION_COORDINATOR_DO.get(id);
+  const response = await stub.fetch("https://internal/execution/intent", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      intent: input.intent,
+      mode: input.mode ?? "inline",
+      auctionWindowMs: input.auctionWindowMs,
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`execution-coordinator-request-failed:${response.status}`);
+  }
+  const payload = (await response.json()) as {
+    ok: boolean;
+    result?: ExecutionCoordinatorDecisionResult;
+  };
+  return payload.ok ? (payload.result ?? null) : null;
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -11,6 +11,10 @@ import {
   newExecutionLatencyTrace,
   recordExecutionReceipt,
 } from "./execution/contracts";
+import {
+  ExecutionCoordinator,
+  requestExecutionCoordinatorDecision,
+} from "./execution/coordinator";
 import { executeSwapViaRouter } from "./execution/router";
 import {
   type ExperienceLevel,
@@ -85,7 +89,12 @@ const EXPERIENCE_EVENT_NAMES = new Set<ExperienceEventName>([
   "terminal_opened_from_consumer",
 ]);
 
-export { LoopACoordinator, MinuteAccumulator, Recommender };
+export {
+  ExecutionCoordinator,
+  LoopACoordinator,
+  MinuteAccumulator,
+  Recommender,
+};
 
 function resolveX402ReadRpcEndpoint(env: Env): string {
   const balanceRpc = String(env.BALANCE_RPC_ENDPOINT ?? "").trim();
@@ -1073,10 +1082,13 @@ export default {
           source: source || "TERMINAL",
           reason: reason || undefined,
           execution,
+          simulateOnly: policy.simulateOnly,
+          dryRun: policy.dryRun,
+          commitment: policy.commitment,
         });
-        const executionRoute =
+        let executionRoute =
           String(execution?.adapter ?? "jupiter").trim() || "jupiter";
-        const decision = createExecutionDecision({
+        let decision = createExecutionDecision({
           intentId: intent.intentId,
           decidedAt: trace.decisionAt,
           route: executionRoute,
@@ -1084,12 +1096,75 @@ export default {
           dryRun: policy.dryRun,
           commitment: policy.commitment,
         });
+        try {
+          const coordinator = await requestExecutionCoordinatorDecision(env, {
+            intent,
+          });
+          if (coordinator && !coordinator.accepted) {
+            const rejectedAt = new Date().toISOString();
+            trace.failedAt = rejectedAt;
+            try {
+              await recordExecutionReceipt(env, {
+                generatedAt: rejectedAt,
+                intent,
+                decision,
+                trace,
+                outcome: {
+                  status: "rejected",
+                  signature: null,
+                  refreshed: false,
+                  lastValidBlockHeight: null,
+                  error: coordinator.reason ?? "execution-rejected",
+                },
+                quote: quoteResponse,
+              });
+            } catch (receiptError) {
+              console.error("trade.swap.receipt.error", {
+                userId: user.id,
+                route: executionRoute,
+                message:
+                  receiptError instanceof Error
+                    ? receiptError.message
+                    : String(receiptError),
+              });
+            }
+            return withCors(
+              json(
+                {
+                  ok: false,
+                  error: "execution-rejected",
+                  reason: coordinator.reason,
+                  queueDepth: coordinator.queueDepth,
+                  queuePosition: coordinator.queuePosition,
+                },
+                { status: 409 },
+              ),
+              env,
+            );
+          }
+          if (coordinator?.accepted && coordinator.decision) {
+            decision = coordinator.decision;
+            executionRoute = coordinator.decision.route;
+          }
+        } catch (coordinatorError) {
+          console.warn("trade.swap.coordinator.fallback", {
+            userId: user.id,
+            message:
+              coordinatorError instanceof Error
+                ? coordinatorError.message
+                : String(coordinatorError),
+          });
+        }
+        const routedExecution: ExecutionConfig | undefined = {
+          ...(execution ?? {}),
+          adapter: executionRoute,
+        };
 
         let result: Awaited<ReturnType<typeof executeSwapViaRouter>>;
         try {
           result = await executeSwapViaRouter({
             env,
-            execution,
+            execution: routedExecution,
             policy,
             rpc,
             jupiter,

--- a/apps/worker/src/types.ts
+++ b/apps/worker/src/types.ts
@@ -52,6 +52,7 @@ export type Env = {
   LOOP_A_COORDINATOR_DO?: DurableObjectNamespace;
   LOOP_B_MINUTE_ACCUMULATOR_DO?: DurableObjectNamespace;
   LOOP_C_RECOMMENDER_DO?: DurableObjectNamespace;
+  EXECUTION_COORDINATOR_DO?: DurableObjectNamespace;
   ALLOWED_ORIGINS?: string;
   ADMIN_TOKEN?: string;
   PRIVY_APP_ID?: string;
@@ -116,4 +117,6 @@ export type Env = {
   LOOP_C_MAX_STALENESS_MS?: string;
   LOOP_C_EXCLUDED_ASSETS?: string;
   LOOP_C_EXCLUDED_PROTOCOLS?: string;
+  EXECUTION_COORDINATOR_ENABLED?: string;
+  EXECUTION_AUCTION_WINDOW_MS?: string;
 };

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -53,6 +53,8 @@ LOOP_C_MIN_LIQUIDITY_SCORE = "0.5"
 LOOP_C_MAX_STALENESS_MS = "180000"
 LOOP_C_EXCLUDED_ASSETS = ""
 LOOP_C_EXCLUDED_PROTOCOLS = ""
+EXECUTION_COORDINATOR_ENABLED = "0"
+EXECUTION_AUCTION_WINDOW_MS = "250"
 
 [[durable_objects.bindings]]
 name = "LOOP_A_COORDINATOR_DO"
@@ -65,6 +67,10 @@ class_name = "MinuteAccumulator"
 [[durable_objects.bindings]]
 name = "LOOP_C_RECOMMENDER_DO"
 class_name = "Recommender"
+
+[[durable_objects.bindings]]
+name = "EXECUTION_COORDINATOR_DO"
+class_name = "ExecutionCoordinator"
 
 [[kv_namespaces]]
 binding = "CONFIG_KV"
@@ -137,6 +143,8 @@ LOOP_C_MIN_LIQUIDITY_SCORE = "0.5"
 LOOP_C_MAX_STALENESS_MS = "180000"
 LOOP_C_EXCLUDED_ASSETS = ""
 LOOP_C_EXCLUDED_PROTOCOLS = ""
+EXECUTION_COORDINATOR_ENABLED = "0"
+EXECUTION_AUCTION_WINDOW_MS = "250"
 
 [[env.staging.kv_namespaces]]
 binding = "CONFIG_KV"
@@ -209,6 +217,8 @@ LOOP_C_MIN_LIQUIDITY_SCORE = "0.5"
 LOOP_C_MAX_STALENESS_MS = "180000"
 LOOP_C_EXCLUDED_ASSETS = ""
 LOOP_C_EXCLUDED_PROTOCOLS = ""
+EXECUTION_COORDINATOR_ENABLED = "0"
+EXECUTION_AUCTION_WINDOW_MS = "250"
 
 [[migrations]]
 tag = "v2-loop-a-coordinator"
@@ -221,6 +231,10 @@ new_sqlite_classes = ["MinuteAccumulator"]
 [[migrations]]
 tag = "v4-loop-c-recommender"
 new_sqlite_classes = ["Recommender"]
+
+[[migrations]]
+tag = "v5-execution-coordinator"
+new_sqlite_classes = ["ExecutionCoordinator"]
 
 [[env.production.kv_namespaces]]
 binding = "CONFIG_KV"

--- a/loop-a-loop-b-architecture.md
+++ b/loop-a-loop-b-architecture.md
@@ -59,6 +59,7 @@ There is already an execution router with adapters for:
 - "Jupiter"
 - "Jito bundle" ([GitHub][6])
 - execution contract artifacts now include versioned `ExecutionIntent`, `ExecutionDecision`, `ExecutionLatencyTrace`, and `ExecutionReceipt` records persisted to content-addressed keys in Cloudflare R2 object storage during swap attempts.
+- a new `ExecutionCoordinator` Durable Object is available (flag-gated) for deterministic queue ordering and route decisions with explicit rejection reasons.
 
 ---
 

--- a/tests/unit/worker_execution_contracts.test.ts
+++ b/tests/unit/worker_execution_contracts.test.ts
@@ -33,6 +33,9 @@ describe("worker execution contracts", () => {
       slippageBps: 50,
       source: "TERMINAL",
       execution: { adapter: "jupiter" },
+      simulateOnly: false,
+      dryRun: false,
+      commitment: "confirmed",
     });
     const decision = createExecutionDecision({
       intentId: intent.intentId,
@@ -97,6 +100,9 @@ describe("worker execution contracts", () => {
       slippageBps: 25,
       source: "TERMINAL",
       execution: { adapter: "jupiter" },
+      simulateOnly: false,
+      dryRun: false,
+      commitment: "confirmed",
     });
     const decision = createExecutionDecision({
       intentId: intent.intentId,

--- a/tests/unit/worker_execution_coordinator.test.ts
+++ b/tests/unit/worker_execution_coordinator.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, test } from "bun:test";
+import type { ExecutionIntent } from "../../apps/worker/src/execution/contracts";
+import {
+  ExecutionCoordinator,
+  type ExecutionCoordinatorDecisionResult,
+  requestExecutionCoordinatorDecision,
+} from "../../apps/worker/src/execution/coordinator";
+import type { Env } from "../../apps/worker/src/types";
+
+function createMockDoState() {
+  const store = new Map<string, unknown>();
+  let alarm: number | null = null;
+  return {
+    state: {
+      storage: {
+        get: async (key: string) => store.get(key),
+        put: async (key: string, value: unknown) => {
+          store.set(key, value);
+        },
+        setAlarm: async (timestamp: number) => {
+          alarm = timestamp;
+        },
+        deleteAlarm: async () => {
+          alarm = null;
+        },
+      },
+      blockConcurrencyWhile: async <T>(fn: () => Promise<T>) => await fn(),
+    } as unknown as DurableObjectState,
+    readAlarm: () => alarm,
+  };
+}
+
+function intent(input: {
+  intentId: string;
+  receivedAt: string;
+  adapter?: string;
+}): ExecutionIntent {
+  return {
+    schemaVersion: "v1",
+    intentId: input.intentId,
+    receivedAt: input.receivedAt,
+    userId: "user-1",
+    wallet: "wallet-1",
+    inputMint: "So11111111111111111111111111111111111111112",
+    outputMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    amountAtomic: "1000000",
+    slippageBps: 50,
+    source: "TERMINAL",
+    reason: null,
+    execution: {
+      adapter: input.adapter ?? "jupiter",
+      params: null,
+    },
+    policy: {
+      simulateOnly: false,
+      dryRun: false,
+      commitment: "confirmed",
+    },
+  };
+}
+
+describe("worker execution coordinator durable object", () => {
+  test("accepts inline first intent and returns deterministic decision", async () => {
+    const mock = createMockDoState();
+    const coordinator = new ExecutionCoordinator(
+      mock.state,
+      { EXECUTION_AUCTION_WINDOW_MS: "250" } as Env,
+      { now: () => "2026-02-21T20:50:00.000Z" },
+    );
+
+    const response = await coordinator.fetch(
+      new Request("https://internal/execution/intent", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          intent: intent({
+            intentId: "intent-1",
+            receivedAt: "2026-02-21T20:49:59.000Z",
+          }),
+          mode: "inline",
+        }),
+      }),
+    );
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as {
+      ok: boolean;
+      result: ExecutionCoordinatorDecisionResult;
+    };
+    expect(payload.ok).toBe(true);
+    expect(payload.result.accepted).toBe(true);
+    expect(payload.result.reason).toBeNull();
+    expect(payload.result.decision?.route).toBe("jupiter");
+    expect(mock.readAlarm()).toBeNull();
+  });
+
+  test("queue tick ordering is deterministic by receivedAt then intentId", async () => {
+    const mock = createMockDoState();
+    const coordinator = new ExecutionCoordinator(
+      mock.state,
+      { EXECUTION_AUCTION_WINDOW_MS: "250" } as Env,
+      { now: () => "2026-02-21T20:55:00.000Z" },
+    );
+
+    const enqueue = async (executionIntent: ExecutionIntent) =>
+      await coordinator.fetch(
+        new Request("https://internal/execution/intent", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            intent: executionIntent,
+            mode: "enqueue",
+          }),
+        }),
+      );
+
+    await enqueue(
+      intent({
+        intentId: "intent-b",
+        receivedAt: "2026-02-21T20:54:50.000Z",
+      }),
+    );
+    await enqueue(
+      intent({
+        intentId: "intent-a",
+        receivedAt: "2026-02-21T20:54:50.000Z",
+      }),
+    );
+
+    const tickResponse = await coordinator.fetch(
+      new Request("https://internal/execution/auction/tick", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+    );
+    expect(tickResponse.status).toBe(200);
+    const tickPayload = (await tickResponse.json()) as {
+      ok: boolean;
+      result: ExecutionCoordinatorDecisionResult;
+    };
+    expect(tickPayload.ok).toBe(true);
+    expect(tickPayload.result.accepted).toBe(true);
+    expect(tickPayload.result.decision?.intentId).toBe("intent-a");
+    expect(mock.readAlarm()).not.toBeNull();
+  });
+
+  test("rejects unsupported execution route with clear reason", async () => {
+    const mock = createMockDoState();
+    const coordinator = new ExecutionCoordinator(mock.state, {} as Env, {
+      now: () => "2026-02-21T21:00:00.000Z",
+    });
+
+    const response = await coordinator.fetch(
+      new Request("https://internal/execution/intent", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          intent: intent({
+            intentId: "intent-x",
+            receivedAt: "2026-02-21T20:59:59.000Z",
+            adapter: "unsupported_venue",
+          }),
+          mode: "inline",
+        }),
+      }),
+    );
+
+    const payload = (await response.json()) as {
+      ok: boolean;
+      result: ExecutionCoordinatorDecisionResult;
+    };
+    expect(response.status).toBe(200);
+    expect(payload.ok).toBe(true);
+    expect(payload.result.accepted).toBe(false);
+    expect(payload.result.reason).toBe("unsupported-route:unsupported_venue");
+  });
+
+  test("helper uses namespace only when coordinator is enabled", async () => {
+    const disabled = await requestExecutionCoordinatorDecision(
+      { EXECUTION_COORDINATOR_ENABLED: "0" } as Env,
+      {
+        intent: intent({
+          intentId: "intent-disabled",
+          receivedAt: "2026-02-21T21:10:00.000Z",
+        }),
+      },
+    );
+    expect(disabled).toBeNull();
+
+    const enabledEnv = {
+      EXECUTION_COORDINATOR_ENABLED: "1",
+      EXECUTION_COORDINATOR_DO: {
+        idFromName(name: string) {
+          return name as never;
+        },
+        get(_id: unknown) {
+          return {
+            fetch: async () =>
+              new Response(
+                JSON.stringify({
+                  ok: true,
+                  result: {
+                    accepted: true,
+                    reason: null,
+                    queueDepth: 0,
+                    queuePosition: 0,
+                    decision: {
+                      schemaVersion: "v1",
+                      decisionId: "decision-1",
+                      intentId: "intent-enabled",
+                      decidedAt: "2026-02-21T21:10:01.000Z",
+                      route: "jupiter",
+                      simulateOnly: false,
+                      dryRun: false,
+                      commitment: "confirmed",
+                    },
+                  },
+                }),
+                {
+                  status: 200,
+                  headers: { "content-type": "application/json" },
+                },
+              ),
+          };
+        },
+      } as unknown as DurableObjectNamespace,
+    } as Env;
+
+    const decision = await requestExecutionCoordinatorDecision(enabledEnv, {
+      intent: intent({
+        intentId: "intent-enabled",
+        receivedAt: "2026-02-21T21:10:00.000Z",
+      }),
+    });
+    expect(decision?.accepted).toBe(true);
+    expect(decision?.decision?.route).toBe("jupiter");
+  });
+});


### PR DESCRIPTION
## What changed
- Added `ExecutionCoordinator` Durable Object (`apps/worker/src/execution/coordinator.ts`) with:
  - deterministic queue ordering by `receivedAt` then `intentId`
  - inline decision path (`/internal/execution/intent`)
  - optional queue tick path (`/internal/execution/auction/tick`)
  - explicit rejection reasons (`queued-behind-priority`, `unsupported-route:*`, `queue-empty`)
- Added coordinator helper:
  - `requestExecutionCoordinatorDecision(...)`
- Extended execution intent contract with policy context (`simulateOnly`, `dryRun`, `commitment`) so coordinator decisions are self-contained.
- Wired `/api/trade/swap` to use coordinator decisions when flag-enabled:
  - fail-open fallback when coordinator call itself fails
  - fail-closed with `409 execution-rejected` when coordinator rejects intent
  - writes rejected execution receipts for auditable outcomes
- Added coordinator bindings/config:
  - `EXECUTION_COORDINATOR_DO` in `wrangler.toml`
  - vars: `EXECUTION_COORDINATOR_ENABLED`, `EXECUTION_AUCTION_WINDOW_MS`
  - migration tag `v6-execution-coordinator`
  - `Env` type additions in `apps/worker/src/types.ts`
- Exported `ExecutionCoordinator` from worker entrypoint.
- Added tests:
  - `tests/unit/worker_execution_coordinator.test.ts`
  - updated `tests/unit/worker_execution_contracts.test.ts` for policy-in-intent
- Updated architecture status in `loop-a-loop-b-architecture.md`.

## Why (EX-02 acceptance mapping)
- **Intake from Worker**: `/api/trade/swap` now optionally delegates route decisions to coordinator.
- **Auction/queue behavior**: coordinator supports deterministic queue ordering and explicit tick endpoint.
- **Routing coverage**: coordinator decisions support `jupiter`, `jito_bundle`, and `magicblock_ephemeral_rollup` routes.
- **Deterministic selection + clear rejection reasons**: implemented and covered in unit tests.

## Test evidence
- `bun run lint`
- `bun run typecheck`
- `bun test tests/unit/worker_execution_contracts.test.ts tests/unit/worker_execution_coordinator.test.ts tests/unit/worker_execution_router.test.ts tests/unit/worker_cutover_routes.test.ts`
- `bun run test:unit`

## Rollout note
- Coordinator behavior is flag-gated (`EXECUTION_COORDINATOR_ENABLED=0` by default), so production behavior is unchanged until explicitly enabled.
