### PR TITLE
ci: fix deploy-portal docs smoke-check route list

### DIFF
--- a/.github/workflows/deploy-portal.yml
+++ b/.github/workflows/deploy-portal.yml
@@ -133,7 +133,7 @@ jobs:
               curl -fsSIL "https://api.trader-ralph.com${path}" > /dev/null
             done
           else
-            for path in /api /api/endpoints.json /api/endpoints.txt /api/llms.txt /api/dev-skills.txt; do
+            for path in /api /api/endpoints.json /api/endpoints.txt /api/dev-skills.txt /endpoints.json /endpoints.txt /llms.txt /dev-skills.txt; do
               curl -fsSIL "${SITE_URL}${path}" > /dev/null
             done
           fi


### PR DESCRIPTION
Fixes a false-failure in `deploy-portal`: `/api/llms.txt` is not a valid route on lane domains.

Updated non-main smoke checks to validate the actual lane docs endpoints:
- `/api`, `/api/endpoints.json`, `/api/endpoints.txt`, `/api/dev-skills.txt`
- `/endpoints.json`, `/endpoints.txt`, `/llms.txt`, `/dev-skills.txt`
