### PR TITLE
Fix x402 RPC selection to use Helius secrets first

### DIFF
--- a/apps/worker/src/x402.ts
+++ b/apps/worker/src/x402.ts
@@ -204,9 +204,9 @@ function defaultRpcEndpointForNetwork(network: string): string {
 
 function resolvePaymentRpcEndpoint(env: Env, network: string): string {
   const configured = String(
-    env.BILLING_RPC_ENDPOINT ??
-      env.BALANCE_RPC_ENDPOINT ??
+    env.BALANCE_RPC_ENDPOINT ??
       env.RPC_ENDPOINT ??
+      env.BILLING_RPC_ENDPOINT ??
       "",
   ).trim();
   return configured || defaultRpcEndpointForNetwork(network);


### PR DESCRIPTION
## Why
Cloudflare worker egress is blocked by public Solana RPC when x402 verification uses BILLING_RPC_ENDPOINT first.

## Change
- x402 payment verification now resolves RPC in this order:
  1. BALANCE_RPC_ENDPOINT
  2. RPC_ENDPOINT
  3. BILLING_RPC_ENDPOINT

## Ops done
- synced local Helius RPC values into Cloudflare staging and production secrets for BALANCE_RPC_ENDPOINT and RPC_ENDPOINT.

## Validation
- lint/typecheck/unit pass locally
