### PR TITLE
feat: TERM-005 dedicated realtime trades tape panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ It provides one execution fabric for:
 - Exchange-grade shell regions (chart, depth, order entry, positions/fills, account/risk)
 - Realtime terminal transport with stream reconnect + polling fallback + staleness badges
 - Live orderbook ladder with grouped levels, spread view, and click-to-prefill order context
+- Dedicated trades tape panel with side/size filters, pause-resume, and compact/expanded modes
 - Account-level Privy wallet model (one wallet per user)
 - x402 paid APIs (`/api/x402/read/*`, `/api/x402/exec/submit`)
 - Execution API scaffold:

--- a/apps/portal/app/terminal/components/dashboard-grid.tsx
+++ b/apps/portal/app/terminal/components/dashboard-grid.tsx
@@ -29,7 +29,7 @@ interface DashboardGridProps {
   allowLayoutEditing?: boolean;
 }
 
-const DASHBOARD_LAYOUT_STORAGE_KEY = "dashboard-grid-layouts:v4";
+const DASHBOARD_LAYOUT_STORAGE_KEY = "dashboard-grid-layouts:v5";
 const LAYOUT_BREAKPOINTS = ["lg", "md", "sm"] as const;
 
 type LayoutBreakpoint = (typeof LAYOUT_BREAKPOINTS)[number];
