### PR TITLE
Fix lane API domain aliases for dev/staging login

### DIFF
--- a/.github/workflows/deploy-portal.yml
+++ b/.github/workflows/deploy-portal.yml
@@ -28,13 +28,13 @@ jobs:
             dev)
               echo "edge_api_base=https://dev.api.trader-ralph.com" >> "$GITHUB_OUTPUT"
               echo "site_url=https://dev.trader-ralph.com" >> "$GITHUB_OUTPUT"
-              echo "alias_domains=dev.trader-ralph.com" >> "$GITHUB_OUTPUT"
+              echo "alias_domains=dev.trader-ralph.com,dev.api.trader-ralph.com" >> "$GITHUB_OUTPUT"
               echo "expected_edge_host=dev.api.trader-ralph.com" >> "$GITHUB_OUTPUT"
               ;;
             staging)
               echo "edge_api_base=https://staging.api.trader-ralph.com" >> "$GITHUB_OUTPUT"
               echo "site_url=https://staging.trader-ralph.com" >> "$GITHUB_OUTPUT"
-              echo "alias_domains=staging.trader-ralph.com" >> "$GITHUB_OUTPUT"
+              echo "alias_domains=staging.trader-ralph.com,staging.api.trader-ralph.com" >> "$GITHUB_OUTPUT"
               echo "expected_edge_host=staging.api.trader-ralph.com" >> "$GITHUB_OUTPUT"
               ;;
             main)
@@ -130,8 +130,10 @@ jobs:
           set -euo pipefail
 
           SITE_URL="${{ steps.lane.outputs.site_url }}"
+          EDGE_API_BASE="${{ steps.lane.outputs.edge_api_base }}"
 
           curl -fsSIL "$SITE_URL" > /dev/null
+          curl -fsSIL "${EDGE_API_BASE}/api/health" > /dev/null
 
           if [ "${GITHUB_REF_NAME}" = "main" ]; then
             for path in /endpoints.json /endpoints.txt /llms.txt /dev-skills.txt; do

--- a/apps/portal/next.config.js
+++ b/apps/portal/next.config.js
@@ -6,6 +6,17 @@ const nextConfig = {
       beforeFiles: [
         {
           source: "/:path*",
+          has: [{ type: "host", value: "dev.api.trader-ralph.com" }],
+          destination: "https://ralph-edge-dev.gui-bibeau.workers.dev/:path*",
+        },
+        {
+          source: "/:path*",
+          has: [{ type: "host", value: "staging.api.trader-ralph.com" }],
+          destination:
+            "https://ralph-edge-staging.gui-bibeau.workers.dev/:path*",
+        },
+        {
+          source: "/:path*",
           has: [{ type: "host", value: "api.trader-ralph.com" }],
           destination: "https://ralph-edge.gui-bibeau.workers.dev/:path*",
         },


### PR DESCRIPTION
## Summary
- add host rewrites for dev.api and staging.api to the corresponding Cloudflare worker lanes
- include dev.api/staging.api in Vercel lane alias enforcement
- add lane API health smoke check to fail fast when alias/routing is broken

## Why
Login on dev/staging depends on NEXT_PUBLIC_EDGE_API_BASE (dev.api/staging.api). Those hosts were not attached/routable, causing auth checks to fail before waitlist logic.

## Validation
- node require check for next.config.js
- verified changed workflow and rewrite config