### PR TITLE
AI-ready API docs with explicit env-specific absolute URLs

### DIFF
--- a/apps/portal/app/api/_discovery.ts
+++ b/apps/portal/app/api/_discovery.ts
@@ -1,0 +1,131 @@
+const DEFAULT_LOCAL_API_ORIGIN = "http://127.0.0.1:8888";
+
+type HeaderLike = {
+  get(name: string): string | null;
+};
+
+function parseForwardedValue(value: string | null): string {
+  return String(value ?? "")
+    .split(",")[0]
+    .trim();
+}
+
+function normalizeProtocol(value: string): "http:" | "https:" {
+  return value.trim().toLowerCase() === "http:" ? "http:" : "https:";
+}
+
+function parseHost(value: string): { hostname: string; port: string } {
+  if (!value.trim()) return { hostname: "", port: "" };
+  try {
+    const parsed = new URL(`http://${value.trim()}`);
+    return {
+      hostname: parsed.hostname.toLowerCase(),
+      port: parsed.port,
+    };
+  } catch {
+    return { hostname: "", port: "" };
+  }
+}
+
+function isDefaultPort(protocol: string, port: string): boolean {
+  if (!port) return true;
+  return (
+    (protocol === "https:" && port === "443") ||
+    (protocol === "http:" && port === "80")
+  );
+}
+
+function isLocalHostname(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "0.0.0.0"
+  );
+}
+
+function mapToApiHostname(hostname: string): string {
+  if (!hostname) return hostname;
+  if (hostname.startsWith("api.") || hostname.includes(".api.")) {
+    return hostname;
+  }
+  if (hostname === "trader-ralph.com" || hostname === "www.trader-ralph.com") {
+    return "api.trader-ralph.com";
+  }
+  if (hostname === "dev.trader-ralph.com") {
+    return "dev.api.trader-ralph.com";
+  }
+  if (hostname === "staging.trader-ralph.com") {
+    return "staging.api.trader-ralph.com";
+  }
+  return hostname;
+}
+
+function configuredApiBase(): string {
+  return String(process.env.NEXT_PUBLIC_EDGE_API_BASE ?? "")
+    .trim()
+    .replace(/\/+$/, "");
+}
+
+function resolveApiOrigin(protocolRaw: string, hostRaw: string): string {
+  const protocol = normalizeProtocol(protocolRaw);
+  const { hostname, port } = parseHost(hostRaw);
+  if (!hostname) return "";
+
+  if (isLocalHostname(hostname)) {
+    return configuredApiBase() || DEFAULT_LOCAL_API_ORIGIN;
+  }
+
+  const apiHostname = mapToApiHostname(hostname);
+  const portSuffix = isDefaultPort(protocol, port) ? "" : `:${port}`;
+  return `${protocol}//${apiHostname}${portSuffix}`;
+}
+
+export function resolveApiOriginFromRequest(request: Request): string {
+  const requestUrl = new URL(request.url);
+  const forwardedProto = parseForwardedValue(
+    request.headers.get("x-forwarded-proto"),
+  );
+  const forwardedHost = parseForwardedValue(
+    request.headers.get("x-forwarded-host"),
+  );
+  return resolveApiOrigin(
+    forwardedProto || requestUrl.protocol,
+    forwardedHost || requestUrl.host,
+  );
+}
+
+export function resolveApiOriginFromHeaders(headers: HeaderLike): string {
+  const forwardedProto =
+    parseForwardedValue(headers.get("x-forwarded-proto")) || "https:";
+  const forwardedHost =
+    parseForwardedValue(headers.get("x-forwarded-host")) ||
+    parseForwardedValue(headers.get("host"));
+  return resolveApiOrigin(forwardedProto, forwardedHost);
+}
+
+export function toApiRuntimePath(path: string): string {
+  const normalized = path.startsWith("/") ? path : `/${path}`;
+  return normalized.startsWith("/api/") ? normalized : `/api${normalized}`;
+}
+
+export function toAbsoluteApiUrl(apiOrigin: string, path: string): string {
+  const origin = apiOrigin.replace(/\/+$/, "");
+  const normalized = path.startsWith("/") ? path : `/${path}`;
+  return `${origin}${normalized}`;
+}
+
+export function buildDiscoveryUrls(apiOrigin: string): {
+  html: string;
+  json: string;
+  text: string;
+  llms: string;
+  skills: string;
+} {
+  return {
+    html: toAbsoluteApiUrl(apiOrigin, "/api"),
+    json: toAbsoluteApiUrl(apiOrigin, "/endpoints.json"),
+    text: toAbsoluteApiUrl(apiOrigin, "/endpoints.txt"),
+    llms: toAbsoluteApiUrl(apiOrigin, "/llms.txt"),
+    skills: toAbsoluteApiUrl(apiOrigin, "/dev-skills.txt"),
+  };
+}

