### PR TITLE
X402-020: Add x402 billing integration for exec submit

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -297,6 +297,48 @@ async function recordEndpointCallSafe(
   }
 }
 
+async function sha256Hex(input: string): Promise<string> {
+  const encoded = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest("SHA-256", encoded);
+  const bytes = new Uint8Array(digest);
+  return Array.from(bytes)
+    .map((value) => value.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function buildExecSubmitBillingAuditMetadata(
+  request: Request,
+  resourcePath: string,
+): Promise<Record<string, unknown>> {
+  const paymentSignature = String(
+    request.headers.get("payment-signature") ?? "",
+  ).trim();
+  const paymentSignatureHash =
+    paymentSignature.length > 0
+      ? `sha256:${await sha256Hex(paymentSignature)}`
+      : null;
+  return {
+    schemaVersion: "v1",
+    model: "x402",
+    routeKey: "exec_submit",
+    resource: {
+      uri: resourcePath,
+      method: request.method.toUpperCase(),
+    },
+    payment: {
+      required: true,
+      signatureProvided: paymentSignature.length > 0,
+      ...(paymentSignatureHash ? { signatureHash: paymentSignatureHash } : {}),
+    },
+    settlementHeader: "payment-response",
+    polling: {
+      statusPath: "/api/x402/exec/status/:requestId",
+      receiptPath: "/api/x402/exec/receipt/:requestId",
+      requiresPayment: false,
+    },
+  };
+}
+
 export {
   ExecutionCoordinator,
   LoopACoordinator,
@@ -466,6 +508,14 @@ export default {
             );
           }
           if (paymentRequired) return withCors(paymentRequired, env);
+          const billingMetadata = await buildExecSubmitBillingAuditMetadata(
+            request,
+            url.pathname,
+          );
+          submitMetadata = {
+            ...(submitMetadata ?? {}),
+            x402Billing: billingMetadata,
+          };
 
           const validation = await validateRelaySignedSubmission(
             env,

--- a/tests/unit/worker_x402_exec_receipt_route.test.ts
+++ b/tests/unit/worker_x402_exec_receipt_route.test.ts
@@ -225,11 +225,18 @@ describe("worker x402 exec receipt route", () => {
       const receipt = await worker.fetch(
         new Request(
           `http://localhost/api/x402/exec/receipt/${submitBody.requestId}`,
+          {
+            headers: {
+              "payment-signature": "ignored-on-receipt",
+            },
+          },
         ),
         env,
         createExecutionContextStub(),
       );
       expect(receipt.status).toBe(200);
+      expect(receipt.headers.get("payment-required")).toBeNull();
+      expect(receipt.headers.get("payment-response")).toBeNull();
       const body = (await receipt.json()) as {
         ok?: boolean;
         ready?: boolean;

--- a/tests/unit/worker_x402_exec_status_route.test.ts
+++ b/tests/unit/worker_x402_exec_status_route.test.ts
@@ -206,11 +206,18 @@ describe("worker x402 exec status route", () => {
       const status = await worker.fetch(
         new Request(
           `http://localhost/api/x402/exec/status/${submitBody.requestId}`,
+          {
+            headers: {
+              "payment-signature": "ignored-on-status",
+            },
+          },
         ),
         env,
         createExecutionContextStub(),
       );
       expect(status.status).toBe(200);
+      expect(status.headers.get("payment-required")).toBeNull();
+      expect(status.headers.get("payment-response")).toBeNull();
       const body = (await status.json()) as {
         ok?: boolean;
         status?: {

--- a/tests/unit/worker_x402_exec_submit_route.test.ts
+++ b/tests/unit/worker_x402_exec_submit_route.test.ts
@@ -112,7 +112,10 @@ function createSqliteD1Adapter(db: Database): D1Database {
   } as unknown as D1Database;
 }
 
-function createExecSubmitEnv(): { env: Env; sqlite: Database } {
+function createExecSubmitEnv(overrides?: Partial<Env>): {
+  env: Env;
+  sqlite: Database;
+} {
   const sqlite = new Database(":memory:");
   sqlite.exec("PRAGMA foreign_keys = ON;");
   sqlite.exec(`
@@ -139,6 +142,7 @@ function createExecSubmitEnv(): { env: Env; sqlite: Database } {
       PRIVY_APP_ID: "privy-app-id",
       X402_EXEC_SUBMIT_PRICE_USD: "0.01",
       EXEC_RELAY_VALIDATE_BLOCKHASH: "0",
+      ...(overrides ?? {}),
     },
   });
   return { env, sqlite };
@@ -196,6 +200,8 @@ describe("worker x402 exec submit scaffold route", () => {
       expect(response.status).toBe(402);
       const payload = (await response.json()) as { error?: string };
       expect(payload.error).toBe("payment-required");
+      expect(response.headers.get("payment-required")).toBeString();
+      expect(response.headers.get("payment-response")).toBeNull();
     } finally {
       sqlite.close();
     }
@@ -268,9 +274,29 @@ describe("worker x402 exec submit scaffold route", () => {
       expect(row?.lane).toBe("fast");
       const metadata = JSON.parse(String(row?.metadataJson ?? "{}")) as {
         laneResolution?: { lane?: string; adapter?: string };
+        x402Billing?: {
+          routeKey?: string;
+          settlementHeader?: string;
+          payment?: {
+            required?: boolean;
+            signatureProvided?: boolean;
+            signatureHash?: string;
+          };
+          polling?: {
+            requiresPayment?: boolean;
+          };
+        };
       };
       expect(metadata.laneResolution?.lane).toBe("fast");
       expect(metadata.laneResolution?.adapter).toBe("helius_sender");
+      expect(metadata.x402Billing?.routeKey).toBe("exec_submit");
+      expect(metadata.x402Billing?.settlementHeader).toBe("payment-response");
+      expect(metadata.x402Billing?.payment?.required).toBe(true);
+      expect(metadata.x402Billing?.payment?.signatureProvided).toBe(true);
+      expect(metadata.x402Billing?.payment?.signatureHash).toMatch(
+        /^sha256:[a-f0-9]{64}$/,
+      );
+      expect(metadata.x402Billing?.polling?.requiresPayment).toBe(false);
 
       const second = await worker.fetch(
         new Request("http://localhost/api/x402/exec/submit", {
@@ -533,6 +559,34 @@ describe("worker x402 exec submit scaffold route", () => {
       expect(response.status).toBe(400);
       const body = (await response.json()) as { error?: string };
       expect(body.error).toBe("invalid-request");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("maps x402 submit config errors to deterministic 503 responses", async () => {
+    const relayPayload = buildRelaySignedPayload();
+    const { env, sqlite } = createExecSubmitEnv({
+      X402_EXEC_SUBMIT_PRICE_USD: undefined,
+    });
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/x402/exec/submit", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "idempotency-key": "idem-anon-config-err",
+            "payment-signature": "unit-signed-payment",
+          },
+          body: JSON.stringify(relayPayload),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(503);
+      const payload = (await response.json()) as { error?: string };
+      expect(payload.error).toBe("x402-route-config-missing");
     } finally {
       sqlite.close();
     }


### PR DESCRIPTION
## Summary
- add deterministic x402 billing audit metadata to relay-signed `/api/x402/exec/submit` requests
- ensure submit stores billing context (route key, settlement header contract, signature hash, unmetered poll policy)
- extend execution route tests to prove `status`/`receipt` polling stays unmetered and x402 config failures map cleanly

## Validation
- bun run lint
- bun run typecheck
- bun test tests/unit/worker_x402_exec_submit_route.test.ts tests/unit/worker_x402_exec_status_route.test.ts tests/unit/worker_x402_exec_receipt_route.test.ts
- bun test tests/unit

Closes #136
