### PR TITLE
X402-017: add canonical execution lifecycle state machine

### DIFF
--- a/apps/worker/src/execution/lifecycle.ts
+++ b/apps/worker/src/execution/lifecycle.ts
@@ -1,0 +1,57 @@
+export type ExecutionLifecycleStatus =
+  | "received"
+  | "validated"
+  | "queued"
+  | "dispatched"
+  | "landed"
+  | "finalized"
+  | "failed"
+  | "expired"
+  | "rejected";
+
+const EXECUTION_TERMINAL_STATUS_SET = new Set<ExecutionLifecycleStatus>([
+  "landed",
+  "finalized",
+  "failed",
+  "expired",
+  "rejected",
+]);
+
+const EXECUTION_STATUS_TRANSITIONS: Record<
+  ExecutionLifecycleStatus,
+  ReadonlySet<ExecutionLifecycleStatus>
+> = {
+  received: new Set(["validated", "failed", "expired", "rejected"]),
+  validated: new Set(["queued", "dispatched", "failed", "expired", "rejected"]),
+  queued: new Set(["dispatched", "failed", "expired", "rejected"]),
+  dispatched: new Set(["landed", "failed", "expired", "rejected"]),
+  landed: new Set(["finalized", "failed", "expired", "rejected"]),
+  finalized: new Set([]),
+  failed: new Set([]),
+  expired: new Set([]),
+  rejected: new Set([]),
+};
+
+export function isTerminalExecutionStatus(
+  status: ExecutionLifecycleStatus,
+): boolean {
+  return EXECUTION_TERMINAL_STATUS_SET.has(status);
+}
+
+export function canTransitionExecutionStatus(
+  fromStatus: ExecutionLifecycleStatus,
+  toStatus: ExecutionLifecycleStatus,
+): boolean {
+  if (fromStatus === toStatus) return true;
+  return EXECUTION_STATUS_TRANSITIONS[fromStatus].has(toStatus);
+}
+
+export function assertExecutionStatusTransition(input: {
+  fromStatus: ExecutionLifecycleStatus;
+  toStatus: ExecutionLifecycleStatus;
+}): void {
+  if (canTransitionExecutionStatus(input.fromStatus, input.toStatus)) return;
+  throw new Error(
+    `illegal-execution-status-transition:${input.fromStatus}->${input.toStatus}`,
+  );
+}

--- a/apps/worker/src/execution/repository.ts
+++ b/apps/worker/src/execution/repository.ts
@@ -1,3 +1,7 @@
+import {
+  assertExecutionStatusTransition,
+  type ExecutionLifecycleStatus,
+} from "./lifecycle";
 import { verifyRelayImmutabilitySnapshot } from "./relay_immutability";
 
 export type JsonPrimitive = string | number | boolean | null;
@@ -13,18 +17,21 @@ export type ExecutionLane = "fast" | "protected" | "safe";
 export type ExecutionStatus =
   | "received"
   | "validated"
+  | "queued"
   | "dispatched"
   | "landed"
+  | "finalized"
   | "failed"
   | "expired"
   | "rejected";
 export type ExecutionTerminalStatus = Extract<
   ExecutionStatus,
