### PR TITLE
X402-009: enforce relay immutability guardrails

### DIFF
--- a/apps/worker/src/execution/relay_immutability.ts
+++ b/apps/worker/src/execution/relay_immutability.ts
@@ -1,0 +1,169 @@
+import type { JsonObject } from "./repository";
+
+export const RELAY_IMMUTABILITY_HASH_ALGORITHM = "sha256";
+
+export type RelayImmutabilitySnapshot = {
+  hashAlgorithm: typeof RELAY_IMMUTABILITY_HASH_ALGORITHM;
+  receivedTxHash: string;
+  submittedTxHash: string;
+  verifiedTxHash: string;
+  verifiedAt: string;
+};
+
+type RelayImmutabilityVerifyResult =
+  | {
+      ok: true;
+      snapshot: RelayImmutabilitySnapshot;
+    }
+  | {
+      ok: false;
+      error: "invalid-transaction" | "policy-denied";
+      reason: string;
+    };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringOrNull(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return normalized ? normalized : null;
+}
+
+function normalizeIso(input: string | undefined): string {
+  if (!input) return new Date().toISOString();
+  const parsed = new Date(input);
+  if (Number.isNaN(parsed.getTime())) return new Date().toISOString();
+  return parsed.toISOString();
+}
+
+function decodeBase64ToBytes(input: string): Uint8Array {
+  const decoded = atob(input);
+  const bytes = new Uint8Array(decoded.length);
+  for (let i = 0; i < decoded.length; i += 1) {
+    bytes[i] = decoded.charCodeAt(i);
+  }
+  return bytes;
+}
+
+async function sha256HexFromBytes(input: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", input);
+  const bytes = new Uint8Array(digest);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  );
+}
+
+export async function hashRelaySignedTransactionBase64(
+  signedTransactionBase64: string,
+): Promise<string | null> {
+  const normalized = String(signedTransactionBase64 ?? "").trim();
+  if (!normalized) return null;
+  let bytes: Uint8Array;
+  try {
+    bytes = decodeBase64ToBytes(normalized);
+  } catch {
+    return null;
+  }
+  if (bytes.length < 1) return null;
+  const digestHex = await sha256HexFromBytes(bytes);
+  return `${RELAY_IMMUTABILITY_HASH_ALGORITHM}:${digestHex}`;
+}
+
+export async function createRelayImmutabilitySnapshot(input: {
+  signedTransactionBase64: string;
+  verifiedAt?: string;
+}): Promise<RelayImmutabilitySnapshot | null> {
+  const txHash = await hashRelaySignedTransactionBase64(
+    input.signedTransactionBase64,
+  );
+  if (!txHash) return null;
+  return {
+    hashAlgorithm: RELAY_IMMUTABILITY_HASH_ALGORITHM,
+    receivedTxHash: txHash,
+    submittedTxHash: txHash,
+    verifiedTxHash: txHash,
+    verifiedAt: normalizeIso(input.verifiedAt),
+  };
+}
+
+export function readRelayImmutabilitySnapshot(
+  metadata: JsonObject | null | undefined,
+): RelayImmutabilitySnapshot | null {
+  if (!metadata) return null;
+  const raw = (metadata as Record<string, unknown>).relayImmutability;
+  if (!isRecord(raw)) return null;
+
+  const hashAlgorithm = stringOrNull(raw.hashAlgorithm);
+  const receivedTxHash = stringOrNull(raw.receivedTxHash);
+  const submittedTxHash = stringOrNull(raw.submittedTxHash);
+  const verifiedTxHash = stringOrNull(raw.verifiedTxHash);
+  const verifiedAt = stringOrNull(raw.verifiedAt);
+  if (
+    hashAlgorithm !== RELAY_IMMUTABILITY_HASH_ALGORITHM ||
+    !receivedTxHash ||
+    !submittedTxHash ||
+    !verifiedTxHash ||
+    !verifiedAt
+  ) {
+    return null;
+  }
+
+  return {
+    hashAlgorithm: RELAY_IMMUTABILITY_HASH_ALGORITHM,
+    receivedTxHash,
+    submittedTxHash,
+    verifiedTxHash,
+    verifiedAt,
+  };
+}
+
+export async function verifyRelayImmutabilitySnapshot(input: {
+  expectedReceivedTxHash: string;
+  signedTransactionBase64: string;
+  verifiedAt?: string;
+}): Promise<RelayImmutabilityVerifyResult> {
+  const expectedReceivedTxHash = String(
+    input.expectedReceivedTxHash ?? "",
+  ).trim();
+  if (
+    !expectedReceivedTxHash ||
+    !expectedReceivedTxHash.startsWith(`${RELAY_IMMUTABILITY_HASH_ALGORITHM}:`)
+  ) {
+    return {
+      ok: false,
+      error: "invalid-transaction",
+      reason: "invalid-relay-immutability-hash",
+    };
+  }
+
+  const submittedTxHash = await hashRelaySignedTransactionBase64(
+    input.signedTransactionBase64,
+  );
+  if (!submittedTxHash) {
+    return {
+      ok: false,
+      error: "invalid-transaction",
+      reason: "invalid-base64",
+    };
+  }
+
+  if (submittedTxHash !== expectedReceivedTxHash) {
+    return {
+      ok: false,
+      error: "policy-denied",
+      reason: "relay-immutability-mismatch",
+    };
+  }
+
+  return {
+    ok: true,
+    snapshot: {
+      hashAlgorithm: RELAY_IMMUTABILITY_HASH_ALGORITHM,
+      receivedTxHash: expectedReceivedTxHash,
+      submittedTxHash,
+      verifiedTxHash: submittedTxHash,
+      verifiedAt: normalizeIso(input.verifiedAt),
+    },
+  };
+}

