### PR TITLE
X402-018: Build canonical receipt assembler

### DIFF
--- a/apps/worker/src/execution/receipt_assembler.ts
+++ b/apps/worker/src/execution/receipt_assembler.ts
@@ -1,0 +1,106 @@
+import type {
+  ExecutionAttemptRecord,
+  ExecutionReceiptRecord,
+  ExecutionRequestRecord,
+} from "./repository";
+
+export type CanonicalExecutionReceiptV1 = {
+  schemaVersion: "v1";
+  receiptId: string;
+  requestId: string;
+  mode: string;
+  lane: string;
+  actorType: string;
+  provider: string;
+  generatedAt: string;
+  outcome: {
+    status: "finalized" | "failed" | "expired";
+    signature: string | null;
+    errorCode: string | null;
+    errorMessage: string | null;
+  };
+  trace: {
+    receivedAt: string;
+    validatedAt: string | null;
+    dispatchedAt: string | null;
+    landedAt: string | null;
+    terminalAt: string | null;
+  };
+  attempts: Array<{
+    attempt: number;
+    provider: string;
+    state: string;
+    at: string;
+  }>;
+  immutability?: {
+    hashAlgorithm: string;
+    receivedTxHash: string;
+    submittedTxHash?: string;
+    verifiedTxHash?: string;
+  };
+};
+
+function toOutcomeStatus(status: string): "finalized" | "failed" | "expired" {
+  if (status === "expired") return "expired";
+  if (status === "landed" || status === "finalized") return "finalized";
+  return "failed";
+}
+
+export function canonicalExecutionReceiptStorageKey(requestId: string): string {
+  return `exec/v1/receipts/request_id=${requestId}.json`;
+}
+
+export function assembleCanonicalExecutionReceiptV1(input: {
+  request: ExecutionRequestRecord;
+  receipt: ExecutionReceiptRecord;
+  attempts: ExecutionAttemptRecord[];
+  immutability?: {
+    hashAlgorithm: string;
+    receivedTxHash: string;
+    submittedTxHash?: string;
+    verifiedTxHash?: string;
+  } | null;
+}): CanonicalExecutionReceiptV1 {
+  const latestAttempt =
+    input.attempts.length > 0
+      ? input.attempts[input.attempts.length - 1]
+      : null;
+  const provider =
+    input.receipt.provider ?? latestAttempt?.provider ?? "unknown";
+  const landedAt =
+    input.receipt.finalizedStatus === "landed" ||
+    input.receipt.finalizedStatus === "finalized"
+      ? input.receipt.readyAt
+      : null;
+
+  return {
+    schemaVersion: "v1",
+    receiptId: input.receipt.receiptId,
+    requestId: input.request.requestId,
+    mode: input.request.mode,
+    lane: input.request.lane,
+    actorType: input.request.actorType,
+    provider,
+    generatedAt: input.receipt.readyAt,
+    outcome: {
+      status: toOutcomeStatus(input.receipt.finalizedStatus),
+      signature: input.receipt.signature,
+      errorCode: input.receipt.errorCode,
+      errorMessage: input.receipt.errorMessage,
+    },
+    trace: {
+      receivedAt: input.request.receivedAt,
+      validatedAt: input.request.validatedAt,
+      dispatchedAt: latestAttempt?.startedAt ?? null,
+      landedAt,
+      terminalAt: input.request.terminalAt,
+    },
+    attempts: input.attempts.map((attempt) => ({
+      attempt: attempt.attemptNo,
+      provider: attempt.provider,
+      state: attempt.status,
+      at: attempt.completedAt ?? attempt.startedAt,
+    })),
+    ...(input.immutability ? { immutability: input.immutability } : {}),
+  };
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -30,6 +30,10 @@ import {
 } from "./execution/idempotency";
 import { resolveExecutionLane } from "./execution/lane_resolver";
 import {
+  assembleCanonicalExecutionReceiptV1,
+  canonicalExecutionReceiptStorageKey,
+} from "./execution/receipt_assembler";
+import {
   createRelayImmutabilitySnapshot,
   readRelayImmutabilitySnapshot,
   verifyRelayImmutabilitySnapshot,
@@ -771,45 +775,30 @@ export default {
           env.WAITLIST_DB,
           requestId,
         );
-        const latestAttempt =
-          attempts.length > 0 ? attempts[attempts.length - 1] : null;
-        const provider =
-          latest.receipt.provider ?? latestAttempt?.provider ?? "unknown";
+        const canonicalReceipt = assembleCanonicalExecutionReceiptV1({
+          request: latest.request,
+          receipt: latest.receipt,
+          attempts,
+          immutability: relayImmutability,
+        });
+        if (env.LOGS_BUCKET) {
+          const key = canonicalExecutionReceiptStorageKey(requestId);
+          try {
+            await env.LOGS_BUCKET.put(key, JSON.stringify(canonicalReceipt));
+          } catch (error) {
+            console.warn("exec.receipt.persist.error", {
+              requestId,
+              key,
+              message: error instanceof Error ? error.message : String(error),
+            });
+          }
+        }
         return withCors(
           json({
             ok: true,
             requestId,
             ready: true,
-            receipt: {
-              schemaVersion: "v1",
-              receiptId: latest.receipt.receiptId,
-              requestId,
-              mode: latest.request.mode,
-              lane: latest.request.lane,
-              actorType: latest.request.actorType,
-              provider,
-              generatedAt: latest.receipt.readyAt,
-              outcome: {
-                status: toExecReceiptOutcomeStatus(
-                  latest.receipt.finalizedStatus,
-                ),
-                signature: latest.receipt.signature,
-                errorCode: latest.receipt.errorCode,
-                errorMessage: latest.receipt.errorMessage,
-              },
-              trace: {
-                receivedAt: latest.request.receivedAt,
-                validatedAt: latest.request.validatedAt,
-                dispatchedAt: latestAttempt?.startedAt ?? null,
-                landedAt:
-                  latest.receipt.finalizedStatus === "landed" ||
-                  latest.receipt.finalizedStatus === "finalized"
-                    ? latest.receipt.readyAt
-                    : null,
-                terminalAt: latest.request.terminalAt,
-              },
-              ...(relayImmutability ? { immutability: relayImmutability } : {}),
-            },
+            receipt: canonicalReceipt,
           }),
           env,
         );
@@ -3297,14 +3286,6 @@ function isExecSubmitTerminalState(state: ExecSubmitState): boolean {
     state === "failed" ||
     state === "expired"
   );
-}
-
-type ExecReceiptOutcomeStatus = "finalized" | "failed" | "expired";
-
-function toExecReceiptOutcomeStatus(status: string): ExecReceiptOutcomeStatus {
-  if (status === "expired") return "expired";
-  if (status === "landed" || status === "finalized") return "finalized";
-  return "failed";
 }
 
 function parsePerpsSymbol(value: string): string {

--- a/tests/unit/worker_execution_receipt_assembler.test.ts
+++ b/tests/unit/worker_execution_receipt_assembler.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import {
+  assembleCanonicalExecutionReceiptV1,
+  canonicalExecutionReceiptStorageKey,
+} from "../../apps/worker/src/execution/receipt_assembler";
+
+describe("execution receipt assembler", () => {
+  test("builds canonical receipt from request, attempts, and terminal receipt row", () => {
+    const receipt = assembleCanonicalExecutionReceiptV1({
+      request: {
+        requestId: "execreq_1",
+        schemaVersion: "v1",
+        idempotencyScope: "anonymous_x402:anon",
+        idempotencyKey: "idem_1",
+        payloadHash: "hash_1",
+        actorType: "anonymous_x402",
+        actorId: null,
+        mode: "relay_signed",
+        lane: "fast",
+        status: "landed",
+        statusReason: null,
+        metadata: null,
+        receivedAt: "2026-03-03T00:00:00.000Z",
+        validatedAt: "2026-03-03T00:00:01.000Z",
+        terminalAt: "2026-03-03T00:00:03.000Z",
+        createdAt: "2026-03-03T00:00:00.000Z",
+        updatedAt: "2026-03-03T00:00:03.000Z",
+      },
+      receipt: {
+        requestId: "execreq_1",
+        receiptId: "exec_abc123",
+        schemaVersion: "v1",
+        finalizedStatus: "landed",
+        lane: "fast",
+        provider: "helius_sender",
+        signature: "sig_1",
+        slot: 123,
+        errorCode: null,
+        errorMessage: null,
+        receipt: null,
+        readyAt: "2026-03-03T00:00:04.000Z",
+        createdAt: "2026-03-03T00:00:04.000Z",
+        updatedAt: "2026-03-03T00:00:04.000Z",
+      },
+      attempts: [
+        {
+          attemptId: "attempt_1",
+          requestId: "execreq_1",
+          attemptNo: 1,
+          lane: "fast",
+          provider: "helius_sender",
+          status: "dispatched",
+          providerRequestId: "prov_1",
+          providerResponse: null,
+          errorCode: null,
+          errorMessage: null,
+          startedAt: "2026-03-03T00:00:02.000Z",
+          completedAt: "2026-03-03T00:00:03.000Z",
+          createdAt: "2026-03-03T00:00:02.000Z",
+          updatedAt: "2026-03-03T00:00:03.000Z",
+        },
+      ],
+      immutability: {
+        hashAlgorithm: "sha256",
+        receivedTxHash: "sha256:abc",
+      },
+    });
+
+    expect(receipt.schemaVersion).toBe("v1");
+    expect(receipt.receiptId).toBe("exec_abc123");
+    expect(receipt.requestId).toBe("execreq_1");
+    expect(receipt.outcome.status).toBe("finalized");
+    expect(receipt.trace.dispatchedAt).toBe("2026-03-03T00:00:02.000Z");
+    expect(receipt.trace.landedAt).toBe("2026-03-03T00:00:04.000Z");
+    expect(receipt.attempts.length).toBe(1);
+    expect(receipt.immutability?.hashAlgorithm).toBe("sha256");
+  });
+
+  test("derives stable storage key by request id", () => {
+    expect(canonicalExecutionReceiptStorageKey("execreq_abc")).toBe(
+      "exec/v1/receipts/request_id=execreq_abc.json",
+    );
+  });
+});

--- a/tests/unit/worker_x402_exec_receipt_route.test.ts
+++ b/tests/unit/worker_x402_exec_receipt_route.test.ts
@@ -110,7 +110,11 @@ function createSqliteD1Adapter(db: Database): D1Database {
   } as unknown as D1Database;
 }
 
-function createExecReceiptEnv(): { env: Env; sqlite: Database } {
+function createExecReceiptEnv(): {
+  env: Env;
+  sqlite: Database;
+  receiptWrites: Array<{ key: string; value: string }>;
+} {
   const sqlite = new Database(":memory:");
   sqlite.exec("PRAGMA foreign_keys = ON;");
   sqlite.exec(`
@@ -131,15 +135,30 @@ function createExecReceiptEnv(): { env: Env; sqlite: Database } {
   );
   sqlite.exec(readFileSync(migrationPath, "utf8"));
 
+  const receiptWrites: Array<{ key: string; value: string }> = [];
+  const logsBucket = {
+    async put(key: string, value: string) {
+      receiptWrites.push({ key, value });
+      return null;
+    },
+    async get() {
+      return null;
+    },
+    async head() {
+      return null;
+    },
+  } as unknown as R2Bucket;
+
   const env = createWorkerLiveEnv({
     overrides: {
       WAITLIST_DB: createSqliteD1Adapter(sqlite),
+      LOGS_BUCKET: logsBucket,
       PRIVY_APP_ID: "privy-app-id",
       X402_EXEC_SUBMIT_PRICE_USD: "0.01",
       EXEC_RELAY_VALIDATE_BLOCKHASH: "0",
     },
   });
-  return { env, sqlite };
+  return { env, sqlite, receiptWrites };
 }
 
 describe("worker x402 exec receipt route", () => {
@@ -238,7 +257,7 @@ describe("worker x402 exec receipt route", () => {
 
   test("returns canonical receipt when available", async () => {
     const relayPayload = buildRelaySignedPayload();
-    const { env, sqlite } = createExecReceiptEnv();
+    const { env, sqlite, receiptWrites } = createExecReceiptEnv();
     try {
       const submit = await worker.fetch(
         new Request("http://localhost/api/x402/exec/submit", {
@@ -386,6 +405,16 @@ describe("worker x402 exec receipt route", () => {
       expect(body.receipt?.immutability?.verifiedTxHash).toBe(
         body.receipt?.immutability?.receivedTxHash,
       );
+      expect(receiptWrites.length).toBe(1);
+      expect(receiptWrites[0]?.key).toBe(
+        `exec/v1/receipts/request_id=${submitBody.requestId}.json`,
+      );
+      const persisted = JSON.parse(String(receiptWrites[0]?.value ?? "{}")) as {
+        receiptId?: string;
+        requestId?: string;
+      };
+      expect(persisted.receiptId).toBe("exec_abcdef1234567890");
+      expect(persisted.requestId).toBe(submitBody.requestId);
     } finally {
       sqlite.close();
     }


### PR DESCRIPTION
## Summary
- add a dedicated canonical receipt assembler for execution receipt responses
- update `/api/x402/exec/receipt/:requestId` to return canonical receipts and persist them in `LOGS_BUCKET`
- extend unit coverage for canonical receipt assembly + route persistence behavior

## Validation
- bun run lint
- bun run typecheck
- bun test tests/unit/worker_execution_receipt_assembler.test.ts tests/unit/worker_x402_exec_receipt_route.test.ts
- bun test tests/unit

Closes #134