-  "landed" | "failed" | "expired" | "rejected"
+  "landed" | "finalized" | "failed" | "expired" | "rejected"
 >;
 
 export const EXECUTION_TERMINAL_STATUSES = new Set<ExecutionStatus>([
   "landed",
+  "finalized",
   "failed",
   "expired",
   "rejected",
@@ -190,6 +197,7 @@ function mapExecutionRequestRow(
       ) ||
       stringValue(row.status) === "received" ||
       stringValue(row.status) === "validated" ||
+      stringValue(row.status) === "queued" ||
       stringValue(row.status) === "dispatched"
         ? (stringValue(row.status) as ExecutionStatus)
         : "received",
@@ -235,9 +243,11 @@ function mapExecutionStatusEventRow(
     requestId: stringValue(row.requestId),
     seq: numberValue(row.seq),
     status:
+      stringValue(row.status) === "queued" ||
       stringValue(row.status) === "validated" ||
       stringValue(row.status) === "dispatched" ||
       stringValue(row.status) === "landed" ||
+      stringValue(row.status) === "finalized" ||
       stringValue(row.status) === "failed" ||
       stringValue(row.status) === "expired" ||
       stringValue(row.status) === "rejected"
@@ -443,6 +453,13 @@ export async function updateExecutionRequestStatus(
     nowIso?: string;
   },
 ): Promise<ExecutionRequestRecord | null> {
+  const current = await getExecutionRequestById(db, input.requestId);
+  if (!current) return null;
+  assertExecutionStatusTransition({
+    fromStatus: current.status as ExecutionLifecycleStatus,
+    toStatus: input.status as ExecutionLifecycleStatus,
+  });
+
   const nowIso = input.nowIso ?? executionNowIso();
   await db
     .prepare(
@@ -454,6 +471,10 @@ export async function updateExecutionRequestStatus(
         validated_at = CASE
           WHEN ?1 = 'validated' AND validated_at IS NULL THEN ?3
           ELSE validated_at
+        END,
+        terminal_at = CASE
+          WHEN ?1 IN ('landed', 'finalized', 'failed', 'expired', 'rejected') AND terminal_at IS NULL THEN ?3
+          ELSE terminal_at
         END,
         updated_at = ?3
       WHERE request_id = ?4
@@ -591,6 +612,19 @@ export async function terminalizeExecutionRequest(
   request: ExecutionRequestRecord | null;
   event: ExecutionStatusEventRecord | null;
 }> {
+  const current = await getExecutionRequestById(db, input.requestId);
+  if (!current) {
+    return {
+      applied: false,
+      request: null,
+      event: null,
+    };
+  }
+  assertExecutionStatusTransition({
+    fromStatus: current.status as ExecutionLifecycleStatus,
+    toStatus: input.status as ExecutionLifecycleStatus,
+  });
+
   const nowIso = input.nowIso ?? executionNowIso();
   const result = await db
     .prepare(
@@ -599,10 +633,16 @@ export async function terminalizeExecutionRequest(
       SET
         status = ?1,
         status_reason = ?2,
-        terminal_at = ?3,
+        terminal_at = CASE
+          WHEN terminal_at IS NULL THEN ?3
+          ELSE terminal_at
+        END,
         updated_at = ?3
       WHERE request_id = ?4
-        AND terminal_at IS NULL
+        AND (
+          terminal_at IS NULL
+          OR (?1 = 'finalized' AND status = 'landed')
+        )
       `,
     )
     .bind(input.status, input.statusReason ?? null, nowIso, input.requestId)

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -3281,8 +3281,10 @@ function isValidExecRequestId(value: string): boolean {
 function toExecSubmitState(status: string): ExecSubmitState {
   if (status === "received") return "received";
   if (status === "validated") return "validated";
+  if (status === "queued") return "queued";
   if (status === "dispatched") return "dispatched";
   if (status === "landed") return "landed";
+  if (status === "finalized") return "finalized";
   if (status === "expired") return "expired";
   if (status === "failed" || status === "rejected") return "failed";
   return "received";

--- a/tests/unit/worker_execution_lifecycle_state_machine.test.ts
+++ b/tests/unit/worker_execution_lifecycle_state_machine.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import {
+  assertExecutionStatusTransition,
+  canTransitionExecutionStatus,
+  isTerminalExecutionStatus,
+} from "../../apps/worker/src/execution/lifecycle";
+
+describe("execution lifecycle state machine", () => {
+  test("accepts canonical forward transitions", () => {
+    expect(canTransitionExecutionStatus("received", "validated")).toBe(true);
+    expect(canTransitionExecutionStatus("validated", "queued")).toBe(true);
+    expect(canTransitionExecutionStatus("queued", "dispatched")).toBe(true);
+    expect(canTransitionExecutionStatus("dispatched", "landed")).toBe(true);
+    expect(canTransitionExecutionStatus("landed", "finalized")).toBe(true);
+    expect(canTransitionExecutionStatus("landed", "failed")).toBe(true);
+    expect(canTransitionExecutionStatus("landed", "expired")).toBe(true);
+  });
+
+  test("rejects illegal transitions", () => {
+    expect(canTransitionExecutionStatus("received", "queued")).toBe(false);
+    expect(canTransitionExecutionStatus("validated", "received")).toBe(false);
+    expect(canTransitionExecutionStatus("queued", "landed")).toBe(false);
+    expect(canTransitionExecutionStatus("failed", "validated")).toBe(false);
+    expect(() =>
+      assertExecutionStatusTransition({
+        fromStatus: "received",
+        toStatus: "queued",
+      }),
+    ).toThrow(/illegal-execution-status-transition/);
+  });
+
+  test("marks terminal statuses correctly", () => {
+    expect(isTerminalExecutionStatus("landed")).toBe(true);
+    expect(isTerminalExecutionStatus("finalized")).toBe(true);
+    expect(isTerminalExecutionStatus("failed")).toBe(true);
+    expect(isTerminalExecutionStatus("expired")).toBe(true);
+    expect(isTerminalExecutionStatus("rejected")).toBe(true);
+    expect(isTerminalExecutionStatus("queued")).toBe(false);
+    expect(isTerminalExecutionStatus("dispatched")).toBe(false);
+  });
+});

--- a/tests/unit/worker_execution_repository.test.ts
+++ b/tests/unit/worker_execution_repository.test.ts
@@ -168,6 +168,55 @@ describe("worker execution repository", () => {
     });
   });
 
+  test("enforces lifecycle transition rules and supports landed->finalized", async () => {
+    await withExecutionRepo(async (_db, d1) => {
+      await createExecutionRequestIdempotent(d1, {
+        requestId: "req_2b",
+        idempotencyScope: "anonymous_x402:anon",
+        idempotencyKey: "idem_2b",
+        payloadHash: "payload_hash_2b",
+        actorType: "anonymous_x402",
+        actorId: "anon",
+        mode: "relay_signed",
+        lane: "fast",
+      });
+
+      await expect(
+        updateExecutionRequestStatus(d1, {
+          requestId: "req_2b",
+          status: "queued",
+          nowIso: "2026-03-03T00:01:00.000Z",
+        }),
+      ).rejects.toThrow(/illegal-execution-status-transition/);
+
+      await updateExecutionRequestStatus(d1, {
+        requestId: "req_2b",
+        status: "validated",
+        nowIso: "2026-03-03T00:01:01.000Z",
+      });
+      await updateExecutionRequestStatus(d1, {
+        requestId: "req_2b",
+        status: "dispatched",
+        nowIso: "2026-03-03T00:01:02.000Z",
+      });
+      const landed = await updateExecutionRequestStatus(d1, {
+        requestId: "req_2b",
+        status: "landed",
+        nowIso: "2026-03-03T00:01:03.000Z",
+      });
+      expect(landed?.terminalAt).toBe("2026-03-03T00:01:03.000Z");
+
+      const finalized = await updateExecutionRequestStatus(d1, {
+        requestId: "req_2b",
+        status: "finalized",
+        nowIso: "2026-03-03T00:01:04.000Z",
+      });
+      expect(finalized?.status).toBe("finalized");
+      // Terminal timestamp is first terminal state timestamp and should remain stable.
+      expect(finalized?.terminalAt).toBe("2026-03-03T00:01:03.000Z");
+    });
+  });
+
   test("terminalization helper prevents duplicate terminalization under concurrency", async () => {
     await withExecutionRepo(async (_db, d1) => {
       await createExecutionRequestIdempotent(d1, {


### PR DESCRIPTION
## Summary
- add lifecycle state machine module with explicit allowed transitions and terminal-status classification
- enforce transition guards in execution repository status updates (`updateExecutionRequestStatus`, `terminalizeExecutionRequest`)
- extend execution status model to include `queued` and `finalized` while preserving existing `landed` terminal compatibility
- update submit status mapping so `queued`/`finalized` surface correctly in API responses
- add unit coverage for lifecycle rules and repository transition enforcement (including invalid-transition rejection)

## Tests
- bun test tests/unit/worker_execution_lifecycle_state_machine.test.ts tests/unit/worker_execution_repository.test.ts
- bun test tests/unit
- bun run typecheck
- bun run lint

Closes #133
