### PR TITLE
feat(execution): standardize canonical execution error taxonomy

### DIFF
--- a/apps/worker/src/execution/error_taxonomy.ts
+++ b/apps/worker/src/execution/error_taxonomy.ts
@@ -1,0 +1,217 @@
+import type { JsonObject } from "./repository";
+
+export type CanonicalExecutionErrorCode =
+  | "payment-required"
+  | "auth-required"
+  | "invalid-request"
+  | "invalid-transaction"
+  | "policy-denied"
+  | "unsupported-lane"
+  | "insufficient-balance"
+  | "venue-timeout"
+  | "submission-failed"
+  | "expired-blockhash"
+  | "not-found"
+  | "not-ready";
+
+const CANONICAL_ERROR_CODES = new Set<CanonicalExecutionErrorCode>([
+  "payment-required",
+  "auth-required",
+  "invalid-request",
+  "invalid-transaction",
+  "policy-denied",
+  "unsupported-lane",
+  "insufficient-balance",
+  "venue-timeout",
+  "submission-failed",
+  "expired-blockhash",
+  "not-found",
+  "not-ready",
+]);
+
+const DEFAULT_MESSAGES: Record<CanonicalExecutionErrorCode, string> = {
+  "payment-required": "x402 payment is required for this request",
+  "auth-required": "authentication is required",
+  "invalid-request": "request payload is invalid",
+  "invalid-transaction": "transaction payload is invalid",
+  "policy-denied": "execution policy denied this request",
+  "unsupported-lane": "requested execution lane is not supported",
+  "insufficient-balance": "insufficient balance for requested execution",
+  "venue-timeout": "execution venue timed out",
+  "submission-failed": "execution submission failed",
+  "expired-blockhash": "transaction blockhash expired",
+  "not-found": "execution request was not found",
+  "not-ready": "execution receipt is not ready",
+};
+
+function readCodeFromObject(value: unknown): string {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return "";
+  return String((value as { code?: unknown }).code ?? "")
+    .trim()
+    .toLowerCase();
+}
+
+function readReasonFromObject(value: unknown): string {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return "";
+  return String((value as { reason?: unknown }).reason ?? "")
+    .trim()
+    .toLowerCase();
+}
+
+function asLowerMessage(value: unknown): string {
+  if (value instanceof Error) return value.message.trim().toLowerCase();
+  if (typeof value === "string") return value.trim().toLowerCase();
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>;
+    const message = String(record.message ?? "")
+      .trim()
+      .toLowerCase();
+    const reason = String(record.reason ?? "")
+      .trim()
+      .toLowerCase();
+    return `${message} ${reason}`.trim();
+  }
+  return "";
+}
+
+export function isCanonicalExecutionErrorCode(
+  value: unknown,
+): value is CanonicalExecutionErrorCode {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase() as CanonicalExecutionErrorCode;
+  return CANONICAL_ERROR_CODES.has(normalized);
+}
+
+export function normalizeExecutionErrorCode(input: {
+  statusHint?: string | null;
+  error?: unknown;
+  fallback?: CanonicalExecutionErrorCode;
+}): CanonicalExecutionErrorCode {
+  const directCode = readCodeFromObject(input.error);
+  if (isCanonicalExecutionErrorCode(directCode)) {
+    return directCode;
+  }
+
+  const directReason = readReasonFromObject(input.error);
+  if (directReason.startsWith("policy-denied")) {
+    return "policy-denied";
+  }
+
+  const message = asLowerMessage(input.error);
+  const joined = `${message} ${String(input.statusHint ?? "")
+    .trim()
+    .toLowerCase()}`;
+
+  if (joined.includes("payment-required")) return "payment-required";
+  if (joined.includes("auth-required") || joined.includes("unauthorized")) {
+    return "auth-required";
+  }
+  if (joined.includes("invalid-transaction")) return "invalid-transaction";
+  if (
+    joined.includes("invalid-request") ||
+    joined.includes("missing-idempotency-key")
+  ) {
+    return "invalid-request";
+  }
+  if (joined.includes("unsupported-lane")) return "unsupported-lane";
+  if (joined.includes("policy-denied")) return "policy-denied";
+  if (
+    joined.includes("insufficient") &&
+    (joined.includes("balance") ||
+      joined.includes("reserve") ||
+      joined.includes("token"))
+  ) {
+    return "insufficient-balance";
+  }
+  if (joined.includes("timeout")) return "venue-timeout";
+  if (
+    joined.includes("blockhash") &&
+    (joined.includes("expired") ||
+      joined.includes("stale") ||
+      joined.includes("not found"))
+  ) {
+    return "expired-blockhash";
+  }
+  if (joined.includes("not-found")) return "not-found";
+  if (joined.includes("not-ready")) return "not-ready";
+
+  if (input.statusHint === "simulate_error" || input.statusHint === "error") {
+    return "submission-failed";
+  }
+
+  return input.fallback ?? "submission-failed";
+}
+
+export function executionErrorStatus(
+  code: CanonicalExecutionErrorCode,
+): number {
+  switch (code) {
+    case "payment-required":
+      return 402;
+    case "auth-required":
+      return 401;
+    case "policy-denied":
+      return 403;
+    case "unsupported-lane":
+      return 400;
+    case "not-found":
+      return 404;
+    case "not-ready":
+      return 409;
+    case "venue-timeout":
+      return 504;
+    case "submission-failed":
+      return 502;
+    case "expired-blockhash":
+      return 409;
+    default:
+      return 400;
+  }
+}
+
+export function executionErrorMessage(
+  code: CanonicalExecutionErrorCode,
+): string {
+  return DEFAULT_MESSAGES[code] ?? DEFAULT_MESSAGES["submission-failed"];
+}
+
+export function buildExecutionErrorEnvelope(input: {
+  code: CanonicalExecutionErrorCode;
+  message?: string | null;
+  details?: JsonObject | null;
+  requestId?: string | null;
+}): {
+  ok: false;
+  requestId?: string | null;
+  error: {
+    code: CanonicalExecutionErrorCode;
+    message: string;
+    details?: JsonObject;
+  };
+} {
+  const message =
+    String(input.message ?? "").trim() || executionErrorMessage(input.code);
+  const envelope: {
+    ok: false;
+    requestId?: string | null;
+    error: {
+      code: CanonicalExecutionErrorCode;
+      message: string;
+      details?: JsonObject;
+    };
+  } = {
+    ok: false,
+    error: {
+      code: input.code,
+      message,
+    },
+  };
+  if (input.requestId !== undefined) {
+    envelope.requestId = input.requestId;
+  }
+  if (input.details && Object.keys(input.details).length > 0) {
+    envelope.error.details = input.details;
+  }
+  return envelope;
+}

