### PR TITLE
feat(terminal): add Regular/Degen/Custom mode framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It provides one execution fabric for:
 ## What Is Live
 
 - Terminal UI at `/terminal`
+- Terminal modes (`Regular`, `Degen`, `Custom`) with profile persistence
 - Account-level Privy wallet model (one wallet per user)
 - x402 paid APIs (`/api/x402/read/*`, `/api/x402/exec/submit`)
 - Execution API scaffold:
@@ -39,6 +40,10 @@ bun run dev:local
 
 - Portal: `http://localhost:3000`
 - Worker health: `http://127.0.0.1:8888/api/health`
+
+Optional portal env:
+
+- `NEXT_PUBLIC_TERMINAL_DEFAULT_MODE=regular|degen|custom`
 
 ### Worker only
 

--- a/apps/portal/app/terminal/components/dashboard-grid.tsx
+++ b/apps/portal/app/terminal/components/dashboard-grid.tsx
@@ -26,6 +26,7 @@ interface DashboardGridProps {
   children: ReactNode[];
   className?: string;
   onLayoutChange?: (layout: Layout[]) => void;
+  allowLayoutEditing?: boolean;
 }
 
 const DASHBOARD_LAYOUT_STORAGE_KEY = "dashboard-grid-layouts:v3";
