### PR TITLE
X402-003: add typed D1 repository layer for execution entities

### DIFF
--- a/apps/worker/src/execution/repository.ts
+++ b/apps/worker/src/execution/repository.ts
@@ -1,0 +1,1031 @@
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | JsonObject;
+export type JsonObject = { [key: string]: JsonValue };
+
+export type ExecutionActorType =
+  | "anonymous_x402"
+  | "privy_user"
+  | "api_key_actor";
+export type ExecutionMode = "relay_signed" | "privy_execute";
+export type ExecutionLane = "fast" | "protected" | "safe";
+export type ExecutionStatus =
+  | "received"
+  | "validated"
+  | "dispatched"
+  | "landed"
+  | "failed"
+  | "expired"
+  | "rejected";
+export type ExecutionTerminalStatus = Extract<
+  ExecutionStatus,
+  "landed" | "failed" | "expired" | "rejected"
+>;
+
+export const EXECUTION_TERMINAL_STATUSES = new Set<ExecutionStatus>([
+  "landed",
+  "failed",
+  "expired",
+  "rejected",
+]);
+
+type D1RunResultLike = {
+  meta?: {
+    changes?: number;
+  };
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string {
+  return String(value ?? "");
+}
+
+function stringOrNull(value: unknown): string | null {
+  const parsed = String(value ?? "").trim();
+  return parsed ? parsed : null;
+}
+
+function numberValue(value: unknown, fallback = 0): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function parseJsonObject(value: unknown): JsonObject | null {
+  if (typeof value !== "string" || !value.trim()) return null;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!isRecord(parsed)) return null;
+    return parsed as JsonObject;
+  } catch {
+    return null;
+  }
+}
+
+function toJsonString(value: JsonObject | null | undefined): string | null {
+  if (!value || !isRecord(value)) return null;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return null;
+  }
+}
+
+function runChanges(value: unknown): number {
+  if (!isRecord(value)) return 0;
+  const meta = (value as D1RunResultLike).meta;
+  if (!isRecord(meta)) return 0;
+  return numberValue(meta.changes, 0);
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.toLowerCase().includes("unique constraint failed");
+}
+
+export function executionNowIso(now = new Date()): string {
+  return now.toISOString();
+}
+
+export type ExecutionRequestRecord = {
+  requestId: string;
+  schemaVersion: string;
+  idempotencyScope: string;
+  idempotencyKey: string;
+  payloadHash: string;
+  actorType: ExecutionActorType;
+  actorId: string | null;
+  mode: ExecutionMode;
+  lane: ExecutionLane;
+  status: ExecutionStatus;
+  statusReason: string | null;
+  metadata: JsonObject | null;
+  receivedAt: string;
+  validatedAt: string | null;
+  terminalAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ExecutionAttemptRecord = {
+  attemptId: string;
+  requestId: string;
+  attemptNo: number;
+  lane: ExecutionLane;
+  provider: string;
+  status: string;
+  providerRequestId: string | null;
+  providerResponse: JsonObject | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+  startedAt: string;
+  completedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ExecutionStatusEventRecord = {
+  eventId: string;
+  requestId: string;
+  seq: number;
+  status: ExecutionStatus;
+  reason: string | null;
+  details: JsonObject | null;
+  createdAt: string;
+};
+
+export type ExecutionReceiptRecord = {
+  requestId: string;
+  receiptId: string;
+  schemaVersion: string;
+  finalizedStatus: string;
+  lane: ExecutionLane;
+  provider: string | null;
+  signature: string | null;
+  slot: number | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+  receipt: JsonObject | null;
+  readyAt: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ExecutionLatestStatusRecord = {
+  request: ExecutionRequestRecord;
+  latestEvent: ExecutionStatusEventRecord | null;
+  latestAttempt: ExecutionAttemptRecord | null;
+  receipt: ExecutionReceiptRecord | null;
+};
+
+function mapExecutionRequestRow(
+  row: Record<string, unknown>,
+): ExecutionRequestRecord {
+  return {
+    requestId: stringValue(row.requestId),
+    schemaVersion: stringValue(row.schemaVersion || "v1"),
+    idempotencyScope: stringValue(row.idempotencyScope),
+    idempotencyKey: stringValue(row.idempotencyKey),
+    payloadHash: stringValue(row.payloadHash),
+    actorType:
+      stringValue(row.actorType) === "privy_user" ||
+      stringValue(row.actorType) === "api_key_actor"
+        ? (stringValue(row.actorType) as ExecutionActorType)
+        : "anonymous_x402",
+    actorId: stringOrNull(row.actorId),
+    mode:
+      stringValue(row.mode) === "privy_execute"
+        ? "privy_execute"
+        : "relay_signed",
+    lane:
+      stringValue(row.lane) === "protected" || stringValue(row.lane) === "safe"
+        ? (stringValue(row.lane) as ExecutionLane)
+        : "fast",
+    status:
+      EXECUTION_TERMINAL_STATUSES.has(
+        stringValue(row.status) as ExecutionStatus,
+      ) ||
+      stringValue(row.status) === "received" ||
+      stringValue(row.status) === "validated" ||
+      stringValue(row.status) === "dispatched"
+        ? (stringValue(row.status) as ExecutionStatus)
+        : "received",
+    statusReason: stringOrNull(row.statusReason),
+    metadata: parseJsonObject(row.metadataJson),
+    receivedAt: stringValue(row.receivedAt),
+    validatedAt: stringOrNull(row.validatedAt),
+    terminalAt: stringOrNull(row.terminalAt),
+    createdAt: stringValue(row.createdAt),
+    updatedAt: stringValue(row.updatedAt),
+  };
+}
+
+function mapExecutionAttemptRow(
+  row: Record<string, unknown>,
+): ExecutionAttemptRecord {
+  return {
+    attemptId: stringValue(row.attemptId),
+    requestId: stringValue(row.requestId),
+    attemptNo: numberValue(row.attemptNo),
+    lane:
+      stringValue(row.lane) === "protected" || stringValue(row.lane) === "safe"
+        ? (stringValue(row.lane) as ExecutionLane)
+        : "fast",
+    provider: stringValue(row.provider),
+    status: stringValue(row.status),
+    providerRequestId: stringOrNull(row.providerRequestId),
+    providerResponse: parseJsonObject(row.providerResponseJson),
+    errorCode: stringOrNull(row.errorCode),
+    errorMessage: stringOrNull(row.errorMessage),
+    startedAt: stringValue(row.startedAt),
+    completedAt: stringOrNull(row.completedAt),
+    createdAt: stringValue(row.createdAt),
+    updatedAt: stringValue(row.updatedAt),
+  };
+}
+
+function mapExecutionStatusEventRow(
+  row: Record<string, unknown>,
+): ExecutionStatusEventRecord {
+  return {
+    eventId: stringValue(row.eventId),
+    requestId: stringValue(row.requestId),
+    seq: numberValue(row.seq),
+    status:
+      stringValue(row.status) === "validated" ||
+      stringValue(row.status) === "dispatched" ||
+      stringValue(row.status) === "landed" ||
+      stringValue(row.status) === "failed" ||
+      stringValue(row.status) === "expired" ||
+      stringValue(row.status) === "rejected"
+        ? (stringValue(row.status) as ExecutionStatus)
+        : "received",
+    reason: stringOrNull(row.reason),
+    details: parseJsonObject(row.detailsJson),
+    createdAt: stringValue(row.createdAt),
+  };
+}
+
+function mapExecutionReceiptRow(
+  row: Record<string, unknown>,
+): ExecutionReceiptRecord {
+  return {
+    requestId: stringValue(row.requestId),
+    receiptId: stringValue(row.receiptId),
+    schemaVersion: stringValue(row.schemaVersion || "v1"),
+    finalizedStatus: stringValue(row.finalizedStatus),
+    lane:
+      stringValue(row.lane) === "protected" || stringValue(row.lane) === "safe"
+        ? (stringValue(row.lane) as ExecutionLane)
+        : "fast",
+    provider: stringOrNull(row.provider),
+    signature: stringOrNull(row.signature),
+    slot:
+      row.slot === null || row.slot === undefined
+        ? null
+        : numberValue(row.slot, 0),
+    errorCode: stringOrNull(row.errorCode),
+    errorMessage: stringOrNull(row.errorMessage),
+    receipt: parseJsonObject(row.receiptJson),
+    readyAt: stringValue(row.readyAt),
+    createdAt: stringValue(row.createdAt),
+    updatedAt: stringValue(row.updatedAt),
+  };
+}
+
+export async function getExecutionRequestById(
+  db: D1Database,
+  requestId: string,
+): Promise<ExecutionRequestRecord | null> {
+  const row = (await db
+    .prepare(
+      `
+      SELECT
+        request_id as requestId,
+        schema_version as schemaVersion,
+        idempotency_scope as idempotencyScope,
+        idempotency_key as idempotencyKey,
+        payload_hash as payloadHash,
+        actor_type as actorType,
+        actor_id as actorId,
+        mode,
+        lane,
+        status,
+        status_reason as statusReason,
+        metadata_json as metadataJson,
+        received_at as receivedAt,
+        validated_at as validatedAt,
+        terminal_at as terminalAt,
+        created_at as createdAt,
+        updated_at as updatedAt
+      FROM execution_requests
+      WHERE request_id = ?1
+      LIMIT 1
+      `,
+    )
+    .bind(requestId)
+    .first()) as unknown;
+  if (!isRecord(row)) return null;
+  return mapExecutionRequestRow(row);
+}
+
+export async function getExecutionRequestByIdempotency(
+  db: D1Database,
+  idempotencyScope: string,
+  idempotencyKey: string,
+): Promise<ExecutionRequestRecord | null> {
+  const row = (await db
+    .prepare(
+      `
+      SELECT
+        request_id as requestId,
+        schema_version as schemaVersion,
+        idempotency_scope as idempotencyScope,
+        idempotency_key as idempotencyKey,
+        payload_hash as payloadHash,
+        actor_type as actorType,
+        actor_id as actorId,
+        mode,
+        lane,
+        status,
+        status_reason as statusReason,
+        metadata_json as metadataJson,
+        received_at as receivedAt,
+        validated_at as validatedAt,
+        terminal_at as terminalAt,
+        created_at as createdAt,
+        updated_at as updatedAt
+      FROM execution_requests
+      WHERE idempotency_scope = ?1
+        AND idempotency_key = ?2
+      LIMIT 1
+      `,
+    )
+    .bind(idempotencyScope, idempotencyKey)
+    .first()) as unknown;
+  if (!isRecord(row)) return null;
+  return mapExecutionRequestRow(row);
+}
+
+export async function createExecutionRequestIdempotent(
+  db: D1Database,
+  input: {
+    requestId: string;
+    idempotencyScope: string;
+    idempotencyKey: string;
+    payloadHash: string;
+    actorType: ExecutionActorType;
+    actorId?: string | null;
+    mode: ExecutionMode;
+    lane: ExecutionLane;
+    status?: ExecutionStatus;
+    statusReason?: string | null;
+    metadata?: JsonObject | null;
+    nowIso?: string;
+  },
+): Promise<{ created: boolean; row: ExecutionRequestRecord }> {
+  const existing = await getExecutionRequestByIdempotency(
+    db,
+    input.idempotencyScope,
+    input.idempotencyKey,
+  );
+  if (existing) {
+    return { created: false, row: existing };
+  }
+
+  const nowIso = input.nowIso ?? executionNowIso();
+  const status = input.status ?? "received";
+  try {
+    await db
+      .prepare(
+        `
+        INSERT INTO execution_requests (
+          request_id,
+          schema_version,
+          idempotency_scope,
+          idempotency_key,
+          payload_hash,
+          actor_type,
+          actor_id,
+          mode,
+          lane,
+          status,
+          status_reason,
+          metadata_json,
+          received_at,
+          created_at,
+          updated_at
+        ) VALUES (?1, 'v1', ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?12, ?12)
+        `,
+      )
+      .bind(
+        input.requestId,
+        input.idempotencyScope,
+        input.idempotencyKey,
+        input.payloadHash,
+        input.actorType,
+        input.actorId ?? null,
+        input.mode,
+        input.lane,
+        status,
+        input.statusReason ?? null,
+        toJsonString(input.metadata),
+        nowIso,
+      )
+      .run();
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error;
+    const raced = await getExecutionRequestByIdempotency(
+      db,
+      input.idempotencyScope,
+      input.idempotencyKey,
+    );
+    if (!raced) throw error;
+    return { created: false, row: raced };
+  }
+
+  const created = await getExecutionRequestById(db, input.requestId);
+  if (!created) {
+    throw new Error("execution-request-create-failed");
+  }
+  return { created: true, row: created };
+}
+
+export async function updateExecutionRequestStatus(
+  db: D1Database,
+  input: {
+    requestId: string;
+    status: ExecutionStatus;
+    statusReason?: string | null;
+    nowIso?: string;
+  },
+): Promise<ExecutionRequestRecord | null> {
+  const nowIso = input.nowIso ?? executionNowIso();
+  await db
+    .prepare(
+      `
+      UPDATE execution_requests
+      SET
+        status = ?1,
+        status_reason = ?2,
+        validated_at = CASE
+          WHEN ?1 = 'validated' AND validated_at IS NULL THEN ?3
+          ELSE validated_at
+        END,
+        updated_at = ?3
+      WHERE request_id = ?4
+      `,
+    )
+    .bind(input.status, input.statusReason ?? null, nowIso, input.requestId)
+    .run();
+  return getExecutionRequestById(db, input.requestId);
+}
+
+export async function appendExecutionStatusEvent(
+  db: D1Database,
+  input: {
+    eventId?: string;
+    requestId: string;
+    status: ExecutionStatus;
+    reason?: string | null;
+    details?: JsonObject | null;
+    createdAt?: string;
+  },
+): Promise<ExecutionStatusEventRecord> {
+  const createdAt = input.createdAt ?? executionNowIso();
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const nextSeqRow = (await db
+      .prepare(
+        `
+        SELECT COALESCE(MAX(seq), 0) + 1 as nextSeq
+        FROM execution_status_events
+        WHERE request_id = ?1
+        `,
+      )
+      .bind(input.requestId)
+      .first()) as unknown;
+    const nextSeq = isRecord(nextSeqRow)
+      ? Math.max(1, numberValue(nextSeqRow.nextSeq, 1))
+      : 1;
+    const eventId = input.eventId ?? crypto.randomUUID();
+    try {
+      await db
+        .prepare(
+          `
+          INSERT INTO execution_status_events (
+            event_id,
+            request_id,
+            seq,
+            status,
+            reason,
+            details_json,
+            created_at
+          ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+          `,
+        )
+        .bind(
+          eventId,
+          input.requestId,
+          nextSeq,
+          input.status,
+          input.reason ?? null,
+          toJsonString(input.details),
+          createdAt,
+        )
+        .run();
+
+      const row = (await db
+        .prepare(
+          `
+          SELECT
+            event_id as eventId,
+            request_id as requestId,
+            seq,
+            status,
+            reason,
+            details_json as detailsJson,
+            created_at as createdAt
+          FROM execution_status_events
+          WHERE event_id = ?1
+          LIMIT 1
+          `,
+        )
+        .bind(eventId)
+        .first()) as unknown;
+      if (!isRecord(row)) {
+        throw new Error("execution-status-event-read-failed");
+      }
+      return mapExecutionStatusEventRow(row);
+    } catch (error) {
+      if (!isUniqueConstraintError(error) || attempt === 4) {
+        throw error;
+      }
+    }
+  }
+  throw new Error("execution-status-event-create-failed");
+}
+
+export async function listExecutionStatusEvents(
+  db: D1Database,
+  requestId: string,
+  limit = 100,
+): Promise<ExecutionStatusEventRecord[]> {
+  const boundedLimit = Math.max(1, Math.min(500, Math.floor(limit)));
+  const rows = (await db
+    .prepare(
+      `
+      SELECT
+        event_id as eventId,
+        request_id as requestId,
+        seq,
+        status,
+        reason,
+        details_json as detailsJson,
+        created_at as createdAt
+      FROM execution_status_events
+      WHERE request_id = ?1
+      ORDER BY seq ASC
+      LIMIT ?2
+      `,
+    )
+    .bind(requestId, boundedLimit)
+    .all()) as { results?: unknown[] };
+  const items = Array.isArray(rows.results) ? rows.results : [];
+  return items.filter(isRecord).map((row) => mapExecutionStatusEventRow(row));
+}
+
+export async function terminalizeExecutionRequest(
+  db: D1Database,
+  input: {
+    requestId: string;
+    status: ExecutionTerminalStatus;
+    statusReason?: string | null;
+    details?: JsonObject | null;
+    nowIso?: string;
+  },
+): Promise<{
+  applied: boolean;
+  request: ExecutionRequestRecord | null;
+  event: ExecutionStatusEventRecord | null;
+}> {
+  const nowIso = input.nowIso ?? executionNowIso();
+  const result = await db
+    .prepare(
+      `
+      UPDATE execution_requests
+      SET
+        status = ?1,
+        status_reason = ?2,
+        terminal_at = ?3,
+        updated_at = ?3
+      WHERE request_id = ?4
+        AND terminal_at IS NULL
+      `,
+    )
+    .bind(input.status, input.statusReason ?? null, nowIso, input.requestId)
+    .run();
+  const applied = runChanges(result) > 0;
+  if (!applied) {
+    return {
+      applied: false,
+      request: await getExecutionRequestById(db, input.requestId),
+      event: null,
+    };
+  }
+
+  const event = await appendExecutionStatusEvent(db, {
+    requestId: input.requestId,
+    status: input.status,
+    reason: input.statusReason ?? null,
+    details: input.details ?? null,
+    createdAt: nowIso,
+  });
+  const request = await getExecutionRequestById(db, input.requestId);
+  return {
+    applied: true,
+    request,
+    event,
+  };
+}
+
+export async function createExecutionAttemptIdempotent(
+  db: D1Database,
+  input: {
+    attemptId: string;
+    requestId: string;
+    attemptNo: number;
+    lane: ExecutionLane;
+    provider: string;
+    status: string;
+    providerRequestId?: string | null;
+    providerResponse?: JsonObject | null;
+    errorCode?: string | null;
+    errorMessage?: string | null;
+    startedAt?: string;
+    nowIso?: string;
+  },
+): Promise<{ created: boolean; row: ExecutionAttemptRecord }> {
+  const existing = await getExecutionAttemptByRequestAndNumber(
+    db,
+    input.requestId,
+    input.attemptNo,
+  );
+  if (existing) return { created: false, row: existing };
+
+  const startedAt = input.startedAt ?? executionNowIso();
+  const nowIso = input.nowIso ?? startedAt;
+  try {
+    await db
+      .prepare(
+        `
+        INSERT INTO execution_attempts (
+          attempt_id,
+          request_id,
+          attempt_no,
+          lane,
+          provider,
+          status,
+          provider_request_id,
+          provider_response_json,
+          error_code,
+          error_message,
+          started_at,
+          created_at,
+          updated_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?12)
+        `,
+      )
+      .bind(
+        input.attemptId,
+        input.requestId,
+        Math.max(1, Math.floor(input.attemptNo)),
+        input.lane,
+        input.provider,
+        input.status,
+        input.providerRequestId ?? null,
+        toJsonString(input.providerResponse),
+        input.errorCode ?? null,
+        input.errorMessage ?? null,
+        startedAt,
+        nowIso,
+      )
+      .run();
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error;
+    const raced = await getExecutionAttemptByRequestAndNumber(
+      db,
+      input.requestId,
+      input.attemptNo,
+    );
+    if (!raced) throw error;
+    return { created: false, row: raced };
+  }
+
+  const row = await getExecutionAttemptById(db, input.attemptId);
+  if (!row) throw new Error("execution-attempt-create-failed");
+  return { created: true, row };
+}
+
+export async function getExecutionAttemptById(
+  db: D1Database,
+  attemptId: string,
+): Promise<ExecutionAttemptRecord | null> {
+  const row = (await db
+    .prepare(
+      `
+      SELECT
+        attempt_id as attemptId,
+        request_id as requestId,
+        attempt_no as attemptNo,
+        lane,
+        provider,
+        status,
+        provider_request_id as providerRequestId,
+        provider_response_json as providerResponseJson,
+        error_code as errorCode,
+        error_message as errorMessage,
+        started_at as startedAt,
+        completed_at as completedAt,
+        created_at as createdAt,
+        updated_at as updatedAt
+      FROM execution_attempts
+      WHERE attempt_id = ?1
+      LIMIT 1
+      `,
+    )
+    .bind(attemptId)
+    .first()) as unknown;
+  if (!isRecord(row)) return null;
+  return mapExecutionAttemptRow(row);
+}
+
+export async function getExecutionAttemptByRequestAndNumber(
+  db: D1Database,
+  requestId: string,
+  attemptNo: number,
+): Promise<ExecutionAttemptRecord | null> {
+  const row = (await db
+    .prepare(
+      `
+      SELECT
+        attempt_id as attemptId,
+        request_id as requestId,
+        attempt_no as attemptNo,
+        lane,
+        provider,
+        status,
+        provider_request_id as providerRequestId,
+        provider_response_json as providerResponseJson,
+        error_code as errorCode,
+        error_message as errorMessage,
+        started_at as startedAt,
+        completed_at as completedAt,
+        created_at as createdAt,
+        updated_at as updatedAt
+      FROM execution_attempts
+      WHERE request_id = ?1
+        AND attempt_no = ?2
+      LIMIT 1
+      `,
+    )
+    .bind(requestId, Math.max(1, Math.floor(attemptNo)))
+    .first()) as unknown;
+  if (!isRecord(row)) return null;
+  return mapExecutionAttemptRow(row);
+}
+
+export async function listExecutionAttempts(
+  db: D1Database,
+  requestId: string,
+): Promise<ExecutionAttemptRecord[]> {
+  const rows = (await db
+    .prepare(
+      `
+      SELECT
+        attempt_id as attemptId,
+        request_id as requestId,
+        attempt_no as attemptNo,
+        lane,
+        provider,
+        status,
+        provider_request_id as providerRequestId,
+        provider_response_json as providerResponseJson,
+        error_code as errorCode,
+        error_message as errorMessage,
+        started_at as startedAt,
+        completed_at as completedAt,
+        created_at as createdAt,
+        updated_at as updatedAt
+      FROM execution_attempts
+      WHERE request_id = ?1
+      ORDER BY attempt_no ASC
+      `,
+    )
+    .bind(requestId)
+    .all()) as { results?: unknown[] };
+  const items = Array.isArray(rows.results) ? rows.results : [];
+  return items.filter(isRecord).map((row) => mapExecutionAttemptRow(row));
+}
+
+export async function finalizeExecutionAttempt(
+  db: D1Database,
+  input: {
+    attemptId: string;
+    status: string;
+    providerResponse?: JsonObject | null;
+    errorCode?: string | null;
+    errorMessage?: string | null;
+    completedAt?: string;
+  },
+): Promise<ExecutionAttemptRecord | null> {
+  const completedAt = input.completedAt ?? executionNowIso();
+  await db
+    .prepare(
+      `
+      UPDATE execution_attempts
+      SET
+        status = ?1,
+        provider_response_json = ?2,
+        error_code = ?3,
+        error_message = ?4,
+        completed_at = ?5,
+        updated_at = ?5
+      WHERE attempt_id = ?6
+      `,
+    )
+    .bind(
+      input.status,
+      toJsonString(input.providerResponse),
+      input.errorCode ?? null,
+      input.errorMessage ?? null,
+      completedAt,
+      input.attemptId,
+    )
+    .run();
+  return getExecutionAttemptById(db, input.attemptId);
+}
+
+export async function getExecutionReceiptByRequestId(
+  db: D1Database,
+  requestId: string,
+): Promise<ExecutionReceiptRecord | null> {
+  const row = (await db
+    .prepare(
+      `
+      SELECT
+        request_id as requestId,
+        receipt_id as receiptId,
+        schema_version as schemaVersion,
+        finalized_status as finalizedStatus,
+        lane,
+        provider,
+        signature,
+        slot,
+        error_code as errorCode,
+        error_message as errorMessage,
+        receipt_json as receiptJson,
+        ready_at as readyAt,
+        created_at as createdAt,
+        updated_at as updatedAt
+      FROM execution_receipts
+      WHERE request_id = ?1
+      LIMIT 1
+      `,
+    )
+    .bind(requestId)
+    .first()) as unknown;
+  if (!isRecord(row)) return null;
+  return mapExecutionReceiptRow(row);
+}
+
+export async function upsertExecutionReceiptIdempotent(
+  db: D1Database,
+  input: {
+    requestId: string;
+    receiptId: string;
+    finalizedStatus: string;
+    lane: ExecutionLane;
+    provider?: string | null;
+    signature?: string | null;
+    slot?: number | null;
+    errorCode?: string | null;
+    errorMessage?: string | null;
+    receipt?: JsonObject | null;
+    readyAt?: string;
+    nowIso?: string;
+  },
+): Promise<{ created: boolean; row: ExecutionReceiptRecord }> {
+  const existing = await getExecutionReceiptByRequestId(db, input.requestId);
+  if (existing) return { created: false, row: existing };
+
+  const readyAt = input.readyAt ?? executionNowIso();
+  const nowIso = input.nowIso ?? readyAt;
+  try {
+    await db
+      .prepare(
+        `
+        INSERT INTO execution_receipts (
+          request_id,
+          receipt_id,
+          schema_version,
+          finalized_status,
+          lane,
+          provider,
+          signature,
+          slot,
+          error_code,
+          error_message,
+          receipt_json,
+          ready_at,
+          created_at,
+          updated_at
+        ) VALUES (?1, ?2, 'v1', ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?12)
+        `,
+      )
+      .bind(
+        input.requestId,
+        input.receiptId,
+        input.finalizedStatus,
+        input.lane,
+        input.provider ?? null,
+        input.signature ?? null,
+        input.slot ?? null,
+        input.errorCode ?? null,
+        input.errorMessage ?? null,
+        toJsonString(input.receipt),
+        readyAt,
+        nowIso,
+      )
+      .run();
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error;
+    const raced = await getExecutionReceiptByRequestId(db, input.requestId);
+    if (!raced) throw error;
+    return { created: false, row: raced };
+  }
+
+  const row = await getExecutionReceiptByRequestId(db, input.requestId);
+  if (!row) throw new Error("execution-receipt-create-failed");
+  return { created: true, row };
+}
+
+async function getLatestExecutionStatusEvent(
+  db: D1Database,
+  requestId: string,
+): Promise<ExecutionStatusEventRecord | null> {
+  const row = (await db
+    .prepare(
+      `
+      SELECT
+        event_id as eventId,
+        request_id as requestId,
+        seq,
+        status,
+        reason,
+        details_json as detailsJson,
+        created_at as createdAt
+      FROM execution_status_events
+      WHERE request_id = ?1
+      ORDER BY seq DESC
+      LIMIT 1
+      `,
+    )
+    .bind(requestId)
+    .first()) as unknown;
+  if (!isRecord(row)) return null;
+  return mapExecutionStatusEventRow(row);
+}
+
+async function getLatestExecutionAttempt(
+  db: D1Database,
+  requestId: string,
+): Promise<ExecutionAttemptRecord | null> {
+  const row = (await db
+    .prepare(
+      `
+      SELECT
+        attempt_id as attemptId,
+        request_id as requestId,
+        attempt_no as attemptNo,
+        lane,
+        provider,
+        status,
+        provider_request_id as providerRequestId,
+        provider_response_json as providerResponseJson,
+        error_code as errorCode,
+        error_message as errorMessage,
+        started_at as startedAt,
+        completed_at as completedAt,
+        created_at as createdAt,
+        updated_at as updatedAt
+      FROM execution_attempts
+      WHERE request_id = ?1
+      ORDER BY attempt_no DESC
+      LIMIT 1
+      `,
+    )
+    .bind(requestId)
+    .first()) as unknown;
+  if (!isRecord(row)) return null;
+  return mapExecutionAttemptRow(row);
+}
+
+export async function getExecutionLatestStatus(
+  db: D1Database,
+  requestId: string,
+): Promise<ExecutionLatestStatusRecord | null> {
+  const request = await getExecutionRequestById(db, requestId);
+  if (!request) return null;
+  const [latestEvent, latestAttempt, receipt] = await Promise.all([
+    getLatestExecutionStatusEvent(db, requestId),
+    getLatestExecutionAttempt(db, requestId),
+    getExecutionReceiptByRequestId(db, requestId),
+  ]);
+  return {
+    request,
+    latestEvent,
+    latestAttempt,
+    receipt,
+  };
+}

--- a/tests/unit/worker_execution_repository.test.ts
+++ b/tests/unit/worker_execution_repository.test.ts
@@ -1,0 +1,339 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  appendExecutionStatusEvent,
+  createExecutionAttemptIdempotent,
+  createExecutionRequestIdempotent,
+  finalizeExecutionAttempt,
+  getExecutionLatestStatus,
+  getExecutionRequestById,
+  getExecutionRequestByIdempotency,
+  listExecutionAttempts,
+  listExecutionStatusEvents,
+  terminalizeExecutionRequest,
+  updateExecutionRequestStatus,
+  upsertExecutionReceiptIdempotent,
+} from "../../apps/worker/src/execution/repository";
+
+function createSqliteD1Adapter(db: Database): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          return {
+            async run() {
+              const statement = db.query(sql);
+              const result = statement.run(...(params as never[])) as {
+                changes?: number;
+              };
+              return {
+                meta: {
+                  changes:
+                    typeof result.changes === "number" ? result.changes : 0,
+                },
+              };
+            },
+            async first() {
+              const statement = db.query(sql);
+              return (statement.get(...(params as never[])) as unknown) ?? null;
+            },
+            async all() {
+              const statement = db.query(sql);
+              return {
+                results: (statement.all(...(params as never[])) ??
+                  []) as unknown[],
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+async function withExecutionRepo(
+  run: (db: Database, d1: D1Database) => Promise<void> | void,
+): Promise<void> {
+  const db = new Database(":memory:");
+  db.exec("PRAGMA foreign_keys = ON;");
+  const migrationPath = resolve(
+    import.meta.dir,
+    "..",
+    "..",
+    "apps/worker/migrations/0025_execution_fabric.sql",
+  );
+  db.exec(readFileSync(migrationPath, "utf8"));
+  const d1 = createSqliteD1Adapter(db);
+  try {
+    await run(db, d1);
+  } finally {
+    db.close();
+  }
+}
+
+describe("worker execution repository", () => {
+  test("creates and reuses execution request idempotently", async () => {
+    await withExecutionRepo(async (_db, d1) => {
+      const created = await createExecutionRequestIdempotent(d1, {
+        requestId: "req_1",
+        idempotencyScope: "anonymous_x402:anon",
+        idempotencyKey: "idem_1",
+        payloadHash: "payload_hash_1",
+        actorType: "anonymous_x402",
+        actorId: "anon",
+        mode: "relay_signed",
+        lane: "fast",
+        metadata: {
+          source: "unit",
+          retries: 0,
+        },
+        nowIso: "2026-03-03T00:00:00.000Z",
+      });
+      expect(created.created).toBe(true);
+      expect(created.row.requestId).toBe("req_1");
+
+      const reused = await createExecutionRequestIdempotent(d1, {
+        requestId: "req_1_duplicate",
+        idempotencyScope: "anonymous_x402:anon",
+        idempotencyKey: "idem_1",
+        payloadHash: "payload_hash_1",
+        actorType: "anonymous_x402",
+        actorId: "anon",
+        mode: "relay_signed",
+        lane: "fast",
+      });
+      expect(reused.created).toBe(false);
+      expect(reused.row.requestId).toBe("req_1");
+
+      const byId = await getExecutionRequestById(d1, "req_1");
+      expect(byId?.idempotencyKey).toBe("idem_1");
+      const byIdempotency = await getExecutionRequestByIdempotency(
+        d1,
+        "anonymous_x402:anon",
+        "idem_1",
+      );
+      expect(byIdempotency?.requestId).toBe("req_1");
+    });
+  });
+
+  test("updates request status and appends ordered lifecycle events", async () => {
+    await withExecutionRepo(async (_db, d1) => {
+      await createExecutionRequestIdempotent(d1, {
+        requestId: "req_2",
+        idempotencyScope: "privy_user:user_1",
+        idempotencyKey: "idem_2",
+        payloadHash: "payload_hash_2",
+        actorType: "privy_user",
+        actorId: "user_1",
+        mode: "privy_execute",
+        lane: "protected",
+      });
+
+      const validated = await updateExecutionRequestStatus(d1, {
+        requestId: "req_2",
+        status: "validated",
+        statusReason: null,
+        nowIso: "2026-03-03T00:01:00.000Z",
+      });
+      expect(validated?.status).toBe("validated");
+      expect(validated?.validatedAt).toBe("2026-03-03T00:01:00.000Z");
+
+      await appendExecutionStatusEvent(d1, {
+        requestId: "req_2",
+        status: "received",
+        createdAt: "2026-03-03T00:00:59.000Z",
+      });
+      await appendExecutionStatusEvent(d1, {
+        requestId: "req_2",
+        status: "validated",
+        createdAt: "2026-03-03T00:01:00.000Z",
+      });
+      await appendExecutionStatusEvent(d1, {
+        requestId: "req_2",
+        status: "dispatched",
+        createdAt: "2026-03-03T00:01:01.000Z",
+      });
+
+      const events = await listExecutionStatusEvents(d1, "req_2");
+      expect(events.map((event) => event.seq)).toEqual([1, 2, 3]);
+      expect(events.map((event) => event.status)).toEqual([
+        "received",
+        "validated",
+        "dispatched",
+      ]);
+    });
+  });
+
+  test("terminalization helper prevents duplicate terminalization under concurrency", async () => {
+    await withExecutionRepo(async (_db, d1) => {
+      await createExecutionRequestIdempotent(d1, {
+        requestId: "req_3",
+        idempotencyScope: "anonymous_x402:bot_1",
+        idempotencyKey: "idem_3",
+        payloadHash: "payload_hash_3",
+        actorType: "anonymous_x402",
+        actorId: "bot_1",
+        mode: "relay_signed",
+        lane: "fast",
+      });
+
+      const results = await Promise.all(
+        Array.from({ length: 8 }, (_value, index) =>
+          terminalizeExecutionRequest(d1, {
+            requestId: "req_3",
+            status: "failed",
+            statusReason: `err-${index}`,
+            nowIso: `2026-03-03T00:02:0${index}.000Z`,
+          }),
+        ),
+      );
+      const appliedCount = results.filter((result) => result.applied).length;
+      expect(appliedCount).toBe(1);
+
+      const events = await listExecutionStatusEvents(d1, "req_3");
+      const terminalEvents = events.filter(
+        (event) => event.status === "failed",
+      );
+      expect(terminalEvents.length).toBe(1);
+
+      const request = await getExecutionRequestById(d1, "req_3");
+      expect(request?.status).toBe("failed");
+      expect(request?.terminalAt).toBeString();
+    });
+  });
+
+  test("creates/finalizes attempts and writes canonical receipt idempotently", async () => {
+    await withExecutionRepo(async (_db, d1) => {
+      await createExecutionRequestIdempotent(d1, {
+        requestId: "req_4",
+        idempotencyScope: "privy_user:user_4",
+        idempotencyKey: "idem_4",
+        payloadHash: "payload_hash_4",
+        actorType: "privy_user",
+        actorId: "user_4",
+        mode: "privy_execute",
+        lane: "protected",
+      });
+
+      const attempt = await createExecutionAttemptIdempotent(d1, {
+        attemptId: "attempt_1",
+        requestId: "req_4",
+        attemptNo: 1,
+        lane: "protected",
+        provider: "jito",
+        status: "dispatched",
+        providerRequestId: "provider_1",
+        providerResponse: { accepted: true },
+        startedAt: "2026-03-03T00:03:00.000Z",
+      });
+      expect(attempt.created).toBe(true);
+      expect(attempt.row.status).toBe("dispatched");
+
+      const attemptDuplicate = await createExecutionAttemptIdempotent(d1, {
+        attemptId: "attempt_1_dup",
+        requestId: "req_4",
+        attemptNo: 1,
+        lane: "protected",
+        provider: "jito",
+        status: "dispatched",
+      });
+      expect(attemptDuplicate.created).toBe(false);
+      expect(attemptDuplicate.row.attemptId).toBe("attempt_1");
+
+      const finalizedAttempt = await finalizeExecutionAttempt(d1, {
+        attemptId: "attempt_1",
+        status: "landed",
+        providerResponse: {
+          signature: "sig_1",
+        },
+        completedAt: "2026-03-03T00:03:02.000Z",
+      });
+      expect(finalizedAttempt?.status).toBe("landed");
+      expect(finalizedAttempt?.completedAt).toBe("2026-03-03T00:03:02.000Z");
+
+      const attempts = await listExecutionAttempts(d1, "req_4");
+      expect(attempts.length).toBe(1);
+      expect(attempts[0]?.status).toBe("landed");
+
+      const receipt = await upsertExecutionReceiptIdempotent(d1, {
+        requestId: "req_4",
+        receiptId: "receipt_1",
+        finalizedStatus: "landed",
+        lane: "protected",
+        provider: "jito",
+        signature: "sig_1",
+        slot: 123,
+        receipt: {
+          route: "jito",
+          signatures: ["sig_1"],
+        },
+        readyAt: "2026-03-03T00:03:03.000Z",
+      });
+      expect(receipt.created).toBe(true);
+      expect(receipt.row.receiptId).toBe("receipt_1");
+
+      const receiptDuplicate = await upsertExecutionReceiptIdempotent(d1, {
+        requestId: "req_4",
+        receiptId: "receipt_2",
+        finalizedStatus: "landed",
+        lane: "protected",
+      });
+      expect(receiptDuplicate.created).toBe(false);
+      expect(receiptDuplicate.row.receiptId).toBe("receipt_1");
+    });
+  });
+
+  test("builds latest-status projection for status endpoint reads", async () => {
+    await withExecutionRepo(async (_db, d1) => {
+      await createExecutionRequestIdempotent(d1, {
+        requestId: "req_5",
+        idempotencyScope: "api_key_actor:svc_1",
+        idempotencyKey: "idem_5",
+        payloadHash: "payload_hash_5",
+        actorType: "api_key_actor",
+        actorId: "svc_1",
+        mode: "relay_signed",
+        lane: "fast",
+      });
+
+      await appendExecutionStatusEvent(d1, {
+        requestId: "req_5",
+        status: "received",
+        createdAt: "2026-03-03T00:04:00.000Z",
+      });
+      await appendExecutionStatusEvent(d1, {
+        requestId: "req_5",
+        status: "validated",
+        createdAt: "2026-03-03T00:04:01.000Z",
+      });
+
+      await createExecutionAttemptIdempotent(d1, {
+        attemptId: "attempt_5_1",
+        requestId: "req_5",
+        attemptNo: 1,
+        lane: "fast",
+        provider: "helius_sender",
+        status: "dispatched",
+        startedAt: "2026-03-03T00:04:02.000Z",
+      });
+      await upsertExecutionReceiptIdempotent(d1, {
+        requestId: "req_5",
+        receiptId: "receipt_5",
+        finalizedStatus: "landed",
+        lane: "fast",
+        provider: "helius_sender",
+        signature: "sig_5",
+        readyAt: "2026-03-03T00:04:04.000Z",
+      });
+
+      const latest = await getExecutionLatestStatus(d1, "req_5");
+      expect(latest).not.toBeNull();
+      expect(latest?.request.requestId).toBe("req_5");
+      expect(latest?.latestEvent?.status).toBe("validated");
+      expect(latest?.latestAttempt?.attemptNo).toBe(1);
+      expect(latest?.receipt?.receiptId).toBe("receipt_5");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add typed execution repository module at `apps/worker/src/execution/repository.ts`
- add repository methods for execution requests, attempts, status events, and receipts
- add idempotent create/read helpers for request/attempt/receipt entities
- add lifecycle helpers:
  - append ordered status events
  - conditional terminalization guard (`terminal_at IS NULL`)
  - latest-status projection for status endpoint reads
- add timestamp and typed JSON serialization helpers to keep repository writes consistent

## Tests
- add `tests/unit/worker_execution_repository.test.ts`
- covers create/update/read across all execution entities
- includes concurrency-style terminalization test to verify only one terminal transition is applied

## Validation
- bun run lint
- bun run typecheck
- bun test tests/unit/worker_execution_repository.test.ts tests/unit/worker_execution_migrations.test.ts

Refs: #119