--- a/apps/worker/src/execution/error_taxonomy.ts
+++ b/apps/worker/src/execution/error_taxonomy.ts
@@ -115,6 +115,14 @@ export function normalizeExecutionErrorCode(input: {
     return "invalid-request";
   }
   if (joined.includes("unsupported-lane")) return "unsupported-lane";
+  if (
+    joined.includes("waitlist-required") ||
+    joined.includes("waitlist-email-required") ||
+    joined.includes("manual-onboarding-required") ||
+    joined.includes("onboarding-not-complete")
+  ) {
+    return "policy-denied";
+  }
   if (joined.includes("policy-denied")) return "policy-denied";
   if (
     joined.includes("insufficient") &&

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -16,6 +16,12 @@ import {
 } from "./execution/abuse_guard";
 import { ExecutionCoordinator } from "./execution/coordinator";
 import {
+  buildExecutionErrorEnvelope,
+  type CanonicalExecutionErrorCode,
+  executionErrorStatus,
+  normalizeExecutionErrorCode,
+} from "./execution/error_taxonomy";
+import {
   hashExecutionSubmitPayload,
   readIdempotencyKey,
   reserveExecutionSubmitRequest,
@@ -333,6 +339,32 @@ function asPolicyDeniedError(reason: string): Error {
   return new Error(`policy-denied:${reason}`);
 }
 
+function execErrorResponse(input: {
+  code: CanonicalExecutionErrorCode;
+  status?: number;
+  message?: string;
+  details?: Record<string, unknown> | null;
+  requestId?: string | null;
+  headers?: HeadersInit;
+}): Response {
+  const details =
+    input.details && Object.keys(input.details).length > 0
+      ? (input.details as unknown as Record<string, unknown>)
+      : null;
+  return json(
+    buildExecutionErrorEnvelope({
+      code: input.code,
+      ...(input.message ? { message: input.message } : {}),
+      ...(details ? { details: details as never } : {}),
+      ...(input.requestId !== undefined ? { requestId: input.requestId } : {}),
+    }),
+    {
+      status: input.status ?? executionErrorStatus(input.code),
+      ...(input.headers ? { headers: input.headers } : {}),
+    },
+  );
+}
+
 function policyDeniedReason(value: unknown): string | null {
   if (value === null || value === undefined) return null;
   if (value instanceof Error) {
@@ -383,10 +415,15 @@ function resolveTerminalFailureFromExecuteResult(
       statusReason: `policy-denied:${deniedReason}`,
     };
   }
+  const canonicalErrorCode = normalizeExecutionErrorCode({
+    statusHint: status,
+    error: err,
+    fallback: "submission-failed",
+  });
   return {
     terminalStatus: "failed",
-    errorCode: status,
-    statusReason: status,
+    errorCode: canonicalErrorCode,
+    statusReason: canonicalErrorCode,
   };
 }
 
@@ -635,24 +672,28 @@ const worker = {
         const payloadRead = await readExecSubmitPayloadWithLimits(request, env);
         if (!payloadRead.ok) {
           return withCors(
-            json(
-              {
-                ok: false,
-                error: payloadRead.error,
+            execErrorResponse({
+              code: "invalid-request",
+              status: payloadRead.status,
+              details: {
                 reason: payloadRead.reason,
                 abuse: {
                   payload: payloadRead.metadata,
                 },
               },
-              { status: payloadRead.status },
-            ),
+            }),
             env,
           );
         }
         const parsed = parseExecSubmitPayload(payloadRead.payload);
         if (!parsed.ok) {
           return withCors(
-            json({ ok: false, error: parsed.error }, { status: 400 }),
+            execErrorResponse({
+              code: "invalid-request",
+              details: {
+                reason: parsed.error,
+              },
+            }),
             env,
           );
         }
@@ -660,10 +701,12 @@ const worker = {
         const idempotencyKey = readIdempotencyKey(request);
         if (!idempotencyKey) {
           return withCors(
-            json(
-              { ok: false, error: "missing-idempotency-key" },
-              { status: 400 },
-            ),
+            execErrorResponse({
+              code: "invalid-request",
+              details: {
+                reason: "missing-idempotency-key",
+              },
+            }),
             env,
           );
         }
@@ -696,14 +739,12 @@ const worker = {
         if (apiKeyActor) {
           if (!apiKeyActor.modes.has(parsed.value.mode)) {
             return withCors(
-              json(
-                {
-                  ok: false,
-                  error: "actor-mode-not-allowed",
+              execErrorResponse({
+                code: "policy-denied",
+                details: {
                   reason: `api-key-mode-not-enabled:${parsed.value.mode}`,
                 },
-                { status: 403 },
-              ),
+              }),
               env,
             );
           }
@@ -718,16 +759,21 @@ const worker = {
             user = await ensureUserWallet(env, user);
             if (!user.walletAddress || !user.privyWalletId) {
               return withCors(
-                json(
-                  { ok: false, error: "user-wallet-missing" },
-                  { status: 503 },
-                ),
+                execErrorResponse({
+                  code: "submission-failed",
+                  status: 503,
+                  details: {
+                    reason: "user-wallet-missing",
+                  },
+                }),
                 env,
               );
             }
             if (parsed.value.privyExecute.wallet !== user.walletAddress) {
               return withCors(
-                json({ ok: false, error: "invalid-request" }, { status: 400 }),
+                execErrorResponse({
+                  code: "invalid-request",
+                }),
                 env,
               );
             }
@@ -769,12 +815,13 @@ const worker = {
             ...(abuseCheck.metadata ?? {}),
           });
           const denied = json(
-            {
-              ok: false,
-              error: abuseCheck.error,
-              reason: abuseCheck.reason,
-              abuse: abuseCheck.metadata,
-            },
+            buildExecutionErrorEnvelope({
+              code: abuseCheck.error,
+              details: {
+                reason: abuseCheck.reason,
+                abuse: abuseCheck.metadata,
+              } as never,
+            }),
             {
               status: abuseCheck.status,
               ...(abuseCheck.retryAfterSeconds
@@ -797,14 +844,12 @@ const worker = {
         });
         if (!laneResolution.ok) {
           return withCors(
-            json(
-              {
-                ok: false,
-                error: laneResolution.error,
+            execErrorResponse({
+              code: laneResolution.error,
+              details: {
                 reason: laneResolution.reason,
               },
-              { status: 400 },
-            ),
+            }),
             env,
           );
         }
@@ -838,11 +883,46 @@ const worker = {
                 ? error.message
                 : "x402-route-config-missing";
             return withCors(
-              json({ ok: false, error: message }, { status: 503 }),
+              execErrorResponse({
+                code: "submission-failed",
+                status: 503,
+                details: {
+                  reason: message,
+                },
+              }),
               env,
             );
           }
-          if (paymentRequired) return withCors(paymentRequired, env);
+          if (paymentRequired) {
+            if (paymentRequired.status === 402) {
+              const upstreamBody = (await paymentRequired
+                .clone()
+                .json()
+                .catch(() => null)) as {
+                reason?: string;
+                paymentRequired?: unknown;
+              } | null;
+              const normalized = json(
+                buildExecutionErrorEnvelope({
+                  code: "payment-required",
+                  details: {
+                    ...(upstreamBody?.reason
+                      ? { reason: upstreamBody.reason }
+                      : {}),
+                    ...(upstreamBody?.paymentRequired
+                      ? { paymentRequired: upstreamBody.paymentRequired }
+                      : {}),
+                  } as never,
+                }),
+                {
+                  status: 402,
+                  headers: paymentRequired.headers,
+                },
+              );
+              return withCors(normalized, env);
+            }
+            return withCors(paymentRequired, env);
+          }
           const billingMetadata = await buildExecSubmitBillingAuditMetadata(
             request,
             url.pathname,
@@ -861,15 +941,14 @@ const worker = {
         });
         if (!submitPolicy.ok) {
           return withCors(
-            json(
-              {
-                ok: false,
-                error: submitPolicy.error,
+            execErrorResponse({
+              code: submitPolicy.error,
+              status: submitPolicy.status,
+              details: {
                 reason: submitPolicy.reason,
                 policy: submitPolicy.metadata,
               },
-              { status: submitPolicy.status },
-            ),
+            }),
             env,
           );
         }
@@ -892,14 +971,12 @@ const worker = {
         if (isRelaySigned) {
           if (!relayValidationParsed) {
             return withCors(
-              json(
-                {
-                  ok: false,
-                  error: "invalid-transaction",
+              execErrorResponse({
+                code: "invalid-transaction",
+                details: {
                   reason: "relay-validation-missing",
                 },
-                { status: 400 },
-              ),
+              }),
               env,
             );
           }
@@ -908,14 +985,12 @@ const worker = {
           });
           if (!relayImmutability) {
             return withCors(
-              json(
-                {
-                  ok: false,
-                  error: "invalid-transaction",
+              execErrorResponse({
+                code: "invalid-transaction",
+                details: {
                   reason: "relay-immutability-hash-failed",
                 },
-                { status: 400 },
-              ),
+              }),
               env,
             );
           }
@@ -948,15 +1023,14 @@ const worker = {
 
         if (reservation.result === "conflict") {
           return withCors(
-            json(
-              {
-                ok: false,
-                error: "invalid-request",
+            execErrorResponse({
+              code: "invalid-request",
+              status: 409,
+              requestId: reservation.request.requestId,
+              details: {
                 reason: reservation.error,
-                requestId: reservation.request.requestId,
               },
-              { status: 409 },
-            ),
+            }),
             env,
           );
         }
@@ -976,19 +1050,16 @@ const worker = {
               });
             if (!immutabilityVerification.ok) {
               return withCors(
-                json(
-                  {
-                    ok: false,
-                    error: immutabilityVerification.error,
+                execErrorResponse({
+                  code: immutabilityVerification.error,
+                  status:
+                    immutabilityVerification.error === "policy-denied"
+                      ? 403
+                      : 400,
+                  details: {
                     reason: immutabilityVerification.reason,
                   },
-                  {
-                    status:
-                      immutabilityVerification.error === "policy-denied"
-                        ? 403
-                        : 400,
-                  },
-                ),
+                }),
                 env,
               );
             }
@@ -1210,10 +1281,13 @@ const worker = {
             const terminalStatus = deniedReason ? "rejected" : "failed";
             const errorCode = deniedReason
               ? "policy-denied"
-              : "execution-failed";
+              : normalizeExecutionErrorCode({
+                  error,
+                  fallback: "submission-failed",
+                });
             const statusReason = deniedReason
               ? `policy-denied:${deniedReason}`
-              : "execution-failed";
+              : errorCode;
             const errorMessage =
               executionErrorMessage(error) ?? "execution-submit-failed";
             await createExecutionAttemptIdempotent(env.WAITLIST_DB, {
@@ -1305,7 +1379,12 @@ const worker = {
         const requestId = url.pathname.slice("/api/x402/exec/status/".length);
         if (!isValidExecRequestId(requestId)) {
           return withCors(
-            json({ ok: false, error: "invalid-request-id" }, { status: 400 }),
+            execErrorResponse({
+              code: "invalid-request",
+              details: {
+                reason: "invalid-request-id",
+              },
+            }),
             env,
           );
         }
@@ -1316,7 +1395,10 @@ const worker = {
         );
         if (!latest) {
           return withCors(
-            json({ ok: false, error: "not-found" }, { status: 404 }),
+            execErrorResponse({
+              code: "not-found",
+              requestId,
+            }),
             env,
           );
         }
@@ -1402,7 +1484,12 @@ const worker = {
         const requestId = url.pathname.slice("/api/x402/exec/receipt/".length);
         if (!isValidExecRequestId(requestId)) {
           return withCors(
-            json({ ok: false, error: "invalid-request-id" }, { status: 400 }),
+            execErrorResponse({
+              code: "invalid-request",
+              details: {
+                reason: "invalid-request-id",
+              },
+            }),
             env,
           );
         }
@@ -1413,7 +1500,10 @@ const worker = {
         );
         if (!latest) {
           return withCors(
-            json({ ok: false, error: "not-found" }, { status: 404 }),
+            execErrorResponse({
+              code: "not-found",
+              requestId,
+            }),
             env,
           );
         }
@@ -3488,6 +3578,35 @@ const worker = {
             /no such column/i.test(rawMessage)
           ? "d1-migrations-not-applied"
           : rawMessage;
+      if (url.pathname.startsWith("/api/x402/exec/")) {
+        const code = normalizeExecutionErrorCode({
+          error: message,
+          fallback: "submission-failed",
+        });
+        const forcedStatus =
+          message === "d1-migrations-not-applied" ||
+          message.startsWith("x402-route-config-")
+            ? 503
+            : undefined;
+        if ((forcedStatus ?? executionErrorStatus(code)) >= 500) {
+          console.error("api.error", {
+            method: request.method,
+            path: url.pathname,
+            message: rawMessage,
+            stack: error instanceof Error ? error.stack : undefined,
+          });
+        }
+        return withCors(
+          execErrorResponse({
+            code,
+            ...(forcedStatus ? { status: forcedStatus } : {}),
+            details: {
+              reason: message,
+            },
+          }),
+          env,
+        );
+      }
       const status =
         message === "unauthorized"
           ? 401

--- a/tests/unit/worker_execution_error_taxonomy.test.ts
+++ b/tests/unit/worker_execution_error_taxonomy.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import Ajv2020 from "ajv/dist/2020";
+import {
+  buildExecutionErrorEnvelope,
+  executionErrorStatus,
+  normalizeExecutionErrorCode,
+} from "../../apps/worker/src/execution/error_taxonomy";
+
+function loadErrorSchema(): unknown {
+  const absolute = resolve(
+    import.meta.dir,
+    "..",
+    "..",
+    "docs/execution/schemas/error.envelope.v1.schema.json",
+  );
+  return JSON.parse(readFileSync(absolute, "utf8")) as unknown;
+}
+
+describe("execution error taxonomy", () => {
+  test("normalizes adapter and runtime failures into canonical codes", () => {
+    expect(
+      normalizeExecutionErrorCode({
+        error: { code: "expired-blockhash" },
+      }),
+    ).toBe("expired-blockhash");
+
+    expect(
+      normalizeExecutionErrorCode({
+        error: new Error("insufficient-token-balance"),
+      }),
+    ).toBe("insufficient-balance");
+
+    expect(
+      normalizeExecutionErrorCode({
+        statusHint: "error",
+        error: "unexpected provider response",
+      }),
+    ).toBe("submission-failed");
+
+    expect(executionErrorStatus("venue-timeout")).toBe(504);
+  });
+
+  test("builds schema-valid uniform error envelope", () => {
+    const schema = loadErrorSchema();
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+    const validate = ajv.compile(schema);
+    const payload = buildExecutionErrorEnvelope({
+      code: "policy-denied",
+      details: {
+        reason: "lane-not-available-for-relay-signed",
+      },
+      requestId: null,
+    });
+    expect(validate(payload)).toBe(true);
+  });
+});

--- a/tests/unit/worker_execution_error_taxonomy.test.ts
+++ b/tests/unit/worker_execution_error_taxonomy.test.ts
@@ -39,7 +39,14 @@ describe("execution error taxonomy", () => {
       }),
     ).toBe("submission-failed");
 
+    expect(
+      normalizeExecutionErrorCode({
+        error: new Error("waitlist-required"),
+      }),
+    ).toBe("policy-denied");
+
     expect(executionErrorStatus("venue-timeout")).toBe(504);
+    expect(executionErrorStatus("policy-denied")).toBe(403);
   });
 
   test("builds schema-valid uniform error envelope", () => {

--- a/tests/unit/worker_x402_exec_receipt_route.test.ts
+++ b/tests/unit/worker_x402_exec_receipt_route.test.ts
@@ -186,7 +186,11 @@ describe("worker x402 exec receipt route", () => {
         createExecutionContextStub(),
       );
       expect(invalid.status).toBe(400);
-      expect((await invalid.json())?.error).toBe("invalid-request-id");
+      const invalidBody = (await invalid.json()) as {
+        error?: { code?: string; details?: { reason?: string } };
+      };
+      expect(invalidBody.error?.code).toBe("invalid-request");
+      expect(invalidBody.error?.details?.reason).toBe("invalid-request-id");
 
       const unknown = await worker.fetch(
         new Request(
@@ -196,7 +200,10 @@ describe("worker x402 exec receipt route", () => {
         createExecutionContextStub(),
       );
       expect(unknown.status).toBe(404);
-      expect((await unknown.json())?.error).toBe("not-found");
+      const unknownBody = (await unknown.json()) as {
+        error?: { code?: string };
+      };
+      expect(unknownBody.error?.code).toBe("not-found");
     } finally {
       sqlite.close();
     }

--- a/tests/unit/worker_x402_exec_status_route.test.ts
+++ b/tests/unit/worker_x402_exec_status_route.test.ts
@@ -167,7 +167,11 @@ describe("worker x402 exec status route", () => {
         createExecutionContextStub(),
       );
       expect(invalid.status).toBe(400);
-      expect((await invalid.json())?.error).toBe("invalid-request-id");
+      const invalidBody = (await invalid.json()) as {
+        error?: { code?: string; details?: { reason?: string } };
+      };
+      expect(invalidBody.error?.code).toBe("invalid-request");
+      expect(invalidBody.error?.details?.reason).toBe("invalid-request-id");
 
       const unknown = await worker.fetch(
         new Request(
@@ -177,7 +181,10 @@ describe("worker x402 exec status route", () => {
         createExecutionContextStub(),
       );
       expect(unknown.status).toBe(404);
-      expect((await unknown.json())?.error).toBe("not-found");
+      const unknownBody = (await unknown.json()) as {
+        error?: { code?: string };
+      };
+      expect(unknownBody.error?.code).toBe("not-found");
     } finally {
       sqlite.close();
     }

--- a/tests/unit/worker_x402_exec_submit_route.test.ts
+++ b/tests/unit/worker_x402_exec_submit_route.test.ts
@@ -164,6 +164,52 @@ const PRIVY_PAYLOAD = {
   },
 };
 
+function execErrorCode(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+  const topLevel = (payload as { error?: unknown }).error;
+  if (typeof topLevel === "string") return topLevel;
+  if (!topLevel || typeof topLevel !== "object" || Array.isArray(topLevel)) {
+    return null;
+  }
+  const code = (topLevel as { code?: unknown }).code;
+  return typeof code === "string" ? code : null;
+}
+
+function execErrorReason(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+  const topLevelReason = (payload as { reason?: unknown }).reason;
+  if (typeof topLevelReason === "string") return topLevelReason;
+  const topLevel = (payload as { error?: unknown }).error;
+  if (!topLevel || typeof topLevel !== "object" || Array.isArray(topLevel)) {
+    return null;
+  }
+  const details = (topLevel as { details?: unknown }).details;
+  if (!details || typeof details !== "object" || Array.isArray(details)) {
+    return null;
+  }
+  const reason = (details as { reason?: unknown }).reason;
+  return typeof reason === "string" ? reason : null;
+}
+
+function execErrorDetails(payload: unknown): Record<string, unknown> | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+  const topLevel = (payload as { error?: unknown }).error;
+  if (!topLevel || typeof topLevel !== "object" || Array.isArray(topLevel)) {
+    return null;
+  }
+  const details = (topLevel as { details?: unknown }).details;
+  if (!details || typeof details !== "object" || Array.isArray(details)) {
+    return null;
+  }
+  return details as Record<string, unknown>;
+}
+
 describe("worker x402 exec submit scaffold route", () => {
   beforeEach(() => {
     requireUserMock.mockClear();
@@ -198,8 +244,8 @@ describe("worker x402 exec submit scaffold route", () => {
       );
 
       expect(response.status).toBe(402);
-      const payload = (await response.json()) as { error?: string };
-      expect(payload.error).toBe("payment-required");
+      const payload = await response.json();
+      expect(execErrorCode(payload)).toBe("payment-required");
       expect(response.headers.get("payment-required")).toBeString();
       expect(response.headers.get("payment-response")).toBeNull();
     } finally {
@@ -225,12 +271,9 @@ describe("worker x402 exec submit scaffold route", () => {
       );
 
       expect(response.status).toBe(400);
-      const body = (await response.json()) as {
-        error?: string;
-        reason?: string;
-      };
-      expect(body.error).toBe("unsupported-lane");
-      expect(body.reason).toBe("lane-not-available-for-relay-signed");
+      const body = await response.json();
+      expect(execErrorCode(body)).toBe("unsupported-lane");
+      expect(execErrorReason(body)).toBe("lane-not-available-for-relay-signed");
     } finally {
       sqlite.close();
     }
@@ -392,12 +435,9 @@ describe("worker x402 exec submit scaffold route", () => {
         createExecutionContextStub(),
       );
       expect(response.status).toBe(409);
-      const body = (await response.json()) as {
-        error?: string;
-        reason?: string;
-      };
-      expect(body.error).toBe("invalid-request");
-      expect(body.reason).toBe("idempotency-key-conflict");
+      const body = await response.json();
+      expect(execErrorCode(body)).toBe("invalid-request");
+      expect(execErrorReason(body)).toBe("idempotency-key-conflict");
     } finally {
       sqlite.close();
     }
@@ -459,12 +499,9 @@ describe("worker x402 exec submit scaffold route", () => {
         createExecutionContextStub(),
       );
       expect(replay.status).toBe(403);
-      const replayBody = (await replay.json()) as {
-        error?: string;
-        reason?: string;
-      };
-      expect(replayBody.error).toBe("policy-denied");
-      expect(replayBody.reason).toBe("relay-immutability-mismatch");
+      const replayBody = await replay.json();
+      expect(execErrorCode(replayBody)).toBe("policy-denied");
+      expect(execErrorReason(replayBody)).toBe("relay-immutability-mismatch");
     } finally {
       sqlite.close();
     }
@@ -528,12 +565,11 @@ describe("worker x402 exec submit scaffold route", () => {
         createExecutionContextStub(),
       );
       expect(response.status).toBe(403);
-      const body = (await response.json()) as {
-        error?: string;
-        reason?: string;
-      };
-      expect(body.error).toBe("actor-mode-not-allowed");
-      expect(body.reason).toBe("api-key-mode-not-enabled:privy_execute");
+      const body = await response.json();
+      expect(execErrorCode(body)).toBe("policy-denied");
+      expect(execErrorReason(body)).toBe(
+        "api-key-mode-not-enabled:privy_execute",
+      );
     } finally {
       sqlite.close();
     }
@@ -668,14 +704,12 @@ describe("worker x402 exec submit scaffold route", () => {
         createExecutionContextStub(),
       );
       expect(response.status).toBe(403);
-      const body = (await response.json()) as {
-        error?: string;
-        reason?: string;
-        policy?: { outcome?: string };
-      };
-      expect(body.error).toBe("policy-denied");
-      expect(body.reason).toBe("privy-wallet-not-allowlisted");
-      expect(body.policy?.outcome).toBe("deny");
+      const body = await response.json();
+      expect(execErrorCode(body)).toBe("policy-denied");
+      expect(execErrorReason(body)).toBe("privy-wallet-not-allowlisted");
+      const details = execErrorDetails(body);
+      const policy = details?.policy as { outcome?: string } | undefined;
+      expect(policy?.outcome).toBe("deny");
     } finally {
       sqlite.close();
     }
@@ -759,9 +793,9 @@ describe("worker x402 exec submit scaffold route", () => {
       );
       expect(second.status).toBe(429);
       expect(second.headers.get("retry-after")).toBe("60");
-      const body = (await second.json()) as { error?: string; reason?: string };
-      expect(body.error).toBe("policy-denied");
-      expect(body.reason).toBe("submit-ip-rate-limit-exceeded");
+      const body = await second.json();
+      expect(execErrorCode(body)).toBe("policy-denied");
+      expect(execErrorReason(body)).toBe("submit-ip-rate-limit-exceeded");
     } finally {
       sqlite.close();
     }
@@ -790,8 +824,8 @@ describe("worker x402 exec submit scaffold route", () => {
         createExecutionContextStub(),
       );
       expect(response.status).toBe(400);
-      const body = (await response.json()) as { error?: string };
-      expect(body.error).toBe("invalid-request");
+      const body = await response.json();
+      expect(execErrorCode(body)).toBe("invalid-request");
     } finally {
       sqlite.close();
     }
@@ -823,8 +857,8 @@ describe("worker x402 exec submit scaffold route", () => {
         createExecutionContextStub(),
       );
       expect(response.status).toBe(400);
-      const body = (await response.json()) as { error?: string };
-      expect(body.error).toBe("invalid-request");
+      const body = await response.json();
+      expect(execErrorCode(body)).toBe("invalid-request");
     } finally {
       sqlite.close();
     }
@@ -851,8 +885,9 @@ describe("worker x402 exec submit scaffold route", () => {
       );
 
       expect(response.status).toBe(503);
-      const payload = (await response.json()) as { error?: string };
-      expect(payload.error).toBe("x402-route-config-missing");
+      const payload = await response.json();
+      expect(execErrorCode(payload)).toBe("submission-failed");
+      expect(execErrorReason(payload)).toBe("x402-route-config-missing");
     } finally {
       sqlite.close();
     }


### PR DESCRIPTION
## Summary
- add a centralized execution error taxonomy module with canonical code normalization and deterministic HTTP mapping
- enforce a uniform error envelope on execution endpoints (submit, status, receipt)
- map adapter/runtime failures to canonical codes so non-canonical errors do not leak to API clients
- normalize x402 payment-required responses for exec submit into the same envelope while preserving required x402 headers
- add dedicated taxonomy tests and update execution route tests

## Testing
- bun run lint
- bun run typecheck
- bun test

Closes #139
