### PR TITLE
ci: automate vercel lane mapping and deploy smoke checks

### DIFF
--- a/.github/workflows/deploy-portal.yml
+++ b/.github/workflows/deploy-portal.yml
@@ -1,0 +1,145 @@
+name: Deploy Portal (Vercel)
+
+on:
+  push:
+    branches: [dev, staging, main]
+
+concurrency:
+  group: deploy-portal-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-portal:
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref_name == 'main' && 'production' || github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Resolve lane config
+        id: lane
+        run: |
+          set -euo pipefail
+
+          case "${GITHUB_REF_NAME}" in
+            dev)
+              echo "edge_api_base=https://dev.api.trader-ralph.com" >> "$GITHUB_OUTPUT"
+              echo "site_url=https://dev.trader-ralph.com" >> "$GITHUB_OUTPUT"
+              echo "alias_domains=dev.trader-ralph.com" >> "$GITHUB_OUTPUT"
+              echo "expected_edge_host=dev.api.trader-ralph.com" >> "$GITHUB_OUTPUT"
+              ;;
+            staging)
+              echo "edge_api_base=https://staging.api.trader-ralph.com" >> "$GITHUB_OUTPUT"
+              echo "site_url=https://staging.trader-ralph.com" >> "$GITHUB_OUTPUT"
+              echo "alias_domains=staging.trader-ralph.com" >> "$GITHUB_OUTPUT"
+              echo "expected_edge_host=staging.api.trader-ralph.com" >> "$GITHUB_OUTPUT"
+              ;;
+            main)
+              echo "edge_api_base=https://api.trader-ralph.com" >> "$GITHUB_OUTPUT"
+              echo "site_url=https://trader-ralph.com" >> "$GITHUB_OUTPUT"
+              echo "alias_domains=trader-ralph.com,www.trader-ralph.com,api.trader-ralph.com" >> "$GITHUB_OUTPUT"
+              echo "expected_edge_host=api.trader-ralph.com" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "unsupported branch: ${GITHUB_REF_NAME}" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Deploy portal
+        id: deploy
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+
+          DEPLOY_ARGS=(
+            deploy
+            --scope guivercelpro
+            --token "$VERCEL_TOKEN"
+            --yes
+            --build-env "NEXT_PUBLIC_EDGE_API_BASE=${{ steps.lane.outputs.edge_api_base }}"
+            --build-env "NEXT_PUBLIC_SITE_URL=${{ steps.lane.outputs.site_url }}"
+            --json
+          )
+
+          if [ "${GITHUB_REF_NAME}" = "main" ]; then
+            DEPLOY_ARGS+=(--prod)
+          fi
+
+          DEPLOY_JSON="$(npx --yes vercel "${DEPLOY_ARGS[@]}")"
+          DEPLOYMENT_URL="$(
+            printf '%s' "$DEPLOY_JSON" | node -e 'const fs = require("node:fs"); const raw = fs.readFileSync(0, "utf8"); const parsed = JSON.parse(raw); process.stdout.write(`https://${parsed.url}`);'
+          )"
+
+          echo "deployment_url=${DEPLOYMENT_URL}" >> "$GITHUB_OUTPUT"
+          echo "Deployment URL: ${DEPLOYMENT_URL}"
+
+      - name: Enforce lane aliases
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+
+          IFS=',' read -r -a domains <<< "${{ steps.lane.outputs.alias_domains }}"
+          for domain in "${domains[@]}"; do
+            npx --yes vercel alias set "${{ steps.deploy.outputs.deployment_url }}" "$domain" --scope guivercelpro --token "$VERCEL_TOKEN"
+            echo "Aliased $domain"
+          done
+
+      - name: Smoke check lane URLs and docs
+        run: |
+          set -euo pipefail
+
+          SITE_URL="${{ steps.lane.outputs.site_url }}"
+
+          curl -fsSIL "$SITE_URL" > /dev/null
+
+          if [ "${GITHUB_REF_NAME}" = "main" ]; then
+            for path in /endpoints.json /endpoints.txt /llms.txt /dev-skills.txt; do
+              curl -fsSIL "https://api.trader-ralph.com${path}" > /dev/null
+            done
+          else
+            for path in /api /api/endpoints.json /api/endpoints.txt /api/llms.txt /api/dev-skills.txt; do
+              curl -fsSIL "${SITE_URL}${path}" > /dev/null
+            done
+          fi
+
+      - name: Smoke check lane API host in login bundle
+        run: |
+          set -euo pipefail
+
+          SITE_URL="${{ steps.lane.outputs.site_url }}"
+          EXPECTED_EDGE_HOST="${{ steps.lane.outputs.expected_edge_host }}"
+          tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp"' EXIT
+
+          curl -fsSL "${SITE_URL}/login" > "${tmp}/login.html"
+          grep -oE '/_next/static/[^" ]+\.js' "${tmp}/login.html" | sort -u > "${tmp}/scripts.txt"
+
+          if [ ! -s "${tmp}/scripts.txt" ]; then
+            echo "No Next.js JS bundle references found on ${SITE_URL}/login" >&2
+            exit 1
+          fi
+
+          while read -r script_path; do
+            curl -fsSL "${SITE_URL}${script_path}" >> "${tmp}/bundle.js"
+          done < "${tmp}/scripts.txt"
+
+          if ! grep -q "${EXPECTED_EDGE_HOST}" "${tmp}/bundle.js"; then
+            echo "Expected API host ${EXPECTED_EDGE_HOST} not found in login bundle" >&2
+            exit 1
+          fi
+
+          if grep -qE 'ralph-edge-(dev|staging)\.gui-bibeau\.workers\.dev' "${tmp}/bundle.js"; then
+            echo "Legacy workers.dev host leaked into login bundle" >&2
+            exit 1
+          fi
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,33 @@
   - `dev` branch -> `dev.trader-ralph.com`
   - `staging` branch -> `staging.trader-ralph.com`
 