@@ -171,6 +172,7 @@ export function DashboardGrid({
   children,
   className,
   onLayoutChange,
+  allowLayoutEditing = true,
 }: DashboardGridProps) {
   // Use the hook to get width
   const { width, containerRef, mounted } = useContainerWidth();
@@ -222,8 +224,8 @@ export function DashboardGrid({
           margin={[1, 1]}
           containerPadding={[0, 0]}
           onLayoutChange={handleLayoutChange}
-          isDraggable
-          isResizable
+          isDraggable={allowLayoutEditing}
+          isResizable={allowLayoutEditing}
           draggableHandle=".dashboard-drag-handle"
           draggableCancel=".no-drag"
         >

--- a/apps/portal/app/terminal/components/dashboard-header.tsx
+++ b/apps/portal/app/terminal/components/dashboard-header.tsx
@@ -5,6 +5,11 @@ import { Wallet } from "lucide-react";
 import Link from "next/link";
 import { cn } from "../../cn";
 import { BTN_PRIMARY, BTN_SECONDARY, formatBalanceSummary } from "../../lib";
+import {
+  getTerminalModeCapabilities,
+  TERMINAL_MODE_OPTIONS,
+  type TerminalMode,
+} from "../terminal-modes";
 
 interface DashboardHeaderProps {
   walletBalances?: {
@@ -17,6 +22,9 @@ interface DashboardHeaderProps {
   isRefreshing?: boolean;
   showFundButton?: boolean;
   showBalance?: boolean;
+  terminalMode: TerminalMode;
+  terminalModeSaving?: boolean;
+  onModeChange?: (mode: TerminalMode) => void;
 }
 
 export function DashboardHeader({
@@ -27,6 +35,9 @@ export function DashboardHeader({
   isRefreshing,
   showFundButton = false,
   showBalance = false,
+  terminalMode,
+  terminalModeSaving = false,
+  onModeChange,
 }: DashboardHeaderProps) {
   const { logout } = usePrivy();
   const balanceText = walletBalanceError
@@ -49,6 +60,35 @@ export function DashboardHeader({
           <span className="ml-2 text-muted font-normal">Terminal</span>
         </Link>
         <div className="flex min-w-0 items-center justify-end gap-2 overflow-x-auto text-xs">
+          <div className="inline-flex h-8 shrink-0 items-center rounded-md border border-border bg-surface p-0.5">
+            {TERMINAL_MODE_OPTIONS.map((modeOption) => {
+              const active = modeOption === terminalMode;
+              const modeView = getTerminalModeCapabilities(modeOption);
+              return (
+                <button
+                  key={modeOption}
+                  className={cn(
+                    "h-6 rounded px-2.5 text-[10px] font-semibold tracking-wide uppercase transition-colors",
+                    active
+                      ? "bg-ink text-surface"
+                      : "text-muted hover:text-ink hover:bg-paper",
+                    !onModeChange && "pointer-events-none opacity-60",
+                  )}
+                  onClick={() => onModeChange?.(modeOption)}
+                  title={modeView.description}
+                  type="button"
+                  aria-pressed={active}
+                >
+                  {modeView.label}
+                </button>
+              );
+            })}
+          </div>
+          {terminalModeSaving ? (
+            <span className="text-[10px] text-muted tabular-nums shrink-0">
+              Saving mode...
+            </span>
+          ) : null}
           <span
             className={cn(
               "inline-flex h-8 w-[25ch] shrink-0 items-center justify-end rounded-md border border-border bg-surface px-2.5 font-mono tabular-nums text-muted whitespace-nowrap",

--- a/apps/portal/app/terminal/components/macro-radar-widget.tsx
+++ b/apps/portal/app/terminal/components/macro-radar-widget.tsx
@@ -12,6 +12,7 @@ type MacroRadarWidgetProps = {
 export function MacroRadarWidget({ onTradeAction }: MacroRadarWidgetProps) {
   const feed = useMacroSignals();
   const data = feed.data;
+  const tradeEnabled = typeof onTradeAction === "function";
 
   const verdictClass =
     data?.verdict === "BUY"
@@ -83,7 +84,10 @@ export function MacroRadarWidget({ onTradeAction }: MacroRadarWidgetProps) {
 
             <div className="flex gap-2">
               <button
-                className={`${BTN_SECONDARY} !h-7 !px-2.5 !py-0 text-[10px]`}
+                className={cn(
+                  `${BTN_SECONDARY} !h-7 !px-2.5 !py-0 text-[10px]`,
+                  !tradeEnabled && "opacity-60 pointer-events-none",
+                )}
                 onClick={() =>
                   onTradeAction?.(
                     createSolUsdcIntent("buy", "MACRO_RADAR", {
@@ -92,11 +96,15 @@ export function MacroRadarWidget({ onTradeAction }: MacroRadarWidgetProps) {
                   )
                 }
                 type="button"
+                disabled={!tradeEnabled}
               >
                 Buy SOL
               </button>
               <button
-                className={`${BTN_SECONDARY} !h-7 !px-2.5 !py-0 text-[10px]`}
+                className={cn(
+                  `${BTN_SECONDARY} !h-7 !px-2.5 !py-0 text-[10px]`,
+                  !tradeEnabled && "opacity-60 pointer-events-none",
+                )}
                 onClick={() =>
                   onTradeAction?.(
                     createSolUsdcIntent("sell", "MACRO_RADAR", {
@@ -105,6 +113,7 @@ export function MacroRadarWidget({ onTradeAction }: MacroRadarWidgetProps) {
                   )
                 }
                 type="button"
+                disabled={!tradeEnabled}
               >
                 Sell SOL
               </button>

--- a/apps/portal/app/terminal/components/macro-stablecoin-widget.tsx
+++ b/apps/portal/app/terminal/components/macro-stablecoin-widget.tsx
@@ -18,6 +18,7 @@ export function MacroStablecoinWidget({
 }: MacroStablecoinWidgetProps) {
   const feed = useMacroStablecoinHealth();
   const data = feed.data;
+  const tradeEnabled = typeof onTradeAction === "function";
   const rows = (data?.stablecoins ?? []).slice(0, 4);
 
   return (
@@ -47,7 +48,9 @@ export function MacroStablecoinWidget({
               </p>
               <div className="mt-2 flex gap-2">
                 <button
-                  className={`${BTN_SECONDARY} !h-7 !px-2.5 !py-0 text-[10px]`}
+                  className={`${BTN_SECONDARY} !h-7 !px-2.5 !py-0 text-[10px] ${
+                    !tradeEnabled ? "opacity-60 pointer-events-none" : ""
+                  }`}
                   onClick={() =>
                     onTradeAction?.(
                       createSolUsdcIntent("buy", "STABLECOIN_HEALTH", {
@@ -56,11 +59,14 @@ export function MacroStablecoinWidget({
                     )
                   }
                   type="button"
+                  disabled={!tradeEnabled}
                 >
                   Deploy USDC -&gt; SOL
                 </button>
                 <button
-                  className={`${BTN_SECONDARY} !h-7 !px-2.5 !py-0 text-[10px]`}
+                  className={`${BTN_SECONDARY} !h-7 !px-2.5 !py-0 text-[10px] ${
+                    !tradeEnabled ? "opacity-60 pointer-events-none" : ""
+                  }`}
                   onClick={() =>
                     onTradeAction?.(
                       createSolUsdcIntent("sell", "STABLECOIN_HEALTH", {
@@ -69,6 +75,7 @@ export function MacroStablecoinWidget({
                     )
                   }
                   type="button"
+                  disabled={!tradeEnabled}
                 >
                   Reduce SOL -&gt; USDC
                 </button>

--- a/apps/portal/app/terminal/context.tsx
+++ b/apps/portal/app/terminal/context.tsx
@@ -8,6 +8,10 @@ import {
   useMemo,
   useState,
 } from "react";
+import {
+  resolveDefaultTerminalMode,
+  type TerminalMode,
+} from "./terminal-modes";
 
 type HeaderState = {
   title?: string;
@@ -19,6 +23,8 @@ type HeaderState = {
   showFundButton: boolean;
   showBalance: boolean;
   isRefreshing: boolean;
+  terminalMode: TerminalMode;
+  terminalModeSaving: boolean;
 };
 
 type HeaderActions = {
@@ -29,11 +35,18 @@ type HeaderActions = {
   setIsRefreshing: (refreshing: boolean) => void;
   setShowFundButton: (show: boolean) => void;
   setShowBalance: (show: boolean) => void;
+  setTerminalMode: (mode: TerminalMode) => void;
+  setTerminalModeSaving: (saving: boolean) => void;
+  setModeAction: (fn: ((mode: TerminalMode) => void) | null) => void;
 };
 
 const DashboardContext = createContext<
   | (HeaderState &
-      HeaderActions & { onFund?: () => void; onRefresh?: () => void })
+      HeaderActions & {
+        onFund?: () => void;
+        onRefresh?: () => void;
+        onModeChange?: (mode: TerminalMode) => void;
+      })
   | null
 >(null);
 
@@ -46,11 +59,18 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
   const [showFundButton, setShowFundButton] = useState(false);
   const [showBalance, setShowBalance] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [terminalMode, setTerminalMode] = useState<TerminalMode>(() =>
+    resolveDefaultTerminalMode(process.env.NEXT_PUBLIC_TERMINAL_DEFAULT_MODE),
+  );
+  const [terminalModeSaving, setTerminalModeSaving] = useState(false);
 
   const [onFund, setOnFund] = useState<(() => void) | undefined>(undefined);
   const [onRefresh, setOnRefresh] = useState<(() => void) | undefined>(
     undefined,
   );
+  const [onModeChange, setOnModeChange] = useState<
+    ((mode: TerminalMode) => void) | undefined
+  >(undefined);
 
   const setFundAction = useCallback((fn: (() => void) | null) => {
     setOnFund(() => fn || undefined);
@@ -59,6 +79,13 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
   const setRefreshAction = useCallback((fn: (() => void) | null) => {
     setOnRefresh(() => fn || undefined);
   }, []);
+
+  const setModeAction = useCallback(
+    (fn: ((mode: TerminalMode) => void) | null) => {
+      setOnModeChange(() => fn || undefined);
+    },
+    [],
+  );
 
   const value = useMemo(
     () => ({
@@ -72,10 +99,16 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
       setShowBalance,
       isRefreshing,
       setIsRefreshing,
+      terminalMode,
+      setTerminalMode,
+      terminalModeSaving,
+      setTerminalModeSaving,
       onFund,
       setFundAction,
       onRefresh,
       setRefreshAction,
+      onModeChange,
+      setModeAction,
     }),
     [
       walletBalances,
@@ -83,10 +116,14 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
       showFundButton,
       showBalance,
       isRefreshing,
+      terminalMode,
+      terminalModeSaving,
       onFund,
       onRefresh,
+      onModeChange,
       setFundAction,
       setRefreshAction,
+      setModeAction,
     ],
   );
 

--- a/apps/portal/app/terminal/dashboard-shell-client.tsx
+++ b/apps/portal/app/terminal/dashboard-shell-client.tsx
@@ -13,6 +13,9 @@ function ConnectedHeader() {
     isRefreshing,
     showFundButton,
     showBalance,
+    terminalMode,
+    terminalModeSaving,
+    onModeChange,
   } = useDashboard();
 
   return (
@@ -24,6 +27,9 @@ function ConnectedHeader() {
       isRefreshing={isRefreshing}
       showFundButton={showFundButton}
       showBalance={showBalance}
+      terminalMode={terminalMode}
+      terminalModeSaving={terminalModeSaving}
+      onModeChange={onModeChange}
     />
   );
 }

--- a/apps/portal/app/terminal/page.tsx
+++ b/apps/portal/app/terminal/page.tsx
@@ -38,6 +38,17 @@ import {
 } from "./components/trade-pairs";
 import type { TradeTicketCompletion } from "./components/trade-ticket-modal";
 import { useDashboard } from "./context";
+import {
+  getTerminalModeCapabilities,
+  mergeProfileWithTerminalMode,
+  modeAllowsAction,
+  modeShowsModule,
+  readLocalTerminalMode,
+  readTerminalModeFromProfile,
+  resolveDefaultTerminalMode,
+  type TerminalMode,
+  writeLocalTerminalMode,
+} from "./terminal-modes";
 
 type Balances = BalanceResponse;
 
@@ -128,6 +139,13 @@ function parseAccountWallet(payload: unknown): AccountWallet | null {
   };
 }
 
+function parseUserProfile(payload: unknown): Record<string, unknown> | null {
+  if (!isRecord(payload)) return null;
+  const user = isRecord(payload.user) ? payload.user : null;
+  if (!user) return null;
+  return isRecord(user.profile) ? user.profile : null;
+}
+
 function isTypingTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
   if (target.isContentEditable) return true;
@@ -187,6 +205,28 @@ function ControlRoom() {
   const [selectedPairId, setSelectedPairId] = useState<PairId>(DEFAULT_PAIR_ID);
   const [gridRevision, setGridRevision] = useState(0);
   const [hasCustomGridLayout, setHasCustomGridLayout] = useState(false);
+  const [terminalMode, setTerminalMode] = useState<TerminalMode>(() =>
+    resolveDefaultTerminalMode(process.env.NEXT_PUBLIC_TERMINAL_DEFAULT_MODE),
+  );
+  const [terminalModeSaving, setTerminalModeSaving] = useState(false);
+  const [userProfile, setUserProfile] = useState<Record<
+    string,
+    unknown
+  > | null>(null);
+  const modeCapabilities = getTerminalModeCapabilities(terminalMode);
+  const canQuickTrade = modeAllowsAction(terminalMode, "quick_trade");
+  const canMacroTrade = modeAllowsAction(terminalMode, "macro_trade");
+  const canLayoutEdit = modeAllowsAction(terminalMode, "layout_edit");
+  const showMarketModule = modeShowsModule(terminalMode, "market");
+  const showWalletModule = modeShowsModule(terminalMode, "wallet");
+  const showMacroRadarModule = modeShowsModule(terminalMode, "macro_radar");
+  const showMacroFredModule = modeShowsModule(terminalMode, "macro_fred");
+  const showMacroEtfModule = modeShowsModule(terminalMode, "macro_etf");
+  const showMacroStablecoinModule = modeShowsModule(
+    terminalMode,
+    "macro_stablecoin",
+  );
+  const showMacroOilModule = modeShowsModule(terminalMode, "macro_oil");
 
   const resetDashboardLayout = useCallback(() => {
     clearDashboardGridLayouts();
@@ -198,8 +238,55 @@ function ControlRoom() {
     setHasCustomGridLayout(hasCustomDashboardGridLayouts());
   }, []);
 
+  const persistTerminalMode = useCallback(
+    async (input: {
+      mode: TerminalMode;
+      profileSnapshot: Record<string, unknown> | null;
+      source: "manual" | "local_fallback" | "default_fallback";
+      previousMode: TerminalMode | null;
+      emitTelemetry: boolean;
+    }): Promise<Record<string, unknown> | null> => {
+      if (!authenticated) return input.profileSnapshot;
+      const token = await getAccessToken();
+      if (!token) return input.profileSnapshot;
+
+      const mergedProfile = mergeProfileWithTerminalMode(
+        input.profileSnapshot,
+        {
+          mode: input.mode,
+          source: input.source,
+        },
+      );
+      await apiFetchJson("/api/me/profile", token, {
+        method: "PATCH",
+        body: JSON.stringify({
+          profile: mergedProfile,
+        }),
+      });
+
+      if (input.emitTelemetry) {
+        await apiFetchJson("/api/events", token, {
+          method: "POST",
+          body: JSON.stringify({
+            name: "terminal_mode_changed",
+            properties: {
+              from: input.previousMode,
+              to: input.mode,
+              source: input.source,
+            },
+          }),
+        }).catch(() => {
+          // Do not block UX on telemetry write failures.
+        });
+      }
+      return mergedProfile;
+    },
+    [authenticated, getAccessToken],
+  );
+
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent): void {
+      if (!canLayoutEdit) return;
       if (isTypingTarget(event.target)) return;
       if (event.metaKey || event.ctrlKey || event.altKey) return;
       if (event.key.toLowerCase() !== "r") return;
@@ -210,7 +297,7 @@ function ControlRoom() {
     return () => {
       window.removeEventListener("keydown", onKeyDown);
     };
-  }, [resetDashboardLayout]);
+  }, [canLayoutEdit, resetDashboardLayout]);
 
   const refresh = useCallback(async (): Promise<void> => {
     if (!authenticated) return;
@@ -223,6 +310,29 @@ function ControlRoom() {
 
       const walletRaw = isRecord(payload) ? payload.wallet : null;
       setWallet(parseAccountWallet(walletRaw));
+      const profile = parseUserProfile(payload);
+      setUserProfile(profile);
+      const serverMode = readTerminalModeFromProfile(profile);
+      const localMode = readLocalTerminalMode();
+      const defaultMode = resolveDefaultTerminalMode(
+        process.env.NEXT_PUBLIC_TERMINAL_DEFAULT_MODE,
+      );
+      const resolvedMode = serverMode ?? localMode ?? defaultMode;
+      setTerminalMode(resolvedMode);
+      // Keep local fallback synced with chosen mode.
+      writeLocalTerminalMode(resolvedMode);
+      if (!serverMode) {
+        const source = localMode ? "local_fallback" : "default_fallback";
+        void persistTerminalMode({
+          mode: resolvedMode,
+          profileSnapshot: profile,
+          source,
+          previousMode: null,
+          emitTelemetry: false,
+        }).then((mergedProfile) => {
+          if (mergedProfile) setUserProfile(mergedProfile);
+        });
+      }
       setLoaded(true);
     } catch (error) {
       setLoaded(true);
@@ -230,7 +340,7 @@ function ControlRoom() {
     } finally {
       setLoading(false);
     }
-  }, [authenticated, getAccessToken]);
+  }, [authenticated, getAccessToken, persistTerminalMode]);
 
   const refreshWalletBalances = useCallback(async (): Promise<void> => {
     if (!authenticated || !wallet) return;
@@ -333,24 +443,53 @@ function ControlRoom() {
   );
 
   const openMarketBuyTrade = useCallback(() => {
+    if (!canQuickTrade) return;
     openTradeTicket(
       createTradeIntent("buy", "MARKET_MONITOR", selectedPairId, {
         reason: `Market action: buy ${selectedPair.baseSymbol}`,
       }),
     );
-  }, [openTradeTicket, selectedPair.baseSymbol, selectedPairId]);
+  }, [canQuickTrade, openTradeTicket, selectedPair.baseSymbol, selectedPairId]);
 
   const openMarketSellTrade = useCallback(() => {
+    if (!canQuickTrade) return;
     openTradeTicket(
       createTradeIntent("sell", "MARKET_MONITOR", selectedPairId, {
         reason: `Market action: reduce ${selectedPair.baseSymbol}`,
       }),
     );
-  }, [openTradeTicket, selectedPair.baseSymbol, selectedPairId]);
+  }, [canQuickTrade, openTradeTicket, selectedPair.baseSymbol, selectedPairId]);
 
   const openFundingModal = useCallback(() => {
     setFundOpen(true);
   }, []);
+
+  const handleTerminalModeChange = useCallback(
+    (nextMode: TerminalMode): void => {
+      if (nextMode === terminalMode) return;
+      const previousMode = terminalMode;
+      setTerminalMode(nextMode);
+      writeLocalTerminalMode(nextMode);
+      setTerminalModeSaving(true);
+      void persistTerminalMode({
+        mode: nextMode,
+        profileSnapshot: userProfile,
+        source: "manual",
+        previousMode,
+        emitTelemetry: true,
+      })
+        .then((mergedProfile) => {
+          if (mergedProfile) setUserProfile(mergedProfile);
+        })
+        .catch(() => {
+          // Keep local mode active even if server persistence fails.
+        })
+        .finally(() => {
+          setTerminalModeSaving(false);
+        });
+    },
+    [persistTerminalMode, terminalMode, userProfile],
+  );
 
   const triggerRefresh = useCallback(() => {
     void refresh();
@@ -421,6 +560,9 @@ function ControlRoom() {
     setWalletBalances: setGlobalWalletBalances,
     setWalletBalanceError: setGlobalWalletBalanceError,
     setFundAction,
+    setTerminalMode: setGlobalTerminalMode,
+    setTerminalModeSaving: setGlobalTerminalModeSaving,
+    setModeAction,
     setRefreshAction,
     setIsRefreshing,
     setShowFundButton,
@@ -436,6 +578,9 @@ function ControlRoom() {
       setGlobalWalletBalanceError(null);
     }
     setFundAction(wallet ? openFundingModal : null);
+    setGlobalTerminalMode(terminalMode);
+    setGlobalTerminalModeSaving(terminalModeSaving);
+    setModeAction(handleTerminalModeChange);
     setRefreshAction(triggerRefresh);
     setIsRefreshing(loading);
     setShowFundButton(Boolean(wallet));
@@ -443,6 +588,7 @@ function ControlRoom() {
 
     return () => {
       setFundAction(null);
+      setModeAction(null);
       setRefreshAction(null);
     };
   }, [
@@ -453,11 +599,17 @@ function ControlRoom() {
     setGlobalWalletBalances,
     setGlobalWalletBalanceError,
     setFundAction,
+    setGlobalTerminalMode,
+    setGlobalTerminalModeSaving,
+    setModeAction,
     setRefreshAction,
     setIsRefreshing,
     setShowFundButton,
     setShowBalance,
     openFundingModal,
+    terminalMode,
+    terminalModeSaving,
+    handleTerminalModeChange,
     triggerRefresh,
   ]);
 
@@ -496,7 +648,18 @@ function ControlRoom() {
             </div>
           ) : (
             <div className="relative h-full">
-              {hasCustomGridLayout && (
+              <div className="pointer-events-none absolute left-2 top-2 z-20 hidden sm:block">
+                <div
+                  className="rounded border border-border/70 bg-paper/90 px-2.5 py-1 text-[11px] text-muted backdrop-blur"
+                  title={modeCapabilities.description}
+                >
+                  Mode:{" "}
+                  <span className="font-semibold text-ink">
+                    {modeCapabilities.label}
+                  </span>
+                </div>
+              </div>
+              {hasCustomGridLayout && canLayoutEdit && (
                 <div className="pointer-events-none absolute right-2 top-2 z-20">
                   <button
                     className={cn(
@@ -515,47 +678,71 @@ function ControlRoom() {
               <DashboardGrid
                 key={gridRevision}
                 className="w-full h-full border border-border bg-border pb-1"
+                allowLayoutEditing={canLayoutEdit}
                 onLayoutChange={() =>
                   setHasCustomGridLayout(hasCustomDashboardGridLayouts())
                 }
               >
-                <div
-                  key="market"
-                  className="flex flex-col overflow-hidden bg-surface"
-                >
-                  <MarketMonitorCard
-                    pairId={selectedPairId}
-                    onPairChange={setSelectedPairId}
-                    onBuy={openMarketBuyTrade}
-                    onSell={openMarketSellTrade}
-                  />
-                </div>
+                {showMarketModule ? (
+                  <div
+                    key="market"
+                    className="flex flex-col overflow-hidden bg-surface"
+                  >
+                    <MarketMonitorCard
+                      pairId={selectedPairId}
+                      onPairChange={setSelectedPairId}
+                      onBuy={openMarketBuyTrade}
+                      onSell={openMarketSellTrade}
+                      tradingEnabled={canQuickTrade}
+                    />
+                  </div>
+                ) : null}
 
-                <div
-                  key="wallet"
-                  className="flex flex-col overflow-hidden bg-surface"
-                >
-                  <WalletMonitorCard
-                    pairId={selectedPairId}
-                    tokenBalancesByMint={tokenBalancesByMint}
-                  />
-                </div>
+                {showWalletModule ? (
+                  <div
+                    key="wallet"
+                    className="flex flex-col overflow-hidden bg-surface"
+                  >
+                    <WalletMonitorCard
+                      pairId={selectedPairId}
+                      tokenBalancesByMint={tokenBalancesByMint}
+                    />
+                  </div>
+                ) : null}
 
-                <div key="macro_radar" className="overflow-hidden">
-                  <MacroRadarWidget onTradeAction={openTradeTicket} />
-                </div>
-                <div key="macro_fred" className="overflow-hidden">
-                  <MacroFredWidget />
-                </div>
-                <div key="macro_etf" className="overflow-hidden">
-                  <MacroEtfWidget />
-                </div>
-                <div key="macro_stablecoin" className="overflow-hidden">
-                  <MacroStablecoinWidget onTradeAction={openTradeTicket} />
-                </div>
-                <div key="macro_oil" className="overflow-hidden">
-                  <MacroOilWidget />
-                </div>
+                {showMacroRadarModule ? (
+                  <div key="macro_radar" className="overflow-hidden">
+                    <MacroRadarWidget
+                      onTradeAction={
+                        canMacroTrade ? openTradeTicket : undefined
+                      }
+                    />
+                  </div>
+                ) : null}
+                {showMacroFredModule ? (
+                  <div key="macro_fred" className="overflow-hidden">
+                    <MacroFredWidget />
+                  </div>
+                ) : null}
+                {showMacroEtfModule ? (
+                  <div key="macro_etf" className="overflow-hidden">
+                    <MacroEtfWidget />
+                  </div>
+                ) : null}
+                {showMacroStablecoinModule ? (
+                  <div key="macro_stablecoin" className="overflow-hidden">
+                    <MacroStablecoinWidget
+                      onTradeAction={
+                        canMacroTrade ? openTradeTicket : undefined
+                      }
+                    />
+                  </div>
+                ) : null}
+                {showMacroOilModule ? (
+                  <div key="macro_oil" className="overflow-hidden">
+                    <MacroOilWidget />
+                  </div>
+                ) : null}
               </DashboardGrid>
             </div>
           )}
@@ -570,8 +757,9 @@ const MarketMonitorCard = memo(function MarketMonitorCard(props: {
   onPairChange: (pairId: PairId) => void;
   onBuy: () => void;
   onSell: () => void;
+  tradingEnabled: boolean;
 }) {
-  const { pairId, onPairChange, onBuy, onSell } = props;
+  const { pairId, onPairChange, onBuy, onSell, tradingEnabled } = props;
   const pair = getPairConfig(pairId);
   const marketFeed = useMarketFeed(pairId);
   const pairLabel = `${pair.baseSymbol}/${pair.quoteSymbol}`;
@@ -609,9 +797,11 @@ const MarketMonitorCard = memo(function MarketMonitorCard(props: {
             className={cn(
               BTN_SECONDARY,
               "!h-6 !px-2 !py-0 text-[10px] !rounded",
+              !tradingEnabled && "opacity-60 pointer-events-none",
             )}
             onClick={onBuy}
             type="button"
+            disabled={!tradingEnabled}
           >
             Buy
           </button>
@@ -619,9 +809,11 @@ const MarketMonitorCard = memo(function MarketMonitorCard(props: {
             className={cn(
               BTN_SECONDARY,
               "!h-6 !px-2 !py-0 text-[10px] !rounded",
+              !tradingEnabled && "opacity-60 pointer-events-none",
             )}
             onClick={onSell}
             type="button"
+            disabled={!tradingEnabled}
           >
             Sell
           </button>

--- a/apps/portal/app/terminal/page.tsx
+++ b/apps/portal/app/terminal/page.tsx
@@ -3,7 +3,7 @@
 import { usePrivy } from "@privy-io/react-auth";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
-import { memo, useCallback, useEffect, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "../cn";
 import {
   type AccountWallet,
@@ -213,6 +213,8 @@ function ControlRoom() {
     string,
     unknown
   > | null>(null);
+  const terminalModeRef = useRef<TerminalMode>(terminalMode);
+  const fallbackModePersistControllerRef = useRef<AbortController | null>(null);
   const modeCapabilities = getTerminalModeCapabilities(terminalMode);
   const canQuickTrade = modeAllowsAction(terminalMode, "quick_trade");
   const canMacroTrade = modeAllowsAction(terminalMode, "macro_trade");
@@ -227,6 +229,17 @@ function ControlRoom() {
     "macro_stablecoin",
   );
   const showMacroOilModule = modeShowsModule(terminalMode, "macro_oil");
+
+  useEffect(() => {
+    terminalModeRef.current = terminalMode;
+  }, [terminalMode]);
+
+  useEffect(
+    () => () => {
+      fallbackModePersistControllerRef.current?.abort();
+    },
+    [],
+  );
 
   const resetDashboardLayout = useCallback(() => {
     clearDashboardGridLayouts();
@@ -250,19 +263,47 @@ function ControlRoom() {
       const token = await getAccessToken();
       if (!token) return input.profileSnapshot;
 
-      const mergedProfile = mergeProfileWithTerminalMode(
-        input.profileSnapshot,
-        {
-          mode: input.mode,
-          source: input.source,
-        },
-      );
+      if (input.source === "manual") {
+        fallbackModePersistControllerRef.current?.abort();
+        fallbackModePersistControllerRef.current = null;
+      } else {
+        fallbackModePersistControllerRef.current?.abort();
+        fallbackModePersistControllerRef.current = new AbortController();
+      }
+      const signal = fallbackModePersistControllerRef.current?.signal;
+
+      if (input.source !== "manual" && terminalModeRef.current !== input.mode) {
+        return null;
+      }
+
+      let mergeBase = input.profileSnapshot;
+      try {
+        const latestPayload = await apiFetchJson("/api/me", token, {
+          method: "GET",
+          ...(signal ? { signal } : {}),
+        });
+        const latestProfile = parseUserProfile(latestPayload);
+        if (latestProfile) mergeBase = latestProfile;
+      } catch {
+        if (signal?.aborted) return null;
+      }
+
+      if (input.source !== "manual" && terminalModeRef.current !== input.mode) {
+        return null;
+      }
+
+      const mergedProfile = mergeProfileWithTerminalMode(mergeBase, {
+        mode: input.mode,
+        source: input.source,
+      });
       await apiFetchJson("/api/me/profile", token, {
         method: "PATCH",
         body: JSON.stringify({
           profile: mergedProfile,
         }),
+        ...(signal ? { signal } : {}),
       });
+      if (signal?.aborted) return null;
 
       if (input.emitTelemetry) {
         await apiFetchJson("/api/events", token, {
@@ -329,9 +370,13 @@ function ControlRoom() {
           source,
           previousMode: null,
           emitTelemetry: false,
-        }).then((mergedProfile) => {
-          if (mergedProfile) setUserProfile(mergedProfile);
-        });
+        })
+          .then((mergedProfile) => {
+            if (mergedProfile) setUserProfile(mergedProfile);
+          })
+          .catch(() => {
+            // Ignore fallback persistence failures.
+          });
       }
       setLoaded(true);
     } catch (error) {

--- a/apps/portal/app/terminal/terminal-modes.ts
+++ b/apps/portal/app/terminal/terminal-modes.ts
@@ -1,0 +1,157 @@
+import { isRecord } from "../lib";
+
+export const TERMINAL_MODE_STORAGE_KEY = "terminal-mode:v1";
+export const TERMINAL_MODE_OPTIONS = ["regular", "degen", "custom"] as const;
+
+export type TerminalMode = (typeof TERMINAL_MODE_OPTIONS)[number];
+
+export type TerminalModule =
+  | "market"
+  | "wallet"
+  | "macro_radar"
+  | "macro_fred"
+  | "macro_etf"
+  | "macro_stablecoin"
+  | "macro_oil";
+
+export type TerminalAction = "quick_trade" | "macro_trade" | "layout_edit";
+
+type TerminalModeCapabilities = {
+  label: string;
+  description: string;
+  visibleModules: readonly TerminalModule[];
+  actions: Record<TerminalAction, boolean>;
+};
+
+const TERMINAL_MODE_CAPABILITIES: Record<
+  TerminalMode,
+  TerminalModeCapabilities
+> = {
+  regular: {
+    label: "Regular",
+    description: "Core market + wallet workspace with lower-risk actions.",
+    visibleModules: ["market", "wallet", "macro_radar", "macro_fred"],
+    actions: {
+      quick_trade: true,
+      macro_trade: false,
+      layout_edit: false,
+    },
+  },
+  degen: {
+    label: "Degen",
+    description: "All modules and fast tactical trading controls.",
+    visibleModules: [
+      "market",
+      "wallet",
+      "macro_radar",
+      "macro_fred",
+      "macro_etf",
+      "macro_stablecoin",
+      "macro_oil",
+    ],
+    actions: {
+      quick_trade: true,
+      macro_trade: true,
+      layout_edit: true,
+    },
+  },
+  custom: {
+    label: "Custom",
+    description: "All modules with personal layout controls.",
+    visibleModules: [
+      "market",
+      "wallet",
+      "macro_radar",
+      "macro_fred",
+      "macro_etf",
+      "macro_stablecoin",
+      "macro_oil",
+    ],
+    actions: {
+      quick_trade: true,
+      macro_trade: true,
+      layout_edit: true,
+    },
+  },
+};
+
+export function isTerminalMode(value: unknown): value is TerminalMode {
+  return (
+    typeof value === "string" &&
+    (TERMINAL_MODE_OPTIONS as readonly string[]).includes(value)
+  );
+}
+
+export function resolveDefaultTerminalMode(raw: unknown): TerminalMode {
+  const normalized = String(raw ?? "")
+    .trim()
+    .toLowerCase();
+  if (isTerminalMode(normalized)) return normalized;
+  return "regular";
+}
+
+export function readLocalTerminalMode(): TerminalMode | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(TERMINAL_MODE_STORAGE_KEY);
+    return isTerminalMode(raw) ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeLocalTerminalMode(mode: TerminalMode): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(TERMINAL_MODE_STORAGE_KEY, mode);
+  } catch {
+    // Ignore storage errors and keep runtime behavior deterministic.
+  }
+}
+
+export function readTerminalModeFromProfile(
+  profile: Record<string, unknown> | null,
+): TerminalMode | null {
+  if (!isRecord(profile)) return null;
+  const terminal = profile.terminal;
+  if (!isRecord(terminal)) return null;
+  return isTerminalMode(terminal.mode) ? terminal.mode : null;
+}
+
+export function mergeProfileWithTerminalMode(
+  profile: Record<string, unknown> | null,
+  input: {
+    mode: TerminalMode;
+    source: "manual" | "local_fallback" | "default_fallback";
+  },
+): Record<string, unknown> {
+  const base = isRecord(profile) ? { ...profile } : {};
+  const terminalExisting = isRecord(base.terminal) ? { ...base.terminal } : {};
+  base.terminal = {
+    ...terminalExisting,
+    mode: input.mode,
+    source: input.source,
+    updatedAt: new Date().toISOString(),
+  };
+  return base;
+}
+
+export function getTerminalModeCapabilities(
+  mode: TerminalMode,
+): TerminalModeCapabilities {
+  return TERMINAL_MODE_CAPABILITIES[mode];
+}
+
+export function modeShowsModule(
+  mode: TerminalMode,
+  module: TerminalModule,
+): boolean {
+  return getTerminalModeCapabilities(mode).visibleModules.includes(module);
+}
+
+export function modeAllowsAction(
+  mode: TerminalMode,
+  action: TerminalAction,
+): boolean {
+  return getTerminalModeCapabilities(mode).actions[action];
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -147,7 +147,8 @@ type ExperienceEventName =
   | "level_assigned_auto"
   | "level_overridden_manual"
   | "degen_acknowledged"
-  | "terminal_opened_from_consumer";
+  | "terminal_opened_from_consumer"
+  | "terminal_mode_changed";
 
 const EXPERIENCE_EVENT_NAMES = new Set<ExperienceEventName>([
   "onboarding_started",
@@ -157,6 +158,7 @@ const EXPERIENCE_EVENT_NAMES = new Set<ExperienceEventName>([
   "level_overridden_manual",
   "degen_acknowledged",
   "terminal_opened_from_consumer",
+  "terminal_mode_changed",
 ]);
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;

--- a/tests/unit/portal_terminal_modes.test.ts
+++ b/tests/unit/portal_terminal_modes.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import {
+  getTerminalModeCapabilities,
+  mergeProfileWithTerminalMode,
+  modeAllowsAction,
+  modeShowsModule,
+  readTerminalModeFromProfile,
+  resolveDefaultTerminalMode,
+} from "../../apps/portal/app/terminal/terminal-modes";
+
+describe("portal terminal modes", () => {
+  test("resolves default mode with regular fallback", () => {
+    expect(resolveDefaultTerminalMode("degen")).toBe("degen");
+    expect(resolveDefaultTerminalMode("custom")).toBe("custom");
+    expect(resolveDefaultTerminalMode("REGULAR")).toBe("regular");
+    expect(resolveDefaultTerminalMode("unknown")).toBe("regular");
+    expect(resolveDefaultTerminalMode("")).toBe("regular");
+  });
+
+  test("reads terminal mode from persisted profile object", () => {
+    expect(
+      readTerminalModeFromProfile({
+        terminal: { mode: "degen" },
+      }),
+    ).toBe("degen");
+    expect(
+      readTerminalModeFromProfile({
+        terminal: { mode: "invalid" },
+      }),
+    ).toBeNull();
+    expect(readTerminalModeFromProfile(null)).toBeNull();
+  });
+
+  test("merges terminal mode into existing profile payload", () => {
+    const merged = mergeProfileWithTerminalMode(
+      {
+        consumer: { riskBand: "balanced" },
+        terminal: { mode: "regular", source: "default_fallback" },
+      },
+      {
+        mode: "custom",
+        source: "manual",
+      },
+    );
+    expect(merged.consumer).toEqual({ riskBand: "balanced" });
+    expect(merged.terminal).toMatchObject({
+      mode: "custom",
+      source: "manual",
+    });
+    expect(typeof (merged.terminal as { updatedAt?: unknown }).updatedAt).toBe(
+      "string",
+    );
+  });
+
+  test("applies deterministic module visibility and action matrix", () => {
+    const regular = getTerminalModeCapabilities("regular");
+    expect(regular.label).toBe("Regular");
+    expect(modeShowsModule("regular", "macro_stablecoin")).toBe(false);
+    expect(modeShowsModule("regular", "macro_radar")).toBe(true);
+    expect(modeAllowsAction("regular", "macro_trade")).toBe(false);
+
+    expect(modeShowsModule("degen", "macro_stablecoin")).toBe(true);
+    expect(modeAllowsAction("degen", "macro_trade")).toBe(true);
+    expect(modeAllowsAction("degen", "layout_edit")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add terminal mode framework (`regular`, `degen`, `custom`) with deterministic capability matrix for module visibility and action gating
- add mode selector in terminal header and sync mode state through dashboard context
- persist mode per user via `/api/me/profile` with local-storage fallback and configurable default (`NEXT_PUBLIC_TERMINAL_DEFAULT_MODE`)
- emit telemetry on manual mode changes through `/api/events` (`terminal_mode_changed`)
- add focused unit coverage for terminal mode parsing/matrix/profile-merge logic

## Testing
- bun run lint
- bun run typecheck
- bun test tests/unit/portal_terminal_modes.test.ts
- bun test tests/unit/worker_x402_exec_submit_route.test.ts

Refs #147
