### PR TITLE
X402-019: implement execution actor auth matrix

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -157,12 +157,124 @@ const DISCOVERY_DOC_PATHS = new Set([
   "/api/agent-registry/metadata.json",
 ]);
 const BEARER_RE = /^bearer\s+/i;
+type ExecutionActorMode = "relay_signed" | "privy_execute";
+type ExecApiKeyActor = {
+  actorId: string;
+  key: string;
+  modes: Set<ExecutionActorMode>;
+};
+type ResolvedExecApiKeyActor = {
+  actorId: string;
+  modes: Set<ExecutionActorMode>;
+  authSource: "x-exec-api-key" | "authorization";
+};
 
 function parseBearerToken(value: string | null): string | null {
   const raw = String(value ?? "").trim();
   if (!raw) return null;
   if (!BEARER_RE.test(raw)) return null;
   return raw.replace(BEARER_RE, "").trim() || null;
+}
+
+function parseExecApiKeyModes(raw: string): Set<ExecutionActorMode> {
+  const modes = new Set<ExecutionActorMode>();
+  const normalized = raw
+    .split(/[|+]/)
+    .map((item) => item.trim().toLowerCase())
+    .filter(Boolean);
+  for (const mode of normalized) {
+    if (mode === "relay_signed" || mode === "relay") {
+      modes.add("relay_signed");
+      continue;
+    }
+    if (mode === "privy_execute" || mode === "privy") {
+      modes.add("privy_execute");
+      continue;
+    }
+    if (mode === "all") {
+      modes.add("relay_signed");
+      modes.add("privy_execute");
+    }
+  }
+  if (modes.size < 1) {
+    modes.add("relay_signed");
+  }
+  return modes;
+}
+
+function parseExecApiKeyActors(raw: unknown): ExecApiKeyActor[] {
+  const entries = String(raw ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  const parsed: ExecApiKeyActor[] = [];
+  for (const entry of entries) {
+    let actorId = "";
+    let key = "";
+    let modesRaw = "";
+
+    if (entry.includes("=")) {
+      const [left, right] = entry.split("=", 2);
+      actorId = left?.trim() ?? "";
+      const rightParts = String(right ?? "")
+        .split(":")
+        .map((item) => item.trim());
+      key = rightParts[0] ?? "";
+      modesRaw = rightParts.slice(1).join("|");
+    } else {
+      const parts = entry.split(":").map((item) => item.trim());
+      actorId = parts[0] ?? "";
+      key = parts[1] ?? "";
+      modesRaw = parts.slice(2).join("|");
+    }
+
+    if (!actorId || !key) continue;
+    parsed.push({
+      actorId,
+      key,
+      modes: parseExecApiKeyModes(modesRaw),
+    });
+  }
+  return parsed;
+}
+
+function resolveExecApiKeyActor(
+  request: Request,
+  env: Env,
+): ResolvedExecApiKeyActor | null {
+  const candidates: Array<{
+    token: string;
+    source: "x-exec-api-key" | "authorization";
+  }> = [];
+  const headerToken = String(
+    request.headers.get("x-exec-api-key") ?? "",
+  ).trim();
+  if (headerToken) {
+    candidates.push({
+      token: headerToken,
+      source: "x-exec-api-key",
+    });
+  }
+  const bearerToken = parseBearerToken(request.headers.get("authorization"));
+  if (bearerToken) {
+    candidates.push({
+      token: bearerToken,
+      source: "authorization",
+    });
+  }
+  if (candidates.length < 1) return null;
+
+  const actors = parseExecApiKeyActors(env.EXEC_API_KEYS);
+  for (const candidate of candidates) {
+    const match = actors.find((item) => item.key === candidate.token);
+    if (!match) continue;
+    return {
+      actorId: match.actorId,
+      modes: new Set(match.modes),
+      authSource: candidate.source,
+    };
+  }
+  return null;
 }
 
 function readBooleanEnv(value: unknown, fallback = false): boolean {
@@ -517,8 +629,10 @@ const worker = {
           );
         }
 
-        let actorType: "anonymous_x402" | "privy_user" = "anonymous_x402";
+        let actorType: "anonymous_x402" | "privy_user" | "api_key_actor" =
+          "anonymous_x402";
         let actorId: string | null = null;
+        let actorAuthSource: string | null = null;
         const isRelaySigned = parsed.value.mode === "relay_signed";
         let submitMetadata = parsed.metadataForStorage;
         let relayImmutability: ReturnType<
@@ -529,31 +643,65 @@ const worker = {
           walletAddress: string;
           privyWalletId: string;
         } | null = null;
-        if (!isRelaySigned) {
-          let user = await requireOnboardedUser(request, env);
-          user = await ensureUserWallet(env, user);
-          if (!user.walletAddress || !user.privyWalletId) {
+        const apiKeyActor = resolveExecApiKeyActor(request, env);
+        if (apiKeyActor) {
+          if (!apiKeyActor.modes.has(parsed.value.mode)) {
             return withCors(
               json(
-                { ok: false, error: "user-wallet-missing" },
-                { status: 503 },
+                {
+                  ok: false,
+                  error: "actor-mode-not-allowed",
+                  reason: `api-key-mode-not-enabled:${parsed.value.mode}`,
+                },
+                { status: 403 },
               ),
               env,
             );
           }
-          if (parsed.value.privyExecute.wallet !== user.walletAddress) {
-            return withCors(
-              json({ ok: false, error: "invalid-request" }, { status: 400 }),
-              env,
-            );
+          actorType = "api_key_actor";
+          actorId = apiKeyActor.actorId;
+          actorAuthSource = `api-key:${apiKeyActor.authSource}`;
+        }
+
+        if (!isRelaySigned) {
+          if (actorType !== "api_key_actor") {
+            let user = await requireOnboardedUser(request, env);
+            user = await ensureUserWallet(env, user);
+            if (!user.walletAddress || !user.privyWalletId) {
+              return withCors(
+                json(
+                  { ok: false, error: "user-wallet-missing" },
+                  { status: 503 },
+                ),
+                env,
+              );
+            }
+            if (parsed.value.privyExecute.wallet !== user.walletAddress) {
+              return withCors(
+                json({ ok: false, error: "invalid-request" }, { status: 400 }),
+                env,
+              );
+            }
+            actorType = "privy_user";
+            actorId = user.id;
+            actorAuthSource = "authorization";
+            privyActorContext = {
+              userId: user.id,
+              walletAddress: user.walletAddress,
+              privyWalletId: user.privyWalletId,
+            };
           }
-          actorType = "privy_user";
-          actorId = user.id;
-          privyActorContext = {
-            userId: user.id,
-            walletAddress: user.walletAddress,
-            privyWalletId: user.privyWalletId,
-          };
+        } else if (actorType !== "api_key_actor") {
+          const relayPrivyActor = await maybeResolvePrivyActorContext(
+            request,
+            env,
+          );
+          if (relayPrivyActor) {
+            actorType = "privy_user";
+            actorId = relayPrivyActor.userId;
+            actorAuthSource = "authorization";
+            privyActorContext = relayPrivyActor;
+          }
         }
 
         const laneResolution = resolveExecutionLane({
@@ -578,6 +726,12 @@ const worker = {
         submitMetadata = {
           ...(submitMetadata ?? {}),
           laneResolution: laneResolution.metadata,
+          actor: {
+            type: actorType,
+            id: actorId,
+            mode: parsed.value.mode,
+            ...(actorAuthSource ? { authSource: actorAuthSource } : {}),
+          },
         };
 
         if (isRelaySigned) {
@@ -3334,6 +3488,32 @@ async function requireOnboardedUser(
   const existing = await findUserByPrivyUserId(env, auth.privyUserId);
   if (existing) return existing;
   return await upsertUser(env, auth.privyUserId);
+}
+
+async function maybeResolvePrivyActorContext(
+  request: Request,
+  env: Env,
+): Promise<{
+  userId: string;
+  walletAddress: string;
+  privyWalletId: string;
+} | null> {
+  const hasAuthorization = Boolean(
+    String(request.headers.get("authorization") ?? "").trim(),
+  );
+  if (!hasAuthorization) return null;
+  try {
+    let user = await requireOnboardedUser(request, env);
+    user = await ensureUserWallet(env, user);
+    if (!user.walletAddress || !user.privyWalletId) return null;
+    return {
+      userId: user.id,
+      walletAddress: user.walletAddress,
+      privyWalletId: user.privyWalletId,
+    };
+  } catch {
+    return null;
+  }
 }
 
 async function ensureUserWallet(env: Env, user: UserRow): Promise<UserRow> {

--- a/apps/worker/src/types.ts
+++ b/apps/worker/src/types.ts
@@ -86,6 +86,7 @@ export type Env = {
   X402_FACILITATOR_TIMEOUT_MS?: string;
   WAITLIST_WRITE_TOKEN?: string;
   X402_TRUSTED_ORIGINS?: string;
+  EXEC_API_KEYS?: string;
   X402_ENFORCE_ONCHAIN?: string;
   X402_MAX_TIMEOUT_SECONDS?: string;
   X402_EXEC_SUBMIT_PRICE_USD?: string;

--- a/tests/unit/worker_x402_exec_submit_route.test.ts
+++ b/tests/unit/worker_x402_exec_submit_route.test.ts
@@ -470,6 +470,153 @@ describe("worker x402 exec submit scaffold route", () => {
     }
   });
 
+  test("accepts relay_signed submit for configured api_key actor", async () => {
+    const relayPayload = buildRelaySignedPayload();
+    const { env, sqlite } = createExecSubmitEnv({
+      EXEC_API_KEYS: "svc_relay:key-relay:relay_signed",
+    });
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/x402/exec/submit", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-exec-api-key": "key-relay",
+            "idempotency-key": "idem-api-key-relay-1",
+            "payment-signature": "unit-signed-payment",
+          },
+          body: JSON.stringify(relayPayload),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { requestId?: string };
+      expect(body.requestId).toBeString();
+      const row = sqlite
+        .query(
+          "SELECT actor_type as actorType, actor_id as actorId, mode FROM execution_requests WHERE request_id = ?1 LIMIT 1",
+        )
+        .get(String(body.requestId)) as
+        | { actorType?: string; actorId?: string; mode?: string }
+        | undefined;
+      expect(row?.actorType).toBe("api_key_actor");
+      expect(row?.actorId).toBe("svc_relay");
+      expect(row?.mode).toBe("relay_signed");
+      expect(requireUserMock).not.toHaveBeenCalled();
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("rejects api_key actor mode when not allowed by key config", async () => {
+    const { env, sqlite } = createExecSubmitEnv({
+      EXEC_API_KEYS: "svc_relay:key-relay:relay_signed",
+    });
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/x402/exec/submit", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-exec-api-key": "key-relay",
+            "idempotency-key": "idem-api-key-privy-1",
+          },
+          body: JSON.stringify(PRIVY_PAYLOAD),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(response.status).toBe(403);
+      const body = (await response.json()) as {
+        error?: string;
+        reason?: string;
+      };
+      expect(body.error).toBe("actor-mode-not-allowed");
+      expect(body.reason).toBe("api-key-mode-not-enabled:privy_execute");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("accepts privy_execute contract path for api_key actor when enabled", async () => {
+    const { env, sqlite } = createExecSubmitEnv({
+      EXEC_API_KEYS: "svc_exec:key-both:all",
+    });
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/x402/exec/submit", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-exec-api-key": "key-both",
+            "idempotency-key": "idem-api-key-privy-2",
+          },
+          body: JSON.stringify(PRIVY_PAYLOAD),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        requestId?: string;
+        status?: { state?: string };
+      };
+      expect(body.requestId).toBeString();
+      expect(body.status?.state).toBe("validated");
+      const row = sqlite
+        .query(
+          "SELECT actor_type as actorType, actor_id as actorId, mode FROM execution_requests WHERE request_id = ?1 LIMIT 1",
+        )
+        .get(String(body.requestId)) as
+        | { actorType?: string; actorId?: string; mode?: string }
+        | undefined;
+      expect(row?.actorType).toBe("api_key_actor");
+      expect(row?.actorId).toBe("svc_exec");
+      expect(row?.mode).toBe("privy_execute");
+      expect(requireUserMock).not.toHaveBeenCalled();
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("maps relay_signed submit with privy auth to privy_user actor", async () => {
+    const relayPayload = buildRelaySignedPayload();
+    const { env, sqlite } = createExecSubmitEnv();
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/x402/exec/submit", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer mock-token",
+            "idempotency-key": "idem-privy-relay-1",
+            "payment-signature": "unit-signed-payment",
+          },
+          body: JSON.stringify(relayPayload),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { requestId?: string };
+      expect(body.requestId).toBeString();
+      const row = sqlite
+        .query(
+          "SELECT actor_type as actorType, actor_id as actorId, mode FROM execution_requests WHERE request_id = ?1 LIMIT 1",
+        )
+        .get(String(body.requestId)) as
+        | { actorType?: string; actorId?: string; mode?: string }
+        | undefined;
+      expect(row?.actorType).toBe("privy_user");
+      expect(row?.actorId).toBe("user_1");
+      expect(row?.mode).toBe("relay_signed");
+      expect(requireUserMock).toHaveBeenCalled();
+    } finally {
+      sqlite.close();
+    }
+  });
+
   test("accepts privy_execute submit for authenticated user", async () => {
     const { env, sqlite } = createExecSubmitEnv();
     try {


### PR DESCRIPTION
## Summary
- implement execution actor auth matrix for `/api/x402/exec/submit` across `anonymous_x402`, `privy_user`, and `api_key_actor`
- add configurable API key actor parsing (`EXEC_API_KEYS`) with per-actor allowed modes (`relay_signed`, `privy_execute`, or `all`)
- support relay attribution to `privy_user` when valid Privy auth is present
- persist actor context into submit metadata and ensure actor type/id persist onto execution requests
- add submit-route tests covering API-key relay, disallowed mode rejection, API-key contract-ready `privy_execute`, and privy relay attribution

## Tests
- bun run typecheck
- bun run lint
- bun test

Closes #135
