### PR TITLE
docs: simplify README and clarify agentic infra positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,36 @@
 # Trader Ralph
 
-Trader Ralph is a Solana-first trading infrastructure stack with two tracks:
-- Agentic hedge fund loops (internal automation)
-- Consumable signals via terminal and x402 endpoints
+Trader Ralph is agentic trading infrastructure for Solana.
 
-Codebase components:
-- Next.js terminal + landing UI (`apps/portal`)
-- Cloudflare Worker API (`apps/worker`)
-- legacy CLI/gateway path under rebuild (`src/`)
+It provides one execution fabric for:
+- external agents
+- first-party terminal users
+- server-driven automation
+
+## What This Repo Contains
+
+- `apps/portal`: Next.js site + terminal UI
+- `apps/worker`: Cloudflare Worker API (execution, x402, discovery)
+- `tests/`: unit + integration tests
+- `docs/`: execution contracts, registry runbooks, and metadata
 
 ## What Is Live
 
-- Landing page + email sign-in flow
-- Terminal at `/terminal` (market, macro, wallet, and trade ticket)
-- Account-level Privy wallet model (one wallet per user account)
-- Multi-pair spot swap execution through server-side policy/sign/submit flow
-- x402-gated market and macro read routes
-- Historical OHLCV and indicators backed by live providers
+- Terminal UI at `/terminal`
+- Account-level Privy wallet model (one wallet per user)
+- x402 paid read APIs (`/api/x402/read/*`)
+- Execution API scaffold:
+  - `POST /api/x402/exec/submit`
+  - `GET /api/x402/exec/status/:requestId`
+  - `GET /api/x402/exec/receipt/:requestId`
+- Agent Registry + discovery artifacts:
+  - `GET /api/agent/query`
+  - `GET /openapi.json`
+  - `GET /agent-registry/metadata.json`
 
-## Direction (In Progress)
+## Quick Start
 
-- **Loop A (per-slot truth):** event decoding + canonical state + marks
-- **Loop B (minute scoring):** feature extraction + scoring + cacheable views
-- External productization focus: stable, explainable Solana intelligence endpoints
-- Pair coverage focuses on Solana, stables, and liquid majors in the current terminal universe
-
-## Execution Contract (Draft)
-
-- Canonical execution contract draft: `docs/execution/exec-api-v1.md`
-- JSON schemas: `docs/execution/schemas/*`
-- Contract fixtures: `docs/execution/fixtures/*`
-
-## Requirements
-
-- Bun
-- Node 18+
-- Wrangler CLI
-
-## Quick Start (Portal + Worker)
+### Full local stack (recommended)
 
 ```bash
 bun install
@@ -45,15 +38,9 @@ bun run dev:local
 ```
 
 - Portal: `http://localhost:3000`
-- Worker: `http://127.0.0.1:8888/api/health`
+- Worker health: `http://127.0.0.1:8888/api/health`
 
-The `bun run dev:local` command pins the UI to your local Cloudflare Worker stack at `http://127.0.0.1:8888`. If you prefer explicit env files, copy the template below to `apps/portal/.env.local` before running:
-
-```bash
-cp apps/portal/.env.local.example apps/portal/.env.local
-```
-
-## Worker Local Quick Start
+### Worker only
 
 ```bash
 cd apps/worker
@@ -62,58 +49,39 @@ bun run db:migrate:local
 bun run dev:local
 ```
 
-## Account Wallet Migration (One-Time)
+## API Overview
 
-Before applying the destructive bot-runtime schema migration, run:
+### Execution API (v1 draft contract)
 
-```bash
-cd apps/worker
-bun run wallet:migrate:users -- --env <dev|staging|production> --dry-run
-bun run wallet:migrate:users -- --env <dev|staging|production> --apply
-```
+- Contract doc: `docs/execution/exec-api-v1.md`
+- Schemas: `docs/execution/schemas/*`
+- Fixtures: `docs/execution/fixtures/*`
 