+## Deployment Automation Guardrails
+
+- Promotion flow is strict: `feature/*` or `codex/*` -> `dev` -> `staging` -> `main`.
+- Cloudflare worker deploys are branch-based and automatic:
+  - `dev` push -> `ralph-edge-dev`
+  - `staging` push -> `ralph-edge-staging`
+  - `main` push -> `ralph-edge`
+- Vercel portal deploys are branch-based and automatic:
+  - `dev` push -> deploy preview + enforce alias `dev.trader-ralph.com`
+  - `staging` push -> deploy preview + enforce alias `staging.trader-ralph.com`
+  - `main` push -> deploy production + enforce aliases `trader-ralph.com`, `www.trader-ralph.com`, `api.trader-ralph.com`
+- Vercel build env routing is injected in CI per branch to prevent drift:
+  - `dev` -> `NEXT_PUBLIC_EDGE_API_BASE=https://dev.api.trader-ralph.com`, `NEXT_PUBLIC_SITE_URL=https://dev.trader-ralph.com`
+  - `staging` -> `NEXT_PUBLIC_EDGE_API_BASE=https://staging.api.trader-ralph.com`, `NEXT_PUBLIC_SITE_URL=https://staging.trader-ralph.com`
+  - `main` -> `NEXT_PUBLIC_EDGE_API_BASE=https://api.trader-ralph.com`, `NEXT_PUBLIC_SITE_URL=https://trader-ralph.com`
+
+## Required CI Secrets (GitHub Actions)
+
+- Cloudflare:
+  - `CLOUDFLARE_API_TOKEN`
+- Vercel:
+  - `VERCEL_TOKEN`
+  - `VERCEL_ORG_ID`
+  - `VERCEL_PROJECT_ID`
+
+## Agentic Execution Checklist
+
+- Before pushing a branch, make sure CI-impacting workflow and env changes are included in the same PR.
+- Before merging each lane PR (`feature -> dev`, `dev -> staging`, `staging -> main`), confirm required checks are green.
+- Do not manually remap `dev`/`staging` custom domains outside CI unless production is degraded and an emergency fix is required.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,24 @@ must ship together so `/api`, `/endpoints.json`, `/endpoints.txt`, and
 - `dev` is promoted to `staging` via PR.
 - `staging` is promoted to `main` via PR.
 - CI runs on push and pull request events for `dev`, `staging`, and `main`.
-- Dev deployment runs on pushes to `dev`; staging/production deploys remain manual via workflow dispatch.
+- Cloudflare worker deploys run automatically on pushes to `dev`, `staging`, and `main`.
+- Vercel portal deploys run automatically on pushes to `dev`, `staging`, and `main`.
+- Vercel deploy automation enforces lane-domain aliases on every deploy:
+  - `dev` -> `dev.trader-ralph.com`
+  - `staging` -> `staging.trader-ralph.com`
+  - `main` -> `trader-ralph.com`, `www.trader-ralph.com`, `api.trader-ralph.com`
+- Vercel deploy automation injects lane build env routing:
+  - `dev` -> `NEXT_PUBLIC_EDGE_API_BASE=https://dev.api.trader-ralph.com`, `NEXT_PUBLIC_SITE_URL=https://dev.trader-ralph.com`
+  - `staging` -> `NEXT_PUBLIC_EDGE_API_BASE=https://staging.api.trader-ralph.com`, `NEXT_PUBLIC_SITE_URL=https://staging.trader-ralph.com`
+  - `main` -> `NEXT_PUBLIC_EDGE_API_BASE=https://api.trader-ralph.com`, `NEXT_PUBLIC_SITE_URL=https://trader-ralph.com`
+- Deploy smoke checks verify docs endpoints and assert the login bundle points to the expected lane API host.
+
+### CI Secrets Required for Deploy Automation
+
+- `CLOUDFLARE_API_TOKEN`
+- `VERCEL_TOKEN`
+- `VERCEL_ORG_ID`
+- `VERCEL_PROJECT_ID`
 
 ## Tests
 


### PR DESCRIPTION
## Summary
- add automated Vercel portal deployment workflow on pushes to `dev`, `staging`, and `main`
- inject lane-specific build env routing (`NEXT_PUBLIC_EDGE_API_BASE`, `NEXT_PUBLIC_SITE_URL`) during deploy to prevent stale preview config drift
- enforce lane alias mappings on each deploy (`dev`, `staging`, and production domains)
- add smoke checks for docs URLs and login bundle host wiring to catch wrong API host early
- update `AGENTS.md` and `README.md` with deployment guardrails and required CI secrets

## Why
We had lane drift where `dev.trader-ralph.com` pointed to the wrong deployment and bundled a staging worker host. This makes lane routing deterministic and self-healing on every push.

## Required Secrets
- `VERCEL_TOKEN`
- `VERCEL_ORG_ID`
- `VERCEL_PROJECT_ID`
- existing `CLOUDFLARE_API_TOKEN` remains required for worker workflows

## Promotion Flow
After this merges to `dev`, promote via PR `dev -> staging`, then `staging -> main` (traffic-light flow).
