### PR TITLE
Add D1 endpoint call statistics tracking

### DIFF
--- a/apps/worker/migrations/0024_endpoint_call_stats.sql
+++ b/apps/worker/migrations/0024_endpoint_call_stats.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS endpoint_call_stats (
+  endpoint_method TEXT NOT NULL,
+  endpoint_path TEXT NOT NULL,
+  call_count INTEGER NOT NULL DEFAULT 0,
+  first_called_at TEXT NOT NULL,
+  last_called_at TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (endpoint_method, endpoint_path)
+);
+
+CREATE INDEX IF NOT EXISTS idx_endpoint_call_stats_count
+ON endpoint_call_stats(call_count DESC);
+
+CREATE INDEX IF NOT EXISTS idx_endpoint_call_stats_last_called
+ON endpoint_call_stats(last_called_at DESC);

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -198,6 +198,43 @@ async function upsertWaitlistEmail(
     .run();
 }
 
+async function recordEndpointCall(
+  env: Env,
+  method: string,
+  path: string,
+): Promise<void> {
+  const nowIso = new Date().toISOString();
+  await env.WAITLIST_DB.prepare(
+    `INSERT INTO endpoint_call_stats (
+      endpoint_method,
+      endpoint_path,
+      call_count,
+      first_called_at,
+      last_called_at,
+      created_at,
+      updated_at
+    ) VALUES (?1, ?2, 1, ?3, ?3, ?3, ?3)
+     ON CONFLICT(endpoint_method, endpoint_path) DO UPDATE SET
+       call_count = endpoint_call_stats.call_count + 1,
+       last_called_at = excluded.last_called_at,
+       updated_at = excluded.updated_at`,
+  )
+    .bind(method.toUpperCase(), path, nowIso)
+    .run();
+}
+
+async function recordEndpointCallSafe(
+  env: Env,
+  method: string,
+  path: string,
+): Promise<void> {
+  try {
+    await recordEndpointCall(env, method, path);
+  } catch {
+    // Do not fail request handling if telemetry write fails.
+  }
+}
+
 export {
   ExecutionCoordinator,
   LoopACoordinator,
@@ -234,12 +271,14 @@ export default {
 
     const url = new URL(request.url);
     if (request.method === "GET" && DISCOVERY_DOC_PATHS.has(url.pathname)) {
+      await recordEndpointCallSafe(env, request.method, url.pathname);
       const proxied = await proxyPortalDiscovery(request, url.pathname);
       return withCors(proxied, env);
     }
     if (url.pathname !== "/api" && !url.pathname.startsWith("/api/")) {
       url.pathname = `/api${url.pathname}`;
     }
+    await recordEndpointCallSafe(env, request.method, url.pathname);
     try {
       if (request.method === "GET" && url.pathname === "/api/health") {
         const loopAHealth = await readLoopAHealthFromKv(env);


### PR DESCRIPTION
## Summary
- add persistent endpoint usage counters in the worker request path
- store per-method/per-path call totals in D1
- add migration for `endpoint_call_stats`

## Details
- tracks all non-OPTIONS requests handled by the worker
- tracks discovery doc proxy paths on `.api` host
- uses UPSERT to increment `call_count` and update `last_called_at`
- writes are fail-safe so telemetry errors do not break API traffic

## Migration
- `0024_endpoint_call_stats.sql`