--- a/apps/worker/src/execution/repository.ts
+++ b/apps/worker/src/execution/repository.ts
@@ -1,3 +1,5 @@
+import { verifyRelayImmutabilitySnapshot } from "./relay_immutability";
+
 export type JsonPrimitive = string | number | boolean | null;
 export type JsonValue = JsonPrimitive | JsonValue[] | JsonObject;
 export type JsonObject = { [key: string]: JsonValue };
@@ -640,6 +642,10 @@ export async function createExecutionAttemptIdempotent(
     status: string;
     providerRequestId?: string | null;
     providerResponse?: JsonObject | null;
+    relayImmutability?: {
+      expectedReceivedTxHash: string;
+      signedTransactionBase64: string;
+    };
     errorCode?: string | null;
     errorMessage?: string | null;
     startedAt?: string;
@@ -655,6 +661,23 @@ export async function createExecutionAttemptIdempotent(
 
   const startedAt = input.startedAt ?? executionNowIso();
   const nowIso = input.nowIso ?? startedAt;
+  let providerResponse = input.providerResponse ?? null;
+  if (input.relayImmutability) {
+    const immutability = await verifyRelayImmutabilitySnapshot({
+      expectedReceivedTxHash: input.relayImmutability.expectedReceivedTxHash,
+      signedTransactionBase64: input.relayImmutability.signedTransactionBase64,
+      verifiedAt: startedAt,
+    });
+    if (!immutability.ok) {
+      throw new Error(
+        `execution-attempt-${immutability.error}:${immutability.reason}`,
+      );
+    }
+    providerResponse = {
+      ...(providerResponse ?? {}),
+      relayImmutability: immutability.snapshot,
+    };
+  }
   try {
     await db
       .prepare(
@@ -684,7 +707,7 @@ export async function createExecutionAttemptIdempotent(
         input.provider,
         input.status,
         input.providerRequestId ?? null,
-        toJsonString(input.providerResponse),
+        toJsonString(providerResponse),
         input.errorCode ?? null,
         input.errorMessage ?? null,
         startedAt,

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -28,6 +28,11 @@ import {
   readIdempotencyKey,
   reserveExecutionSubmitRequest,
 } from "./execution/idempotency";
+import {
+  createRelayImmutabilitySnapshot,
+  readRelayImmutabilitySnapshot,
+  verifyRelayImmutabilitySnapshot,
+} from "./execution/relay_immutability";
 import { validateRelaySignedSubmission } from "./execution/relay_signed_validator";
 import {
   appendExecutionStatusEvent,
@@ -387,6 +392,9 @@ export default {
         let actorId: string | null = null;
         const isRelaySigned = parsed.value.mode === "relay_signed";
         let submitMetadata = parsed.metadataForStorage;
+        let relayImmutability: ReturnType<
+          typeof readRelayImmutabilitySnapshot
+        > = null;
         if (isRelaySigned) {
           let paymentRequired: Response | null = null;
           try {
@@ -425,6 +433,22 @@ export default {
               env,
             );
           }
+          relayImmutability = await createRelayImmutabilitySnapshot({
+            signedTransactionBase64: parsed.value.relaySigned.signedTransaction,
+          });
+          if (!relayImmutability) {
+            return withCors(
+              json(
+                {
+                  ok: false,
+                  error: "invalid-transaction",
+                  reason: "relay-immutability-hash-failed",
+                },
+                { status: 400 },
+              ),
+              env,
+            );
+          }
           submitMetadata = {
             ...(submitMetadata ?? {}),
             relayValidation: {
@@ -435,6 +459,7 @@ export default {
               recentBlockhash: validation.parsed.recentBlockhash,
               programIds: validation.parsed.programIds,
             },
+            relayImmutability,
           };
         } else {
           let user = await requireOnboardedUser(request, env);
@@ -484,6 +509,40 @@ export default {
             ),
             env,
           );
+        }
+
+        if (isRelaySigned && reservation.result !== "created") {
+          const storedImmutability = readRelayImmutabilitySnapshot(
+            reservation.request.metadata,
+          );
+          if (storedImmutability) {
+            const immutabilityVerification =
+              await verifyRelayImmutabilitySnapshot({
+                expectedReceivedTxHash: storedImmutability.receivedTxHash,
+                signedTransactionBase64:
+                  parsed.value.mode === "relay_signed"
+                    ? parsed.value.relaySigned.signedTransaction
+                    : "",
+              });
+            if (!immutabilityVerification.ok) {
+              return withCors(
+                json(
+                  {
+                    ok: false,
+                    error: immutabilityVerification.error,
+                    reason: immutabilityVerification.reason,
+                  },
+                  {
+                    status:
+                      immutabilityVerification.error === "policy-denied"
+                        ? 403
+                        : 400,
+                  },
+                ),
+                env,
+              );
+            }
+          }
         }
 
         if (reservation.result === "created") {
@@ -588,6 +647,9 @@ export default {
         const state = toExecSubmitState(latest.request.status);
         const queueDepthRaw = Number(latest.request.metadata?.queueDepth);
         const queuePositionRaw = Number(latest.request.metadata?.queuePosition);
+        const relayImmutability = readRelayImmutabilitySnapshot(
+          latest.request.metadata,
+        );
         return withCors(
           json({
             ok: true,
@@ -607,6 +669,7 @@ export default {
               ...(Number.isFinite(queuePositionRaw) && queuePositionRaw >= 0
                 ? { queuePosition: Math.floor(queuePositionRaw) }
                 : {}),
+              ...(relayImmutability ? { immutability: relayImmutability } : {}),
             },
             events: timelineEvents.map((event) => {
               const mappedState = toExecSubmitState(event.status);
@@ -655,6 +718,9 @@ export default {
 
         const state = toExecSubmitState(latest.request.status);
         const terminal = isExecSubmitTerminalState(state);
+        const relayImmutability = readRelayImmutabilitySnapshot(
+          latest.request.metadata,
+        );
         if (!latest.receipt) {
           return withCors(
             json({
@@ -665,6 +731,9 @@ export default {
                 state,
                 terminal,
                 updatedAt: latest.request.updatedAt,
+                ...(relayImmutability
+                  ? { immutability: relayImmutability }
+                  : {}),
               },
             }),
             env,
@@ -712,6 +781,7 @@ export default {
                     : null,
                 terminalAt: latest.request.terminalAt,
               },
+              ...(relayImmutability ? { immutability: relayImmutability } : {}),
             },
           }),
           env,

--- a/tests/unit/worker_execution_repository.test.ts
+++ b/tests/unit/worker_execution_repository.test.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { createRelayImmutabilitySnapshot } from "../../apps/worker/src/execution/relay_immutability";
 import {
   appendExecutionStatusEvent,
   createExecutionAttemptIdempotent,
@@ -16,6 +17,7 @@ import {
   updateExecutionRequestStatus,
   upsertExecutionReceiptIdempotent,
 } from "../../apps/worker/src/execution/repository";
+import { buildRelaySignedPayload } from "./_relay_signed_test_utils";
 
 function createSqliteD1Adapter(db: Database): D1Database {
   return {
@@ -334,6 +336,63 @@ describe("worker execution repository", () => {
       expect(latest?.latestEvent?.status).toBe("validated");
       expect(latest?.latestAttempt?.attemptNo).toBe(1);
       expect(latest?.receipt?.receiptId).toBe("receipt_5");
+    });
+  });
+
+  test("enforces relay immutability before attempt creation when provided", async () => {
+    await withExecutionRepo(async (_db, d1) => {
+      await createExecutionRequestIdempotent(d1, {
+        requestId: "req_6",
+        idempotencyScope: "anonymous_x402:bot_6",
+        idempotencyKey: "idem_6",
+        payloadHash: "payload_hash_6",
+        actorType: "anonymous_x402",
+        actorId: "bot_6",
+        mode: "relay_signed",
+        lane: "fast",
+      });
+
+      const relayPayload = buildRelaySignedPayload();
+      const relaySnapshot = await createRelayImmutabilitySnapshot({
+        signedTransactionBase64: relayPayload.relaySigned.signedTransaction,
+      });
+      expect(relaySnapshot).not.toBeNull();
+      if (!relaySnapshot) return;
+
+      const created = await createExecutionAttemptIdempotent(d1, {
+        attemptId: "attempt_6_1",
+        requestId: "req_6",
+        attemptNo: 1,
+        lane: "fast",
+        provider: "helius_sender",
+        status: "dispatched",
+        relayImmutability: {
+          expectedReceivedTxHash: relaySnapshot.receivedTxHash,
+          signedTransactionBase64: relayPayload.relaySigned.signedTransaction,
+        },
+        startedAt: "2026-03-03T00:05:00.000Z",
+      });
+      expect(created.created).toBe(true);
+      expect(
+        created.row.providerResponse?.relayImmutability?.receivedTxHash,
+      ).toBe(relaySnapshot.receivedTxHash);
+
+      await expect(
+        createExecutionAttemptIdempotent(d1, {
+          attemptId: "attempt_6_2",
+          requestId: "req_6",
+          attemptNo: 2,
+          lane: "fast",
+          provider: "helius_sender",
+          status: "dispatched",
+          relayImmutability: {
+            expectedReceivedTxHash: relaySnapshot.receivedTxHash,
+            signedTransactionBase64: buildRelaySignedPayload({ lamports: 2 })
+              .relaySigned.signedTransaction,
+          },
+          startedAt: "2026-03-03T00:05:01.000Z",
+        }),
+      ).rejects.toThrow("execution-attempt-policy-denied");
     });
   });
 });

--- a/tests/unit/worker_relay_immutability.test.ts
+++ b/tests/unit/worker_relay_immutability.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createRelayImmutabilitySnapshot,
+  readRelayImmutabilitySnapshot,
+  verifyRelayImmutabilitySnapshot,
+} from "../../apps/worker/src/execution/relay_immutability";
+import { buildRelaySignedPayload } from "./_relay_signed_test_utils";
+
+describe("relay immutability helpers", () => {
+  test("creates deterministic relay immutability snapshot from signed tx", async () => {
+    const payload = buildRelaySignedPayload();
+    const snapshot = await createRelayImmutabilitySnapshot({
+      signedTransactionBase64: payload.relaySigned.signedTransaction,
+      verifiedAt: "2026-03-03T05:00:00.000Z",
+    });
+    expect(snapshot).not.toBeNull();
+    if (!snapshot) return;
+    expect(snapshot.hashAlgorithm).toBe("sha256");
+    expect(snapshot.receivedTxHash).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(snapshot.submittedTxHash).toBe(snapshot.receivedTxHash);
+    expect(snapshot.verifiedTxHash).toBe(snapshot.receivedTxHash);
+    expect(snapshot.verifiedAt).toBe("2026-03-03T05:00:00.000Z");
+  });
+
+  test("verifies matching relay tx hash and rejects mutated payloads", async () => {
+    const original = buildRelaySignedPayload();
+    const mutated = buildRelaySignedPayload({ lamports: 2 });
+
+    const created = await createRelayImmutabilitySnapshot({
+      signedTransactionBase64: original.relaySigned.signedTransaction,
+    });
+    expect(created).not.toBeNull();
+    if (!created) return;
+
+    const verified = await verifyRelayImmutabilitySnapshot({
+      expectedReceivedTxHash: created.receivedTxHash,
+      signedTransactionBase64: original.relaySigned.signedTransaction,
+      verifiedAt: "2026-03-03T05:10:00.000Z",
+    });
+    expect(verified.ok).toBe(true);
+
+    const mismatch = await verifyRelayImmutabilitySnapshot({
+      expectedReceivedTxHash: created.receivedTxHash,
+      signedTransactionBase64: mutated.relaySigned.signedTransaction,
+    });
+    expect(mismatch.ok).toBe(false);
+    if (mismatch.ok) return;
+    expect(mismatch.error).toBe("policy-denied");
+    expect(mismatch.reason).toBe("relay-immutability-mismatch");
+  });
+
+  test("reads relay immutability snapshot from execution metadata", () => {
+    const snapshot = readRelayImmutabilitySnapshot({
+      relayImmutability: {
+        hashAlgorithm: "sha256",
+        receivedTxHash:
+          "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        submittedTxHash:
+          "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        verifiedTxHash:
+          "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        verifiedAt: "2026-03-03T05:20:00.000Z",
+      },
+    });
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.hashAlgorithm).toBe("sha256");
+  });
+});

--- a/tests/unit/worker_x402_exec_receipt_route.test.ts
+++ b/tests/unit/worker_x402_exec_receipt_route.test.ts
@@ -214,12 +214,23 @@ describe("worker x402 exec receipt route", () => {
       const body = (await receipt.json()) as {
         ok?: boolean;
         ready?: boolean;
-        status?: { state?: string; terminal?: boolean };
+        status?: {
+          state?: string;
+          terminal?: boolean;
+          immutability?: {
+            hashAlgorithm?: string;
+            receivedTxHash?: string;
+          };
+        };
       };
       expect(body.ok).toBe(true);
       expect(body.ready).toBe(false);
       expect(body.status?.state).toBe("validated");
       expect(body.status?.terminal).toBe(false);
+      expect(body.status?.immutability?.hashAlgorithm).toBe("sha256");
+      expect(body.status?.immutability?.receivedTxHash).toMatch(
+        /^sha256:[a-f0-9]{64}$/,
+      );
     } finally {
       sqlite.close();
     }
@@ -337,6 +348,12 @@ describe("worker x402 exec receipt route", () => {
             landedAt?: string | null;
             terminalAt?: string | null;
           };
+          immutability?: {
+            hashAlgorithm?: string;
+            receivedTxHash?: string;
+            submittedTxHash?: string;
+            verifiedTxHash?: string;
+          };
         };
       };
       expect(body.ready).toBe(true);
@@ -359,6 +376,16 @@ describe("worker x402 exec receipt route", () => {
       );
       expect(body.receipt?.trace?.landedAt).toBe("2026-03-03T03:00:03.000Z");
       expect(body.receipt?.trace?.terminalAt).toBe("2026-03-03T03:00:02.000Z");
+      expect(body.receipt?.immutability?.hashAlgorithm).toBe("sha256");
+      expect(body.receipt?.immutability?.receivedTxHash).toMatch(
+        /^sha256:[a-f0-9]{64}$/,
+      );
+      expect(body.receipt?.immutability?.submittedTxHash).toBe(
+        body.receipt?.immutability?.receivedTxHash,
+      );
+      expect(body.receipt?.immutability?.verifiedTxHash).toBe(
+        body.receipt?.immutability?.receivedTxHash,
+      );
     } finally {
       sqlite.close();
     }

--- a/tests/unit/worker_x402_exec_status_route.test.ts
+++ b/tests/unit/worker_x402_exec_status_route.test.ts
@@ -219,6 +219,12 @@ describe("worker x402 exec status route", () => {
           mode?: string;
           lane?: string;
           actorType?: string;
+          immutability?: {
+            hashAlgorithm?: string;
+            receivedTxHash?: string;
+            submittedTxHash?: string;
+            verifiedTxHash?: string;
+          };
         };
         events?: Array<{ state?: string; at?: string }>;
       };
@@ -228,6 +234,16 @@ describe("worker x402 exec status route", () => {
       expect(body.status?.mode).toBe("relay_signed");
       expect(body.status?.lane).toBe("fast");
       expect(body.status?.actorType).toBe("anonymous_x402");
+      expect(body.status?.immutability?.hashAlgorithm).toBe("sha256");
+      expect(body.status?.immutability?.receivedTxHash).toMatch(
+        /^sha256:[a-f0-9]{64}$/,
+      );
+      expect(body.status?.immutability?.submittedTxHash).toBe(
+        body.status?.immutability?.receivedTxHash,
+      );
+      expect(body.status?.immutability?.verifiedTxHash).toBe(
+        body.status?.immutability?.receivedTxHash,
+      );
       expect(Array.isArray(body.events)).toBe(true);
       expect(body.events?.map((event) => event.state)).toEqual([
         "received",

--- a/tests/unit/worker_x402_exec_submit_route.test.ts
+++ b/tests/unit/worker_x402_exec_submit_route.test.ts
@@ -297,6 +297,73 @@ describe("worker x402 exec submit scaffold route", () => {
     }
   });
 
+  test("rejects relay replay when stored immutability hash diverges", async () => {
+    const relayPayload = buildRelaySignedPayload();
+    const { env, sqlite } = createExecSubmitEnv();
+    try {
+      const first = await worker.fetch(
+        new Request("http://localhost/api/x402/exec/submit", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "idempotency-key": "idem-anon-4",
+            "payment-signature": "unit-signed-payment",
+          },
+          body: JSON.stringify(relayPayload),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(first.status).toBe(200);
+      const firstBody = (await first.json()) as { requestId?: string };
+      const requestId = String(firstBody.requestId ?? "");
+      expect(requestId).toBeString();
+
+      const metadataRow = sqlite
+        .query(
+          "SELECT metadata_json as metadataJson FROM execution_requests WHERE request_id = ?1 LIMIT 1",
+        )
+        .get(requestId) as { metadataJson?: string } | undefined;
+      const metadata = JSON.parse(
+        String(metadataRow?.metadataJson ?? "{}"),
+      ) as {
+        relayImmutability?: { receivedTxHash?: string };
+      };
+      metadata.relayImmutability = {
+        ...(metadata.relayImmutability ?? {}),
+        receivedTxHash: `sha256:${"f".repeat(64)}`,
+      };
+      sqlite
+        .query(
+          "UPDATE execution_requests SET metadata_json = ?2 WHERE request_id = ?1",
+        )
+        .run(requestId, JSON.stringify(metadata));
+
+      const replay = await worker.fetch(
+        new Request("http://localhost/api/x402/exec/submit", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "idempotency-key": "idem-anon-4",
+            "payment-signature": "unit-signed-payment",
+          },
+          body: JSON.stringify(relayPayload),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(replay.status).toBe(403);
+      const replayBody = (await replay.json()) as {
+        error?: string;
+        reason?: string;
+      };
+      expect(replayBody.error).toBe("policy-denied");
+      expect(replayBody.reason).toBe("relay-immutability-mismatch");
+    } finally {
+      sqlite.close();
+    }
+  });
+
   test("accepts privy_execute submit for authenticated user", async () => {
     const { env, sqlite } = createExecSubmitEnv();
     try {


### PR DESCRIPTION
## Summary
- add relay immutability hashing helpers to derive deterministic tx hashes from signed base64 payloads and verify equality over replays
- persist relay immutability snapshots in execution request metadata at intake (received/submitted/verified hashes)
- enforce immutability checks on relay replays and before execution attempt creation when relay immutability data is provided
- expose auditable immutability fields on exec status and receipt responses for relay_signed requests
- add unit tests for helpers, repository guardrails, replay mismatch rejection, and status/receipt immutability fields

## Validation
- bun test tests/unit/worker_relay_immutability.test.ts tests/unit/worker_execution_repository.test.ts tests/unit/worker_x402_exec_submit_route.test.ts tests/unit/worker_x402_exec_status_route.test.ts tests/unit/worker_x402_exec_receipt_route.test.ts
- bun test tests/unit
- bun run typecheck
- bun run lint

Closes #125