### PR TITLE
feat: TERM-006 synchronized depth chart module

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ It provides one execution fabric for:
 - Realtime terminal transport with stream reconnect + polling fallback + staleness badges
 - Live orderbook ladder with grouped levels, spread view, and click-to-prefill order context
 - Dedicated trades tape panel with side/size filters, pause-resume, and compact/expanded modes
+- Synchronized depth chart overlays with cumulative curves, spread, and imbalance annotations
 - Account-level Privy wallet model (one wallet per user)
 - x402 paid APIs (`/api/x402/read/*`, `/api/x402/exec/submit`)
 - Execution API scaffold:

--- a/apps/portal/app/terminal/components/depth-chart.ts
+++ b/apps/portal/app/terminal/components/depth-chart.ts
@@ -1,0 +1,84 @@
+import type { LadderRow } from "./orderbook-ladder";
+
+export type DepthCurvePoint = {
+  price: number;
+  cumulativeSize: number;
+};
+
+export type DepthChartModel = {
+  bids: DepthCurvePoint[];
+  asks: DepthCurvePoint[];
+  totalBidSize: number;
+  totalAskSize: number;
+  spreadAbs: number | null;
+  imbalance: number | null;
+  sequence: number | null;
+};
+
+export function buildDepthChartModel(input: {
+  bids: LadderRow[];
+  asks: LadderRow[];
+  sequence: number | null;
+}): DepthChartModel {
+  const bids = input.bids
+    .map((row) => ({
+      price: row.price,
+      cumulativeSize: row.cumulativeSize,
+    }))
+    .filter(
+      (point) =>
+        Number.isFinite(point.price) &&
+        point.price > 0 &&
+        Number.isFinite(point.cumulativeSize) &&
+        point.cumulativeSize >= 0,
+    );
+
+  const asks = input.asks
+    .map((row) => ({
+      price: row.price,
+      cumulativeSize: row.cumulativeSize,
+    }))
+    .filter(
+      (point) =>
+        Number.isFinite(point.price) &&
+        point.price > 0 &&
+        Number.isFinite(point.cumulativeSize) &&
+        point.cumulativeSize >= 0,
+    );
+
+  const bestBid = bids[0] ?? null;
+  const bestAsk = asks[0] ?? null;
+  const spreadAbs =
+    bestBid && bestAsk ? Math.max(0, bestAsk.price - bestBid.price) : null;
+  const totalBidSize = bids[bids.length - 1]?.cumulativeSize ?? 0;
+  const totalAskSize = asks[asks.length - 1]?.cumulativeSize ?? 0;
+  const depthTotal = totalBidSize + totalAskSize;
+  const imbalance =
+    depthTotal > 0 ? (totalBidSize - totalAskSize) / depthTotal : null;
+
+  return {
+    bids,
+    asks,
+    totalBidSize,
+    totalAskSize,
+    spreadAbs,
+    imbalance,
+    sequence: input.sequence,
+  };
+}
+
+export function findNearestDepthPoint(
+  points: DepthCurvePoint[],
+  price: number,
+): DepthCurvePoint | null {
+  let nearest: DepthCurvePoint | null = null;
+  let nearestDelta = Number.POSITIVE_INFINITY;
+  for (const point of points) {
+    const delta = Math.abs(point.price - price);
+    if (delta < nearestDelta) {
+      nearest = point;
+      nearestDelta = delta;
+    }
+  }
+  return nearest;
+}

--- a/apps/portal/app/terminal/page.tsx
+++ b/apps/portal/app/terminal/page.tsx
@@ -18,6 +18,10 @@ import {
   DashboardGrid,
   hasCustomDashboardGridLayouts,
 } from "./components/dashboard-grid";
+import {
+  buildDepthChartModel,
+  findNearestDepthPoint,
+} from "./components/depth-chart";
 import { MacroEtfWidget } from "./components/macro-etf-widget";
 import { MacroFredWidget } from "./components/macro-fred-widget";
 import { MacroOilWidget } from "./components/macro-oil-widget";