-Migration report output:
-- `.tmp/wallet-migration-report-<env>.json`
+### x402 Read API
 
-## x402 Read Endpoints
+All are `POST` routes under `/api/x402/read/*`:
 
-All are `POST` under `/x402/read/*`:
-- `market_snapshot`
-- `market_snapshot_v2`
-- `market_token_balance`
-- `market_jupiter_quote`
-- `market_jupiter_quote_batch`
-- `market_ohlcv`
-- `market_indicators`
-- `solana_marks_latest`
-- `solana_scores_latest`
-- `solana_views_top`
-- `macro_signals`
-- `macro_fred_indicators`
-- `macro_etf_flows`
-- `macro_stablecoin_health`
-- `macro_oil_analytics`
-- `perps_funding_surface`
-- `perps_open_interest_surface`
-- `perps_venue_score`
+- Market: `market_snapshot`, `market_snapshot_v2`, `market_token_balance`, `market_jupiter_quote`, `market_jupiter_quote_batch`, `market_ohlcv`, `market_indicators`
+- Solana loop views: `solana_marks_latest`, `solana_scores_latest`, `solana_views_top`
+- Macro: `macro_signals`, `macro_fred_indicators`, `macro_etf_flows`, `macro_stablecoin_health`, `macro_oil_analytics`
+- Perps: `perps_funding_surface`, `perps_open_interest_surface`, `perps_venue_score`
 
-## Agent Registry Integration
+Use discovery/openapi for machine-readable catalog:
+- `/api`
+- `/endpoints.json`
+- `/endpoints.txt`
+- `/llms.txt`
+- `/openapi.json`
 
-Public registry/discovery routes:
-- `GET /api/agent/query` (or `GET /api/agent/query?q=...`)
-- `POST /api/agent/query` with `{ "query": "..." }`
-- `GET /openapi.json`
-- `GET /agent-registry/metadata.json`
+## Agent Registry
 
-Alias routes under `/api/*` are also available for `openapi.json` and
-`agent-registry/metadata.json`.
+- Metadata source-of-truth:
+  - `docs/agent-registry/metadata.dev.json`
+  - `docs/agent-registry/metadata.staging.json`
+  - `docs/agent-registry/metadata.production.json`
+- Runbook: `docs/agent-registry/runbook.md`
 
-Static metadata source-of-truth files:
-- `docs/agent-registry/metadata.dev.json`
-- `docs/agent-registry/metadata.staging.json`
-- `docs/agent-registry/metadata.production.json`
-
-Manual registry tooling:
+Manual tooling:
 
 ```bash
 bun run agent-registry:validate -- --lane dev
@@ -121,69 +89,14 @@ bun run agent-registry:sync -- --lane dev --step all --dry-run
 bun run agent-registry:sync -- --lane production --step all
 ```
 
-Runbook: `docs/agent-registry/runbook.md`
+## Branch and Deploy Model
 
