### PR TITLE
docs(api): ensure perps endpoints are documented in discovery

### DIFF
--- a/apps/portal/app/api/_catalog.ts
+++ b/apps/portal/app/api/_catalog.ts
@@ -1,4 +1,7 @@
-import { SUPPORTED_PAIRS, TOKEN_CONFIGS } from "../terminal/components/trade-pairs";
+import {
+  SUPPORTED_PAIRS,
+  TOKEN_CONFIGS,
+} from "../terminal/components/trade-pairs";
 
 export type FieldSpec = {
   name: string;

--- a/apps/portal/app/api/page.tsx
+++ b/apps/portal/app/api/page.tsx
@@ -10,7 +10,7 @@ import {
 export const metadata: Metadata = {
   title: "API Catalog | Trader Ralph",
   description:
-    "Public x402 endpoint catalog for Trader Ralph market and macro reads.",
+    "Public x402 endpoint catalog for Trader Ralph market, macro, and perps reads.",
 };
 
 function renderFieldList(

--- a/apps/portal/app/llms.txt/route.ts
+++ b/apps/portal/app/llms.txt/route.ts
@@ -13,6 +13,8 @@ export function GET(request: Request): Response {
     `API catalog TXT: ${origin}/api/endpoints.txt`,
     "",
     "Catalog scope: public x402 read endpoints only.",
+    "Catalog includes market snapshots/quotes, loop views, macro analytics, and cross-venue perps intelligence.",
+    "Perps endpoints: /api/x402/read/perps_funding_surface, /api/x402/read/perps_open_interest_surface, /api/x402/read/perps_venue_score.",
     "Supported trading tokens/pairs are published in the catalog under supportedTrading.",
     "Authenticated account/trading routes are not listed here.",
     "",

--- a/apps/portal/app/page.tsx
+++ b/apps/portal/app/page.tsx
@@ -589,8 +589,8 @@ function Roadmap() {
                 <div>
                   <p className="font-medium">x402 Read Endpoints</p>
                   <p className="text-sm text-muted">
-                    Paid market, macro, and perps reads exposed over HTTP for agent
-                    consumption.
+                    Paid market, macro, and perps reads exposed over HTTP for
+                    agent consumption.
                   </p>
                 </div>
               </li>

--- a/apps/portal/app/terminal/components/sol-market-feed.ts
+++ b/apps/portal/app/terminal/components/sol-market-feed.ts
@@ -5,8 +5,8 @@ import { apiBase, isRecord } from "../../lib";
 import {
   getPairConfig,
   marketQuoteAmountAtomic,
-  TOKEN_CONFIGS,
   type PairId,
+  TOKEN_CONFIGS,
 } from "./trade-pairs";
 
 export type MarketPoint = {
@@ -120,7 +120,10 @@ function toChartPoints(
   return out;
 }
 
-function mergePoints(basePoints: MarketPoint[], livePoints: MarketPoint[]): MarketPoint[] {
+function mergePoints(
+  basePoints: MarketPoint[],
+  livePoints: MarketPoint[],
+): MarketPoint[] {
   const merged = [...basePoints, ...livePoints].sort((a, b) => a.ts - b.ts);
   const deduped: MarketPoint[] = [];
   let lastTs = -1;
@@ -299,19 +302,22 @@ export function useMarketFeed(pairId: PairId): MarketState {
       const base = apiBase();
       if (!base) throw new Error("missing NEXT_PUBLIC_EDGE_API_BASE");
 
-      const response = await fetch(`${base}/api/x402/read/market_jupiter_quote`, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "payment-signature": "portal-market-widget",
+      const response = await fetch(
+        `${base}/api/x402/read/market_jupiter_quote`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "payment-signature": "portal-market-widget",
+          },
+          body: JSON.stringify({
+            inputMint: baseMint,
+            outputMint: quoteMint,
+            amount: marketQuoteAmountAtomic(pair.id),
+            slippageBps: 50,
+          }),
         },
-        body: JSON.stringify({
-          inputMint: baseMint,
-          outputMint: quoteMint,
-          amount: marketQuoteAmountAtomic(pair.id),
-          slippageBps: 50,
-        }),
-      });
+      );
       const payload = (await response.json().catch(() => null)) as unknown;
       if (!response.ok) {
         const error =
@@ -320,7 +326,11 @@ export function useMarketFeed(pairId: PairId): MarketState {
             : `http-${response.status}`;
         throw new Error(error);
       }
-      if (!isRecord(payload) || payload.ok !== true || !isRecord(payload.quote)) {
+      if (
+        !isRecord(payload) ||
+        payload.ok !== true ||
+        !isRecord(payload.quote)
+      ) {
         throw new Error("invalid-quote-payload");
       }
 

--- a/apps/portal/app/terminal/components/trade-intent.ts
+++ b/apps/portal/app/terminal/components/trade-intent.ts
@@ -45,7 +45,8 @@ export function createTradeIntent(
   return {
     pairId: pair.id,
     source,
-    reason: opts?.reason ?? (buy ? `Buy ${outputSymbol}` : `Sell ${inputSymbol}`),
+    reason:
+      opts?.reason ?? (buy ? `Buy ${outputSymbol}` : `Sell ${inputSymbol}`),
     direction,
     inputMint: inputToken.mint,
     outputMint: outputToken.mint,

--- a/apps/portal/app/terminal/page.tsx
+++ b/apps/portal/app/terminal/page.tsx
@@ -28,10 +28,7 @@ import {
   type MarketState,
   useMarketFeed,
 } from "./components/sol-market-feed";
-import {
-  createTradeIntent,
-  type TradeIntent,
-} from "./components/trade-intent";
+import { createTradeIntent, type TradeIntent } from "./components/trade-intent";
 import {
   DEFAULT_PAIR_ID,
   getPairConfig,
@@ -61,17 +58,14 @@ const MarketChart = dynamic<{
   className?: string;
   market: MarketState;
   pairLabel: string;
-}>(
-  () => import("./components/market-chart").then((mod) => mod.MarketChart),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="flex h-full items-center justify-center">
-        <div className="h-6 w-6 animate-spin rounded-full border-2 border-emerald-500/30 border-t-emerald-500" />
-      </div>
-    ),
-  },
-);
+}>(() => import("./components/market-chart").then((mod) => mod.MarketChart), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-full items-center justify-center">
+      <div className="h-6 w-6 animate-spin rounded-full border-2 border-emerald-500/30 border-t-emerald-500" />
+    </div>
+  ),
+});
 
 function toNumericString(value: unknown): string | null {
   if (typeof value === "string" && value.trim() !== "") return value;

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -69,8 +69,8 @@ import {
   fetchPerpsFundingSurface,
   fetchPerpsOpenInterestSurface,
   fetchPerpsVenueScore,
-  SUPPORTED_PERPS_VENUES,
   type PerpsVenue,
+  SUPPORTED_PERPS_VENUES,
 } from "./perps_sources";
 import { enforcePolicy, normalizePolicy } from "./policy";
 import { createPrivySolanaWallet } from "./privy";
@@ -457,7 +457,10 @@ export default {
           !SUPPORTED_TRADING_MINT_SET.has(outputMint) ||
           !isSupportedTradingPairByMint(inputMint, outputMint)
         ) {
-          return withCors(json(unsupportedTradePairPayload(), { status: 400 }), env);
+          return withCors(
+            json(unsupportedTradePairPayload(), { status: 400 }),
+            env,
+          );
         }
 
         // Public x402 read routes always serve mainnet market data.
@@ -642,8 +645,15 @@ export default {
         const payload = await readPayload(request);
         const baseMint = String(payload.baseMint ?? "").trim();
         const quoteMint = String(payload.quoteMint ?? "").trim();
-        if (baseMint && quoteMint && !isSupportedTradingPairByMint(baseMint, quoteMint)) {
-          return withCors(json(unsupportedTradePairPayload(), { status: 400 }), env);
+        if (
+          baseMint &&
+          quoteMint &&
+          !isSupportedTradingPairByMint(baseMint, quoteMint)
+        ) {
+          return withCors(
+            json(unsupportedTradePairPayload(), { status: 400 }),
+            env,
+          );
         }
         let ohlcv: Awaited<ReturnType<typeof fetchHistoricalOhlcvRuntime>>;
         try {
@@ -717,8 +727,15 @@ export default {
         const payload = await readPayload(request);
         const baseMint = String(payload.baseMint ?? "").trim();
         const quoteMint = String(payload.quoteMint ?? "").trim();
-        if (baseMint && quoteMint && !isSupportedTradingPairByMint(baseMint, quoteMint)) {
-          return withCors(json(unsupportedTradePairPayload(), { status: 400 }), env);
+        if (
+          baseMint &&
+          quoteMint &&
+          !isSupportedTradingPairByMint(baseMint, quoteMint)
+        ) {
+          return withCors(
+            json(unsupportedTradePairPayload(), { status: 400 }),
+            env,
+          );
         }
         let ohlcv: Awaited<ReturnType<typeof fetchHistoricalOhlcvRuntime>>;
         try {
@@ -1279,10 +1296,7 @@ export default {
         const parsedPerpsInput = parsePerpsReadInput(payload);
         if (!parsedPerpsInput.ok) {
           return withCors(
-            json(
-              { ok: false, error: parsedPerpsInput.error },
-              { status: 400 },
-            ),
+            json({ ok: false, error: parsedPerpsInput.error }, { status: 400 }),
             env,
           );
         }
@@ -1342,10 +1356,7 @@ export default {
         const parsedPerpsInput = parsePerpsReadInput(payload);
         if (!parsedPerpsInput.ok) {
           return withCors(
-            json(
-              { ok: false, error: parsedPerpsInput.error },
-              { status: 400 },
-            ),
+            json({ ok: false, error: parsedPerpsInput.error }, { status: 400 }),
             env,
           );
         }
@@ -1409,10 +1420,7 @@ export default {
         const parsedPerpsInput = parsePerpsReadInput(payload);
         if (!parsedPerpsInput.ok) {
           return withCors(
-            json(
-              { ok: false, error: parsedPerpsInput.error },
-              { status: 400 },
-            ),
+            json({ ok: false, error: parsedPerpsInput.error }, { status: 400 }),
             env,
           );
         }
@@ -2527,7 +2535,8 @@ function formatAtomicDisplay(
 ): string {
   let atomic = 0n;
   try {
-    atomic = typeof atomicInput === "bigint" ? atomicInput : BigInt(atomicInput);
+    atomic =
+      typeof atomicInput === "bigint" ? atomicInput : BigInt(atomicInput);
   } catch {
     return "0.0";
   }

--- a/apps/worker/src/perps_sources.ts
+++ b/apps/worker/src/perps_sources.ts
@@ -191,18 +191,26 @@ async function fetchJsonWithTimeout(
 }
 
 async function fetchHyperliquidRows(): Promise<PerpsVenueRow[]> {
-  const raw = await fetchJsonWithTimeout(HYPERLIQUID_INFO_URL, PERPS_FETCH_TIMEOUT_MS, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ type: "metaAndAssetCtxs" }),
-  });
+  const raw = await fetchJsonWithTimeout(
+    HYPERLIQUID_INFO_URL,
+    PERPS_FETCH_TIMEOUT_MS,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ type: "metaAndAssetCtxs" }),
+    },
+  );
   if (!Array.isArray(raw) || raw.length < 2) {
     throw new Error("invalid-hyperliquid-response");
   }
 
   const meta = raw[0];
   const ctxList = raw[1];
-  if (!isRecord(meta) || !Array.isArray(meta.universe) || !Array.isArray(ctxList)) {
+  if (
+    !isRecord(meta) ||
+    !Array.isArray(meta.universe) ||
+    !Array.isArray(ctxList)
+  ) {
     throw new Error("invalid-hyperliquid-response");
   }
 
@@ -218,7 +226,8 @@ async function fetchHyperliquidRows(): Promise<PerpsVenueRow[]> {
     const status = market.isDelisted === true ? "INACTIVE" : "ACTIVE";
 
     const fundingRate1h = toFiniteNumber(ctx.funding);
-    const markPrice = toFiniteNumber(ctx.markPx) ?? toFiniteNumber(ctx.oraclePx);
+    const markPrice =
+      toFiniteNumber(ctx.markPx) ?? toFiniteNumber(ctx.oraclePx);
     const openInterestNative = toFiniteNumber(ctx.openInterest);
     const openInterestUsd =
       markPrice === null || openInterestNative === null
@@ -263,7 +272,9 @@ async function fetchDydxRows(): Promise<PerpsVenueRow[]> {
     const symbol = normalizeSymbol(ticker.split("-")[0] ?? "");
     if (!symbol) continue;
 
-    const statusRaw = String(market.status ?? "").trim().toUpperCase();
+    const statusRaw = String(market.status ?? "")
+      .trim()
+      .toUpperCase();
     const status = statusRaw || "UNKNOWN";
 
     const fundingRate1h = toFiniteNumber(market.nextFundingRate);
@@ -452,7 +463,9 @@ function buildFundingRows(rows: PerpsVenueRow[]): PerpsSymbolFundingRow[] {
   });
 }
 
-function buildOpenInterestRows(rows: PerpsVenueRow[]): PerpsSymbolOpenInterestRow[] {
+function buildOpenInterestRows(
+  rows: PerpsVenueRow[],
+): PerpsSymbolOpenInterestRow[] {
   const grouped = groupRowsBySymbol(rows);
   return grouped.map(({ symbol, rows: symbolRows }) => {
     const totalOpenInterestUsd = round(
@@ -495,7 +508,9 @@ function buildOpenInterestRows(rows: PerpsVenueRow[]): PerpsSymbolOpenInterestRo
   });
 }
 
-function buildVenueScores(rows: PerpsVenueRow[]): PerpsVenueScoreResponse["scores"] {
+function buildVenueScores(
+  rows: PerpsVenueRow[],
+): PerpsVenueScoreResponse["scores"] {
   const byVenue = new Map<
     PerpsVenue,
     {
@@ -560,8 +575,14 @@ function buildVenueScores(rows: PerpsVenueRow[]): PerpsVenueScoreResponse["score
     };
   });
 
-  const minRaw = rawRows.reduce((min, row) => Math.min(min, row.rawScore), Infinity);
-  const maxRaw = rawRows.reduce((max, row) => Math.max(max, row.rawScore), -Infinity);
+  const minRaw = rawRows.reduce(
+    (min, row) => Math.min(min, row.rawScore),
+    Infinity,
+  );
+  const maxRaw = rawRows.reduce(
+    (max, row) => Math.max(max, row.rawScore),
+    -Infinity,
+  );
 
   const withScores = rawRows.map((row) => {
     const score =
@@ -586,9 +607,7 @@ function buildVenueScores(rows: PerpsVenueRow[]): PerpsVenueScoreResponse["score
   return withScores;
 }
 
-async function resolveFilteredRows(
-  input: PerpsRequestInput,
-): Promise<{
+async function resolveFilteredRows(input: PerpsRequestInput): Promise<{
   snapshotTs: string;
   rows: PerpsVenueRow[];
   unavailableVenues: PerpsUnavailableVenue[];
@@ -605,7 +624,8 @@ async function resolveFilteredRows(
 export async function fetchPerpsFundingSurface(
   input: PerpsRequestInput,
 ): Promise<PerpsFundingSurfaceResponse> {
-  const { snapshotTs, rows, unavailableVenues } = await resolveFilteredRows(input);
+  const { snapshotTs, rows, unavailableVenues } =
+    await resolveFilteredRows(input);
   return {
     timestamp: snapshotTs,
     symbols: resolveSymbolsFromRows(rows),
@@ -620,7 +640,8 @@ export async function fetchPerpsFundingSurface(
 export async function fetchPerpsOpenInterestSurface(
   input: PerpsRequestInput,
 ): Promise<PerpsOpenInterestSurfaceResponse> {
-  const { snapshotTs, rows, unavailableVenues } = await resolveFilteredRows(input);
+  const { snapshotTs, rows, unavailableVenues } =
+    await resolveFilteredRows(input);
   return {
     timestamp: snapshotTs,
     symbols: resolveSymbolsFromRows(rows),
@@ -635,7 +656,8 @@ export async function fetchPerpsOpenInterestSurface(
 export async function fetchPerpsVenueScore(
   input: PerpsRequestInput,
 ): Promise<PerpsVenueScoreResponse> {
-  const { snapshotTs, rows, unavailableVenues } = await resolveFilteredRows(input);
+  const { snapshotTs, rows, unavailableVenues } =
+    await resolveFilteredRows(input);
   const scores = buildVenueScores(rows);
   return {
     timestamp: snapshotTs,

--- a/tests/unit/portal_api_catalog_routes.test.ts
+++ b/tests/unit/portal_api_catalog_routes.test.ts
@@ -79,15 +79,11 @@ describe("portal x402 api catalog routes", () => {
       ? supportedTrading.tokens
       : [];
     expect(supportedPairs.length).toBeGreaterThan(10);
+    expect(supportedPairs.some((row) => toRecord(row)?.id === "SOL/USDT")).toBe(
+      true,
+    );
     expect(
-      supportedPairs.some(
-        (row) => toRecord(row)?.id === "SOL/USDT",
-      ),
-    ).toBe(true);
-    expect(
-      supportedTokens.some(
-        (row) => toRecord(row)?.symbol === "USDT",
-      ),
+      supportedTokens.some((row) => toRecord(row)?.symbol === "USDT"),
     ).toBe(true);
 
     const oilEndpoint =
@@ -129,5 +125,10 @@ describe("portal x402 api catalog routes", () => {
     expect(body.includes("https://portal.example/api/endpoints.txt")).toBe(
       true,
     );
+    expect(body.includes("/api/x402/read/perps_funding_surface")).toBe(true);
+    expect(body.includes("/api/x402/read/perps_open_interest_surface")).toBe(
+      true,
+    );
+    expect(body.includes("/api/x402/read/perps_venue_score")).toBe(true);
   });
 });

--- a/tests/unit/worker_execution_jito_bundle.test.ts
+++ b/tests/unit/worker_execution_jito_bundle.test.ts
@@ -3,6 +3,14 @@ import { normalizePolicy } from "../../apps/worker/src/policy";
 import type { Env } from "../../apps/worker/src/types";
 
 const signTransactionWithPrivyByIdMock = mock(async () => "signed-base64");
+const createPrivySolanaWalletMock = mock(async () => ({
+  walletId: "mock-wallet-id",
+  address: "mock-wallet-address",
+}));
+const getPrivyWalletAddressByIdMock = mock(
+  async () => "mock-wallet-address-by-id",
+);
+const getPrivyWalletAddressMock = mock(async () => "mock-wallet-address");
 const swapWithRetryMock = mock(async () => ({
   swap: {
     swapTransaction: "unsigned-base64",
@@ -18,6 +26,9 @@ const swapWithRetryMock = mock(async () => ({
 }));
 
 mock.module("../../apps/worker/src/privy", () => ({
+  createPrivySolanaWallet: createPrivySolanaWalletMock,
+  getPrivyWalletAddress: getPrivyWalletAddressMock,
+  getPrivyWalletAddressById: getPrivyWalletAddressByIdMock,
   signTransactionWithPrivyById: signTransactionWithPrivyByIdMock,
 }));
 mock.module("../../apps/worker/src/swap", () => ({
@@ -32,6 +43,9 @@ const ORIGINAL_FETCH = globalThis.fetch;
 
 describe("worker jito bundle execution adapter", () => {
   beforeEach(() => {
+    createPrivySolanaWalletMock.mockClear();
+    getPrivyWalletAddressByIdMock.mockClear();
+    getPrivyWalletAddressMock.mockClear();
     signTransactionWithPrivyByIdMock.mockClear();
     swapWithRetryMock.mockClear();
     globalThis.fetch = ORIGINAL_FETCH;


### PR DESCRIPTION
## Summary
- update `llms.txt` discovery content to explicitly list perps x402 endpoints
- update API catalog page metadata description to include perps reads
- add test assertions ensuring `llms.txt` contains perps endpoint paths

## Endpoints explicitly documented
- `/api/x402/read/perps_funding_surface`
- `/api/x402/read/perps_open_interest_surface`
- `/api/x402/read/perps_venue_score`

## Validation
- `bun test tests/unit/portal_api_catalog_routes.test.ts`
