### PR TITLE
feat: TERM-008 advanced order entry ticket

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ It provides one execution fabric for:
 - Dedicated trades tape panel with side/size filters, pause-resume, and compact/expanded modes
 - Synchronized depth chart overlays with cumulative curves, spread, and imbalance annotations
 - Terminal-grade market chart controls (timeframes, line/candles, mark/index/reference overlays, keyboard cursor nav)
+- Advanced trade ticket with market/limit/trigger modes, TIF/flags, quantity modes, and TP/SL bracket validation
 - Account-level Privy wallet model (one wallet per user)
 - x402 paid APIs (`/api/x402/read/*`, `/api/x402/exec/submit`)
 - Execution API scaffold:

--- a/apps/portal/app/execution-client.ts
+++ b/apps/portal/app/execution-client.ts
@@ -54,6 +54,15 @@ export type ExecutionSubmitPayload = {
       commitment?: "processed" | "confirmed" | "finalized";
       simulateOnly?: boolean;
       dryRun?: boolean;
+      orderType?: "market" | "limit" | "trigger";
+      timeInForce?: "gtc" | "ioc" | "fok";
+      reduceOnly?: boolean;
+      postOnly?: boolean;
+      quantityMode?: "base" | "quote" | "notional";
+      limitPriceAtomic?: string;
+      triggerPriceAtomic?: string;
+      takeProfitPriceAtomic?: string;
+      stopLossPriceAtomic?: string;
     };
   };
 };

--- a/apps/portal/app/terminal/components/trade-ticket-modal.tsx
+++ b/apps/portal/app/terminal/components/trade-ticket-modal.tsx
@@ -50,11 +50,16 @@ type QuoteState = {
   priceImpactPct: number | null;
 };
 
+type OrderType = "market" | "limit" | "trigger";
+type TimeInForce = "gtc" | "ioc" | "fok";
+type QuantityMode = "base" | "quote" | "notional";
+
 const MIN_SLIPPAGE_BPS = "1";
 const MAX_SLIPPAGE_BPS = "5000";
 const BEARER_RE = /^bearer\s+/i;
 const EXEC_POLL_INTERVAL_MS = 1200;
 const EXEC_POLL_TIMEOUT_MS = 45000;
