### PR TITLE
X402-025: Wrap /api/trade/swap with exec submit compatibility

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -3317,7 +3317,14 @@ function resolveTradeSwapExecutionLane(
   const adapter = String(execution?.adapter ?? "")
     .trim()
     .toLowerCase();
-  if (!adapter || adapter === "jupiter" || adapter === "fast") return "fast";
+  if (!adapter || adapter === "jupiter") return "safe";
+  if (
+    adapter === "fast" ||
+    adapter === "helius" ||
+    adapter === "helius_sender"
+  ) {
+    return "fast";
+  }
   if (
     adapter === "jito" ||
     adapter === "jito_bundle" ||
@@ -3332,7 +3339,6 @@ function resolveTradeSwapExecutionLane(
   ) {
     return "safe";
   }
-  if (adapter === "helius" || adapter === "helius_sender") return "fast";
   return undefined;
 }
 

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -10,19 +10,7 @@ import {
   SUPPORTED_WALLET_TOKEN_BALANCES,
   USDC_MINT,
 } from "./defaults";
-import {
-  applyExecutionResultToTrace,
-  buildExecutionOutcomeFromError,
-  buildExecutionOutcomeFromResult,
-  createExecutionDecision,
-  createExecutionIntent,
-  newExecutionLatencyTrace,
-  recordExecutionReceipt,
-} from "./execution/contracts";
-import {
-  ExecutionCoordinator,
-  requestExecutionCoordinatorDecision,
-} from "./execution/coordinator";
+import { ExecutionCoordinator } from "./execution/coordinator";
 import {
   hashExecutionSubmitPayload,
   readIdempotencyKey,
@@ -46,7 +34,6 @@ import {
   listExecutionStatusEvents,
   updateExecutionRequestStatus,
 } from "./execution/repository";
-import { executeSwapViaRouter } from "./execution/router";
 import { parseExecSubmitPayload } from "./execution/submit_contract";
 import {
   type ExperienceLevel,
@@ -100,7 +87,7 @@ import {
   type PerpsVenue,
   SUPPORTED_PERPS_VENUES,
 } from "./perps_sources";
-import { enforcePolicy, normalizePolicy } from "./policy";
+import { normalizePolicy } from "./policy";
 import { createPrivySolanaWallet } from "./privy";
 import { gatherMarketSnapshot } from "./research";
 import { json, okCors, withCors } from "./response";
@@ -367,7 +354,7 @@ function resolveX402ReadRpcEndpoint(env: Env): string {
   return X402_READ_RPC_ENDPOINT_FALLBACK;
 }
 
-export default {
+const worker = {
   async fetch(request: Request, env: Env, _ctx: ExecutionContext) {
     if (request.method === "OPTIONS") {
       return okCors(env);
@@ -2176,7 +2163,6 @@ export default {
       }
 
       if (request.method === "POST" && url.pathname === "/api/trade/swap") {
-        const requestReceivedAt = new Date().toISOString();
         let user = await requireOnboardedUser(request, env);
         user = await ensureUserWallet(env, user);
         if (!user.walletAddress || !user.privyWalletId) {
@@ -2226,28 +2212,6 @@ export default {
           );
         }
 
-        const rpcEndpoint = String(env.RPC_ENDPOINT ?? "").trim();
-        if (!rpcEndpoint) {
-          return withCors(
-            json({ ok: false, error: "rpc-endpoint-missing" }, { status: 500 }),
-            env,
-          );
-        }
-
-        const jupiter = new JupiterClient(
-          String(env.JUPITER_BASE_URL ?? "").trim() ||
-            X402_READ_JUPITER_BASE_URL,
-          env.JUPITER_API_KEY,
-        );
-        const rpc = new SolanaRpc(rpcEndpoint);
-        const policy = normalizePolicy({
-          allowedMints: SUPPORTED_TRADING_MINTS,
-          slippageBps,
-          maxPriceImpactPct: 0.05,
-          minSolReserveLamports: "50000000",
-          commitment: "confirmed",
-        });
-
         const walletAddress = user.walletAddress;
         const inputAmount = BigInt(amount);
         if (inputAmount <= 0n) {
@@ -2259,243 +2223,99 @@ export default {
             env,
           );
         }
-        if (inputMint === X402_SOL_MINT) {
-          const balanceLamports = await rpc.getBalanceLamports(walletAddress);
-          const minSolReserveLamports = BigInt(policy.minSolReserveLamports);
-          if (inputAmount + minSolReserveLamports > balanceLamports) {
-            return withCors(
-              json(
-                {
-                  ok: false,
-                  error: "insufficient-sol-reserve",
-                  reserveLamports: minSolReserveLamports.toString(),
-                  balanceLamports: balanceLamports.toString(),
+        const lane = resolveTradeSwapExecutionLane(execution);
+        const idempotencyKey =
+          readIdempotencyKey(request) ??
+          newTradeSwapCompatibilityIdempotencyKey();
+        const submitPayload: Record<string, unknown> = {
+          schemaVersion: "v1",
+          mode: "privy_execute",
+          ...(lane ? { lane } : {}),
+          ...(source || reason
+            ? {
+                metadata: {
+                  ...(source ? { source } : {}),
+                  ...(reason ? { reason } : {}),
                 },
-                { status: 400 },
-              ),
-              env,
-            );
-          }
-        } else {
-          const tokenBalance = await rpc.getTokenBalanceAtomic(
-            walletAddress,
-            inputMint,
-          );
-          if (inputAmount > tokenBalance) {
-            return withCors(
-              json(
-                {
-                  ok: false,
-                  error: "insufficient-token-balance",
-                  balanceAtomic: tokenBalance.toString(),
-                },
-                { status: 400 },
-              ),
-              env,
-            );
-          }
-        }
-
-        const quoteResponse = await jupiter.quote({
-          inputMint,
-          outputMint,
-          amount,
-          slippageBps: policy.slippageBps,
-          swapMode: "ExactIn",
-        });
-        enforcePolicy(policy, quoteResponse);
-
-        const trace = newExecutionLatencyTrace(requestReceivedAt);
-        trace.validatedAt = new Date().toISOString();
-        trace.decisionAt = new Date().toISOString();
-
-        const intent = createExecutionIntent({
-          receivedAt: requestReceivedAt,
-          userId: user.id,
-          wallet: walletAddress,
-          inputMint,
-          outputMint,
-          amountAtomic: amount,
-          slippageBps: policy.slippageBps,
-          source: source || "TERMINAL",
-          reason: reason || undefined,
-          execution,
-          simulateOnly: policy.simulateOnly,
-          dryRun: policy.dryRun,
-          commitment: policy.commitment,
-        });
-        let executionRoute =
-          String(execution?.adapter ?? "jupiter").trim() || "jupiter";
-        let decision = createExecutionDecision({
-          intentId: intent.intentId,
-          decidedAt: trace.decisionAt,
-          route: executionRoute,
-          simulateOnly: policy.simulateOnly,
-          dryRun: policy.dryRun,
-          commitment: policy.commitment,
-        });
-        try {
-          const coordinator = await requestExecutionCoordinatorDecision(env, {
-            intent,
-          });
-          if (coordinator && !coordinator.accepted) {
-            const rejectedAt = new Date().toISOString();
-            trace.failedAt = rejectedAt;
-            try {
-              await recordExecutionReceipt(env, {
-                generatedAt: rejectedAt,
-                intent,
-                decision,
-                trace,
-                outcome: {
-                  status: "rejected",
-                  signature: null,
-                  refreshed: false,
-                  lastValidBlockHeight: null,
-                  error: coordinator.reason ?? "execution-rejected",
-                },
-                quote: quoteResponse,
-              });
-            } catch (receiptError) {
-              console.error("trade.swap.receipt.error", {
-                userId: user.id,
-                route: executionRoute,
-                message:
-                  receiptError instanceof Error
-                    ? receiptError.message
-                    : String(receiptError),
-              });
-            }
-            return withCors(
-              json(
-                {
-                  ok: false,
-                  error: "execution-rejected",
-                  reason: coordinator.reason,
-                  queueDepth: coordinator.queueDepth,
-                  queuePosition: coordinator.queuePosition,
-                },
-                { status: 409 },
-              ),
-              env,
-            );
-          }
-          if (coordinator?.accepted && coordinator.decision) {
-            decision = coordinator.decision;
-            executionRoute = coordinator.decision.route;
-          }
-        } catch (coordinatorError) {
-          console.warn("trade.swap.coordinator.fallback", {
-            userId: user.id,
-            message:
-              coordinatorError instanceof Error
-                ? coordinatorError.message
-                : String(coordinatorError),
-          });
-        }
-        const routedExecution: ExecutionConfig | undefined = {
-          ...(execution ?? {}),
-          adapter: executionRoute,
-        };
-
-        let result: Awaited<ReturnType<typeof executeSwapViaRouter>>;
-        try {
-          result = await executeSwapViaRouter({
-            env,
-            execution: routedExecution,
-            policy,
-            rpc,
-            jupiter,
-            quoteResponse,
-            userPublicKey: walletAddress,
-            privyWalletId: user.privyWalletId,
-            log(level, message, meta) {
-              console[level]("trade.swap", {
-                userId: user.id,
-                inputMint,
-                outputMint,
-                amount,
-                slippageBps: policy.slippageBps,
-                source: source || "TERMINAL",
-                reason: reason || undefined,
-                executionRoute,
-                message,
-                ...(meta ?? {}),
-              });
+              }
+            : {}),
+          privyExecute: {
+            intentType: "swap",
+            wallet: walletAddress,
+            swap: {
+              inputMint,
+              outputMint,
+              amountAtomic: amount,
+              slippageBps,
             },
-          });
-        } catch (error) {
-          trace.failedAt = new Date().toISOString();
-          try {
-            await recordExecutionReceipt(env, {
-              generatedAt: trace.failedAt,
-              intent,
-              decision,
-              trace,
-              outcome: buildExecutionOutcomeFromError(error),
-              quote: quoteResponse,
-            });
-          } catch (receiptError) {
-            console.error("trade.swap.receipt.error", {
-              userId: user.id,
-              route: executionRoute,
-              message:
-                receiptError instanceof Error
-                  ? receiptError.message
-                  : String(receiptError),
-            });
-          }
-          throw error;
-        }
-
-        const settledAt = new Date().toISOString();
-        const traceSettled = applyExecutionResultToTrace({
-          trace,
-          result,
-          settledAt,
+          },
+        };
+        const submitHeaders = new Headers({
+          "content-type": "application/json",
+          "idempotency-key": idempotencyKey,
         });
-        let executionReceipt: Awaited<
-          ReturnType<typeof recordExecutionReceipt>
-        > | null = null;
+        const authorization = request.headers.get("authorization");
+        if (authorization) submitHeaders.set("authorization", authorization);
+        const submitRequest = new Request(
+          new URL("/api/x402/exec/submit", url.origin).toString(),
+          {
+            method: "POST",
+            headers: submitHeaders,
+            body: JSON.stringify(submitPayload),
+          },
+        );
+        const submitResponse = await worker.fetch(submitRequest, env, _ctx);
+        let submitPayloadRaw: unknown = null;
         try {
-          executionReceipt = await recordExecutionReceipt(env, {
-            generatedAt: settledAt,
-            intent,
-            decision,
-            trace: traceSettled,
-            outcome: buildExecutionOutcomeFromResult(result),
-            quote: result.usedQuote,
-          });
-        } catch (receiptError) {
-          console.error("trade.swap.receipt.error", {
-            userId: user.id,
-            route: executionRoute,
-            message:
-              receiptError instanceof Error
-                ? receiptError.message
-                : String(receiptError),
-          });
+          submitPayloadRaw = await submitResponse.json();
+        } catch {
+          submitPayloadRaw = null;
         }
-
+        if (!isRecord(submitPayloadRaw)) {
+          return withCors(
+            json({ ok: false, error: "trade-submit-failed" }, { status: 502 }),
+            env,
+          );
+        }
+        if (submitResponse.status >= 400 || submitPayloadRaw.ok !== true) {
+          const error =
+            typeof submitPayloadRaw.error === "string"
+              ? submitPayloadRaw.error
+              : "trade-submit-failed";
+          return withCors(
+            json({ ok: false, error }, { status: submitResponse.status }),
+            env,
+          );
+        }
+        const requestId = String(submitPayloadRaw.requestId ?? "").trim();
+        if (!requestId) {
+          return withCors(
+            json({ ok: false, error: "trade-submit-failed" }, { status: 502 }),
+            env,
+          );
+        }
+        const status = isRecord(submitPayloadRaw.status)
+          ? String(submitPayloadRaw.status.state ?? "").trim()
+          : "";
         return withCors(
           json({
             ok: true,
-            status: result.status,
-            signature: result.signature,
-            refreshed: result.refreshed,
-            lastValidBlockHeight: result.lastValidBlockHeight,
-            quote: summarizeJupiterQuote(
-              result.usedQuote as unknown as Record<string, unknown>,
-            ),
+            requestId,
+            status: status || "validated",
+            signature: null,
+            refreshed: false,
+            lastValidBlockHeight: null,
             source: source || "TERMINAL",
-            err: result.err ?? null,
-            executionReceipt:
-              executionReceipt === null
-                ? null
-                : {
-                    receiptId: executionReceipt.receiptId,
-                    key: executionReceipt.storage.key,
-                  },
+            err: null,
+            executionReceipt: null,
+            ...(isRecord(submitPayloadRaw.poll)
+              ? { poll: submitPayloadRaw.poll }
+              : {}),
+            compatibility: {
+              route: "/api/trade/swap",
+              deprecated: true,
+              replacement: "/api/x402/exec/submit",
+            },
           }),
           env,
         );
@@ -3142,6 +2962,8 @@ export default {
   },
 };
 
+export default worker;
+
 async function requireOnboardedUser(
   request: Request,
   env: Env,
@@ -3487,6 +3309,35 @@ function parseExecutionConfig(value: unknown): ExecutionConfig | undefined {
     ...(adapter ? { adapter } : {}),
     ...(params ? { params } : {}),
   };
+}
+
+function resolveTradeSwapExecutionLane(
+  execution: ExecutionConfig | undefined,
+): "fast" | "protected" | "safe" | undefined {
+  const adapter = String(execution?.adapter ?? "")
+    .trim()
+    .toLowerCase();
+  if (!adapter || adapter === "jupiter" || adapter === "fast") return "fast";
+  if (
+    adapter === "jito" ||
+    adapter === "jito_bundle" ||
+    adapter === "protected"
+  ) {
+    return "protected";
+  }
+  if (
+    adapter === "magicblock" ||
+    adapter === "magicblock_ephemeral_rollup" ||
+    adapter === "safe"
+  ) {
+    return "safe";
+  }
+  if (adapter === "helius" || adapter === "helius_sender") return "fast";
+  return undefined;
+}
+
+function newTradeSwapCompatibilityIdempotencyKey(): string {
+  return `trade_swap_${crypto.randomUUID().replace(/-/g, "")}`;
 }
 
 function parseRiskMode(

--- a/tests/unit/worker_cutover_routes.test.ts
+++ b/tests/unit/worker_cutover_routes.test.ts
@@ -14,6 +14,11 @@ function createExecutionContextStub(): ExecutionContext {
 
 async function loadWorker() {
   mock.restore();
+  mock.module("../../apps/worker/src/auth", () => ({
+    requireUser: async () => {
+      throw new Error("unauthorized");
+    },
+  }));
   const module = (await import(
     `../../apps/worker/src/index?cutover=${Date.now()}-${Math.random()}`
   )) as typeof import("../../apps/worker/src/index");

--- a/tests/unit/worker_cutover_routes.test.ts
+++ b/tests/unit/worker_cutover_routes.test.ts
@@ -1,5 +1,4 @@
-import { describe, expect, test } from "bun:test";
-import worker from "../../apps/worker/src/index";
+import { describe, expect, mock, test } from "bun:test";
 import type { Env } from "../../apps/worker/src/types";
 
 const env = {
@@ -13,8 +12,17 @@ function createExecutionContextStub(): ExecutionContext {
   } as ExecutionContext;
 }
 
+async function loadWorker() {
+  mock.restore();
+  const module = (await import(
+    `../../apps/worker/src/index?cutover=${Date.now()}-${Math.random()}`
+  )) as typeof import("../../apps/worker/src/index");
+  return module.default;
+}
+
 describe("worker botless cutover routes", () => {
   test("health endpoint remains unchanged", async () => {
+    const worker = await loadWorker();
     const response = await worker.fetch(
       new Request("http://localhost/api/health", { method: "GET" }),
       env,
@@ -26,6 +34,7 @@ describe("worker botless cutover routes", () => {
   });
 
   test("removed bot/admin/runtime endpoints return 410", async () => {
+    const worker = await loadWorker();
     const cases: Array<{ method: string; path: string }> = [
       { method: "GET", path: "/api/bots" },
       { method: "GET", path: "/api/bots/bot-1" },
@@ -55,6 +64,7 @@ describe("worker botless cutover routes", () => {
   });
 
   test("account wallet routes enforce auth", async () => {
+    const worker = await loadWorker();
     const authEnv = {
       ...env,
       PRIVY_APP_ID: "app_test",

--- a/tests/unit/worker_trade_swap_wrapper_route.test.ts
+++ b/tests/unit/worker_trade_swap_wrapper_route.test.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import type { Env } from "../../apps/worker/src/types";
@@ -143,6 +143,10 @@ function createTradeSwapEnv(): { env: Env; sqlite: Database } {
 }
 
 describe("worker trade swap compatibility wrapper route", () => {
+  afterAll(() => {
+    mock.restore();
+  });
+
   beforeEach(() => {
     requireUserMock.mockClear();
     findUserByPrivyUserIdMock.mockClear();

--- a/tests/unit/worker_trade_swap_wrapper_route.test.ts
+++ b/tests/unit/worker_trade_swap_wrapper_route.test.ts
@@ -224,7 +224,7 @@ describe("worker trade swap compatibility wrapper route", () => {
           }
         | undefined;
       expect(requestRow?.mode).toBe("privy_execute");
-      expect(requestRow?.lane).toBe("fast");
+      expect(requestRow?.lane).toBe("safe");
       const metadata = JSON.parse(String(requestRow?.metadataJson ?? "{}")) as {
         source?: string;
         reason?: string;

--- a/tests/unit/worker_trade_swap_wrapper_route.test.ts
+++ b/tests/unit/worker_trade_swap_wrapper_route.test.ts
@@ -1,0 +1,322 @@
+import { Database } from "bun:sqlite";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Env } from "../../apps/worker/src/types";
+import {
+  createExecutionContextStub,
+  createWorkerLiveEnv,
+  MAINNET_USDC_MINT,
+  SOL_MINT,
+} from "../integration/_worker_live_test_utils";
+
+const requireUserMock = mock(async () => ({
+  privyUserId: "did:privy:user_1",
+  email: "user@example.com",
+}));
+const findUserByPrivyUserIdMock = mock(async () => ({
+  id: "user_1",
+  privyUserId: "did:privy:user_1",
+  onboardingStatus: "active",
+  profile: null,
+  signerType: "privy",
+  privyWalletId: "wallet_1",
+  walletAddress: "11111111111111111111111111111111",
+  walletMigratedAt: "2026-03-03T00:00:00.000Z",
+  experienceLevel: "beginner",
+  levelSource: "auto",
+  onboardingCompletedAt: "2026-03-03T00:00:00.000Z",
+  onboardingVersion: 1,
+  feedSeedVersion: 1,
+  degenAcknowledgedAt: null,
+  createdAt: "2026-03-03T00:00:00.000Z",
+}));
+const upsertUserMock = mock(async () =>
+  findUserByPrivyUserIdMock("did:privy:user_1"),
+);
+const setUserWalletMock = mock(async () => {});
+const setUserProfileMock = mock(async () => {});
+const setUserOnboardingStatusMock = mock(async () => {});
+const setUserExperienceMock = mock(async () => {});
+const createPrivySolanaWalletMock = mock(async () => ({
+  walletId: "wallet_new",
+  address: "11111111111111111111111111111111",
+}));
+const getPrivyWalletAddressByIdMock = mock(
+  async () => "11111111111111111111111111111111",
+);
+const getPrivyWalletAddressMock = mock(
+  async () => "11111111111111111111111111111111",
+);
+const getPrivyUserByIdMock = mock(async () => ({
+  id: "did:privy:user_1",
+  linked_accounts: [],
+}));
+const signTransactionWithPrivyByIdMock = mock(async () => "signed-tx");
+
+mock.module("../../apps/worker/src/auth", () => ({
+  requireUser: requireUserMock,
+}));
+mock.module("../../apps/worker/src/users_db", () => ({
+  findUserByPrivyUserId: findUserByPrivyUserIdMock,
+  upsertUser: upsertUserMock,
+  setUserWallet: setUserWalletMock,
+  setUserProfile: setUserProfileMock,
+  setUserOnboardingStatus: setUserOnboardingStatusMock,
+  setUserExperience: setUserExperienceMock,
+}));
+mock.module("../../apps/worker/src/privy", () => ({
+  createPrivySolanaWallet: createPrivySolanaWalletMock,
+  getPrivyWalletAddressById: getPrivyWalletAddressByIdMock,
+  getPrivyWalletAddress: getPrivyWalletAddressMock,
+  getPrivyUserById: getPrivyUserByIdMock,
+  signTransactionWithPrivyById: signTransactionWithPrivyByIdMock,
+}));
+
+const worker = (await import("../../apps/worker/src/index")).default;
+
+function createSqliteD1Adapter(db: Database): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          return {
+            async run() {
+              const statement = db.query(sql);
+              const result = statement.run(...(params as never[])) as {
+                changes?: number;
+              };
+              return {
+                meta: {
+                  changes:
+                    typeof result.changes === "number" ? result.changes : 0,
+                },
+              };
+            },
+            async first() {
+              const statement = db.query(sql);
+              return (statement.get(...(params as never[])) as unknown) ?? null;
+            },
+            async all() {
+              const statement = db.query(sql);
+              return {
+                results: (statement.all(...(params as never[])) ??
+                  []) as unknown[],
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+function createTradeSwapEnv(): { env: Env; sqlite: Database } {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA foreign_keys = ON;");
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS waitlist (
+      email TEXT PRIMARY KEY,
+      source TEXT,
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+  sqlite
+    .query("INSERT INTO waitlist (email, source) VALUES (?1, ?2)")
+    .run("user@example.com", "unit-test");
+  const migrationPath = resolve(
+    import.meta.dir,
+    "..",
+    "..",
+    "apps/worker/migrations/0025_execution_fabric.sql",
+  );
+  sqlite.exec(readFileSync(migrationPath, "utf8"));
+
+  const env = createWorkerLiveEnv({
+    overrides: {
+      WAITLIST_DB: createSqliteD1Adapter(sqlite),
+      PRIVY_APP_ID: "privy-app-id",
+      EXEC_RELAY_VALIDATE_BLOCKHASH: "0",
+    },
+  });
+  return { env, sqlite };
+}
+
+describe("worker trade swap compatibility wrapper route", () => {
+  beforeEach(() => {
+    requireUserMock.mockClear();
+    findUserByPrivyUserIdMock.mockClear();
+    upsertUserMock.mockClear();
+    setUserWalletMock.mockClear();
+    setUserProfileMock.mockClear();
+    setUserOnboardingStatusMock.mockClear();
+    setUserExperienceMock.mockClear();
+    createPrivySolanaWalletMock.mockClear();
+    getPrivyWalletAddressByIdMock.mockClear();
+    getPrivyWalletAddressMock.mockClear();
+    getPrivyUserByIdMock.mockClear();
+    signTransactionWithPrivyByIdMock.mockClear();
+  });
+
+  test("wraps /api/trade/swap into privy_execute submit + compatibility response", async () => {
+    const { env, sqlite } = createTradeSwapEnv();
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/trade/swap", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            inputMint: SOL_MINT,
+            outputMint: MAINNET_USDC_MINT,
+            amount: "1000000",
+            slippageBps: 50,
+            source: "TERMINAL",
+            reason: "manual",
+          }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        ok?: boolean;
+        requestId?: string;
+        status?: string;
+        signature?: string | null;
+        executionReceipt?: unknown;
+        compatibility?: { replacement?: string };
+        poll?: { statusUrl?: string; receiptUrl?: string };
+      };
+      expect(body.ok).toBe(true);
+      expect(body.requestId).toMatch(/^execreq_[A-Za-z0-9]{16,}$/);
+      expect(body.status).toBe("validated");
+      expect(body.signature).toBeNull();
+      expect(body.executionReceipt).toBeNull();
+      expect(body.compatibility?.replacement).toBe("/api/x402/exec/submit");
+      expect(body.poll?.statusUrl).toBe(
+        `/api/x402/exec/status/${body.requestId}`,
+      );
+      expect(body.poll?.receiptUrl).toBe(
+        `/api/x402/exec/receipt/${body.requestId}`,
+      );
+
+      const requestRow = sqlite
+        .query(
+          `
+          SELECT mode, lane, metadata_json as metadataJson
+          FROM execution_requests
+          WHERE request_id = ?1
+          LIMIT 1
+          `,
+        )
+        .get(body.requestId) as
+        | {
+            mode?: string;
+            lane?: string;
+            metadataJson?: string;
+          }
+        | undefined;
+      expect(requestRow?.mode).toBe("privy_execute");
+      expect(requestRow?.lane).toBe("fast");
+      const metadata = JSON.parse(String(requestRow?.metadataJson ?? "{}")) as {
+        source?: string;
+        reason?: string;
+      };
+      expect(metadata.source).toBe("TERMINAL");
+      expect(metadata.reason).toBe("manual");
+
+      const lifecycle = sqlite
+        .query(
+          `
+          SELECT status
+          FROM execution_status_events
+          WHERE request_id = ?1
+          ORDER BY seq ASC
+          `,
+        )
+        .all(body.requestId) as Array<{ status?: string }>;
+      expect(lifecycle.map((event) => event.status)).toEqual([
+        "received",
+        "validated",
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("maps legacy execution.adapter to protected lane", async () => {
+    const { env, sqlite } = createTradeSwapEnv();
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/trade/swap", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            inputMint: SOL_MINT,
+            outputMint: MAINNET_USDC_MINT,
+            amount: "1000000",
+            execution: {
+              adapter: "jito_bundle",
+            },
+          }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { requestId?: string };
+      const row = sqlite
+        .query(
+          "SELECT lane FROM execution_requests WHERE request_id = ?1 LIMIT 1",
+        )
+        .get(body.requestId) as { lane?: string } | undefined;
+      expect(row?.lane).toBe("protected");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("keeps compatibility errors for invalid and unsupported trade payloads", async () => {
+    const { env, sqlite } = createTradeSwapEnv();
+    try {
+      const invalid = await worker.fetch(
+        new Request("http://localhost/api/trade/swap", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            inputMint: SOL_MINT,
+            outputMint: SOL_MINT,
+            amount: "1000000",
+          }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(invalid.status).toBe(400);
+      expect((await invalid.json())?.error).toBe("invalid-trade-request");
+
+      const unsupported = await worker.fetch(
+        new Request("http://localhost/api/trade/swap", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            inputMint: SOL_MINT,
+            outputMint: "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
+            amount: "1000000",
+          }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(unsupported.status).toBe(400);
+      expect((await unsupported.json())?.error).toBe("unsupported-trade-pair");
+    } finally {
+      sqlite.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- replace direct `/api/trade/swap` execution path with a compatibility wrapper into `/api/x402/exec/submit` (`privy_execute` mode)
- preserve legacy trade-swap response fields while returning new execution `requestId` + poll URLs
- map legacy `execution.adapter` values to execution lanes and keep existing payload validation behavior
- add dedicated unit coverage proving wrapper behavior and lifecycle writes in execution tables

## Validation
- bun run lint
- bun run typecheck
- bun test tests/unit/worker_trade_swap_wrapper_route.test.ts tests/unit/worker_x402_exec_submit_route.test.ts tests/unit/worker_x402_exec_status_route.test.ts tests/unit/worker_x402_exec_receipt_route.test.ts
- bun test tests/unit

Closes #141
