### PR TITLE
Fix Vercel deployment URL parsing in deploy workflow

### DIFF
--- a/.github/workflows/deploy-portal.yml
+++ b/.github/workflows/deploy-portal.yml
@@ -98,7 +98,7 @@ jobs:
 
           DEPLOY_OUTPUT="$(npx --yes vercel "${DEPLOY_ARGS[@]}")"
           DEPLOYMENT_URL="$(
-            printf '%s\n' "$DEPLOY_OUTPUT" | grep -Eo 'https://[^ ]+\\.vercel\\.app' | tail -n 1
+            printf '%s\n' "$DEPLOY_OUTPUT" | grep -Eo 'https://[^ ]+\.vercel\.app' | tail -n 1
           )"
 
           if [ -z "${DEPLOYMENT_URL}" ]; then


### PR DESCRIPTION
Fixes the preview URL grep regex so deploy-portal can parse Vercel CLI output and continue to alias/smoke checks.