+const ORDER_PRICE_DECIMALS = 6;
 
 type CloseModalOptions = {
   cancelExecution?: boolean;
@@ -151,6 +156,73 @@ const EMPTY_QUOTE: QuoteState = {
   priceImpactPct: null,
 };
 
+export function validateOrderConfig(input: {
+  orderType: OrderType;
+  timeInForce: TimeInForce;
+  reduceOnly: boolean;
+  postOnly: boolean;
+  quantityMode: QuantityMode;
+  amountAtomic: string | null;
+  limitPriceAtomic: string | null;
+  triggerPriceAtomic: string | null;
+  takeProfitPriceAtomic: string | null;
+  stopLossPriceAtomic: string | null;
+  bracketEnabled: boolean;
+}): string[] {
+  const errors: string[] = [];
+  if (!input.amountAtomic) {
+    errors.push("Amount must be greater than zero.");
+  }
+  if (input.orderType === "limit" && !input.limitPriceAtomic) {
+    errors.push("Limit orders require a limit price.");
+  }
+  if (input.orderType === "trigger" && !input.triggerPriceAtomic) {
+    errors.push("Trigger orders require a trigger price.");
+  }
+  if (
+    input.postOnly &&
+    (input.timeInForce === "ioc" || input.timeInForce === "fok")
+  ) {
+    errors.push("Post-only cannot be combined with IOC or FOK.");
+  }
+  if (input.orderType === "market" && input.postOnly) {
+    errors.push("Post-only is only valid for limit or trigger orders.");
+  }
+  if (
+    input.bracketEnabled &&
+    !input.takeProfitPriceAtomic &&
+    !input.stopLossPriceAtomic
+  ) {
+    errors.push("Bracket mode requires TP and/or SL price.");
+  }
+  if (
+    input.bracketEnabled &&
+    input.takeProfitPriceAtomic &&
+    input.stopLossPriceAtomic
+  ) {
+    try {
+      if (
+        BigInt(input.takeProfitPriceAtomic) ===
+        BigInt(input.stopLossPriceAtomic)
+      ) {
+        errors.push("TP and SL cannot be equal.");
+      }
+    } catch {
+      errors.push("Invalid TP/SL values.");
+    }
+  }
+  if (
+    input.quantityMode !== "quote" &&
+    input.orderType === "market" &&
+    input.reduceOnly
+  ) {
+    errors.push(
+      "Reduce-only market orders currently require quote quantity mode.",
+    );
+  }
+  return errors;
+}
+
 export function TradeTicketModal({
   open,
   intent,
@@ -162,6 +234,16 @@ export function TradeTicketModal({
 }: TradeTicketModalProps) {
   const [amountUi, setAmountUi] = useState("");
   const [slippageInput, setSlippageInput] = useState("50");
+  const [orderType, setOrderType] = useState<OrderType>("market");
+  const [timeInForce, setTimeInForce] = useState<TimeInForce>("gtc");
+  const [quantityMode, setQuantityMode] = useState<QuantityMode>("quote");
+  const [reduceOnly, setReduceOnly] = useState(false);
+  const [postOnly, setPostOnly] = useState(false);
+  const [limitPriceUi, setLimitPriceUi] = useState("");
+  const [triggerPriceUi, setTriggerPriceUi] = useState("");
+  const [takeProfitPriceUi, setTakeProfitPriceUi] = useState("");
+  const [stopLossPriceUi, setStopLossPriceUi] = useState("");
+  const [bracketEnabled, setBracketEnabled] = useState(false);
   const [quote, setQuote] = useState<QuoteState>(EMPTY_QUOTE);
   const [submitStatus, setSubmitStatus] = useState<
     "idle" | "submitting" | "tracking" | "error"
@@ -239,6 +321,16 @@ export function TradeTicketModal({
     quoteAbortRef.current?.abort();
     setAmountUi(intent.amountUi);
     setSlippageInput(String(intent.slippageBps));
+    setOrderType("market");
+    setTimeInForce("gtc");
+    setQuantityMode("quote");
+    setReduceOnly(false);
+    setPostOnly(false);
+    setLimitPriceUi("");
+    setTriggerPriceUi("");
+    setTakeProfitPriceUi("");
+    setStopLossPriceUi("");
+    setBracketEnabled(false);
     setQuote(EMPTY_QUOTE);
     setSubmitStatus("idle");
     setSubmitMessage(null);
@@ -263,6 +355,56 @@ export function TradeTicketModal({
   const resolvedSlippageBps = useMemo(
     () => toBoundedSlippage(deferredSlippageInput, intent?.slippageBps ?? 50),
     [deferredSlippageInput, intent?.slippageBps],
+  );
+
+  const amountAtomicForValidation = useMemo(
+    () => parseUiAmountToAtomic(deferredAmountUi, intent?.inputDecimals ?? 0),
+    [deferredAmountUi, intent?.inputDecimals],
+  );
+  const limitPriceAtomic = useMemo(
+    () => parseUiAmountToAtomic(limitPriceUi, ORDER_PRICE_DECIMALS),
+    [limitPriceUi],
+  );
+  const triggerPriceAtomic = useMemo(
+    () => parseUiAmountToAtomic(triggerPriceUi, ORDER_PRICE_DECIMALS),
+    [triggerPriceUi],
+  );
+  const takeProfitPriceAtomic = useMemo(
+    () => parseUiAmountToAtomic(takeProfitPriceUi, ORDER_PRICE_DECIMALS),
+    [takeProfitPriceUi],
+  );
+  const stopLossPriceAtomic = useMemo(
+    () => parseUiAmountToAtomic(stopLossPriceUi, ORDER_PRICE_DECIMALS),
+    [stopLossPriceUi],
+  );
+  const orderValidationErrors = useMemo(
+    () =>
+      validateOrderConfig({
+        orderType,
+        timeInForce,
+        reduceOnly,
+        postOnly,
+        quantityMode,
+        amountAtomic: amountAtomicForValidation,
+        limitPriceAtomic,
+        triggerPriceAtomic,
+        takeProfitPriceAtomic,
+        stopLossPriceAtomic,
+        bracketEnabled,
+      }),
+    [
+      amountAtomicForValidation,
+      bracketEnabled,
+      limitPriceAtomic,
+      orderType,
+      postOnly,
+      quantityMode,
+      reduceOnly,
+      stopLossPriceAtomic,
+      takeProfitPriceAtomic,
+      timeInForce,
+      triggerPriceAtomic,
+    ],
   );
 
   const refreshQuote = useCallback(async (): Promise<void> => {
@@ -406,6 +548,11 @@ export function TradeTicketModal({
 
   const executeTrade = useCallback(async (): Promise<void> => {
     if (!intent) return;
+    if (orderValidationErrors.length > 0) {
+      setSubmitStatus("error");
+      setSubmitMessage(orderValidationErrors[0] ?? "invalid-order-config");
+      return;
+    }
     if (!walletAddress) {
       setSubmitStatus("error");
       setSubmitMessage("wallet-unavailable");
@@ -426,6 +573,18 @@ export function TradeTicketModal({
       slippageInput,
       resolvedSlippageBps,
     );
+    const options = {
+      commitment: "confirmed" as const,
+      orderType,
+      timeInForce,
+      reduceOnly,
+      postOnly,
+      quantityMode,
+      ...(limitPriceAtomic ? { limitPriceAtomic } : {}),
+      ...(triggerPriceAtomic ? { triggerPriceAtomic } : {}),
+      ...(takeProfitPriceAtomic ? { takeProfitPriceAtomic } : {}),
+      ...(stopLossPriceAtomic ? { stopLossPriceAtomic } : {}),
+    };
     setSubmitStatus("submitting");
     setSubmitMessage(null);
     let execToastId: string | number | null = null;
@@ -453,7 +612,7 @@ export function TradeTicketModal({
           lane: "safe",
           metadata: {
             source: intent.source,
-            reason: intent.reason,
+            reason: `${intent.reason} • ${orderType}/${timeInForce}/${quantityMode}`,
             clientRequestId: idempotencyKey,
           },
           privyExecute: {
@@ -465,9 +624,7 @@ export function TradeTicketModal({
               amountAtomic: quote.inAmountAtomic,
               slippageBps: boundedSlippageBps,
             },
-            options: {
-              commitment: "confirmed",
-            },
+            options,
           },
         },
         {
@@ -538,11 +695,21 @@ export function TradeTicketModal({
     dismissExecuteToast,
     getAccessToken,
     intent,
+    limitPriceAtomic,
     onTradeComplete,
+    orderType,
+    orderValidationErrors,
+    postOnly,
+    quantityMode,
     quote.inAmountAtomic,
     quote.outAmountAtomic,
+    reduceOnly,
     resolvedSlippageBps,
     slippageInput,
+    stopLossPriceAtomic,
+    takeProfitPriceAtomic,
+    timeInForce,
+    triggerPriceAtomic,
     walletAddress,
   ]);
 
@@ -613,6 +780,7 @@ export function TradeTicketModal({
             amountUi={amountUi}
             amountPresets={amountPresets}
             inputSymbol={intent.inputSymbol}
+            quantityMode={quantityMode}
             amountMinValue={intent.inputMinAmountUi}
             amountMaxValue={maxAmountUi}
             slippageInput={slippageInput}
@@ -624,6 +792,29 @@ export function TradeTicketModal({
             onSetSlippageMin={setSlippageMin}
             onSetSlippageMax={setSlippageMax}
             onRefreshQuote={refreshQuote}
+          />
+          <AdvancedOrderConfigSection
+            orderType={orderType}
+            timeInForce={timeInForce}
+            quantityMode={quantityMode}
+            reduceOnly={reduceOnly}
+            postOnly={postOnly}
+            bracketEnabled={bracketEnabled}
+            limitPriceUi={limitPriceUi}
+            triggerPriceUi={triggerPriceUi}
+            takeProfitPriceUi={takeProfitPriceUi}
+            stopLossPriceUi={stopLossPriceUi}
+            validationErrors={orderValidationErrors}
+            onOrderTypeChange={setOrderType}
+            onTimeInForceChange={setTimeInForce}
+            onQuantityModeChange={setQuantityMode}
+            onReduceOnlyChange={setReduceOnly}
+            onPostOnlyChange={setPostOnly}
+            onBracketEnabledChange={setBracketEnabled}
+            onLimitPriceChange={setLimitPriceUi}
+            onTriggerPriceChange={setTriggerPriceUi}
+            onTakeProfitPriceChange={setTakeProfitPriceUi}
+            onStopLossPriceChange={setStopLossPriceUi}
           />
           <QuoteSummaryCard
             outputSymbol={intent.outputSymbol}
@@ -659,7 +850,8 @@ export function TradeTicketModal({
                 submitStatus === "submitting" ||
                 submitStatus === "tracking" ||
                 quote.status !== "ready" ||
-                !quote.inAmountAtomic
+                !quote.inAmountAtomic ||
+                orderValidationErrors.length > 0
               }
             >
               {submitStatus === "submitting" || submitStatus === "tracking"
@@ -706,6 +898,7 @@ const TradeInputsSection = memo(function TradeInputsSection(props: {
   amountUi: string;
   amountPresets: readonly string[];
   inputSymbol: string;
+  quantityMode: QuantityMode;
   amountMinValue: string;
   amountMaxValue: string | null;
   slippageInput: string;
@@ -722,6 +915,7 @@ const TradeInputsSection = memo(function TradeInputsSection(props: {
     amountUi,
     amountPresets,
     inputSymbol,
+    quantityMode,
     amountMinValue,
     amountMaxValue,
     slippageInput,
@@ -741,7 +935,7 @@ const TradeInputsSection = memo(function TradeInputsSection(props: {
       <div>
         <div className="mb-2 flex items-center justify-between gap-2">
           <label className="label block" htmlFor="trade-ticket-amount">
-            Amount ({inputSymbol})
+            Amount ({quantityMode === "quote" ? inputSymbol : quantityMode})
           </label>
           <div className="flex items-center gap-1.5">
             <button
@@ -835,6 +1029,217 @@ const TradeInputsSection = memo(function TradeInputsSection(props: {
     </>
   );
 });
+
+const AdvancedOrderConfigSection = memo(
+  function AdvancedOrderConfigSection(props: {
+    orderType: OrderType;
+    timeInForce: TimeInForce;
+    quantityMode: QuantityMode;
+    reduceOnly: boolean;
+    postOnly: boolean;
+    bracketEnabled: boolean;
+    limitPriceUi: string;
+    triggerPriceUi: string;
+    takeProfitPriceUi: string;
+    stopLossPriceUi: string;
+    validationErrors: string[];
+    onOrderTypeChange: (value: OrderType) => void;
+    onTimeInForceChange: (value: TimeInForce) => void;
+    onQuantityModeChange: (value: QuantityMode) => void;
+    onReduceOnlyChange: (value: boolean) => void;
+    onPostOnlyChange: (value: boolean) => void;
+    onBracketEnabledChange: (value: boolean) => void;
+    onLimitPriceChange: (value: string) => void;
+    onTriggerPriceChange: (value: string) => void;
+    onTakeProfitPriceChange: (value: string) => void;
+    onStopLossPriceChange: (value: string) => void;
+  }) {
+    const {
+      orderType,
+      timeInForce,
+      quantityMode,
+      reduceOnly,
+      postOnly,
+      bracketEnabled,
+      limitPriceUi,
+      triggerPriceUi,
+      takeProfitPriceUi,
+      stopLossPriceUi,
+      validationErrors,
+      onOrderTypeChange,
+      onTimeInForceChange,
+      onQuantityModeChange,
+      onReduceOnlyChange,
+      onPostOnlyChange,
+      onBracketEnabledChange,
+      onLimitPriceChange,
+      onTriggerPriceChange,
+      onTakeProfitPriceChange,
+      onStopLossPriceChange,
+    } = props;
+
+    return (
+      <div className="rounded border border-border bg-subtle px-3 py-2 text-xs space-y-3">
+        <p className="label">ADVANCED_ORDER_CONFIG</p>
+
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+          <label className="space-y-1">
+            <span className="text-muted text-[10px] uppercase tracking-wider">
+              Order Type
+            </span>
+            <select
+              className="input-field !py-2 font-mono"
+              value={orderType}
+              onChange={(event) =>
+                onOrderTypeChange(event.target.value as OrderType)
+              }
+            >
+              <option value="market">market</option>
+              <option value="limit">limit</option>
+              <option value="trigger">trigger</option>
+            </select>
+          </label>
+          <label className="space-y-1">
+            <span className="text-muted text-[10px] uppercase tracking-wider">
+              Time In Force
+            </span>
+            <select
+              className="input-field !py-2 font-mono"
+              value={timeInForce}
+              onChange={(event) =>
+                onTimeInForceChange(event.target.value as TimeInForce)
+              }
+            >
+              <option value="gtc">gtc</option>
+              <option value="ioc">ioc</option>
+              <option value="fok">fok</option>
+            </select>
+          </label>
+          <label className="space-y-1">
+            <span className="text-muted text-[10px] uppercase tracking-wider">
+              Quantity Mode
+            </span>
+            <select
+              className="input-field !py-2 font-mono"
+              value={quantityMode}
+              onChange={(event) =>
+                onQuantityModeChange(event.target.value as QuantityMode)
+              }
+            >
+              <option value="quote">quote</option>
+              <option value="base">base</option>
+              <option value="notional">notional</option>
+            </select>
+          </label>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 text-[11px]">
+          <label className="flex items-center gap-2">
+            <input
+              checked={reduceOnly}
+              onChange={(event) => onReduceOnlyChange(event.target.checked)}
+              type="checkbox"
+            />
+            <span>Reduce-only</span>
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              checked={postOnly}
+              onChange={(event) => onPostOnlyChange(event.target.checked)}
+              type="checkbox"
+            />
+            <span>Post-only</span>
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              checked={bracketEnabled}
+              onChange={(event) => onBracketEnabledChange(event.target.checked)}
+              type="checkbox"
+            />
+            <span>Bracket TP/SL</span>
+          </label>
+        </div>
+
+        {orderType !== "market" ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {orderType === "limit" ? (
+              <label className="space-y-1">
+                <span className="text-muted text-[10px] uppercase tracking-wider">
+                  Limit Price
+                </span>
+                <input
+                  className="input-field !py-2 font-mono"
+                  inputMode="decimal"
+                  placeholder="0.00"
+                  value={limitPriceUi}
+                  onChange={(event) => onLimitPriceChange(event.target.value)}
+                />
+              </label>
+            ) : null}
+            {orderType === "trigger" ? (
+              <label className="space-y-1">
+                <span className="text-muted text-[10px] uppercase tracking-wider">
+                  Trigger Price
+                </span>
+                <input
+                  className="input-field !py-2 font-mono"
+                  inputMode="decimal"
+                  placeholder="0.00"
+                  value={triggerPriceUi}
+                  onChange={(event) => onTriggerPriceChange(event.target.value)}
+                />
+              </label>
+            ) : null}
+          </div>
+        ) : null}
+
+        {bracketEnabled ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <label className="space-y-1">
+              <span className="text-muted text-[10px] uppercase tracking-wider">
+                Take Profit
+              </span>
+              <input
+                className="input-field !py-2 font-mono"
+                inputMode="decimal"
+                placeholder="0.00"
+                value={takeProfitPriceUi}
+                onChange={(event) =>
+                  onTakeProfitPriceChange(event.target.value)
+                }
+              />
+            </label>
+            <label className="space-y-1">
+              <span className="text-muted text-[10px] uppercase tracking-wider">
+                Stop Loss
+              </span>
+              <input
+                className="input-field !py-2 font-mono"
+                inputMode="decimal"
+                placeholder="0.00"
+                value={stopLossPriceUi}
+                onChange={(event) => onStopLossPriceChange(event.target.value)}
+              />
+            </label>
+          </div>
+        ) : null}
+
+        <p className="text-[10px] text-muted">
+          Quantity mode and order flags are mapped into the execution contract
+          options for policy-aware routing.
+        </p>
+
+        {validationErrors.length > 0 ? (
+          <ul className="rounded border border-red-500/40 bg-red-500/10 px-2 py-1.5 text-[11px] text-red-300 space-y-1">
+            {validationErrors.map((error) => (
+              <li key={error}>• {error}</li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+    );
+  },
+);
 
 const QuoteSummaryCard = memo(function QuoteSummaryCard(props: {
   outputSymbol: string;

--- a/apps/worker/src/execution/submit_contract.ts
+++ b/apps/worker/src/execution/submit_contract.ts
@@ -100,6 +100,15 @@ function parsePrivyExecute(value: unknown): {
     simulateOnly?: boolean;
     dryRun?: boolean;
     commitment?: "processed" | "confirmed" | "finalized";
+    orderType?: "market" | "limit" | "trigger";
+    timeInForce?: "gtc" | "ioc" | "fok";
+    reduceOnly?: boolean;
+    postOnly?: boolean;
+    quantityMode?: "base" | "quote" | "notional";
+    limitPriceAtomic?: string;
+    triggerPriceAtomic?: string;
+    takeProfitPriceAtomic?: string;
+    stopLossPriceAtomic?: string;
   };
 } | null {
   if (!isRecord(value)) return null;
@@ -146,7 +155,20 @@ function parsePrivyExecute(value: unknown): {
 
   if (value.options !== undefined && !isRecord(value.options)) return null;
   const options = isRecord(value.options) ? value.options : {};
-  const optionKeys = new Set(["simulateOnly", "dryRun", "commitment"]);
+  const optionKeys = new Set([
+    "simulateOnly",
+    "dryRun",
+    "commitment",
+    "orderType",
+    "timeInForce",
+    "reduceOnly",
+    "postOnly",
+    "quantityMode",
+    "limitPriceAtomic",
+    "triggerPriceAtomic",
+    "takeProfitPriceAtomic",
+    "stopLossPriceAtomic",
+  ]);
   for (const key of Object.keys(options)) {
     if (!optionKeys.has(key)) return null;
   }
@@ -164,6 +186,63 @@ function parsePrivyExecute(value: unknown): {
     options.commitment !== "processed" &&
     options.commitment !== "confirmed" &&
     options.commitment !== "finalized"
+  ) {
+    return null;
+  }
+  if (
+    options.orderType !== undefined &&
+    options.orderType !== "market" &&
+    options.orderType !== "limit" &&
+    options.orderType !== "trigger"
+  ) {
+    return null;
+  }
+  if (
+    options.timeInForce !== undefined &&
+    options.timeInForce !== "gtc" &&
+    options.timeInForce !== "ioc" &&
+    options.timeInForce !== "fok"
+  ) {
+    return null;
+  }
+  if (
+    options.reduceOnly !== undefined &&
+    typeof options.reduceOnly !== "boolean"
+  ) {
+    return null;
+  }
+  if (options.postOnly !== undefined && typeof options.postOnly !== "boolean") {
+    return null;
+  }
+  if (
+    options.quantityMode !== undefined &&
+    options.quantityMode !== "base" &&
+    options.quantityMode !== "quote" &&
+    options.quantityMode !== "notional"
+  ) {
+    return null;
+  }
+  if (
+    options.limitPriceAtomic !== undefined &&
+    !/^[1-9][0-9]*$/.test(String(options.limitPriceAtomic))
+  ) {
+    return null;
+  }
+  if (
+    options.triggerPriceAtomic !== undefined &&
+    !/^[1-9][0-9]*$/.test(String(options.triggerPriceAtomic))
+  ) {
+    return null;
+  }
+  if (
+    options.takeProfitPriceAtomic !== undefined &&
+    !/^[1-9][0-9]*$/.test(String(options.takeProfitPriceAtomic))
+  ) {
+    return null;
+  }
+  if (
+    options.stopLossPriceAtomic !== undefined &&
+    !/^[1-9][0-9]*$/.test(String(options.stopLossPriceAtomic))
   ) {
     return null;
   }
@@ -193,6 +272,45 @@ function parsePrivyExecute(value: unknown): {
                     | "confirmed"
                     | "finalized",
                 }
+              : {}),
+            ...(options.orderType !== undefined
+              ? {
+                  orderType: options.orderType as
+                    | "market"
+                    | "limit"
+                    | "trigger",
+                }
+              : {}),
+            ...(options.timeInForce !== undefined
+              ? {
+                  timeInForce: options.timeInForce as "gtc" | "ioc" | "fok",
+                }
+              : {}),
+            ...(options.reduceOnly !== undefined
+              ? { reduceOnly: options.reduceOnly as boolean }
+              : {}),
+            ...(options.postOnly !== undefined
+              ? { postOnly: options.postOnly as boolean }
+              : {}),
+            ...(options.quantityMode !== undefined
+              ? {
+                  quantityMode: options.quantityMode as
+                    | "base"
+                    | "quote"
+                    | "notional",
+                }
+              : {}),
+            ...(options.limitPriceAtomic !== undefined
+              ? { limitPriceAtomic: String(options.limitPriceAtomic) }
+              : {}),
+            ...(options.triggerPriceAtomic !== undefined
+              ? { triggerPriceAtomic: String(options.triggerPriceAtomic) }
+              : {}),
+            ...(options.takeProfitPriceAtomic !== undefined
+              ? { takeProfitPriceAtomic: String(options.takeProfitPriceAtomic) }
+              : {}),
+            ...(options.stopLossPriceAtomic !== undefined
+              ? { stopLossPriceAtomic: String(options.stopLossPriceAtomic) }
               : {}),
           },
         }
@@ -226,6 +344,15 @@ export type ExecSubmitRequestV1 = {
       simulateOnly?: boolean;
       dryRun?: boolean;
       commitment?: "processed" | "confirmed" | "finalized";
+      orderType?: "market" | "limit" | "trigger";
+      timeInForce?: "gtc" | "ioc" | "fok";
+      reduceOnly?: boolean;
+      postOnly?: boolean;
+      quantityMode?: "base" | "quote" | "notional";
+      limitPriceAtomic?: string;
+      triggerPriceAtomic?: string;
+      takeProfitPriceAtomic?: string;
+      stopLossPriceAtomic?: string;
     };
   };
 };

--- a/tests/unit/portal_terminal_trade_ticket_validation.test.ts
+++ b/tests/unit/portal_terminal_trade_ticket_validation.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { validateOrderConfig } from "../../apps/portal/app/terminal/components/trade-ticket-modal";
+
+describe("portal terminal advanced trade ticket validation", () => {
+  test("rejects invalid limit and post-only combinations", () => {
+    const errors = validateOrderConfig({
+      orderType: "limit",
+      timeInForce: "ioc",
+      reduceOnly: false,
+      postOnly: true,
+      quantityMode: "quote",
+      amountAtomic: "1000",
+      limitPriceAtomic: null,
+      triggerPriceAtomic: null,
+      takeProfitPriceAtomic: null,
+      stopLossPriceAtomic: null,
+      bracketEnabled: false,
+    });
+    expect(errors).toContain("Limit orders require a limit price.");
+    expect(errors).toContain("Post-only cannot be combined with IOC or FOK.");
+  });
+
+  test("accepts valid trigger + bracket configuration", () => {
+    const errors = validateOrderConfig({
+      orderType: "trigger",
+      timeInForce: "gtc",
+      reduceOnly: true,
+      postOnly: false,
+      quantityMode: "quote",
+      amountAtomic: "1000",
+      limitPriceAtomic: null,
+      triggerPriceAtomic: "900000",
+      takeProfitPriceAtomic: "1100000",
+      stopLossPriceAtomic: "850000",
+      bracketEnabled: true,
+    });
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/tests/unit/worker_exec_submit_contract_privy.test.ts
+++ b/tests/unit/worker_exec_submit_contract_privy.test.ts
@@ -44,6 +44,34 @@ describe("exec submit contract: privy_execute", () => {
     });
   });
 
+  test("accepts advanced order options for privy_execute submits", () => {
+    const parsed = parseExecSubmitPayload({
+      ...VALID_PRIVY_SUBMIT,
+      privyExecute: {
+        ...VALID_PRIVY_SUBMIT.privyExecute,
+        options: {
+          ...VALID_PRIVY_SUBMIT.privyExecute.options,
+          orderType: "trigger",
+          timeInForce: "ioc",
+          reduceOnly: true,
+          postOnly: false,
+          quantityMode: "notional",
+          limitPriceAtomic: "1000000",
+          triggerPriceAtomic: "950000",
+          takeProfitPriceAtomic: "1200000",
+          stopLossPriceAtomic: "880000",
+        },
+      },
+    });
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.value.privyExecute?.options?.orderType).toBe("trigger");
+    expect(parsed.value.privyExecute?.options?.quantityMode).toBe("notional");
+    expect(parsed.value.privyExecute?.options?.triggerPriceAtomic).toBe(
+      "950000",
+    );
+  });
+
   test("rejects invalid privy_execute payloads deterministically", () => {
     const invalidIntentType = parseExecSubmitPayload({
       ...VALID_PRIVY_SUBMIT,


### PR DESCRIPTION
## Summary
- upgrade trade ticket with advanced order configuration: market/limit/trigger, TIF, quantity mode, reduce/post-only flags, and optional TP/SL bracket inputs
- add inline validation for invalid config combinations before submit
- map advanced order fields into execution fabric payload options for `privy_execute` submits
- extend execution submit contract parsing to accept structured advanced order options
- add unit coverage for trade-ticket validation and contract parsing

## Validation
- bun run lint
- bun run typecheck
- bun test tests/unit/worker_exec_submit_contract_privy.test.ts tests/unit/portal_terminal_trade_ticket_validation.test.ts tests/unit/portal_terminal_market_chart.test.ts tests/unit/portal_terminal_depth_chart.test.ts tests/unit/portal_terminal_trades_tape.test.ts tests/unit/portal_terminal_orderbook_ladder.test.ts tests/unit/portal_terminal_realtime_transport.test.ts tests/unit/portal_terminal_modes.test.ts

Closes #154
