### PR TITLE
X402-011: add Privy swap builder/signing service

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -14,6 +14,7 @@
     "deploy": "wrangler deploy"
   },
   "dependencies": {
+    "@solana/web3.js": "^1.98.4",
     "bs58": "^6.0.0",
     "jose": "^6.1.3",
     "zod": "^4.3.6"

--- a/apps/worker/src/execution/jito_bundle_executor.ts
+++ b/apps/worker/src/execution/jito_bundle_executor.ts
@@ -1,5 +1,4 @@
-import { signTransactionWithPrivyById } from "../privy";
-import { swapWithRetry } from "../swap";
+import { buildAndSignPrivySwapTransaction } from "./privy_swap_builder";
 import type { ExecuteSwapInput, ExecuteSwapResult } from "./types";
 
 type JitoRpcResponse = {
@@ -165,21 +164,23 @@ export async function executeJitoBundleSwap(
   if (guardEnabled) await guardEnabled();
 
   const {
-    swap,
-    quoteResponse: usedQuote,
+    signedBase64,
+    usedQuote,
     refreshed,
-  } = await swapWithRetry(jupiter, quoteResponse, userPublicKey, policy);
-  const txBuiltAt = nowIso();
-
-  if (!privyWalletId) {
-    throw new Error("missing-privy-wallet-id");
-  }
-
-  const signedBase64 = await signTransactionWithPrivyById(
+    lastValidBlockHeight,
+    txBuiltAt,
+  } = await buildAndSignPrivySwapTransaction({
     env,
+    policy,
+    rpc,
+    jupiter,
+    quoteResponse,
+    userPublicKey,
     privyWalletId,
-    swap.swapTransaction,
-  );
+    log,
+    execution: input.execution,
+    guardEnabled,
+  });
 
   if (policy.simulateOnly) {
     const sim = await rpc.simulateTransactionBase64(signedBase64, {
@@ -193,7 +194,7 @@ export async function executeJitoBundleSwap(
       signature: null,
       usedQuote,
       refreshed,
-      lastValidBlockHeight: swap.lastValidBlockHeight,
+      lastValidBlockHeight,
       err: sim.err ?? null,
       executionMeta: {
         route,
@@ -255,7 +256,7 @@ export async function executeJitoBundleSwap(
     signature: null,
     usedQuote,
     refreshed,
-    lastValidBlockHeight: swap.lastValidBlockHeight,
+    lastValidBlockHeight,
     err:
       status === "error"
         ? {

--- a/apps/worker/src/execution/jupiter_executor.ts
+++ b/apps/worker/src/execution/jupiter_executor.ts
@@ -1,5 +1,4 @@
-import { signTransactionWithPrivyById } from "../privy";
-import { swapWithRetry } from "../swap";
+import { buildAndSignPrivySwapTransaction } from "./privy_swap_builder";
 import type { ExecuteSwapInput, ExecuteSwapResult } from "./types";
 
 function nowIso(): string {
@@ -55,23 +54,23 @@ export async function executeJupiterSwap(
   if (guardEnabled) await guardEnabled();
 
   const {
-    swap,
-    quoteResponse: usedQuote,
+    signedBase64,
+    usedQuote,
     refreshed,
-  } = await swapWithRetry(jupiter, quoteResponse, userPublicKey, policy);
-  const txBuiltAt = nowIso();
-
-  if (!privyWalletId) {
-    throw new Error("missing-privy-wallet-id");
-  }
-
-  log("info", "signing transaction", { walletId: privyWalletId });
-  const signedBase64 = await signTransactionWithPrivyById(
+    lastValidBlockHeight,
+    txBuiltAt,
+  } = await buildAndSignPrivySwapTransaction({
     env,
+    policy,
+    rpc,
+    jupiter,
+    quoteResponse,
+    userPublicKey,
     privyWalletId,
-    swap.swapTransaction,
-  );
-  log("info", "transaction signed");
+    log,
+    execution: input.execution,
+    guardEnabled,
+  });
 
   if (policy.simulateOnly) {
     const sim = await rpc.simulateTransactionBase64(signedBase64, {
@@ -90,7 +89,7 @@ export async function executeJupiterSwap(
       signature: null,
       usedQuote,
       refreshed,
-      lastValidBlockHeight: swap.lastValidBlockHeight,
+      lastValidBlockHeight,
       err: sim.err ?? null,
       executionMeta: {
         route,
@@ -114,7 +113,7 @@ export async function executeJupiterSwap(
 
   log("info", "tx submitted", {
     signature,
-    lastValidBlockHeight: swap.lastValidBlockHeight,
+    lastValidBlockHeight,
   });
 
   const confirmation = await rpc.confirmSignature(signature, {
@@ -135,7 +134,7 @@ export async function executeJupiterSwap(
     signature,
     usedQuote,
     refreshed,
-    lastValidBlockHeight: swap.lastValidBlockHeight,
+    lastValidBlockHeight,
     err: confirmation.err ?? null,
     executionMeta: {
       route,

--- a/apps/worker/src/execution/privy_swap_builder.ts
+++ b/apps/worker/src/execution/privy_swap_builder.ts
@@ -1,0 +1,53 @@
+import type { JupiterQuoteResponse } from "../jupiter";
+import { signTransactionWithPrivyById } from "../privy";
+import { swapWithRetry } from "../swap";
+import type { ExecuteSwapInput } from "./types";
+
+export type BuiltPrivySwapTransaction = {
+  signedBase64: string;
+  usedQuote: JupiterQuoteResponse;
+  refreshed: boolean;
+  lastValidBlockHeight: number | null;
+  txBuiltAt: string;
+};
+
+export async function buildAndSignPrivySwapTransaction(
+  input: ExecuteSwapInput,
+): Promise<BuiltPrivySwapTransaction> {
+  const {
+    env,
+    policy,
+    jupiter,
+    quoteResponse,
+    userPublicKey,
+    privyWalletId,
+    log,
+  } = input;
+
+  if (!privyWalletId) {
+    throw new Error("missing-privy-wallet-id");
+  }
+
+  const {
+    swap,
+    quoteResponse: usedQuote,
+    refreshed,
+  } = await swapWithRetry(jupiter, quoteResponse, userPublicKey, policy);
+  const txBuiltAt = new Date().toISOString();
+
+  log("info", "signing transaction", { walletId: privyWalletId });
+  const signedBase64 = await signTransactionWithPrivyById(
+    env,
+    privyWalletId,
+    swap.swapTransaction,
+  );
+  log("info", "transaction signed");
+
+  return {
+    signedBase64,
+    usedQuote,
+    refreshed,
+    lastValidBlockHeight: swap.lastValidBlockHeight,
+    txBuiltAt,
+  };
+}

--- a/tests/unit/worker_privy_swap_builder.test.ts
+++ b/tests/unit/worker_privy_swap_builder.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { ExecuteSwapInput } from "../../apps/worker/src/execution/types";
+
+const signTransactionWithPrivyByIdMock = mock(async () => "signed-base64-tx");
+const swapWithRetryMock = mock(async () => ({
+  swap: {
+    swapTransaction: "unsigned-base64-tx",
+    lastValidBlockHeight: 12345,
+  },
+  quoteResponse: {
+    inputMint: "So11111111111111111111111111111111111111112",
+    outputMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    inAmount: "1000000",
+    outAmount: "999000",
+  },
+  refreshed: false,
+}));
+
+mock.module("../../apps/worker/src/privy", () => ({
+  signTransactionWithPrivyById: signTransactionWithPrivyByIdMock,
+}));
+mock.module("../../apps/worker/src/swap", () => ({
+  swapWithRetry: swapWithRetryMock,
+}));
+
+const { buildAndSignPrivySwapTransaction } = await import(
+  "../../apps/worker/src/execution/privy_swap_builder"
+);
+
+function createInput(overrides?: Partial<ExecuteSwapInput>): ExecuteSwapInput {
+  return {
+    env: {} as ExecuteSwapInput["env"],
+    execution: { adapter: "jupiter" },
+    policy: {} as ExecuteSwapInput["policy"],
+    rpc: {} as ExecuteSwapInput["rpc"],
+    jupiter: {} as ExecuteSwapInput["jupiter"],
+    quoteResponse: {
+      inputMint: "So11111111111111111111111111111111111111112",
+      outputMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      inAmount: "1000000",
+      outAmount: "999000",
+    },
+    userPublicKey: "11111111111111111111111111111111",
+    privyWalletId: "wallet_123",
+    log: () => {},
+    ...overrides,
+  };
+}
+
+describe("worker privy swap builder", () => {
+  beforeEach(() => {
+    signTransactionWithPrivyByIdMock.mockClear();
+    swapWithRetryMock.mockClear();
+  });
+
+  test("builds and signs swap transactions with privy custody", async () => {
+    const result = await buildAndSignPrivySwapTransaction(createInput());
+    expect(result.signedBase64).toBe("signed-base64-tx");
+    expect(result.lastValidBlockHeight).toBe(12345);
+    expect(result.usedQuote.outputMint).toBe(
+      "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    );
+    expect(signTransactionWithPrivyByIdMock).toHaveBeenCalledTimes(1);
+    expect(swapWithRetryMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("fails fast when privy wallet id is missing", async () => {
+    await expect(
+      buildAndSignPrivySwapTransaction(
+        createInput({ privyWalletId: undefined }),
+      ),
+    ).rejects.toThrow("missing-privy-wallet-id");
+    expect(signTransactionWithPrivyByIdMock).not.toHaveBeenCalled();
+    expect(swapWithRetryMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared buildAndSignPrivySwapTransaction service that converts swap intents into Jupiter swap transactions and signs with Privy custody
- refactor Jupiter and Jito execution adapters to use the shared Privy builder/signing service
- add focused unit coverage for Privy builder behavior (successful signing and fast-fail missing wallet)
- add @solana/web3.js to apps/worker dependencies to fix Deploy (dev) worker build failures caused by relay validator imports

## Validation
- bun test tests/unit/worker_privy_swap_builder.test.ts tests/unit/worker_execution_jito_bundle.test.ts tests/unit/worker_execution_router.test.ts
- bun test tests/unit
- bun run typecheck
- bun run lint

Closes #127