### PR TITLE
X402-010: validate privy_execute intent contract

### DIFF
--- a/apps/worker/src/execution/submit_contract.ts
+++ b/apps/worker/src/execution/submit_contract.ts
@@ -136,7 +136,7 @@ function parsePrivyExecute(value: unknown): {
     outputMint.length < 32 ||
     outputMint.length > 64 ||
     !BASE58_RE.test(outputMint) ||
-    !/^[0-9]+$/.test(amountAtomic) ||
+    !/^[1-9][0-9]*$/.test(amountAtomic) ||
     !Number.isInteger(slippageBps) ||
     slippageBps < 1 ||
     slippageBps > 5_000

--- a/docs/execution/fixtures/submit.invalid.privy-zero-amount.v1.json
+++ b/docs/execution/fixtures/submit.invalid.privy-zero-amount.v1.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "v1",
+  "mode": "privy_execute",
+  "lane": "protected",
+  "privyExecute": {
+    "intentType": "swap",
+    "wallet": "11111111111111111111111111111111",
+    "swap": {
+      "inputMint": "So11111111111111111111111111111111111111112",
+      "outputMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "amountAtomic": "0",
+      "slippageBps": 50
+    }
+  }
+}

--- a/docs/execution/schemas/exec.submit.request.v1.schema.json
+++ b/docs/execution/schemas/exec.submit.request.v1.schema.json
@@ -69,7 +69,7 @@
               "maxLength": 64,
               "pattern": "^[1-9A-HJ-NP-Za-km-z]+$"
             },
-            "amountAtomic": { "type": "string", "pattern": "^[0-9]+$" },
+            "amountAtomic": { "type": "string", "pattern": "^[1-9][0-9]*$" },
             "slippageBps": { "type": "integer", "minimum": 1, "maximum": 5000 }
           }
         },

--- a/tests/unit/execution_contract_v1_schemas.test.ts
+++ b/tests/unit/execution_contract_v1_schemas.test.ts
@@ -49,6 +49,12 @@ describe("execution contract v1 schemas", () => {
         "docs/execution/fixtures/submit.invalid.missing-lane.v1.json",
       ),
     ).toBe(false);
+    expect(
+      validate(
+        schema,
+        "docs/execution/fixtures/submit.invalid.privy-zero-amount.v1.json",
+      ),
+    ).toBe(false);
   });
 
   test("submit response fixture validates", () => {

--- a/tests/unit/worker_exec_submit_contract_privy.test.ts
+++ b/tests/unit/worker_exec_submit_contract_privy.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import { parseExecSubmitPayload } from "../../apps/worker/src/execution/submit_contract";
+
+const VALID_PRIVY_SUBMIT = {
+  schemaVersion: "v1",
+  mode: "privy_execute",
+  lane: "protected",
+  metadata: {
+    source: "terminal-ui",
+    reason: "manual-swap",
+    clientRequestId: "req_abc_001",
+  },
+  privyExecute: {
+    intentType: "swap",
+    wallet: "11111111111111111111111111111111",
+    swap: {
+      inputMint: "So11111111111111111111111111111111111111112",
+      outputMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      amountAtomic: "1000000",
+      slippageBps: 50,
+    },
+    options: {
+      simulateOnly: true,
+      dryRun: false,
+      commitment: "confirmed",
+    },
+  },
+} as const;
+
+describe("exec submit contract: privy_execute", () => {
+  test("parses a valid privy_execute intent into typed adapter-ready payload", () => {
+    const parsed = parseExecSubmitPayload(VALID_PRIVY_SUBMIT);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.value.mode).toBe("privy_execute");
+    expect(parsed.value.privyExecute?.intentType).toBe("swap");
+    expect(parsed.value.privyExecute?.swap.amountAtomic).toBe("1000000");
+    expect(parsed.value.privyExecute?.options?.simulateOnly).toBe(true);
+    expect(parsed.value.privyExecute?.options?.commitment).toBe("confirmed");
+    expect(parsed.metadataForStorage).toEqual({
+      source: "terminal-ui",
+      reason: "manual-swap",
+      clientRequestId: "req_abc_001",
+    });
+  });
+
+  test("rejects invalid privy_execute payloads deterministically", () => {
+    const invalidIntentType = parseExecSubmitPayload({
+      ...VALID_PRIVY_SUBMIT,
+      privyExecute: {
+        ...VALID_PRIVY_SUBMIT.privyExecute,
+        intentType: "bridge",
+      },
+    });
+    expect(invalidIntentType).toEqual({ ok: false, error: "invalid-request" });
+
+    const zeroAmount = parseExecSubmitPayload({
+      ...VALID_PRIVY_SUBMIT,
+      privyExecute: {
+        ...VALID_PRIVY_SUBMIT.privyExecute,
+        swap: {
+          ...VALID_PRIVY_SUBMIT.privyExecute.swap,
+          amountAtomic: "0",
+        },
+      },
+    });
+    expect(zeroAmount).toEqual({ ok: false, error: "invalid-request" });
+
+    const invalidOptionShape = parseExecSubmitPayload({
+      ...VALID_PRIVY_SUBMIT,
+      privyExecute: {
+        ...VALID_PRIVY_SUBMIT.privyExecute,
+        options: {
+          ...VALID_PRIVY_SUBMIT.privyExecute.options,
+          simulateOnly: "yes",
+        },
+      },
+    });
+    expect(invalidOptionShape).toEqual({
+      ok: false,
+      error: "invalid-request",
+    });
+  });
+
+  test("rejects mode/payload mismatches", () => {
+    const modeMismatch = parseExecSubmitPayload({
+      ...VALID_PRIVY_SUBMIT,
+      mode: "relay_signed",
+      relaySigned: {
+        encoding: "base64",
+        signedTransaction: "QUFBQUFBQUFBQUFBQUFBQQ==",
+      },
+    });
+    expect(modeMismatch).toEqual({ ok: false, error: "invalid-request" });
+  });
+});

--- a/tests/unit/worker_x402_exec_submit_route.test.ts
+++ b/tests/unit/worker_x402_exec_submit_route.test.ts
@@ -424,4 +424,37 @@ describe("worker x402 exec submit scaffold route", () => {
       sqlite.close();
     }
   });
+
+  test("rejects malformed privy_execute intent payloads deterministically", async () => {
+    const { env, sqlite } = createExecSubmitEnv();
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/x402/exec/submit", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer mock-token",
+            "idempotency-key": "idem-privy-3",
+          },
+          body: JSON.stringify({
+            ...PRIVY_PAYLOAD,
+            privyExecute: {
+              ...PRIVY_PAYLOAD.privyExecute,
+              swap: {
+                ...PRIVY_PAYLOAD.privyExecute.swap,
+                amountAtomic: "0",
+              },
+            },
+          }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe("invalid-request");
+    } finally {
+      sqlite.close();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- tighten privy_execute swap validation by requiring positive non-zero amountAtomic values
- add dedicated unit coverage for privy_execute parser behavior and deterministic invalid-request rejections
- add route-level test coverage for malformed privy_execute payload handling in exec submit
- update execution contract JSON schema and invalid fixture to enforce/represent zero-amount rejection

## Validation
- bun test tests/unit/worker_exec_submit_contract_privy.test.ts tests/unit/execution_contract_v1_schemas.test.ts tests/unit/worker_x402_exec_submit_route.test.ts
- bun test tests/unit
- bun run typecheck
- bun run lint

Closes #126