-### x402 Environment Policy
-
-- `dev`: expects a real devnet transaction signature paying devnet USDC (`4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU`)
-- `staging` and `production`: expect a real mainnet transaction signature paying mainnet USDC (`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`)
-- `payment-signature` is validated on-chain against route requirements (`network`, `asset`, `payTo`, and `amount`)
-
-### Supported Trading Pairs (Terminal + Trade APIs)
-
-- `SOL/USDC`
-- `SOL/USDT`
-- `USDC/USDT`
-- `USDC/PYUSD`
-- `USDC/USD1`
-- `USDC/USDG`
-- `SOL/JITOSOL`
-- `SOL/MSOL`
-- `SOL/JUPSOL`
-- `RAY/USDC`
-- `WIF/USDC`
-- `JUP/USDC`
-- `BONK/USDC`
-- `JTO/USDC`
-- `PYTH/USDC`
-
-## API Catalog Maintenance Rule
-
-When a new public x402 read endpoint is production-ready, update the public
-catalog in the same PR before merge:
-- `/Users/guillaumebibeau-laviolette/github/serious-trader-ralph/apps/portal/app/api/_catalog.ts`
-- `/Users/guillaumebibeau-laviolette/github/serious-trader-ralph/apps/portal/app/api/page.tsx` (if presentation needs adjustment)
-- `/Users/guillaumebibeau-laviolette/github/serious-trader-ralph/tests/unit/portal_api_catalog_routes.test.ts`
-
-Rule: worker route changes under `/x402/read/*` and catalog/discovery docs
-must ship together so `/api`, `/endpoints.json`, `/endpoints.txt`, and
-`/llms.txt` remain accurate.
-
-## Branch Promotion Flow
-
-- Feature branches (`codex/*` or `feature/*`) open PRs into `dev`.
-- `dev` is promoted to `staging` via PR.
-- `staging` is promoted to `main` via PR.
-- CI runs on push and pull request events for `dev`, `staging`, and `main`.
-- Cloudflare worker deploys run automatically on pushes to `dev`, `staging`, and `main`.
-- Vercel portal deploys run automatically on pushes to `dev`, `staging`, and `main`.
-- Vercel deploy automation enforces lane-domain aliases on every deploy:
-  - `dev` -> `dev.trader-ralph.com`
-  - `staging` -> `staging.trader-ralph.com`
+- Promotion flow: `codex/*` or `feature/*` -> `dev` -> `staging` -> `main`
+- Branch environments:
+  - `dev` -> `dev.trader-ralph.com` and `dev.api.trader-ralph.com`
+  - `staging` -> `staging.trader-ralph.com` and `staging.api.trader-ralph.com`
   - `main` -> `trader-ralph.com`, `www.trader-ralph.com`, `api.trader-ralph.com`
-- Vercel deploy automation injects lane build env routing:
-  - `dev` -> `NEXT_PUBLIC_EDGE_API_BASE=https://dev.api.trader-ralph.com`, `NEXT_PUBLIC_SITE_URL=https://dev.trader-ralph.com`
-  - `staging` -> `NEXT_PUBLIC_EDGE_API_BASE=https://staging.api.trader-ralph.com`, `NEXT_PUBLIC_SITE_URL=https://staging.trader-ralph.com`
-  - `main` -> `NEXT_PUBLIC_EDGE_API_BASE=https://api.trader-ralph.com`, `NEXT_PUBLIC_SITE_URL=https://trader-ralph.com`
-- Deploy smoke checks verify docs endpoints and assert the login bundle points to the expected lane API host.
-
-### CI Secrets Required for Deploy Automation
-
-- `CLOUDFLARE_API_TOKEN`
-- `VERCEL_TOKEN`
-- `VERCEL_ORG_ID`
-- `VERCEL_PROJECT_ID`
-- Configure Vercel secrets at minimum in GitHub Environments `dev`, `staging`, and `production`.
+- Cloudflare Worker and Vercel deploys are branch-driven in CI.
 
 ## Tests
 
@@ -192,12 +105,3 @@ bun run test:unit
 bun run test:integration
 bun run test:integration:worker:live
 ```
-
-`test:integration:worker:live` runs the x402 live integration suite.
-
-## Monorepo Layout
-
-- `apps/portal`: Next.js UI
-- `apps/worker`: Cloudflare Worker API
-- `src/`: legacy CLI/gateway toolchain
-- `tests/`: unit + integration tests


### PR DESCRIPTION
## Summary
- simplify README structure and language for faster onboarding
- position Trader Ralph clearly as agentic trading infrastructure for Solana
- trim legacy/verbose sections and keep a concise, practical overview
- keep key runtime/API/discovery/registry references in the document

## Notes
- This PR is documentation-only.
- Repo About metadata (description/homepage/topics) was updated directly on GitHub separately.