@@ -46,9 +46,10 @@ type DashboardLayouts = Record<string, Layout[]>;
 const DEFAULT_DASHBOARD_LAYOUTS: Record<LayoutBreakpoint, Layout[]> = {
   lg: [
     { i: "chart", x: 0, y: 0, w: 7, h: 6 },
-    { i: "orderbook", x: 7, y: 0, w: 3, h: 3 },
+    { i: "orderbook", x: 7, y: 0, w: 3, h: 4 },
     { i: "order_entry", x: 10, y: 0, w: 2, h: 3 },
-    { i: "positions", x: 7, y: 3, w: 5, h: 3 },
+    { i: "trades_tape", x: 10, y: 3, w: 2, h: 3 },
+    { i: "positions", x: 7, y: 4, w: 3, h: 2 },
     { i: "account_risk", x: 0, y: 6, w: 4, h: 3 },
     { i: "macro_radar", x: 4, y: 6, w: 4, h: 3 },
     { i: "macro_fred", x: 8, y: 6, w: 4, h: 3 },
@@ -60,7 +61,8 @@ const DEFAULT_DASHBOARD_LAYOUTS: Record<LayoutBreakpoint, Layout[]> = {
     { i: "chart", x: 0, y: 0, w: 6, h: 6 },
     { i: "orderbook", x: 6, y: 0, w: 2, h: 3 },
     { i: "order_entry", x: 8, y: 0, w: 2, h: 3 },
-    { i: "positions", x: 6, y: 3, w: 4, h: 3 },
+    { i: "trades_tape", x: 8, y: 3, w: 2, h: 3 },
+    { i: "positions", x: 6, y: 3, w: 2, h: 3 },
     { i: "account_risk", x: 0, y: 6, w: 5, h: 3 },
     { i: "macro_radar", x: 5, y: 6, w: 5, h: 3 },
     { i: "macro_fred", x: 0, y: 9, w: 5, h: 3 },
@@ -72,13 +74,14 @@ const DEFAULT_DASHBOARD_LAYOUTS: Record<LayoutBreakpoint, Layout[]> = {
     { i: "chart", x: 0, y: 0, w: 6, h: 5 },
     { i: "orderbook", x: 0, y: 5, w: 3, h: 3 },
     { i: "order_entry", x: 3, y: 5, w: 3, h: 3 },
-    { i: "positions", x: 0, y: 8, w: 6, h: 3 },
-    { i: "account_risk", x: 0, y: 11, w: 6, h: 3 },
-    { i: "macro_radar", x: 0, y: 14, w: 6, h: 3 },
-    { i: "macro_fred", x: 0, y: 17, w: 6, h: 3 },
-    { i: "macro_etf", x: 0, y: 20, w: 6, h: 3 },
-    { i: "macro_stablecoin", x: 0, y: 23, w: 6, h: 3 },
-    { i: "macro_oil", x: 0, y: 26, w: 6, h: 3 },
+    { i: "trades_tape", x: 0, y: 8, w: 6, h: 3 },
+    { i: "positions", x: 0, y: 11, w: 6, h: 3 },
+    { i: "account_risk", x: 0, y: 14, w: 6, h: 3 },
+    { i: "macro_radar", x: 0, y: 17, w: 6, h: 3 },
+    { i: "macro_fred", x: 0, y: 20, w: 6, h: 3 },
+    { i: "macro_etf", x: 0, y: 23, w: 6, h: 3 },
+    { i: "macro_stablecoin", x: 0, y: 26, w: 6, h: 3 },
+    { i: "macro_oil", x: 0, y: 29, w: 6, h: 3 },
   ],
 };
 

--- a/apps/portal/app/terminal/components/trades-tape.ts
+++ b/apps/portal/app/terminal/components/trades-tape.ts
@@ -1,0 +1,39 @@
+import type { RealtimeTradeTick } from "./realtime-transport";
+
+export type TapeSideFilter = "all" | "buy" | "sell";
+export type TapeDisplayMode = "compact" | "expanded";
+
+export function filterTradeTicks(input: {
+  trades: RealtimeTradeTick[];
+  side: TapeSideFilter;
+  minSize: number;
+  mode: TapeDisplayMode;
+}): RealtimeTradeTick[] {
+  const side = input.side;
+  const minSize = Number.isFinite(input.minSize)
+    ? Math.max(0, input.minSize)
+    : 0;
+  const maxRows = input.mode === "compact" ? 28 : 80;
+
+  return input.trades
+    .filter((trade) => {
+      if (side !== "all" && trade.side !== side) return false;
+      if (!Number.isFinite(trade.size) || trade.size < minSize) return false;
+      return true;
+    })
+    .slice(0, maxRows);
+}
+
+export function countMissingTradeTicks(trades: RealtimeTradeTick[]): number {
+  let missed = 0;
+  for (let i = 0; i < trades.length - 1; i += 1) {
+    const current = trades[i];
+    const next = trades[i + 1];
+    if (!current || !next) continue;
+    const gap = current.seq - next.seq;
+    if (gap > 1) {
+      missed += gap - 1;
+    }
+  }
+  return missed;
+}

--- a/apps/portal/app/terminal/page.tsx
+++ b/apps/portal/app/terminal/page.tsx
@@ -1318,8 +1318,8 @@ const TradesTapePanel = memo(function TradesTapePanel(props: {
     [displayMode, displayedTrades, minSize, sideFilter],
   );
   const missedCount = useMemo(
-    () => countMissingTradeTicks(filteredTrades),
-    [filteredTrades],
+    () => countMissingTradeTicks(displayedTrades),
+    [displayedTrades],
   );
 
   const togglePaused = useCallback(() => {

--- a/apps/portal/app/terminal/page.tsx
+++ b/apps/portal/app/terminal/page.tsx
@@ -44,6 +44,12 @@ import {
   TOKEN_CONFIGS,
 } from "./components/trade-pairs";
 import type { TradeTicketCompletion } from "./components/trade-ticket-modal";
+import {
+  countMissingTradeTicks,
+  filterTradeTicks,
+  type TapeDisplayMode,
+  type TapeSideFilter,
+} from "./components/trades-tape";
 import { useDashboard } from "./context";
 import {
   getTerminalModeCapabilities,
@@ -855,13 +861,19 @@ function ControlRoom() {
 
                 {showMarketModule ? (
                   <div
+                    key="trades_tape"
+                    className="flex flex-col overflow-hidden bg-surface"
+                  >
+                    <TradesTapePanel realtime={realtimeTransport} />
+                  </div>
+                ) : null}
+
+                {showMarketModule ? (
+                  <div
                     key="positions"
                     className="flex flex-col overflow-hidden bg-surface"
                   >
-                    <PositionsOrdersFillsPanel
-                      entries={recentExecutions}
-                      realtime={realtimeTransport}
-                    />
+                    <PositionsOrdersFillsPanel entries={recentExecutions} />
                   </div>
                 ) : null}
 
@@ -1259,72 +1271,201 @@ const OrderEntryPanel = memo(function OrderEntryPanel(props: {
   );
 });
 
+const TradesTapePanel = memo(function TradesTapePanel(props: {
+  realtime: TerminalRealtimeState;
+}) {
+  const { realtime } = props;
+  const [paused, setPaused] = useState(false);
+  const [sideFilter, setSideFilter] = useState<TapeSideFilter>("all");
+  const [minSize, setMinSize] = useState(0);
+  const [displayMode, setDisplayMode] = useState<TapeDisplayMode>("compact");
+  const [displayedTrades, setDisplayedTrades] = useState<RealtimeTradeTick[]>(
+    () => realtime.trades.slice(0, 80),
+  );
+  const [bufferedCount, setBufferedCount] = useState(0);
+  const latestHeadSeqRef = useRef<number | null>(
+    realtime.trades[0]?.seq ?? null,
+  );
+
+  useEffect(() => {
+    const currentHeadSeq = realtime.trades[0]?.seq ?? null;
+    const previousHeadSeq = latestHeadSeqRef.current;
+    latestHeadSeqRef.current = currentHeadSeq;
+
+    if (paused) {
+      if (
+        currentHeadSeq !== null &&
+        previousHeadSeq !== null &&
+        currentHeadSeq > previousHeadSeq
+      ) {
+        setBufferedCount((count) => count + (currentHeadSeq - previousHeadSeq));
+      }
+      return;
+    }
+
+    setDisplayedTrades(realtime.trades.slice(0, 80));
+    setBufferedCount(0);
+  }, [paused, realtime.trades]);
+
+  const filteredTrades = useMemo(
+    () =>
+      filterTradeTicks({
+        trades: displayedTrades,
+        side: sideFilter,
+        minSize,
+        mode: displayMode,
+      }),
+    [displayMode, displayedTrades, minSize, sideFilter],
+  );
+  const missedCount = useMemo(
+    () => countMissingTradeTicks(filteredTrades),
+    [filteredTrades],
+  );
+
+  const togglePaused = useCallback(() => {
+    setPaused((current) => {
+      const next = !current;
+      if (!next) {
+        setDisplayedTrades(realtime.trades.slice(0, 80));
+        setBufferedCount(0);
+      }
+      return next;
+    });
+  }, [realtime.trades]);
+
+  return (
+    <>
+      <div className="flex items-center justify-between border-b border-border bg-surface px-3 py-1.5 shrink-0">
+        <p className="label dashboard-drag-handle cursor-move select-none">
+          TRADES_TAPE
+        </p>
+        <div className="flex items-center gap-1.5 text-[10px] font-mono">
+          <button
+            className={cn(
+              BTN_SECONDARY,
+              "h-6 rounded px-2 text-[10px] uppercase tracking-wider",
+              paused && "border-amber-500/40 bg-amber-500/10 text-amber-300",
+            )}
+            onClick={togglePaused}
+            type="button"
+          >
+            {paused ? "Resume" : "Pause"}
+          </button>
+          <span
+            className={cn(
+              "rounded border px-1.5 py-0.5 uppercase tracking-wider",
+              realtime.mode === "poll"
+                ? "border-amber-500/40 bg-amber-500/10 text-amber-300"
+                : realtime.isStale
+                  ? "border-red-500/40 bg-red-500/10 text-red-300"
+                  : "border-emerald-500/40 bg-emerald-500/10 text-emerald-300",
+            )}
+          >
+            {realtime.mode === "poll" ? "fallback" : "stream"}
+          </span>
+        </div>
+      </div>
+      <div className="flex-1 overflow-auto p-3 text-xs space-y-2">
+        <div className="grid grid-cols-2 gap-2">
+          <select
+            className="h-7 rounded border border-border bg-paper px-2 text-[10px] uppercase tracking-wider text-muted"
+            value={sideFilter}
+            onChange={(event) =>
+              setSideFilter(event.target.value as TapeSideFilter)
+            }
+            title="Filter side"
+          >
+            <option value="all">All sides</option>
+            <option value="buy">Buys</option>
+            <option value="sell">Sells</option>
+          </select>
+          <select
+            className="h-7 rounded border border-border bg-paper px-2 text-[10px] uppercase tracking-wider text-muted"
+            value={String(minSize)}
+            onChange={(event) => setMinSize(Number(event.target.value))}
+            title="Minimum size"
+          >
+            <option value="0">Min size 0</option>
+            <option value="10">Min size 10</option>
+            <option value="20">Min size 20</option>
+            <option value="30">Min size 30</option>
+          </select>
+        </div>
+        <div className="flex items-center justify-between rounded border border-border/60 bg-subtle px-2 py-1.5">
+          <div className="flex items-center gap-2 text-[10px] text-muted uppercase tracking-wider">
+            <span>{displayedTrades.length} cached</span>
+            {bufferedCount > 0 ? <span>{bufferedCount} buffered</span> : null}
+            {missedCount > 0 ? <span>{missedCount} missed</span> : null}
+          </div>
+          <button
+            className={cn(
+              BTN_SECONDARY,
+              "h-6 rounded px-2 text-[10px] uppercase tracking-wider",
+            )}
+            onClick={() =>
+              setDisplayMode((current) =>
+                current === "compact" ? "expanded" : "compact",
+              )
+            }
+            type="button"
+          >
+            {displayMode === "compact" ? "Expanded" : "Compact"}
+          </button>
+        </div>
+        <div className="space-y-1">
+          {filteredTrades.length === 0 ? (
+            <p className="rounded border border-border/50 bg-subtle px-2 py-2 text-muted">
+              No trades matching current tape filters.
+            </p>
+          ) : null}
+          {filteredTrades.map((trade) => (
+            <div
+              key={`tape-${trade.seq}`}
+              className="grid grid-cols-[auto_1fr_auto_auto] items-center gap-2 rounded border border-border/60 px-2 py-1"
+            >
+              <p
+                className={cn(
+                  "text-[10px] uppercase",
+                  trade.side === "buy" ? "text-emerald-300" : "text-red-300",
+                )}
+              >
+                {trade.side}
+              </p>
+              <p className="font-mono text-[11px] text-ink">
+                {trade.price.toFixed(4)}
+              </p>
+              <p className="text-[10px] text-muted">{trade.size.toFixed(2)}</p>
+              {displayMode === "expanded" ? (
+                <p className="text-[10px] text-muted">
+                  {new Date(trade.ts).toLocaleTimeString()}
+                </p>
+              ) : (
+                <p className="text-[10px] text-muted">#{trade.seq}</p>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+});
+
 const PositionsOrdersFillsPanel = memo(
   function PositionsOrdersFillsPanel(props: {
     entries: ExecutionActivityRow[];
-    realtime: TerminalRealtimeState;
   }) {
-    const { entries, realtime } = props;
-    const tradeTape: RealtimeTradeTick[] = realtime.trades.slice(0, 8);
+    const { entries } = props;
     return (
       <>
         <div className="flex items-center justify-between border-b border-border bg-surface px-3 py-1.5 shrink-0">
           <p className="label dashboard-drag-handle cursor-move select-none">
             POSITIONS_ORDERS_FILLS
           </p>
-          <div className="flex items-center gap-2 text-[10px] font-mono text-muted">
-            <span>{entries.length} recent</span>
-            <span
-              className={cn(
-                "rounded border px-1.5 py-0.5 uppercase tracking-wider",
-                realtime.mode === "poll"
-                  ? "border-amber-500/40 bg-amber-500/10 text-amber-300"
-                  : realtime.isStale
-                    ? "border-red-500/40 bg-red-500/10 text-red-300"
-                    : "border-emerald-500/40 bg-emerald-500/10 text-emerald-300",
-              )}
-            >
-              {realtime.mode === "poll" ? "degraded" : "stream"}
-            </span>
-          </div>
+          <span className="text-[10px] font-mono text-muted">
+            {entries.length} recent
+          </span>
         </div>
         <div className="flex-1 overflow-auto p-3 text-xs space-y-3">
-          <div className="rounded border border-border bg-subtle p-2">
-            <p className="text-[10px] uppercase tracking-wider text-muted">
-              Tape (Realtime)
-            </p>
-            <div className="mt-2 space-y-1.5">
-              {tradeTape.length === 0 ? (
-                <p className="text-muted">
-                  Waiting for transport events ({formatTransportBadge(realtime)}
-                  ).
-                </p>
-              ) : null}
-              {tradeTape.map((trade) => (
-                <div
-                  key={`tape-${trade.seq}`}
-                  className="grid grid-cols-[auto_1fr_auto] items-center gap-2 rounded border border-border/60 px-2 py-1"
-                >
-                  <p
-                    className={cn(
-                      "text-[10px] uppercase",
-                      trade.side === "buy"
-                        ? "text-emerald-300"
-                        : "text-red-300",
-                    )}
-                  >
-                    {trade.side}
-                  </p>
-                  <p className="font-mono text-[11px] text-ink">
-                    {trade.price.toFixed(4)}
-                  </p>
-                  <p className="text-[10px] text-muted">
-                    {trade.size.toFixed(2)}
-                  </p>
-                </div>
-              ))}
-            </div>
-          </div>
           <div className="rounded border border-border bg-subtle p-2">
             <p className="text-[10px] uppercase tracking-wider text-muted">
               Open Positions

--- a/tests/unit/portal_terminal_trades_tape.test.ts
+++ b/tests/unit/portal_terminal_trades_tape.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import {
+  countMissingTradeTicks,
+  filterTradeTicks,
+} from "../../apps/portal/app/terminal/components/trades-tape";
+
+describe("portal terminal trades tape helpers", () => {
+  test("filters by side and size with compact row cap", () => {
+    const trades = Array.from({ length: 40 }).map((_, index) => ({
+      seq: 100 - index,
+      ts: 1_000 + index,
+      side: index % 2 === 0 ? ("buy" as const) : ("sell" as const),
+      price: 100 + index / 10,
+      size: index + 1,
+    }));
+
+    const filtered = filterTradeTicks({
+      trades,
+      side: "buy",
+      minSize: 10,
+      mode: "compact",
+    });
+
+    expect(filtered.length).toBeLessThanOrEqual(28);
+    expect(filtered.every((trade) => trade.side === "buy")).toBe(true);
+    expect(filtered.every((trade) => trade.size >= 10)).toBe(true);
+  });
+
+  test("counts missed ticks from sequence gaps", () => {
+    const missed = countMissingTradeTicks([
+      { seq: 15, ts: 1, side: "buy", price: 100, size: 1 },
+      { seq: 14, ts: 2, side: "buy", price: 101, size: 1 },
+      { seq: 10, ts: 3, side: "sell", price: 99, size: 1 },
+      { seq: 8, ts: 4, side: "sell", price: 98, size: 1 },
+    ]);
+    expect(missed).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated `TRADES_TAPE` panel in the terminal layout with side/size filters, pause/resume, and compact/expanded display modes
- keep tape performant by maintaining bounded cached rows and burst buffering when paused
- add missed-window detection from sequence gaps to make feed recovery explicit
- update grid defaults for the new tape module and add helper unit tests

## Validation
- bun run lint
- bun run typecheck
- bun test tests/unit/portal_terminal_modes.test.ts tests/unit/portal_terminal_realtime_transport.test.ts tests/unit/portal_terminal_orderbook_ladder.test.ts tests/unit/portal_terminal_trades_tape.test.ts

Closes #151
