### PR TITLE
ci: guard portal deploy workflow on missing env secrets

### DIFF
--- a/.github/workflows/deploy-portal.yml
+++ b/.github/workflows/deploy-portal.yml
@@ -66,6 +66,13 @@ jobs:
           echo "::warning::Skipping managed Vercel deploy because one or more Vercel secrets are missing for environment ${GITHUB_REF_NAME}."
           echo "enabled=false" >> "$GITHUB_OUTPUT"
 
+      - name: Enforce Vercel credentials on staging and main
+        if: steps.vercel_auth.outputs.enabled != 'true' && github.ref_name != 'dev'
+        run: |
+          set -euo pipefail
+          echo "::error::Missing Vercel secrets for ${GITHUB_REF_NAME}. Configure VERCEL_TOKEN, VERCEL_ORG_ID, and VERCEL_PROJECT_ID in this GitHub Environment."
+          exit 1
+
       - name: Deploy portal
         id: deploy
         if: steps.vercel_auth.outputs.enabled == 'true'

--- a/.github/workflows/deploy-portal.yml
+++ b/.github/workflows/deploy-portal.yml
@@ -49,8 +49,26 @@ jobs:
               ;;
           esac
 
+      - name: Check Vercel credentials
+        id: vercel_auth
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${VERCEL_TOKEN:-}" ] && [ -n "${VERCEL_ORG_ID:-}" ] && [ -n "${VERCEL_PROJECT_ID:-}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "::warning::Skipping managed Vercel deploy because one or more Vercel secrets are missing for environment ${GITHUB_REF_NAME}."
+          echo "enabled=false" >> "$GITHUB_OUTPUT"
+
       - name: Deploy portal
         id: deploy
+        if: steps.vercel_auth.outputs.enabled == 'true'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -81,6 +99,7 @@ jobs:
           echo "Deployment URL: ${DEPLOYMENT_URL}"
 
       - name: Enforce lane aliases
+        if: steps.vercel_auth.outputs.enabled == 'true'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -142,4 +161,3 @@ jobs:
             echo "Legacy workers.dev host leaked into login bundle" >&2
             exit 1
           fi
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@
   - `VERCEL_TOKEN`
   - `VERCEL_ORG_ID`
   - `VERCEL_PROJECT_ID`
+- Store Vercel secrets in each GitHub Environment used by workflows: `dev`, `staging`, and `production`.
 
 ## Agentic Execution Checklist
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ must ship together so `/api`, `/endpoints.json`, `/endpoints.txt`, and
 - `VERCEL_TOKEN`
 - `VERCEL_ORG_ID`
 - `VERCEL_PROJECT_ID`
+- Configure Vercel secrets at minimum in GitHub Environments `dev`, `staging`, and `production`.
 
 ## Tests
 


### PR DESCRIPTION
## Summary
- add preflight secret check for `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` in `deploy-portal.yml`
- skip deploy/alias steps with warning when credentials are not configured in the current GitHub Environment
- keep smoke checks active so lane health still validates
- clarify in docs that Vercel secrets must exist in `dev`, `staging`, and `production` environments

## Why
`deploy-portal` failed in `dev` because the workflow environment had no Vercel credentials. This change prevents false-negative CI failures while preserving enforcement where credentials exist.