--- a/apps/portal/app/api/dev-skills.txt/route.ts
+++ b/apps/portal/app/api/dev-skills.txt/route.ts
@@ -1,0 +1,1 @@
+export { GET } from "../../dev-skills.txt/route";

--- a/apps/portal/app/api/endpoints.json/route.ts
+++ b/apps/portal/app/api/endpoints.json/route.ts
@@ -6,11 +6,19 @@ import {
   X402_PAYMENT_REQUIRED_RESPONSE_EXAMPLE,
   X402_SUPPORTED_TRADING,
 } from "../_catalog";
+import {
+  buildDiscoveryUrls,
+  resolveApiOriginFromRequest,
+  toAbsoluteApiUrl,
+  toApiRuntimePath,
+} from "../_discovery";
 
 const CACHE_CONTROL = "public, max-age=300, stale-while-revalidate=600";
 
 export function GET(request: Request): Response {
-  const origin = new URL(request.url).origin;
+  const apiOrigin = resolveApiOriginFromRequest(request);
+  const discovery = buildDiscoveryUrls(apiOrigin);
+  const runtimeBasePath = toApiRuntimePath("/x402/read");
 
   const payload: CatalogDoc & {
     examples: {
@@ -21,6 +29,18 @@ export function GET(request: Request): Response {
       json: string;
       text: string;
       llms: string;
+      skills: string;
+    };
+    runtime: {
+      apiOrigin: string;
+      x402BasePath: string;
+      x402BaseUrl: string;
+      endpoints: Array<{
+        id: string;
+        method: "POST";
+        runtimePath: string;
+        url: string;
+      }>;
     };
   } = {
     name: "Trader Ralph x402 API Catalog",
@@ -38,11 +58,20 @@ export function GET(request: Request): Response {
     examples: {
       paymentRequiredResponse: X402_PAYMENT_REQUIRED_RESPONSE_EXAMPLE,
     },
-    discovery: {
-      html: `${origin}/api`,
-      json: `${origin}/endpoints.json`,
-      text: `${origin}/endpoints.txt`,
-      llms: `${origin}/llms.txt`,
+    discovery,
+    runtime: {
+      apiOrigin,
+      x402BasePath: runtimeBasePath,
+      x402BaseUrl: toAbsoluteApiUrl(apiOrigin, runtimeBasePath),
+      endpoints: X402_ENDPOINTS.map((endpoint) => {
+        const runtimePath = toApiRuntimePath(endpoint.path);
+        return {
+          id: endpoint.id,
+          method: endpoint.method,
+          runtimePath,
+          url: toAbsoluteApiUrl(apiOrigin, runtimePath),
+        };
+      }),
     },
   };
 

--- a/apps/portal/app/api/endpoints.txt/route.ts
+++ b/apps/portal/app/api/endpoints.txt/route.ts
@@ -6,6 +6,12 @@ import {
   X402_SUPPORTED_TRADING,
   type X402EndpointSpec,
 } from "../_catalog";
+import {
+  buildDiscoveryUrls,
+  resolveApiOriginFromRequest,
+  toAbsoluteApiUrl,
+  toApiRuntimePath,
+} from "../_discovery";
 
 const CACHE_CONTROL = "public, max-age=300, stale-while-revalidate=600";
 
@@ -26,7 +32,8 @@ function formatExample(value: Record<string, unknown>): string {
 }
 
 export function GET(request: Request): Response {
-  const origin = new URL(request.url).origin;
+  const apiOrigin = resolveApiOriginFromRequest(request);
+  const discovery = buildDiscoveryUrls(apiOrigin);
 
   const lines: string[] = [
     "Trader Ralph x402 API Catalog",
@@ -49,22 +56,32 @@ export function GET(request: Request): Response {
     "request: payment-signature",
     "response: payment-required, payment-response",
     "",
+    "runtime urls:",
+    `api origin: ${apiOrigin}`,
+    `x402 base path: ${toApiRuntimePath("/x402/read")}`,
+    `x402 base url: ${toAbsoluteApiUrl(apiOrigin, toApiRuntimePath("/x402/read"))}`,
+    "",
     `example 402 response: ${JSON.stringify(X402_PAYMENT_REQUIRED_RESPONSE_EXAMPLE)}`,
     "",
     `supported trading tokens: ${X402_SUPPORTED_TRADING.tokens.map((token) => token.symbol).join(", ")}`,
     `supported trading pairs: ${X402_SUPPORTED_TRADING.pairs.map((pair) => pair.id).join(", ")}`,
     "",
     "discovery:",
-    `html: ${origin}/api`,
-    `json: ${origin}/endpoints.json`,
-    `text: ${origin}/endpoints.txt`,
-    `llms: ${origin}/llms.txt`,
+    `html: ${discovery.html}`,
+    `json: ${discovery.json}`,
+    `text: ${discovery.text}`,
+    `llms: ${discovery.llms}`,
+    `skills: ${discovery.skills}`,
     "",
     "endpoints:",
   ];
 
   for (const endpoint of X402_ENDPOINTS) {
-    lines.push(`${endpoint.method} ${endpoint.path} - ${endpoint.summary}`);
+    const runtimePath = toApiRuntimePath(endpoint.path);
+    const runtimeUrl = toAbsoluteApiUrl(apiOrigin, runtimePath);
+    lines.push(
+      `${endpoint.method} ${endpoint.path} (runtime: ${runtimeUrl}) - ${endpoint.summary}`,
+    );
     lines.push(`  ${formatFields("required", endpoint.requiredFields)}`);
     lines.push(`  ${formatFields("optional", endpoint.optionalFields)}`);
     lines.push(`  example request: ${formatExample(endpoint.requestExample)}`);

--- a/apps/portal/app/api/page.tsx
+++ b/apps/portal/app/api/page.tsx
@@ -1,3 +1,4 @@
+import { headers } from "next/headers";
 import type { Metadata } from "next";
 import {
   X402_CATALOG_VERSION,
@@ -6,6 +7,12 @@ import {
   X402_PAYMENT_REQUIRED_RESPONSE_EXAMPLE,
   X402_SUPPORTED_TRADING,
 } from "./_catalog";
+import {
+  buildDiscoveryUrls,
+  resolveApiOriginFromHeaders,
+  toAbsoluteApiUrl,
+  toApiRuntimePath,
+} from "./_discovery";
 
 export const metadata: Metadata = {
   title: "API Catalog | Trader Ralph",
@@ -44,7 +51,13 @@ function hasFields(record: Record<string, unknown>): boolean {
   return Object.keys(record).length > 0;
 }
 
-export default function ApiCatalogPage() {
+export default async function ApiCatalogPage() {
+  const requestHeaders = await headers();
+  const apiOrigin = resolveApiOriginFromHeaders(requestHeaders);
+  const discovery = buildDiscoveryUrls(apiOrigin);
+  const x402BasePath = toApiRuntimePath("/x402/read");
+  const x402BaseUrl = toAbsoluteApiUrl(apiOrigin, x402BasePath);
+
   return (
     <main>
       <section className="py-[clamp(3rem,6vw,6rem)] border-t border-border">
@@ -57,20 +70,32 @@ export default function ApiCatalogPage() {
               Catalog version: <code>{X402_CATALOG_VERSION}</code>
             </p>
             <p className="text-xs text-muted mt-2">
+              API origin: <code>{apiOrigin}</code>
+            </p>
+            <p className="text-xs text-muted mt-2">
+              x402 base URL: <code>{x402BaseUrl}</code>
+            </p>
+            <p className="text-xs text-muted mt-2">
               Supported trading pairs:{" "}
               <code>
                 {X402_SUPPORTED_TRADING.pairs.map((pair) => pair.id).join(", ")}
               </code>
             </p>
             <div className="mt-4 flex flex-wrap items-center gap-3 text-sm">
-              <a className="underline hover:text-accent" href="/endpoints.json">
-                /endpoints.json
+              <a className="underline hover:text-accent" href={discovery.json}>
+                {discovery.json}
               </a>
-              <a className="underline hover:text-accent" href="/endpoints.txt">
-                /endpoints.txt
+              <a className="underline hover:text-accent" href={discovery.text}>
+                {discovery.text}
               </a>
-              <a className="underline hover:text-accent" href="/llms.txt">
-                /llms.txt
+              <a className="underline hover:text-accent" href={discovery.llms}>
+                {discovery.llms}
+              </a>
+              <a
+                className="underline hover:text-accent"
+                href={discovery.skills}
+              >
+                {discovery.skills}
               </a>
             </div>
           </div>
@@ -79,7 +104,7 @@ export default function ApiCatalogPage() {
             <p className="label">How x402 Works</p>
             <ol className="mt-3 space-y-2 text-sm">
               <li>
-                1. Request an endpoint under <code>/x402/read/*</code>.
+                1. Request an endpoint under <code>{x402BasePath}/*</code>.
               </li>
               <li>
                 2. If payment is missing, you get <code>402</code> with{" "}
@@ -127,6 +152,7 @@ export default function ApiCatalogPage() {
                   <code>
                     {endpoint.method} {endpoint.path}
                   </code>
+                  <code>{toAbsoluteApiUrl(apiOrigin, toApiRuntimePath(endpoint.path))}</code>
                   <span className="text-[11px] rounded-full border border-border px-2 py-0.5 text-muted">
                     {endpoint.access}
                   </span>

--- a/apps/portal/app/api/page.tsx
+++ b/apps/portal/app/api/page.tsx
@@ -1,5 +1,5 @@
-import { headers } from "next/headers";
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import {
   X402_CATALOG_VERSION,
   X402_ENDPOINTS,
@@ -152,7 +152,12 @@ export default async function ApiCatalogPage() {
                   <code>
                     {endpoint.method} {endpoint.path}
                   </code>
-                  <code>{toAbsoluteApiUrl(apiOrigin, toApiRuntimePath(endpoint.path))}</code>
+                  <code>
+                    {toAbsoluteApiUrl(
+                      apiOrigin,
+                      toApiRuntimePath(endpoint.path),
+                    )}
+                  </code>
                   <span className="text-[11px] rounded-full border border-border px-2 py-0.5 text-muted">
                     {endpoint.access}
                   </span>

--- a/apps/portal/app/dev-skills.txt/route.ts
+++ b/apps/portal/app/dev-skills.txt/route.ts
@@ -1,0 +1,137 @@
+import {
+  buildDiscoveryUrls,
+  resolveApiOriginFromRequest,
+  toAbsoluteApiUrl,
+  toApiRuntimePath,
+} from "../api/_discovery";
+
+const CACHE_CONTROL = "public, max-age=300, stale-while-revalidate=600";
+
+type SkillSpec = {
+  id: string;
+  title: string;
+  sourceUrl: string;
+  purpose: string;
+};
+
+function codexSkillContent(skill: SkillSpec, apiOrigin: string): string {
+  return [
+    `# Skill: ${skill.id}`,
+    "",
+    "## Trigger",
+    `Use this skill when the user asks for ${skill.title} from Trader Ralph.`,
+    "",
+    "## Source",
+    `- Primary URL: ${skill.sourceUrl}`,
+    `- API origin: ${apiOrigin}`,
+    "",
+    "## Workflow",
+    "1. Fetch the source URL.",
+    "2. Parse response body as authoritative for the current environment.",
+    "3. Return explicit absolute URLs, not relative paths.",
+    "4. If fields are missing, report the exact gap and fallback source.",
+    "",
+    "## Output Rules",
+    "- Keep endpoint URLs fully-qualified.",
+    "- Preserve x402 header requirements and method/path exactly.",
+    "- Prefer machine-readable payload fields where available.",
+  ].join("\n");
+}
+
+function claudeSkillContent(skill: SkillSpec, apiOrigin: string): string {
+  return [
+    "---",
+    `name: ${skill.id}`,
+    `description: Resolve and use ${skill.title} for the current Trader Ralph environment.`,
+    "---",
+    "",
+    `Primary source: ${skill.sourceUrl}`,
+    `API origin: ${apiOrigin}`,
+    "",
+    "Instructions:",
+    "1. Read the source URL first.",
+    "2. Extract absolute URLs for endpoints/discovery links.",
+    "3. Keep outputs concise and machine-usable.",
+    "4. Surface missing/invalid fields explicitly.",
+  ].join("\n");
+}
+
+export function GET(request: Request): Response {
+  const apiOrigin = resolveApiOriginFromRequest(request);
+  const discovery = buildDiscoveryUrls(apiOrigin);
+
+  const skills: SkillSpec[] = [
+    {
+      id: "trader-ralph-api-docs",
+      title: "/api",
+      sourceUrl: discovery.html,
+      purpose: "Human-readable API overview and x402 flow guidance.",
+    },
+    {
+      id: "trader-ralph-endpoints-json",
+      title: "/endpoints.json",
+      sourceUrl: discovery.json,
+      purpose: "Machine-readable catalog with endpoint metadata.",
+    },
+    {
+      id: "trader-ralph-endpoints-txt",
+      title: "/endpoints.txt",
+      sourceUrl: discovery.text,
+      purpose: "Plain text catalog for agents and quick CLI ingestion.",
+    },
+    {
+      id: "trader-ralph-llms-txt",
+      title: "/llms.txt",
+      sourceUrl: discovery.llms,
+      purpose: "LLM discovery metadata and endpoint index.",
+    },
+  ];
+
+  const lines: string[] = [
+    "Trader Ralph Developer Skills Pack",
+    "",
+    "AI-first, environment-aware skills for API discovery and ingestion.",
+    `API origin: ${apiOrigin}`,
+    `x402 runtime base: ${toAbsoluteApiUrl(apiOrigin, toApiRuntimePath("/x402/read"))}`,
+    "",
+    "Skill index:",
+    ...skills.map(
+      (skill) =>
+        `- ${skill.id} | source=${skill.sourceUrl} | purpose=${skill.purpose}`,
+    ),
+    "",
+    "Installation (Codex format):",
+    "1) Create one folder per skill under $CODEX_HOME/skills/<skill-id>/",
+    "2) Save SKILL.md with the corresponding block content below.",
+    "",
+    "Installation (Claude format):",
+    "1) Create .claude/skills/ in your repo (or your Claude skills directory).",
+    "2) Save one <skill-id>.md file per block below.",
+    "",
+    "Download this file:",
+    `curl -fsSL ${discovery.skills} -o trader-ralph-dev-skills.txt`,
+    "",
+  ];
+
+  for (const skill of skills) {
+    lines.push(`=== CODEX SKILL START: ${skill.id} ===`);
+    lines.push(codexSkillContent(skill, apiOrigin));
+    lines.push(`=== CODEX SKILL END: ${skill.id} ===`);
+    lines.push("");
+    lines.push(`=== CLAUDE SKILL START: ${skill.id} ===`);
+    lines.push(claudeSkillContent(skill, apiOrigin));
+    lines.push(`=== CLAUDE SKILL END: ${skill.id} ===`);
+    lines.push("");
+  }
+
+  const body = `${lines.join("\n")}\n`;
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "cache-control": CACHE_CONTROL,
+      "content-disposition":
+        'attachment; filename="trader-ralph-dev-skills.txt"',
+      "content-type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/apps/portal/app/llms.txt/route.ts
+++ b/apps/portal/app/llms.txt/route.ts
@@ -1,24 +1,40 @@
 import { X402_ENDPOINTS } from "../api/_catalog";
+import {
+  buildDiscoveryUrls,
+  resolveApiOriginFromRequest,
+  toAbsoluteApiUrl,
+  toApiRuntimePath,
+} from "../api/_discovery";
 
 const CACHE_CONTROL = "public, max-age=300, stale-while-revalidate=600";
 
 export function GET(request: Request): Response {
-  const origin = new URL(request.url).origin;
-  const endpointLines = X402_ENDPOINTS.map((endpoint) => endpoint.path);
+  const apiOrigin = resolveApiOriginFromRequest(request);
+  const discovery = buildDiscoveryUrls(apiOrigin);
+  const endpointLines = X402_ENDPOINTS.map((endpoint) => ({
+    path: endpoint.path,
+    runtimePath: toApiRuntimePath(endpoint.path),
+    url: toAbsoluteApiUrl(apiOrigin, toApiRuntimePath(endpoint.path)),
+  }));
   const body = [
     "Trader Ralph",
     "",
     "Solana-focused intelligence infrastructure.",
     "This file points agents to the public x402 API catalog resources.",
     "",
-    `API docs: ${origin}/api`,
-    `API catalog JSON: ${origin}/endpoints.json`,
-    `API catalog TXT: ${origin}/endpoints.txt`,
+    `API origin: ${apiOrigin}`,
+    `API docs: ${discovery.html}`,
+    `API catalog JSON: ${discovery.json}`,
+    `API catalog TXT: ${discovery.text}`,
+    `API skills pack: ${discovery.skills}`,
     "",
     "Catalog scope: public x402 read endpoints only.",
     "Catalog includes market snapshots/quotes, loop views, macro analytics, and cross-venue perps intelligence.",
-    "Public x402 endpoints:",
-    ...endpointLines.map((path) => `- ${path}`),
+    "Public x402 endpoint URLs (runtime):",
+    ...endpointLines.map(
+      (endpoint) =>
+        `- ${endpoint.url} (catalog path: ${endpoint.path}, runtime path: ${endpoint.runtimePath})`,
+    ),
     "Perps endpoints: /x402/read/perps_funding_surface, /x402/read/perps_open_interest_surface, /x402/read/perps_venue_score.",
     "x402 verification policy: payment-signature must be an on-chain Solana transaction signature.",
     "Environment policy: dev expects devnet USDC; staging and production expect mainnet USDC.",


### PR DESCRIPTION
## Summary
- make `/api`, `/endpoints.json`, `/endpoints.txt`, and `/llms.txt` emit explicit full API URLs for the current environment
- add runtime endpoint URL materialization for x402 routes (absolute URL + runtime path)
- add downloadable `dev-skills.txt` pack with install-ready Codex and Claude skill templates for:
  - `/api`
  - `/endpoints.json`
  - `/endpoints.txt`
  - `/llms.txt`

## Why
Improve machine discoverability and agent integration by removing ambiguity around host/path resolution across dev/staging/prod and providing installable skill definitions for AI workflows.

## Notes
- API origin is resolved from request host/proto and mapped to `.api` environment domains
- local fallback uses `NEXT_PUBLIC_EDGE_API_BASE` or `http://127.0.0.1:8888`
- includes both `/dev-skills.txt` and `/api/dev-skills.txt`
