### PR TITLE
feat: TERM-007 terminal-grade market chart controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ It provides one execution fabric for:
 - Live orderbook ladder with grouped levels, spread view, and click-to-prefill order context
 - Dedicated trades tape panel with side/size filters, pause-resume, and compact/expanded modes
 - Synchronized depth chart overlays with cumulative curves, spread, and imbalance annotations
+- Terminal-grade market chart controls (timeframes, line/candles, mark/index/reference overlays, keyboard cursor nav)
 - Account-level Privy wallet model (one wallet per user)
 - x402 paid APIs (`/api/x402/read/*`, `/api/x402/exec/submit`)
 - Execution API scaffold:

--- a/apps/portal/app/terminal/components/market-chart.tsx
+++ b/apps/portal/app/terminal/components/market-chart.tsx
@@ -1,12 +1,20 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { useEffect, useId, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { cn } from "../../cn";
 import {
   formatAgeMs,
   formatPercent,
   formatPrice,
+  type MarketPoint,
   type MarketState,
 } from "./sol-market-feed";
 
@@ -26,6 +34,53 @@ function formatVolume(value: number | undefined): string {
   });
 }
 
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  const tag = target.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+}
+
+export const CHART_TIMEFRAME_WINDOWS_MS = {
+  "1H": 60 * 60 * 1000,
+  "6H": 6 * 60 * 60 * 1000,
+  "24H": 24 * 60 * 60 * 1000,
+  "7D": 7 * 24 * 60 * 60 * 1000,
+} as const;
+
+export type ChartTimeframe = keyof typeof CHART_TIMEFRAME_WINDOWS_MS;
+type ChartStyle = "line" | "candles";
+
+type OverlayState = {
+  mark: boolean;
+  index: boolean;
+  reference: boolean;
+};
+
+export function selectMarketPointsForTimeframe(
+  points: MarketPoint[],
+  timeframe: ChartTimeframe,
+): MarketPoint[] {
+  if (points.length < 2) return points;
+  const windowMs = CHART_TIMEFRAME_WINDOWS_MS[timeframe];
+  const endTs = points[points.length - 1]?.ts ?? Date.now();
+  const floorTs = endTs - windowMs;
+  const filtered = points.filter((point) => point.ts >= floorTs);
+  if (filtered.length >= 2) return filtered;
+  return points.slice(-Math.min(points.length, 96));
+}
+
+export function computeIndexOverlayPrice(points: MarketPoint[]): number | null {
+  if (points.length < 1) return null;
+  const tail = points.slice(-Math.min(points.length, 24));
+  let sum = 0;
+  for (const point of tail) {
+    sum += point.price;
+  }
+  const average = sum / tail.length;
+  return Number.isFinite(average) ? average : null;
+}
+
 export function MarketChart({
   className,
   market,
@@ -35,7 +90,15 @@ export function MarketChart({
   market: MarketState;
   pairLabel: string;
 }) {
+  const [timeframe, setTimeframe] = useState<ChartTimeframe>("24H");
+  const [chartStyle, setChartStyle] = useState<ChartStyle>("line");
+  const [overlayState, setOverlayState] = useState<OverlayState>({
+    mark: true,
+    index: true,
+    reference: true,
+  });
   const [hoverRatio, setHoverRatio] = useState<number | null>(null);
+  const [keyboardIndex, setKeyboardIndex] = useState<number | null>(null);
   const gradientId = useId();
   const frameRef = useRef<number | null>(null);
   const pendingHoverRef = useRef<number | null>(null);
@@ -49,7 +112,7 @@ export function MarketChart({
     };
   }, []);
 
-  function setHoverRatioBatched(next: number | null): void {
+  const setHoverRatioBatched = useCallback((next: number | null): void => {
     pendingHoverRef.current = next;
     if (frameRef.current !== null) return;
     frameRef.current = window.requestAnimationFrame(() => {
@@ -59,12 +122,52 @@ export function MarketChart({
         return pendingHoverRef.current;
       });
     });
-  }
+  }, []);
+
+  const applyTimeframe = useCallback(
+    (next: ChartTimeframe): void => {
+      setTimeframe(next);
+      setHoverRatioBatched(null);
+      setKeyboardIndex(null);
+    },
+    [setHoverRatioBatched],
+  );
+
+  const applyChartStyle = useCallback(
+    (next: ChartStyle): void => {
+      setChartStyle(next);
+      setHoverRatioBatched(null);
+      setKeyboardIndex(null);
+    },
+    [setHoverRatioBatched],
+  );
+
+  const visiblePoints = useMemo(
+    () => selectMarketPointsForTimeframe(market.points, timeframe),
+    [market.points, timeframe],
+  );
 
   const chart = useMemo(() => {
-    const points = market.points;
+    const points = visiblePoints;
     if (points.length < 2) {
-      return { pathData: "", min: 0, max: 0, range: 1, last: 0 };
+      return {
+        pathData: "",
+        min: 0,
+        max: 0,
+        range: 1,
+        last: 0,
+        candles: [] as Array<{
+          ts: number;
+          x: number;
+          openY: number;
+          closeY: number;
+          highY: number;
+          lowY: number;
+          rising: boolean;
+          width: number;
+        }>,
+        yForPrice: (_price: number): number => 0,
+      };
     }
 
     const prices = points.map((point) => point.price);
@@ -72,26 +175,47 @@ export function MarketChart({
     const max = Math.max(...prices);
     const range = max - min || 1;
     const last = points.length - 1;
+    const yForPrice = (price: number): number =>
+      200 - ((price - min) / range) * 160 - 20;
     const pathData = points
       .map((point, idx) => {
         const x = (idx / last) * 1000;
-        const normalizedY = (point.price - min) / range;
-        const y = 200 - normalizedY * 160 - 20;
+        const y = yForPrice(point.price);
         return `${idx === 0 ? "M" : "L"}${x},${y}`;
       })
       .join(" ");
-    return { pathData, min, max, range, last };
-  }, [market.points]);
+    const candleWidth = Math.max(2, Math.min(14, 900 / points.length));
+    const candles = points.map((point, idx) => {
+      const x = (idx / last) * 1000;
+      const openY = yForPrice(point.open);
+      const closeY = yForPrice(point.close);
+      const highY = yForPrice(point.high);
+      const lowY = yForPrice(point.low);
+      return {
+        ts: point.ts,
+        x,
+        openY,
+        closeY,
+        highY,
+        lowY,
+        rising: point.close >= point.open,
+        width: candleWidth,
+      };
+    });
+    return { pathData, min, max, range, last, candles, yForPrice };
+  }, [visiblePoints]);
 
-  const hasData = market.points.length >= 2;
+  const hasData = visiblePoints.length >= 2;
   const isHovering = hoverRatio !== null;
   const activeIdx = hasData
-    ? hoverRatio === null
-      ? chart.last
-      : Math.max(0, Math.min(chart.last, Math.round(hoverRatio * chart.last)))
+    ? keyboardIndex !== null
+      ? Math.max(0, Math.min(chart.last, keyboardIndex))
+      : hoverRatio === null
+        ? chart.last
+        : Math.max(0, Math.min(chart.last, Math.round(hoverRatio * chart.last)))
     : -1;
-  const activePoint = activeIdx >= 0 ? market.points[activeIdx] : null;
-  const prevPoint = activeIdx > 0 ? market.points[activeIdx - 1] : null;
+  const activePoint = activeIdx >= 0 ? visiblePoints[activeIdx] : null;
+  const prevPoint = activeIdx > 0 ? visiblePoints[activeIdx - 1] : null;
   const isUp =
     hoverRatio === null
       ? (market.change24hPct ?? 0) >= 0
@@ -109,12 +233,75 @@ export function MarketChart({
     hasData && activePoint
       ? 200 - ((activePoint.price - chart.min) / chart.range) * 160 - 20
       : 0;
+  const cursorRatio =
+    keyboardIndex !== null && chart.last > 0
+      ? keyboardIndex / chart.last
+      : hoverRatio;
   const hoverTooltipLeftPct =
-    hoverRatio === null ? 86 : Math.max(12, Math.min(88, hoverRatio * 100));
+    cursorRatio === null ? 86 : Math.max(12, Math.min(88, cursorRatio * 100));
+  const isCursorActive = isHovering || keyboardIndex !== null;
   const hoverOpen = activePoint ? activePoint.open : null;
   const hoverHigh = activePoint ? activePoint.high : null;
   const hoverLow = activePoint ? activePoint.low : null;
   const hoverClose = activePoint ? activePoint.close : null;
+  const indexOverlayPrice = useMemo(
+    () => computeIndexOverlayPrice(visiblePoints),
+    [visiblePoints],
+  );
+  const referenceOverlayPrice = visiblePoints[0]?.price ?? null;
+  const markOverlayPrice = market.latestPrice ?? null;
+
+  useEffect(() => {
+    setKeyboardIndex((current) => {
+      if (current === null) return current;
+      if (current <= chart.last) return current;
+      return chart.last;
+    });
+  }, [chart.last]);
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent): void {
+      if (!hasData || isTypingTarget(event.target)) return;
+      const key = event.key.toLowerCase();
+      if (key === "arrowleft" || key === "arrowright") {
+        event.preventDefault();
+        setHoverRatioBatched(null);
+        setKeyboardIndex((current) => {
+          const base = current ?? chart.last;
+          const delta = key === "arrowleft" ? -1 : 1;
+          return Math.max(0, Math.min(chart.last, base + delta));
+        });
+        return;
+      }
+      if (key === "1") applyTimeframe("1H");
+      if (key === "2") applyTimeframe("6H");
+      if (key === "3") applyTimeframe("24H");
+      if (key === "4") applyTimeframe("7D");
+      if (key === "l") applyChartStyle("line");
+      if (key === "c") applyChartStyle("candles");
+      if (key === "m") {
+        setOverlayState((current) => ({ ...current, mark: !current.mark }));
+      }
+      if (key === "i") {
+        setOverlayState((current) => ({ ...current, index: !current.index }));
+      }
+      if (key === "r") {
+        setOverlayState((current) => ({
+          ...current,
+          reference: !current.reference,
+        }));
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [
+    applyChartStyle,
+    applyTimeframe,
+    chart.last,
+    hasData,
+    setHoverRatioBatched,
+  ]);
 
   return (
     <div
@@ -122,13 +309,14 @@ export function MarketChart({
         "relative w-full h-full overflow-hidden bg-[var(--color-chart-bg)]",
         className,
       )}
-      role="img"
-      aria-label="Market price chart"
+      role="application"
+      aria-label="Interactive market price chart"
       onMouseMove={(event) => {
         if (!hasData) return;
         const rect = event.currentTarget.getBoundingClientRect();
         if (rect.width <= 0) return;
         const ratio = (event.clientX - rect.left) / rect.width;
+        setKeyboardIndex(null);
         setHoverRatioBatched(Math.max(0, Math.min(1, ratio)));
       }}
       onMouseLeave={() => setHoverRatioBatched(null)}
@@ -166,7 +354,7 @@ export function MarketChart({
         </defs>
 
         {/* Area under the curve */}
-        {hasData ? (
+        {hasData && chartStyle === "line" ? (
           <motion.path
             d={`${chart.pathData} L1000,200 L0,200 Z`}
             fill={`url(#${gradientId})`}
@@ -177,7 +365,7 @@ export function MarketChart({
         ) : null}
 
         {/* The Line Itself */}
-        {hasData ? (
+        {hasData && chartStyle === "line" ? (
           <motion.path
             d={chart.pathData}
             fill="none"
@@ -191,7 +379,67 @@ export function MarketChart({
           />
         ) : null}
 
-        {hasData && isHovering && activePoint ? (
+        {hasData && chartStyle === "candles"
+          ? chart.candles.map((candle) => (
+              <g key={`candle-${candle.ts}`}>
+                <line
+                  x1={candle.x}
+                  x2={candle.x}
+                  y1={candle.highY}
+                  y2={candle.lowY}
+                  stroke={candle.rising ? "#10b981" : "#ef4444"}
+                  strokeWidth="1"
+                />
+                <rect
+                  x={candle.x - candle.width / 2}
+                  y={Math.min(candle.openY, candle.closeY)}
+                  width={candle.width}
+                  height={Math.max(1, Math.abs(candle.closeY - candle.openY))}
+                  rx="1"
+                  fill={candle.rising ? "#10b981" : "#ef4444"}
+                  fillOpacity="0.75"
+                />
+              </g>
+            ))
+          : null}
+
+        {hasData && overlayState.mark && markOverlayPrice !== null ? (
+          <line
+            x1={0}
+            x2={1000}
+            y1={chart.yForPrice(markOverlayPrice)}
+            y2={chart.yForPrice(markOverlayPrice)}
+            stroke="rgba(245, 158, 11, 0.85)"
+            strokeWidth="1"
+            strokeDasharray="5 4"
+          />
+        ) : null}
+
+        {hasData && overlayState.index && indexOverlayPrice !== null ? (
+          <line
+            x1={0}
+            x2={1000}
+            y1={chart.yForPrice(indexOverlayPrice)}
+            y2={chart.yForPrice(indexOverlayPrice)}
+            stroke="rgba(56, 189, 248, 0.85)"
+            strokeWidth="1"
+            strokeDasharray="4 3"
+          />
+        ) : null}
+
+        {hasData && overlayState.reference && referenceOverlayPrice !== null ? (
+          <line
+            x1={0}
+            x2={1000}
+            y1={chart.yForPrice(referenceOverlayPrice)}
+            y2={chart.yForPrice(referenceOverlayPrice)}
+            stroke="rgba(167, 139, 250, 0.8)"
+            strokeWidth="1"
+            strokeDasharray="2 3"
+          />
+        ) : null}
+
+        {hasData && activePoint && isCursorActive ? (
           <>
             <line
               x1={crosshairX}
@@ -261,14 +509,116 @@ export function MarketChart({
         </span>
       </div>
 
+      <div className="absolute left-4 bottom-4 z-20 rounded border border-white/10 bg-black/55 px-2.5 py-2 backdrop-blur-sm">
+        <div className="mb-1 flex flex-wrap items-center gap-1.5">
+          {(Object.keys(CHART_TIMEFRAME_WINDOWS_MS) as ChartTimeframe[]).map(
+            (option) => (
+              <button
+                key={option}
+                type="button"
+                className={cn(
+                  "rounded border px-1.5 py-0.5 text-[10px] font-mono uppercase transition-colors",
+                  option === timeframe
+                    ? "border-emerald-400/80 bg-emerald-500/15 text-emerald-200"
+                    : "border-white/20 bg-white/5 text-slate-200 hover:bg-white/10",
+                )}
+                onClick={() => applyTimeframe(option)}
+              >
+                {option}
+              </button>
+            ),
+          )}
+          <button
+            type="button"
+            className={cn(
+              "rounded border px-1.5 py-0.5 text-[10px] font-mono uppercase transition-colors",
+              chartStyle === "line"
+                ? "border-sky-400/80 bg-sky-500/15 text-sky-200"
+                : "border-white/20 bg-white/5 text-slate-200 hover:bg-white/10",
+            )}
+            onClick={() => applyChartStyle("line")}
+          >
+            Line
+          </button>
+          <button
+            type="button"
+            className={cn(
+              "rounded border px-1.5 py-0.5 text-[10px] font-mono uppercase transition-colors",
+              chartStyle === "candles"
+                ? "border-fuchsia-400/80 bg-fuchsia-500/15 text-fuchsia-200"
+                : "border-white/20 bg-white/5 text-slate-200 hover:bg-white/10",
+            )}
+            onClick={() => applyChartStyle("candles")}
+          >
+            Candles
+          </button>
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <button
+            type="button"
+            className={cn(
+              "rounded border px-1.5 py-0.5 text-[10px] font-mono uppercase transition-colors",
+              overlayState.mark
+                ? "border-amber-300/80 bg-amber-500/15 text-amber-200"
+                : "border-white/20 bg-white/5 text-slate-200 hover:bg-white/10",
+            )}
+            onClick={() =>
+              setOverlayState((current) => ({
+                ...current,
+                mark: !current.mark,
+              }))
+            }
+          >
+            Mark
+          </button>
+          <button
+            type="button"
+            className={cn(
+              "rounded border px-1.5 py-0.5 text-[10px] font-mono uppercase transition-colors",
+              overlayState.index
+                ? "border-sky-300/80 bg-sky-500/15 text-sky-200"
+                : "border-white/20 bg-white/5 text-slate-200 hover:bg-white/10",
+            )}
+            onClick={() =>
+              setOverlayState((current) => ({
+                ...current,
+                index: !current.index,
+              }))
+            }
+          >
+            Index
+          </button>
+          <button
+            type="button"
+            className={cn(
+              "rounded border px-1.5 py-0.5 text-[10px] font-mono uppercase transition-colors",
+              overlayState.reference
+                ? "border-violet-300/80 bg-violet-500/15 text-violet-200"
+                : "border-white/20 bg-white/5 text-slate-200 hover:bg-white/10",
+            )}
+            onClick={() =>
+              setOverlayState((current) => ({
+                ...current,
+                reference: !current.reference,
+              }))
+            }
+          >
+            Ref
+          </button>
+          <span className="text-[10px] font-mono text-slate-300/90">
+            Arrows: cursor
+          </span>
+        </div>
+      </div>
+
       {hasData && activePoint ? (
         <div
           className={cn(
             "absolute top-12 z-20 rounded border border-white/15 bg-black/75 px-2.5 py-2 font-mono text-[10px] text-slate-200 backdrop-blur min-w-[180px]",
-            isHovering ? "" : "right-4",
+            isCursorActive ? "" : "right-4",
           )}
           style={
-            isHovering
+            isCursorActive
               ? {
                   left: `${hoverTooltipLeftPct}%`,
                   transform: "translateX(-50%)",

--- a/apps/portal/app/terminal/components/market-chart.tsx
+++ b/apps/portal/app/terminal/components/market-chart.tsx
@@ -99,6 +99,7 @@ export function MarketChart({
   });
   const [hoverRatio, setHoverRatio] = useState<number | null>(null);
   const [keyboardIndex, setKeyboardIndex] = useState<number | null>(null);
+  const [chartActive, setChartActive] = useState(false);
   const gradientId = useId();
   const frameRef = useRef<number | null>(null);
   const pendingHoverRef = useRef<number | null>(null);
@@ -261,7 +262,8 @@ export function MarketChart({
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent): void {
-      if (!hasData || isTypingTarget(event.target)) return;
+      if (!hasData || !chartActive || isTypingTarget(event.target)) return;
+      if (event.altKey || event.ctrlKey || event.metaKey) return;
       const key = event.key.toLowerCase();
       if (key === "arrowleft" || key === "arrowright") {
         event.preventDefault();
@@ -299,6 +301,7 @@ export function MarketChart({
     applyChartStyle,
     applyTimeframe,
     chart.last,
+    chartActive,
     hasData,
     setHoverRatioBatched,
   ]);
@@ -311,6 +314,7 @@ export function MarketChart({
       )}
       role="application"
       aria-label="Interactive market price chart"
+      onMouseEnter={() => setChartActive(true)}
       onMouseMove={(event) => {
         if (!hasData) return;
         const rect = event.currentTarget.getBoundingClientRect();
@@ -319,7 +323,10 @@ export function MarketChart({
         setKeyboardIndex(null);
         setHoverRatioBatched(Math.max(0, Math.min(1, ratio)));
       }}
-      onMouseLeave={() => setHoverRatioBatched(null)}
+      onMouseLeave={() => {
+        setChartActive(false);
+        setHoverRatioBatched(null);
+      }}
     >
       {/* Grid Background */}
       <div

--- a/tests/unit/portal_terminal_market_chart.test.ts
+++ b/tests/unit/portal_terminal_market_chart.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import {
+  computeIndexOverlayPrice,
+  selectMarketPointsForTimeframe,
+} from "../../apps/portal/app/terminal/components/market-chart";
+
+describe("portal terminal market chart helpers", () => {
+  test("selects timeframe window with safe fallback", () => {
+    const now = Date.now();
+    const points = Array.from({ length: 12 }).map((_, index) => ({
+      ts: now - (11 - index) * 60 * 60 * 1000,
+      price: 100 + index,
+      kind: "ohlcv" as const,
+      open: 100 + index,
+      high: 101 + index,
+      low: 99 + index,
+      close: 100 + index,
+      volume: 10 + index,
+    }));
+
+    const oneHour = selectMarketPointsForTimeframe(points, "1H");
+    const sevenDay = selectMarketPointsForTimeframe(points, "7D");
+
+    expect(oneHour.length).toBeGreaterThanOrEqual(2);
+    expect(oneHour.length).toBeLessThan(points.length);
+    expect(sevenDay.length).toBe(points.length);
+  });
+
+  test("computes index overlay from tail average", () => {
+    const points = Array.from({ length: 4 }).map((_, index) => ({
+      ts: index,
+      price: 100 + index * 10,
+      kind: "ohlcv" as const,
+      open: 100,
+      high: 100,
+      low: 100,
+      close: 100,
+    }));
+    const index = computeIndexOverlayPrice(points);
+    expect(index).toBe(115);
+  });
+});


### PR DESCRIPTION
## Summary
- upgrade market chart with timeframe switching (`1H/6H/24H/7D`) and line/candles rendering modes
- add mark/index/reference overlay lines with independent toggles
- improve cursor workflow with keyboard navigation (arrow cursor, hotkeys) and stable tooltip behavior
- add unit tests for timeframe selection and index overlay calculations

## Validation
- bun run lint
- bun run typecheck
- bun test tests/unit/portal_terminal_market_chart.test.ts tests/unit/portal_terminal_depth_chart.test.ts tests/unit/portal_terminal_trades_tape.test.ts tests/unit/portal_terminal_orderbook_ladder.test.ts tests/unit/portal_terminal_realtime_transport.test.ts tests/unit/portal_terminal_modes.test.ts

Closes #153
