### PR TITLE
Fix waitlist email lookup fallback for Privy tokens

### DIFF
--- a/apps/worker/src/auth.ts
+++ b/apps/worker/src/auth.ts
@@ -1,5 +1,6 @@
 import { createRemoteJWKSet, jwtVerify } from "jose";
 
+import { getPrivyUserById } from "./privy";
 import type { Env } from "./types";
 
 type AuthUser = {
@@ -142,8 +143,20 @@ export async function requireUser(
     throw new Error("unauthorized");
   }
 
+  let email = extractUserEmail(payload as Record<string, unknown>);
+  if (!email) {
+    try {
+      const profile = await getPrivyUserById(env, privyUserId);
+      email = extractUserEmail(
+        isRecord(profile) ? profile : ({} as Record<string, unknown>),
+      );
+    } catch {
+      // Fall back to null email; caller will enforce waitlist constraints.
+    }
+  }
+
   return {
     privyUserId,
-    email: extractUserEmail(payload as Record<string, unknown>),
+    email,
   };
 }

--- a/apps/worker/src/privy.ts
+++ b/apps/worker/src/privy.ts
@@ -151,6 +151,22 @@ export async function getPrivyWalletAddress(env: Env): Promise<string> {
   return await getPrivyWalletAddressById(env, requirePrivyWalletId(env));
 }
 
+export async function getPrivyUserById(
+  env: Env,
+  userId: string,
+): Promise<unknown> {
+  const { baseUrl, headers } = privyHeaders(env);
+  const response = await privyFetchWithRetry(
+    `${baseUrl}/users/${encodeURIComponent(userId)}`,
+    { method: "GET", headers },
+  );
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`privy-user-fetch-failed: ${response.status} ${text}`);
+  }
+  return (await response.json()) as unknown;
+}
+
 export async function signTransactionWithPrivyById(
   env: Env,
   walletId: string,

--- a/tests/unit/worker_execution_jito_bundle.test.ts
+++ b/tests/unit/worker_execution_jito_bundle.test.ts
@@ -11,6 +11,10 @@ const getPrivyWalletAddressByIdMock = mock(
   async () => "mock-wallet-address-by-id",
 );
 const getPrivyWalletAddressMock = mock(async () => "mock-wallet-address");
+const getPrivyUserByIdMock = mock(async () => ({
+  id: "did:privy:mock-user",
+  linked_accounts: [],
+}));
 const swapWithRetryMock = mock(async () => ({
   swap: {
     swapTransaction: "unsigned-base64",
@@ -29,6 +33,7 @@ mock.module("../../apps/worker/src/privy", () => ({
   createPrivySolanaWallet: createPrivySolanaWalletMock,
   getPrivyWalletAddress: getPrivyWalletAddressMock,
   getPrivyWalletAddressById: getPrivyWalletAddressByIdMock,
+  getPrivyUserById: getPrivyUserByIdMock,
   signTransactionWithPrivyById: signTransactionWithPrivyByIdMock,
 }));
 mock.module("../../apps/worker/src/swap", () => ({
@@ -46,6 +51,7 @@ describe("worker jito bundle execution adapter", () => {
     createPrivySolanaWalletMock.mockClear();
     getPrivyWalletAddressByIdMock.mockClear();
     getPrivyWalletAddressMock.mockClear();
+    getPrivyUserByIdMock.mockClear();
     signTransactionWithPrivyByIdMock.mockClear();
     swapWithRetryMock.mockClear();
     globalThis.fetch = ORIGINAL_FETCH;


### PR DESCRIPTION
- keep existing JWT email extraction\n- add fallback: fetch Privy user profile by subject when token has no email\n- reuse same strict email normalization before waitlist lookup\n\nThis matches the fix currently deployed to Cloudflare dev for validation.