### PR TITLE
feat(portal): add execution sdk client + contract tests

### DIFF
--- a/apps/portal/app/execution-client.ts
+++ b/apps/portal/app/execution-client.ts
@@ -1,0 +1,680 @@
+import { apiBase, isRecord } from "./lib";
+
+const BEARER_RE = /^bearer\s+/i;
+
+const EXECUTION_ERROR_CODES = new Set([
+  "payment-required",
+  "auth-required",
+  "invalid-request",
+  "invalid-transaction",
+  "policy-denied",
+  "unsupported-lane",
+  "insufficient-balance",
+  "venue-timeout",
+  "submission-failed",
+  "expired-blockhash",
+  "not-found",
+  "not-ready",
+] as const);
+
+export type ExecutionErrorCode =
+  | "payment-required"
+  | "auth-required"
+  | "invalid-request"
+  | "invalid-transaction"
+  | "policy-denied"
+  | "unsupported-lane"
+  | "insufficient-balance"
+  | "venue-timeout"
+  | "submission-failed"
+  | "expired-blockhash"
+  | "not-found"
+  | "not-ready"
+  | "unknown";
+
+export type ExecutionSubmitPayload = {
+  schemaVersion: "v1";
+  mode: "relay_signed" | "privy_execute";
+  lane: "fast" | "protected" | "safe";
+  metadata?: Record<string, unknown>;
+  relaySigned?: {
+    signedTransaction: string;
+    encoding?: string;
+  };
+  privyExecute?: {
+    intentType: "swap";
+    wallet: string;
+    swap: {
+      inputMint: string;
+      outputMint: string;
+      amountAtomic: string;
+      slippageBps: number;
+    };
+    options?: {
+      commitment?: "processed" | "confirmed" | "finalized";
+      simulateOnly?: boolean;
+      dryRun?: boolean;
+    };
+  };
+};
+
+export type ExecutionSubmitAck = {
+  requestId: string;
+  state: string;
+  terminal: boolean;
+  updatedAt: string | null;
+};
+
+export type ExecutionStatusSnapshot = {
+  requestId: string;
+  state: string;
+  terminal: boolean;
+  updatedAt: string | null;
+  terminalAt: string | null;
+};
+
+export type ExecutionReceiptSnapshot = {
+  requestId: string;
+  ready: boolean;
+  outcomeStatus: string | null;
+  signature: string | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+};
+
+export type ExecutionTerminalResult = {
+  requestId: string;
+  status: string;
+  signature: string | null;
+};
+
+export type ExecutionTransportRequest = {
+  path: string;
+  method: "GET" | "POST";
+  headers: Record<string, string>;
+  body?: string;
+  signal?: AbortSignal;
+};
+
+export type ExecutionTransportResponse = {
+  status: number;
+  payload: unknown;
+};
+
+export type ExecutionTransport = (
+  request: ExecutionTransportRequest,
+) => Promise<ExecutionTransportResponse>;
+
+export class ExecutionClientError extends Error {
+  readonly code: ExecutionErrorCode;
+  readonly status: number;
+  readonly details: Record<string, unknown> | null;
+  readonly requestId: string | null;
+  readonly retryable: boolean;
+  readonly data: unknown;
+
+  constructor(input: {
+    message: string;
+    code: ExecutionErrorCode;
+    status: number;
+    details?: Record<string, unknown> | null;
+    requestId?: string | null;
+    retryable: boolean;
+    data?: unknown;
+  }) {
+    super(input.message);
+    this.name = "ExecutionClientError";
+    this.code = input.code;
+    this.status = input.status;
+    this.details = input.details ?? null;
+    this.requestId = input.requestId ?? null;
+    this.retryable = input.retryable;
+    this.data = input.data;
+  }
+}
+
+function normalizeAuthToken(token: string): string {
+  const trimmed = token.trim();
+  if (!trimmed) return "";
+  return BEARER_RE.test(trimmed) ? trimmed : `Bearer ${trimmed}`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function isExecutionErrorCode(value: unknown): value is ExecutionErrorCode {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  return (
+    normalized === "unknown" || EXECUTION_ERROR_CODES.has(normalized as never)
+  );
+}
+
+function fallbackCodeForStatus(status: number): ExecutionErrorCode {
+  if (status === 401) return "auth-required";
+  if (status === 402) return "payment-required";
+  if (status === 404) return "not-found";
+  if (status === 409) return "not-ready";
+  if (status >= 400 && status < 500) return "invalid-request";
+  if (status >= 500) return "submission-failed";
+  return "unknown";
+}
+
+export function isRetryableExecutionError(input: {
+  code: ExecutionErrorCode;
+  status: number;
+}): boolean {
+  if (input.status === 429 || input.status === 503 || input.status === 504) {
+    return true;
+  }
+  if (
+    input.code === "venue-timeout" ||
+    input.code === "submission-failed" ||
+    input.code === "not-ready"
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function decodeExecutionError(input: {
+  payload: unknown;
+  status: number;
+  defaultMessage: string;
+}): ExecutionClientError {
+  const payload = input.payload;
+  let code: ExecutionErrorCode = fallbackCodeForStatus(input.status);
+  let message = input.defaultMessage;
+  let details: Record<string, unknown> | null = null;
+  let requestId: string | null = null;
+
+  if (isRecord(payload)) {
+    const rawRequestId = String(payload.requestId ?? "").trim();
+    requestId = rawRequestId || null;
+
+    const errorField = payload.error;
+    if (isRecord(errorField)) {
+      const rawCode = String(errorField.code ?? "")
+        .trim()
+        .toLowerCase();
+      if (isExecutionErrorCode(rawCode)) {
+        code = rawCode;
+      }
+      const rawMessage = String(errorField.message ?? "").trim();
+      if (rawMessage) {
+        message = rawMessage;
+      }
+      details = isRecord(errorField.details)
+        ? (errorField.details as Record<string, unknown>)
+        : null;
+    } else if (typeof errorField === "string" && errorField.trim()) {
+      message = errorField.trim();
+      const rawCode = message.toLowerCase();
+      if (isExecutionErrorCode(rawCode)) {
+        code = rawCode;
+      }
+      const reason = String(payload.reason ?? "").trim();
+      if (reason) {
+        details = { reason };
+      }
+    }
+  }
+
+  return new ExecutionClientError({
+    message,
+    code,
+    status: input.status,
+    details,
+    requestId,
+    retryable: isRetryableExecutionError({ code, status: input.status }),
+    data: payload,
+  });
+}
+
+function parseSubmitAck(payload: unknown): ExecutionSubmitAck {
+  if (!isRecord(payload) || payload.ok !== true) {
+    throw new ExecutionClientError({
+      message: "invalid-exec-submit-response",
+      code: "unknown",
+      status: 500,
+      retryable: false,
+      data: payload,
+    });
+  }
+  const requestId = String(payload.requestId ?? "").trim();
+  const status = isRecord(payload.status) ? payload.status : null;
+  const state = String(status?.state ?? "").trim();
+  if (!requestId || !state) {
+    throw new ExecutionClientError({
+      message: "invalid-exec-submit-response",
+      code: "unknown",
+      status: 500,
+      retryable: false,
+      data: payload,
+    });
+  }
+  return {
+    requestId,
+    state,
+    terminal: status?.terminal === true,
+    updatedAt:
+      typeof status?.updatedAt === "string" && status.updatedAt.trim()
+        ? status.updatedAt.trim()
+        : null,
+  };
+}
+
+function parseStatusSnapshot(payload: unknown): ExecutionStatusSnapshot {
+  if (!isRecord(payload) || payload.ok !== true) {
+    throw new ExecutionClientError({
+      message: "invalid-exec-status-response",
+      code: "unknown",
+      status: 500,
+      retryable: false,
+      data: payload,
+    });
+  }
+  const requestId = String(payload.requestId ?? "").trim();
+  const status = isRecord(payload.status) ? payload.status : null;
+  const state = String(status?.state ?? "").trim();
+  if (!requestId || !state) {
+    throw new ExecutionClientError({
+      message: "invalid-exec-status-response",
+      code: "unknown",
+      status: 500,
+      retryable: false,
+      data: payload,
+    });
+  }
+  return {
+    requestId,
+    state,
+    terminal: status?.terminal === true,
+    updatedAt:
+      typeof status?.updatedAt === "string" && status.updatedAt.trim()
+        ? status.updatedAt.trim()
+        : null,
+    terminalAt:
+      typeof status?.terminalAt === "string" && status.terminalAt.trim()
+        ? status.terminalAt.trim()
+        : null,
+  };
+}
+
+function parseReceiptSnapshot(payload: unknown): ExecutionReceiptSnapshot {
+  if (!isRecord(payload) || payload.ok !== true) {
+    throw new ExecutionClientError({
+      message: "invalid-exec-receipt-response",
+      code: "unknown",
+      status: 500,
+      retryable: false,
+      data: payload,
+    });
+  }
+  const requestId = String(payload.requestId ?? "").trim();
+  if (!requestId) {
+    throw new ExecutionClientError({
+      message: "invalid-exec-receipt-response",
+      code: "unknown",
+      status: 500,
+      retryable: false,
+      data: payload,
+    });
+  }
+
+  if (payload.ready !== true) {
+    return {
+      requestId,
+      ready: false,
+      outcomeStatus: null,
+      signature: null,
+      errorCode: null,
+      errorMessage: null,
+    };
+  }
+
+  const receipt = isRecord(payload.receipt) ? payload.receipt : null;
+  const outcome = receipt && isRecord(receipt.outcome) ? receipt.outcome : null;
+  return {
+    requestId,
+    ready: true,
+    outcomeStatus: String(outcome?.status ?? "").trim() || null,
+    signature:
+      typeof outcome?.signature === "string" && outcome.signature.trim()
+        ? outcome.signature.trim()
+        : null,
+    errorCode:
+      typeof outcome?.errorCode === "string" && outcome.errorCode.trim()
+        ? outcome.errorCode.trim()
+        : null,
+    errorMessage:
+      typeof outcome?.errorMessage === "string" && outcome.errorMessage.trim()
+        ? outcome.errorMessage.trim()
+        : null,
+  };
+}
+
+function isExecutionSuccessStatus(status: string | null): boolean {
+  if (!status) return false;
+  const normalized = status.trim().toLowerCase();
+  return normalized === "landed" || normalized === "finalized";
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+async function defaultTransport(
+  input: ExecutionTransportRequest,
+): Promise<ExecutionTransportResponse> {
+  const base = apiBase();
+  if (!base) {
+    throw new ExecutionClientError({
+      message: "missing NEXT_PUBLIC_EDGE_API_BASE",
+      code: "submission-failed",
+      status: 503,
+      retryable: true,
+    });
+  }
+  const response = await fetch(`${base}${input.path}`, {
+    method: input.method,
+    headers: input.headers,
+    ...(input.body ? { body: input.body } : {}),
+    signal: input.signal,
+  });
+  const payload = (await response.json().catch(() => null)) as unknown;
+  return {
+    status: response.status,
+    payload,
+  };
+}
+
+type ExecutionClientOptions = {
+  authToken?: string | null;
+  transport?: ExecutionTransport;
+  pollIntervalMs?: number;
+  pollTimeoutMs?: number;
+  requestRetryCount?: number;
+  requestRetryBaseDelayMs?: number;
+};
+
+type RequestOptions = {
+  signal?: AbortSignal;
+  headers?: Record<string, string>;
+};
+
+type SubmitOptions = RequestOptions & {
+  idempotencyKey?: string;
+};
+
+async function withRetries<T>(input: {
+  fn: () => Promise<T>;
+  retries: number;
+  baseDelayMs: number;
+  signal?: AbortSignal;
+}): Promise<T> {
+  let attempt = 0;
+  while (true) {
+    if (input.signal?.aborted) {
+      throw new Error("execution-cancelled");
+    }
+    try {
+      return await input.fn();
+    } catch (error) {
+      if (isAbortError(error)) throw error;
+      const typed =
+        error instanceof ExecutionClientError
+          ? error
+          : new ExecutionClientError({
+              message:
+                error instanceof Error ? error.message : "execution-error",
+              code: "submission-failed",
+              status: 502,
+              retryable: true,
+              data: error,
+            });
+      if (!typed.retryable || attempt >= input.retries) {
+        throw typed;
+      }
+      const backoff = input.baseDelayMs * 2 ** attempt;
+      attempt += 1;
+      await sleep(backoff);
+    }
+  }
+}
+
+export function newExecutionIdempotencyKey(prefix = "exec"): string {
+  const ts = Date.now().toString(36);
+  const token =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID().replace(/-/g, "").slice(0, 12)
+      : Math.random().toString(36).slice(2, 14);
+  return `${prefix}-${ts}-${token}`;
+}
+
+export function describeExecutionClientError(
+  error: unknown,
+  fallback = "execution-failed",
+): string {
+  if (error instanceof ExecutionClientError) {
+    const reason = String(error.details?.reason ?? "").trim();
+    if (reason) return `${error.code}:${reason}`;
+    return `${error.code}:${error.message}`;
+  }
+  if (error instanceof Error && error.message.trim()) return error.message;
+  return fallback;
+}
+
+export function createExecutionClient(options: ExecutionClientOptions) {
+  const transport = options.transport ?? defaultTransport;
+  const authToken = String(options.authToken ?? "").trim();
+  const pollIntervalMs = Math.max(
+    100,
+    Math.floor(options.pollIntervalMs ?? 1200),
+  );
+  const pollTimeoutMs = Math.max(
+    1000,
+    Math.floor(options.pollTimeoutMs ?? 45000),
+  );
+  const requestRetryCount = Math.max(
+    0,
+    Math.floor(options.requestRetryCount ?? 2),
+  );
+  const requestRetryBaseDelayMs = Math.max(
+    50,
+    Math.floor(options.requestRetryBaseDelayMs ?? 250),
+  );
+
+  async function requestJson(input: {
+    path: string;
+    method: "GET" | "POST";
+    body?: unknown;
+    signal?: AbortSignal;
+    headers?: Record<string, string>;
+  }): Promise<unknown> {
+    const headers: Record<string, string> = {
+      ...(input.headers ?? {}),
+    };
+    if (authToken && !headers.authorization) {
+      headers.authorization = normalizeAuthToken(authToken);
+    }
+    if (input.body !== undefined && !headers["content-type"]) {
+      headers["content-type"] = "application/json";
+    }
+
+    let response: ExecutionTransportResponse;
+    try {
+      response = await transport({
+        path: input.path,
+        method: input.method,
+        headers,
+        ...(input.body !== undefined
+          ? { body: JSON.stringify(input.body) }
+          : {}),
+        signal: input.signal,
+      });
+    } catch (error) {
+      if (isAbortError(error)) throw error;
+      throw new ExecutionClientError({
+        message: error instanceof Error ? error.message : "network-error",
+        code: "submission-failed",
+        status: 502,
+        retryable: true,
+        data: error,
+      });
+    }
+
+    if (response.status >= 200 && response.status < 300) {
+      return response.payload;
+    }
+
+    throw decodeExecutionError({
+      payload: response.payload,
+      status: response.status,
+      defaultMessage: `http-${response.status}`,
+    });
+  }
+
+  async function submit(
+    payload: ExecutionSubmitPayload,
+    options?: SubmitOptions,
+  ): Promise<ExecutionSubmitAck> {
+    const idempotencyKey =
+      options?.idempotencyKey ?? newExecutionIdempotencyKey("exec");
+    const response = await requestJson({
+      path: "/api/x402/exec/submit",
+      method: "POST",
+      body: payload,
+      signal: options?.signal,
+      headers: {
+        "idempotency-key": idempotencyKey,
+        ...(options?.headers ?? {}),
+      },
+    });
+    return parseSubmitAck(response);
+  }
+
+  async function status(
+    requestId: string,
+    options?: RequestOptions,
+  ): Promise<ExecutionStatusSnapshot> {
+    const response = await requestJson({
+      path: `/api/x402/exec/status/${encodeURIComponent(requestId)}`,
+      method: "GET",
+      signal: options?.signal,
+      headers: options?.headers,
+    });
+    return parseStatusSnapshot(response);
+  }
+
+  async function receipt(
+    requestId: string,
+    options?: RequestOptions,
+  ): Promise<ExecutionReceiptSnapshot> {
+    const response = await requestJson({
+      path: `/api/x402/exec/receipt/${encodeURIComponent(requestId)}`,
+      method: "GET",
+      signal: options?.signal,
+      headers: options?.headers,
+    });
+    return parseReceiptSnapshot(response);
+  }
+
+  async function waitForTerminalReceipt(input: {
+    requestId: string;
+    signal?: AbortSignal;
+  }): Promise<ExecutionTerminalResult> {
+    const startedAt = Date.now();
+    let latestState = "queued";
+
+    while (Date.now() - startedAt < pollTimeoutMs) {
+      if (input.signal?.aborted) {
+        throw new Error("execution-cancelled");
+      }
+
+      const statusSnapshot = await withRetries({
+        fn: () => status(input.requestId, { signal: input.signal }),
+        retries: requestRetryCount,
+        baseDelayMs: requestRetryBaseDelayMs,
+        signal: input.signal,
+      });
+      latestState = statusSnapshot.state;
+
+      if (statusSnapshot.terminal) {
+        const receiptSnapshot = await withRetries({
+          fn: () => receipt(input.requestId, { signal: input.signal }),
+          retries: requestRetryCount,
+          baseDelayMs: requestRetryBaseDelayMs,
+          signal: input.signal,
+        });
+
+        if (!receiptSnapshot.ready) {
+          if (
+            latestState === "failed" ||
+            latestState === "expired" ||
+            latestState === "rejected"
+          ) {
+            throw new ExecutionClientError({
+              message: `execution-${latestState}`,
+              code: "submission-failed",
+              status: 409,
+              retryable: false,
+              requestId: input.requestId,
+            });
+          }
+          await sleep(pollIntervalMs);
+          continue;
+        }
+
+        const outcomeStatus =
+          receiptSnapshot.outcomeStatus?.toLowerCase() ??
+          latestState.toLowerCase();
+
+        if (isExecutionSuccessStatus(outcomeStatus)) {
+          return {
+            requestId: input.requestId,
+            status: outcomeStatus,
+            signature: receiptSnapshot.signature,
+          };
+        }
+
+        throw new ExecutionClientError({
+          message:
+            receiptSnapshot.errorCode ??
+            receiptSnapshot.errorMessage ??
+            `execution-${outcomeStatus}`,
+          code: isExecutionErrorCode(receiptSnapshot.errorCode)
+            ? receiptSnapshot.errorCode
+            : "submission-failed",
+          status: 409,
+          retryable: false,
+          requestId: input.requestId,
+          details: {
+            outcomeStatus,
+          },
+        });
+      }
+
+      await sleep(pollIntervalMs);
+    }
+
+    throw new ExecutionClientError({
+      message: `execution-timeout:${latestState}`,
+      code: "venue-timeout",
+      status: 504,
+      retryable: true,
+      requestId: input.requestId,
+    });
+  }
+
+  return {
+    submit,
+    status,
+    receipt,
+    waitForTerminalReceipt,
+  };
+}

--- a/apps/portal/app/terminal/components/trade-ticket-modal.tsx
+++ b/apps/portal/app/terminal/components/trade-ticket-modal.tsx
@@ -12,13 +12,11 @@ import {
 } from "react";
 import { toast } from "sonner";
 import {
-  ApiError,
-  apiBase,
-  apiFetchJson,
-  BTN_PRIMARY,
-  BTN_SECONDARY,
-  isRecord,
-} from "../../lib";
+  createExecutionClient,
+  describeExecutionClientError,
+  newExecutionIdempotencyKey,
+} from "../../execution-client";
+import { apiBase, BTN_PRIMARY, BTN_SECONDARY, isRecord } from "../../lib";
 import type { TradeIntent } from "./trade-intent";
 
 type TradeTicketModalProps = {
@@ -58,113 +56,9 @@ const BEARER_RE = /^bearer\s+/i;
 const EXEC_POLL_INTERVAL_MS = 1200;
 const EXEC_POLL_TIMEOUT_MS = 45000;
 
-type ExecTerminalResult = {
-  status: string;
-  signature: string | null;
-};
-
 type CloseModalOptions = {
   cancelExecution?: boolean;
 };
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    window.setTimeout(resolve, ms);
-  });
-}
-
-function newIdempotencyKey(): string {
-  const prefix = "trade";
-  const ts = Date.now().toString(36);
-  const token =
-    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
-      ? crypto.randomUUID().replace(/-/g, "").slice(0, 12)
-      : Math.random().toString(36).slice(2, 14);
-  return `${prefix}-${ts}-${token}`;
-}
-
-function parseExecSubmitAck(payload: unknown): {
-  requestId: string;
-  state: string;
-} | null {
-  if (!isRecord(payload) || payload.ok !== true) return null;
-  const requestId = String(payload.requestId ?? "").trim();
-  const status = isRecord(payload.status) ? payload.status : null;
-  const state = String(status?.state ?? "").trim();
-  if (!requestId || !state) return null;
-  return { requestId, state };
-}
-
-function parseExecStatusSnapshot(payload: unknown): {
-  state: string;
-  terminal: boolean;
-} | null {
-  if (!isRecord(payload) || payload.ok !== true) return null;
-  const status = isRecord(payload.status) ? payload.status : null;
-  const state = String(status?.state ?? "").trim();
-  const terminal = status?.terminal === true;
-  if (!state) return null;
-  return { state, terminal };
-}
-
-function parseExecReceipt(payload: unknown): {
-  ready: boolean;
-  outcomeStatus: string | null;
-  signature: string | null;
-  errorCode: string | null;
-  errorMessage: string | null;
-} | null {
-  if (!isRecord(payload) || payload.ok !== true) return null;
-  const ready = payload.ready === true;
-  if (!ready) {
-    return {
-      ready: false,
-      outcomeStatus: null,
-      signature: null,
-      errorCode: null,
-      errorMessage: null,
-    };
-  }
-  const receipt = isRecord(payload.receipt) ? payload.receipt : null;
-  const outcome = receipt && isRecord(receipt.outcome) ? receipt.outcome : null;
-  return {
-    ready: true,
-    outcomeStatus: String(outcome?.status ?? "").trim() || null,
-    signature:
-      typeof outcome?.signature === "string" && outcome.signature.trim()
-        ? outcome.signature.trim()
-        : null,
-    errorCode:
-      typeof outcome?.errorCode === "string" && outcome.errorCode.trim()
-        ? outcome.errorCode.trim()
-        : null,
-    errorMessage:
-      typeof outcome?.errorMessage === "string" && outcome.errorMessage.trim()
-        ? outcome.errorMessage.trim()
-        : null,
-  };
-}
-
-function isExecSuccessStatus(status: string): boolean {
-  return status === "landed" || status === "finalized";
-}
-
-function describeExecError(
-  error: unknown,
-  fallback = "execution-failed",
-): string {
-  if (error instanceof ApiError) {
-    if (isRecord(error.data)) {
-      const reason = String(error.data.reason ?? "").trim();
-      const detail = String(error.data.error ?? "").trim();
-      if (reason) return `${detail || error.message}:${reason}`;
-      if (detail) return detail;
-    }
-    return error.message || fallback;
-  }
-  if (error instanceof Error && error.message.trim()) return error.message;
-  return fallback;
-}
 
 function parseUiAmountToAtomic(value: string, decimals: number): string | null {
   const trimmed = value.trim();
@@ -546,14 +440,14 @@ export function TradeTicketModal({
       const token = await getAccessToken();
       if (!token) throw new Error("missing-access-token");
 
-      const idempotencyKey = newIdempotencyKey();
-      const submitPayload = await apiFetchJson("/api/x402/exec/submit", token, {
-        method: "POST",
-        headers: {
-          "Idempotency-Key": idempotencyKey,
-        },
-        signal: controller.signal,
-        body: JSON.stringify({
+      const executionClient = createExecutionClient({
+        authToken: token,
+        pollIntervalMs: EXEC_POLL_INTERVAL_MS,
+        pollTimeoutMs: EXEC_POLL_TIMEOUT_MS,
+      });
+      const idempotencyKey = newExecutionIdempotencyKey("trade");
+      const submitAck = await executionClient.submit(
+        {
           schemaVersion: "v1",
           mode: "privy_execute",
           lane: "safe",
@@ -575,13 +469,12 @@ export function TradeTicketModal({
               commitment: "confirmed",
             },
           },
-        }),
-      });
-
-      const submitAck = parseExecSubmitAck(submitPayload);
-      if (!submitAck) {
-        throw new Error("invalid-exec-submit-response");
-      }
+        },
+        {
+          idempotencyKey,
+          signal: controller.signal,
+        },
+      );
 
       continueExecutionOnUnmountRef.current = true;
       closeModal();
@@ -591,65 +484,10 @@ export function TradeTicketModal({
       });
       executeToastIdRef.current = execToastId;
 
-      const startedAtMs = Date.now();
-      let latestState = submitAck.state;
-      let terminal: ExecTerminalResult | null = null;
-      while (Date.now() - startedAtMs < EXEC_POLL_TIMEOUT_MS) {
-        if (controller.signal.aborted) {
-          throw new Error("execution-cancelled");
-        }
-
-        const statusPayload = await apiFetchJson(
-          `/api/x402/exec/status/${submitAck.requestId}`,
-          token,
-          {
-            method: "GET",
-            signal: controller.signal,
-          },
-        );
-        const statusSnapshot = parseExecStatusSnapshot(statusPayload);
-        if (!statusSnapshot) throw new Error("invalid-exec-status-response");
-
-        latestState = statusSnapshot.state;
-        if (statusSnapshot.terminal) {
-          const receiptPayload = await apiFetchJson(
-            `/api/x402/exec/receipt/${submitAck.requestId}`,
-            token,
-            {
-              method: "GET",
-              signal: controller.signal,
-            },
-          );
-          const receipt = parseExecReceipt(receiptPayload);
-          if (!receipt) throw new Error("invalid-exec-receipt-response");
-
-          if (receipt.ready) {
-            const outcomeStatus =
-              receipt.outcomeStatus?.toLowerCase() || latestState.toLowerCase();
-            if (isExecSuccessStatus(outcomeStatus)) {
-              terminal = {
-                status: outcomeStatus,
-                signature: receipt.signature,
-              };
-              break;
-            }
-            const failureReason =
-              receipt.errorCode ??
-              receipt.errorMessage ??
-              `execution-${outcomeStatus}`;
-            throw new Error(failureReason);
-          }
-          if (latestState === "failed" || latestState === "expired") {
-            throw new Error(`execution-${latestState}`);
-          }
-        }
-
-        await sleep(EXEC_POLL_INTERVAL_MS);
-      }
-
-      if (!terminal) {
-        throw new Error(`execution-timeout:${latestState}`);
-      }
+      const terminal = await executionClient.waitForTerminalReceipt({
+        requestId: submitAck.requestId,
+        signal: controller.signal,
+      });
 
       onTradeComplete?.({
         inputMint: intent.inputMint,
@@ -673,7 +511,7 @@ export function TradeTicketModal({
       executeToastIdRef.current = null;
     } catch (error) {
       if (executeAbortRef.current?.signal.aborted) return;
-      const message = describeExecError(error, "execution-failed");
+      const message = describeExecutionClientError(error, "execution-failed");
       if (executeToastIdRef.current !== null || execToastId !== null) {
         toast.error("Trade execution failed", {
           id: executeToastIdRef.current ?? execToastId ?? undefined,

--- a/docs/execution/execution-client-sdk.md
+++ b/docs/execution/execution-client-sdk.md
@@ -1,0 +1,33 @@
+# Execution Client SDK (Portal)
+
+`apps/portal/app/execution-client.ts` is the typed internal SDK for the execution fabric.
+
+## Supported Calls
+
+- `submit(payload, options)`
+- `status(requestId)`
+- `receipt(requestId)`
+- `waitForTerminalReceipt({ requestId })`
+
+## Built-In Utilities
+
+- `newExecutionIdempotencyKey(prefix)`
+- canonical error decoding into `ExecutionClientError`
+- retry helper for transient execution errors in status/receipt polling
+
+## Browser Usage (Portal)
+
+```ts
+const client = createExecutionClient({ authToken });
+const idempotencyKey = newExecutionIdempotencyKey("trade");
+
+const submit = await client.submit(payload, { idempotencyKey, signal });
+const terminal = await client.waitForTerminalReceipt({
+  requestId: submit.requestId,
+  signal,
+});
+```
+
+## Custom Transport Usage (Jobs/Automation)
+
+The client accepts a custom `transport` so internal services can run against local worker stubs, test harnesses, or alternate request runners while preserving the same decoding and retry behavior.

--- a/tests/unit/portal_execution_client.test.ts
+++ b/tests/unit/portal_execution_client.test.ts
@@ -1,0 +1,241 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  createExecutionClient,
+  ExecutionClientError,
+  type ExecutionTransport,
+} from "../../apps/portal/app/execution-client";
+import type { Env } from "../../apps/worker/src/types";
+import {
+  createExecutionContextStub,
+  createWorkerLiveEnv,
+} from "../integration/_worker_live_test_utils";
+import { buildRelaySignedPayload } from "./_relay_signed_test_utils";
+
+const worker = (await import("../../apps/worker/src/index")).default;
+
+function createSqliteD1Adapter(db: Database): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          return {
+            async run() {
+              const statement = db.query(sql);
+              const result = statement.run(...(params as never[])) as {
+                changes?: number;
+              };
+              return {
+                meta: {
+                  changes:
+                    typeof result.changes === "number" ? result.changes : 0,
+                },
+              };
+            },
+            async first() {
+              const statement = db.query(sql);
+              return (statement.get(...(params as never[])) as unknown) ?? null;
+            },
+            async all() {
+              const statement = db.query(sql);
+              return {
+                results: (statement.all(...(params as never[])) ??
+                  []) as unknown[],
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+function createExecClientEnv(): { env: Env; sqlite: Database } {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA foreign_keys = ON;");
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS waitlist (
+      email TEXT PRIMARY KEY,
+      source TEXT,
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+  sqlite
+    .query("INSERT INTO waitlist (email, source) VALUES (?1, ?2)")
+    .run("user@example.com", "unit-test");
+
+  const migrationPath = resolve(
+    import.meta.dir,
+    "..",
+    "..",
+    "apps/worker/migrations/0025_execution_fabric.sql",
+  );
+  sqlite.exec(readFileSync(migrationPath, "utf8"));
+
+  const env = createWorkerLiveEnv({
+    overrides: {
+      WAITLIST_DB: createSqliteD1Adapter(sqlite),
+      X402_EXEC_SUBMIT_PRICE_USD: "0.01",
+      EXEC_RELAY_VALIDATE_BLOCKHASH: "0",
+    },
+  });
+  return { env, sqlite };
+}
+
+function createWorkerTransport(env: Env): ExecutionTransport {
+  return async (input) => {
+    const response = await worker.fetch(
+      new Request(`http://localhost${input.path}`, {
+        method: input.method,
+        headers: input.headers,
+        ...(input.body ? { body: input.body } : {}),
+        signal: input.signal,
+      }),
+      env,
+      createExecutionContextStub(),
+    );
+    const payload = (await response.json().catch(() => null)) as unknown;
+    return {
+      status: response.status,
+      payload,
+    };
+  };
+}
+
+describe("portal execution client", () => {
+  test("submit/status/receipt contract works against local worker", async () => {
+    const { env, sqlite } = createExecClientEnv();
+    try {
+      const relayPayload = buildRelaySignedPayload();
+      const client = createExecutionClient({
+        transport: createWorkerTransport(env),
+      });
+
+      const submit = await client.submit(
+        {
+          schemaVersion: "v1",
+          mode: "relay_signed",
+          lane: "fast",
+          relaySigned: {
+            signedTransaction: relayPayload.relaySigned.signedTransaction,
+            encoding: "base64",
+          },
+        },
+        {
+          idempotencyKey: "sdk-relay-idem-1",
+          headers: {
+            "payment-signature": "unit-signed-payment",
+          },
+        },
+      );
+
+      expect(submit.requestId.startsWith("execreq_")).toBe(true);
+      expect(submit.state).toBe("validated");
+
+      const status = await client.status(submit.requestId);
+      expect(status.requestId).toBe(submit.requestId);
+      expect(status.state).toBe("validated");
+      expect(status.terminal).toBe(false);
+
+      const receipt = await client.receipt(submit.requestId);
+      expect(receipt.requestId).toBe(submit.requestId);
+      expect(receipt.ready).toBe(false);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("decodes canonical execution errors", async () => {
+    const { env, sqlite } = createExecClientEnv();
+    try {
+      const client = createExecutionClient({
+        transport: createWorkerTransport(env),
+      });
+
+      try {
+        await client.status("not_valid");
+        throw new Error("expected status() to throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ExecutionClientError);
+        const typed = error as ExecutionClientError;
+        expect(typed.code).toBe("invalid-request");
+        expect(typed.status).toBe(400);
+        expect(typed.retryable).toBe(false);
+      }
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("waitForTerminalReceipt retries transient failures", async () => {
+    let statusCalls = 0;
+    let receiptCalls = 0;
+    const transport: ExecutionTransport = async (input) => {
+      if (input.path.includes("/status/")) {
+        statusCalls += 1;
+        if (statusCalls === 1) {
+          return {
+            status: 503,
+            payload: {
+              ok: false,
+              error: {
+                code: "submission-failed",
+                message: "temporary-status-failure",
+              },
+            },
+          };
+        }
+        return {
+          status: 200,
+          payload: {
+            ok: true,
+            requestId: "execreq_retry1234567890",
+            status: {
+              state: "finalized",
+              terminal: true,
+            },
+          },
+        };
+      }
+      if (input.path.includes("/receipt/")) {
+        receiptCalls += 1;
+        return {
+          status: 200,
+          payload: {
+            ok: true,
+            requestId: "execreq_retry1234567890",
+            ready: true,
+            receipt: {
+              outcome: {
+                status: "finalized",
+                signature: "sig_retry",
+              },
+            },
+          },
+        };
+      }
+      return {
+        status: 404,
+        payload: { ok: false, error: { code: "not-found", message: "nf" } },
+      };
+    };
+
+    const client = createExecutionClient({
+      transport,
+      pollIntervalMs: 10,
+      pollTimeoutMs: 500,
+      requestRetryCount: 2,
+      requestRetryBaseDelayMs: 5,
+    });
+
+    const terminal = await client.waitForTerminalReceipt({
+      requestId: "execreq_retry1234567890",
+    });
+    expect(terminal.status).toBe("finalized");
+    expect(terminal.signature).toBe("sig_retry");
+    expect(statusCalls).toBe(2);
+    expect(receiptCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add `apps/portal/app/execution-client.ts` as the typed execution SDK for submit/status/receipt polling
- include SDK idempotency helper (`newExecutionIdempotencyKey`) and canonical execution error decoding (`ExecutionClientError`)
- add built-in transient retry logic for status/receipt polling inside `waitForTerminalReceipt`
- refactor `TradeTicketModal` to use the SDK instead of ad-hoc submit/status/receipt fetch + parsing logic
- add contract tests that validate SDK behavior against a local in-memory worker execution runtime
- add SDK usage docs under `docs/execution/execution-client-sdk.md`

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun test tests/unit/portal_execution_client.test.ts`
- `bun test`

Closes #143