@@ -1001,6 +1005,7 @@ const OrderbookDepthPanel = memo(function OrderbookDepthPanel(props: {
 }) {
   const { market, realtime, selectedPrefill, onPrefill } = props;
   const [groupingBps, setGroupingBps] = useState(5);
+  const [hoverPrice, setHoverPrice] = useState<number | null>(null);
   const lastPrice = market.latestPrice ?? null;
   const depth = realtime.depth;
   const asks = depth?.asks ?? [];
@@ -1045,6 +1050,104 @@ const OrderbookDepthPanel = memo(function OrderbookDepthPanel(props: {
       ? "--"
       : `${ladder.spreadAbs.toFixed(4)} (${ladder.spreadBps.toFixed(2)} bps)`;
   const groupingOptions = [2, 5, 10, 25];
+  const depthChart = useMemo(
+    () =>
+      buildDepthChartModel({
+        bids: ladder.bids,
+        asks: ladder.asks,
+        sequence: depth?.seq ?? null,
+      }),
+    [depth?.seq, ladder.asks, ladder.bids],
+  );
+  const chartSpec = useMemo(() => {
+    const width = 320;
+    const height = 140;
+    const padLeft = 28;
+    const padRight = 10;
+    const padTop = 8;
+    const padBottom = 20;
+
+    const bidLow = depthChart.bids[depthChart.bids.length - 1]?.price ?? null;
+    const bidHigh = depthChart.bids[0]?.price ?? null;
+    const askLow = depthChart.asks[0]?.price ?? null;
+    const askHigh = depthChart.asks[depthChart.asks.length - 1]?.price ?? null;
+
+    const minPrice = Math.min(
+      bidLow ?? Number.POSITIVE_INFINITY,
+      askLow ?? Number.POSITIVE_INFINITY,
+    );
+    const maxPrice = Math.max(
+      bidHigh ?? Number.NEGATIVE_INFINITY,
+      askHigh ?? Number.NEGATIVE_INFINITY,
+    );
+    const maxCumulative = Math.max(
+      depthChart.totalBidSize,
+      depthChart.totalAskSize,
+      1,
+    );
+    if (
+      !Number.isFinite(minPrice) ||
+      !Number.isFinite(maxPrice) ||
+      maxPrice <= minPrice
+    ) {
+      return null;
+    }
+
+    const innerWidth = width - padLeft - padRight;
+    const innerHeight = height - padTop - padBottom;
+    const xForPrice = (price: number): number =>
+      padLeft + ((price - minPrice) / (maxPrice - minPrice)) * innerWidth;
+    const yForCumulative = (cumulative: number): number =>
+      padTop + (1 - cumulative / maxCumulative) * innerHeight;
+    const toPath = (
+      points: Array<{ price: number; cumulativeSize: number }>,
+    ): string =>
+      points
+        .map((point, index) => {
+          const x = xForPrice(point.price).toFixed(2);
+          const y = yForCumulative(point.cumulativeSize).toFixed(2);
+          return `${index === 0 ? "M" : "L"} ${x} ${y}`;
+        })
+        .join(" ");
+
+    return {
+      width,
+      height,
+      padLeft,
+      padRight,
+      padTop,
+      padBottom,
+      minPrice,
+      maxPrice,
+      innerWidth,
+      bidPath: toPath(depthChart.bids),
+      askPath: toPath(depthChart.asks),
+      xForPrice,
+    };
+  }, [
+    depthChart.asks,
+    depthChart.bids,
+    depthChart.totalAskSize,
+    depthChart.totalBidSize,
+  ]);
+  const hoverBidPoint = useMemo(
+    () =>
+      hoverPrice === null
+        ? null
+        : findNearestDepthPoint(depthChart.bids, hoverPrice),
+    [depthChart.bids, hoverPrice],
+  );
+  const hoverAskPoint = useMemo(
+    () =>
+      hoverPrice === null
+        ? null
+        : findNearestDepthPoint(depthChart.asks, hoverPrice),
+    [depthChart.asks, hoverPrice],
+  );
+  const imbalanceLabel =
+    depthChart.imbalance === null
+      ? "--"
+      : `${(depthChart.imbalance * 100).toFixed(1)}%`;
 
   return (
     <>
@@ -1092,6 +1195,90 @@ const OrderbookDepthPanel = memo(function OrderbookDepthPanel(props: {
               ))}
             </select>
           </div>
+        </div>
+        <div className="mb-2 rounded border border-border/60 bg-subtle px-2 py-1.5">
+          <div className="mb-1 flex items-center justify-between text-[10px] uppercase tracking-wider text-muted">
+            <span>Depth chart</span>
+            <span>
+              seq {depthChart.sequence ?? "--"} • imbalance {imbalanceLabel}
+            </span>
+          </div>
+          {chartSpec ? (
+            <>
+              <svg
+                className="h-[130px] w-full rounded border border-border/40 bg-paper/70"
+                viewBox={`0 0 ${chartSpec.width} ${chartSpec.height}`}
+                onMouseLeave={() => setHoverPrice(null)}
+                onMouseMove={(event) => {
+                  const rect = event.currentTarget.getBoundingClientRect();
+                  const rawX = event.clientX - rect.left;
+                  const clampedX = Math.max(
+                    chartSpec.padLeft,
+                    Math.min(rawX, chartSpec.width - chartSpec.padRight),
+                  );
+                  const ratio =
+                    (clampedX - chartSpec.padLeft) / chartSpec.innerWidth;
+                  const price =
+                    chartSpec.minPrice +
+                    ratio * (chartSpec.maxPrice - chartSpec.minPrice);
+                  setHoverPrice(price);
+                }}
+              >
+                <title>Cumulative bid and ask depth chart</title>
+                <path
+                  d={chartSpec.bidPath}
+                  fill="none"
+                  stroke="rgba(16,185,129,0.95)"
+                  strokeWidth="2"
+                />
+                <path
+                  d={chartSpec.askPath}
+                  fill="none"
+                  stroke="rgba(248,113,113,0.95)"
+                  strokeWidth="2"
+                />
+                {hoverPrice !== null ? (
+                  <line
+                    x1={chartSpec.xForPrice(hoverPrice)}
+                    x2={chartSpec.xForPrice(hoverPrice)}
+                    y1={chartSpec.padTop}
+                    y2={chartSpec.height - chartSpec.padBottom}
+                    stroke="rgba(148,163,184,0.7)"
+                    strokeWidth="1"
+                    strokeDasharray="3 3"
+                  />
+                ) : null}
+              </svg>
+              <div className="mt-1 grid grid-cols-2 gap-2 text-[10px] text-muted">
+                <p>
+                  Hover price:{" "}
+                  {hoverPrice === null ? "--" : hoverPrice.toFixed(4)}
+                </p>
+                <p className="text-right">
+                  Spread:{" "}
+                  {depthChart.spreadAbs === null
+                    ? "--"
+                    : depthChart.spreadAbs.toFixed(4)}
+                </p>
+                <p>
+                  Bid cum:{" "}
+                  {hoverBidPoint
+                    ? hoverBidPoint.cumulativeSize.toFixed(2)
+                    : "--"}
+                </p>
+                <p className="text-right">
+                  Ask cum:{" "}
+                  {hoverAskPoint
+                    ? hoverAskPoint.cumulativeSize.toFixed(2)
+                    : "--"}
+                </p>
+              </div>
+            </>
+          ) : (
+            <p className="rounded border border-border/40 bg-paper/70 px-2 py-2 text-[10px] text-muted">
+              Not enough depth points to render synchronized chart.
+            </p>
+          )}
         </div>
         <div className="grid grid-cols-[auto_1fr_auto_auto] gap-2 px-1 pb-1 text-[10px] uppercase tracking-wider text-muted">
           <span>Side</span>

--- a/tests/unit/portal_terminal_depth_chart.test.ts
+++ b/tests/unit/portal_terminal_depth_chart.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildDepthChartModel,
+  findNearestDepthPoint,
+} from "../../apps/portal/app/terminal/components/depth-chart";
+
+describe("portal terminal depth chart helpers", () => {
+  test("builds spread and imbalance from ladder rows", () => {
+    const model = buildDepthChartModel({
+      sequence: 42,
+      bids: [
+        {
+          side: "bid",
+          price: 100,
+          size: 10,
+          cumulativeSize: 10,
+          isTopOfBook: true,
+        },
+        {
+          side: "bid",
+          price: 99.9,
+          size: 8,
+          cumulativeSize: 18,
+          isTopOfBook: false,
+        },
+      ],
+      asks: [
+        {
+          side: "ask",
+          price: 100.1,
+          size: 9,
+          cumulativeSize: 9,
+          isTopOfBook: true,
+        },
+        {
+          side: "ask",
+          price: 100.2,
+          size: 7,
+          cumulativeSize: 16,
+          isTopOfBook: false,
+        },
+      ],
+    });
+
+    expect(model.sequence).toBe(42);
+    expect(model.spreadAbs).toBeCloseTo(0.1, 6);
+    expect(model.totalBidSize).toBe(18);
+    expect(model.totalAskSize).toBe(16);
+    expect(model.imbalance).toBeCloseTo((18 - 16) / 34, 6);
+  });
+
+  test("finds nearest point for crosshair hover", () => {
+    const nearest = findNearestDepthPoint(
+      [
+        { price: 99.8, cumulativeSize: 5 },
+        { price: 100.0, cumulativeSize: 8 },
+        { price: 100.4, cumulativeSize: 12 },
+      ],
+      100.1,
+    );
+    expect(nearest?.price).toBe(100.0);
+    expect(nearest?.cumulativeSize).toBe(8);
+  });
+});


### PR DESCRIPTION
## Summary
- add synchronized depth chart utilities derived from the same orderbook ladder snapshot sequence
- render bid/ask cumulative depth curves inside the orderbook panel with hover crosshair values
- show spread + imbalance annotations and sequence marker to verify chart/ladder sync
- add depth chart unit tests for spread, imbalance, and nearest-point hover lookup

## Validation
- bun run lint
- bun run typecheck
- bun test tests/unit/portal_terminal_modes.test.ts tests/unit/portal_terminal_realtime_transport.test.ts tests/unit/portal_terminal_orderbook_ladder.test.ts tests/unit/portal_terminal_trades_tape.test.ts tests/unit/portal_terminal_depth_chart.test.ts

Closes #152
