### PR TITLE
feat: TERM-009 execution quality controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ It provides one execution fabric for:
 - Synchronized depth chart overlays with cumulative curves, spread, and imbalance annotations
 - Terminal-grade market chart controls (timeframes, line/candles, mark/index/reference overlays, keyboard cursor nav)
 - Advanced trade ticket with market/limit/trigger modes, TIF/flags, quantity modes, and TP/SL bracket validation
+- Execution quality controls in ticket (lane, simulation preference, slippage, priority fee hints) with terminal activity surfacing
 - Account-level Privy wallet model (one wallet per user)
 - x402 paid APIs (`/api/x402/read/*`, `/api/x402/exec/submit`)
 - Execution API scaffold:

--- a/apps/portal/app/execution-client.ts
+++ b/apps/portal/app/execution-client.ts
@@ -53,7 +53,9 @@ export type ExecutionSubmitPayload = {
     options?: {
       commitment?: "processed" | "confirmed" | "finalized";
       simulateOnly?: boolean;
+      requireSimulation?: boolean;
       dryRun?: boolean;
+      priorityMicroLamports?: number;
       orderType?: "market" | "limit" | "trigger";
       timeInForce?: "gtc" | "ioc" | "fok";
       reduceOnly?: boolean;

--- a/apps/portal/app/terminal/components/trade-ticket-modal.tsx
+++ b/apps/portal/app/terminal/components/trade-ticket-modal.tsx
@@ -38,6 +38,11 @@ export type TradeTicketCompletion = {
   outAmountAtomic: string;
   status: string;
   signature: string | null;
+  lane: ExecutionLane;
+  simulationPreference: SimulationPreference;
+  slippageBps: number;
+  priorityLevel: PriorityLevel;
+  priorityMicroLamports: number;
 };
 
 type QuoteState = {
@@ -53,6 +58,9 @@ type QuoteState = {
 type OrderType = "market" | "limit" | "trigger";
 type TimeInForce = "gtc" | "ioc" | "fok";
 type QuantityMode = "base" | "quote" | "notional";
+type ExecutionLane = "fast" | "protected" | "safe";
+type SimulationPreference = "auto" | "always" | "never";
+type PriorityLevel = "normal" | "high" | "urgent";
 
 const MIN_SLIPPAGE_BPS = "1";
 const MAX_SLIPPAGE_BPS = "5000";
@@ -60,6 +68,15 @@ const BEARER_RE = /^bearer\s+/i;
 const EXEC_POLL_INTERVAL_MS = 1200;
 const EXEC_POLL_TIMEOUT_MS = 45000;
 const ORDER_PRICE_DECIMALS = 6;
+const MAX_PRIORITY_MICRO_LAMPORTS = 2_000_000;
+const DEFAULT_EXECUTION_LANE: ExecutionLane = "safe";
+const DEFAULT_SIMULATION_PREFERENCE: SimulationPreference = "auto";
+const DEFAULT_PRIORITY_LEVEL: PriorityLevel = "normal";
+const PRIORITY_MICRO_LAMPORTS_BY_LEVEL: Record<PriorityLevel, number> = {
+  normal: 5_000,
+  high: 50_000,
+  urgent: 200_000,
+};
 
 type CloseModalOptions = {
   cancelExecution?: boolean;
@@ -223,6 +240,58 @@ export function validateOrderConfig(input: {
   return errors;
 }
 
+function qualityHint(input: {
+  lane: ExecutionLane;
+  simulationPreference: SimulationPreference;
+  priorityLevel: PriorityLevel;
+}): string {
+  const laneHint =
+    input.lane === "safe"
+      ? "Safe lane routes with stronger validation."
+      : input.lane === "protected"
+        ? "Protected lane prioritizes private execution."
+        : "Fast lane targets lowest latency routing.";
+  const simulationHint =
+    input.simulationPreference === "always"
+      ? "Simulation is always required before dispatch."
+      : input.simulationPreference === "never"
+        ? "Simulation is skipped unless policy enforces it."
+        : "Simulation follows lane and policy defaults.";
+  const priorityHint =
+    input.priorityLevel === "urgent"
+      ? "Urgent priority increases fee pressure for speed."
+      : input.priorityLevel === "high"
+        ? "High priority balances speed and fee spend."
+        : "Normal priority uses conservative fee settings.";
+  return `${laneHint} ${simulationHint} ${priorityHint}`;
+}
+
+export function validateExecutionQualityConfig(input: {
+  lane: ExecutionLane;
+  simulationPreference: SimulationPreference;
+  slippageBps: number;
+  priorityMicroLamports: number;
+}): string[] {
+  const errors: string[] = [];
+  if (input.lane === "safe" && input.simulationPreference === "never") {
+    errors.push("Safe lane requires simulation (choose auto or always).");
+  }
+  if (!Number.isInteger(input.slippageBps) || input.slippageBps < 1) {
+    errors.push("Slippage must be at least 1 bps.");
+  }
+  if (input.slippageBps > 5_000) {
+    errors.push("Slippage cannot exceed 5000 bps.");
+  }
+  if (
+    !Number.isInteger(input.priorityMicroLamports) ||
+    input.priorityMicroLamports < 0 ||
+    input.priorityMicroLamports > MAX_PRIORITY_MICRO_LAMPORTS
+  ) {
+    errors.push("Priority fee is outside allowed bounds.");
+  }
+  return errors;
+}
+
 export function TradeTicketModal({
   open,
   intent,
@@ -234,6 +303,14 @@ export function TradeTicketModal({
 }: TradeTicketModalProps) {
   const [amountUi, setAmountUi] = useState("");
   const [slippageInput, setSlippageInput] = useState("50");
+  const [executionLane, setExecutionLane] = useState<ExecutionLane>(
+    DEFAULT_EXECUTION_LANE,
+  );
+  const [simulationPreference, setSimulationPreference] =
+    useState<SimulationPreference>(DEFAULT_SIMULATION_PREFERENCE);
+  const [priorityLevel, setPriorityLevel] = useState<PriorityLevel>(
+    DEFAULT_PRIORITY_LEVEL,
+  );
   const [orderType, setOrderType] = useState<OrderType>("market");
   const [timeInForce, setTimeInForce] = useState<TimeInForce>("gtc");
   const [quantityMode, setQuantityMode] = useState<QuantityMode>("quote");
@@ -321,6 +398,9 @@ export function TradeTicketModal({
     quoteAbortRef.current?.abort();
     setAmountUi(intent.amountUi);
     setSlippageInput(String(intent.slippageBps));
+    setExecutionLane(DEFAULT_EXECUTION_LANE);
+    setSimulationPreference(DEFAULT_SIMULATION_PREFERENCE);
+    setPriorityLevel(DEFAULT_PRIORITY_LEVEL);
     setOrderType("market");
     setTimeInForce("gtc");
     setQuantityMode("quote");
@@ -355,6 +435,34 @@ export function TradeTicketModal({
   const resolvedSlippageBps = useMemo(
     () => toBoundedSlippage(deferredSlippageInput, intent?.slippageBps ?? 50),
     [deferredSlippageInput, intent?.slippageBps],
+  );
+  const priorityMicroLamports = useMemo(
+    () => PRIORITY_MICRO_LAMPORTS_BY_LEVEL[priorityLevel],
+    [priorityLevel],
+  );
+  const executionQualityHint = useMemo(
+    () =>
+      qualityHint({
+        lane: executionLane,
+        simulationPreference,
+        priorityLevel,
+      }),
+    [executionLane, priorityLevel, simulationPreference],
+  );
+  const executionQualityErrors = useMemo(
+    () =>
+      validateExecutionQualityConfig({
+        lane: executionLane,
+        simulationPreference,
+        slippageBps: resolvedSlippageBps,
+        priorityMicroLamports,
+      }),
+    [
+      executionLane,
+      priorityMicroLamports,
+      resolvedSlippageBps,
+      simulationPreference,
+    ],
   );
 
   const amountAtomicForValidation = useMemo(
@@ -548,9 +656,13 @@ export function TradeTicketModal({
 
   const executeTrade = useCallback(async (): Promise<void> => {
     if (!intent) return;
-    if (orderValidationErrors.length > 0) {
+    if (orderValidationErrors.length > 0 || executionQualityErrors.length > 0) {
       setSubmitStatus("error");
-      setSubmitMessage(orderValidationErrors[0] ?? "invalid-order-config");
+      setSubmitMessage(
+        orderValidationErrors[0] ??
+          executionQualityErrors[0] ??
+          "invalid-order-config",
+      );
       return;
     }
     if (!walletAddress) {
@@ -575,6 +687,12 @@ export function TradeTicketModal({
     );
     const options = {
       commitment: "confirmed" as const,
+      ...(simulationPreference === "always"
+        ? { requireSimulation: true }
+        : simulationPreference === "never"
+          ? { requireSimulation: false }
+          : {}),
+      priorityMicroLamports,
       orderType,
       timeInForce,
       reduceOnly,
@@ -609,10 +727,10 @@ export function TradeTicketModal({
         {
           schemaVersion: "v1",
           mode: "privy_execute",
-          lane: "safe",
+          lane: executionLane,
           metadata: {
             source: intent.source,
-            reason: `${intent.reason} • ${orderType}/${timeInForce}/${quantityMode}`,
+            reason: `${intent.reason} • ${orderType}/${timeInForce}/${quantityMode} • ${executionLane}/${simulationPreference}/${priorityLevel}`,
             clientRequestId: idempotencyKey,
           },
           privyExecute: {
@@ -655,6 +773,11 @@ export function TradeTicketModal({
         outAmountAtomic: quote.outAmountAtomic,
         status: terminal.status,
         signature: terminal.signature,
+        lane: executionLane,
+        simulationPreference,
+        slippageBps: boundedSlippageBps,
+        priorityLevel,
+        priorityMicroLamports,
       });
       toast.success("Trade executed", {
         id: execToastId ?? undefined,
@@ -699,7 +822,11 @@ export function TradeTicketModal({
     onTradeComplete,
     orderType,
     orderValidationErrors,
+    executionLane,
+    executionQualityErrors,
     postOnly,
+    priorityLevel,
+    priorityMicroLamports,
     quantityMode,
     quote.inAmountAtomic,
     quote.outAmountAtomic,
@@ -707,6 +834,7 @@ export function TradeTicketModal({
     resolvedSlippageBps,
     slippageInput,
     stopLossPriceAtomic,
+    simulationPreference,
     takeProfitPriceAtomic,
     timeInForce,
     triggerPriceAtomic,
@@ -793,6 +921,18 @@ export function TradeTicketModal({
             onSetSlippageMax={setSlippageMax}
             onRefreshQuote={refreshQuote}
           />
+          <ExecutionQualitySection
+            lane={executionLane}
+            simulationPreference={simulationPreference}
+            priorityLevel={priorityLevel}
+            priorityMicroLamports={priorityMicroLamports}
+            slippageBps={resolvedSlippageBps}
+            hint={executionQualityHint}
+            validationErrors={executionQualityErrors}
+            onLaneChange={setExecutionLane}
+            onSimulationPreferenceChange={setSimulationPreference}
+            onPriorityLevelChange={setPriorityLevel}
+          />
           <AdvancedOrderConfigSection
             orderType={orderType}
             timeInForce={timeInForce}
@@ -851,7 +991,8 @@ export function TradeTicketModal({
                 submitStatus === "tracking" ||
                 quote.status !== "ready" ||
                 !quote.inAmountAtomic ||
-                orderValidationErrors.length > 0
+                orderValidationErrors.length > 0 ||
+                executionQualityErrors.length > 0
               }
             >
               {submitStatus === "submitting" || submitStatus === "tracking"
@@ -1027,6 +1168,103 @@ const TradeInputsSection = memo(function TradeInputsSection(props: {
         />
       </div>
     </>
+  );
+});
+
+const ExecutionQualitySection = memo(function ExecutionQualitySection(props: {
+  lane: ExecutionLane;
+  simulationPreference: SimulationPreference;
+  priorityLevel: PriorityLevel;
+  priorityMicroLamports: number;
+  slippageBps: number;
+  hint: string;
+  validationErrors: string[];
+  onLaneChange: (value: ExecutionLane) => void;
+  onSimulationPreferenceChange: (value: SimulationPreference) => void;
+  onPriorityLevelChange: (value: PriorityLevel) => void;
+}) {
+  const {
+    lane,
+    simulationPreference,
+    priorityLevel,
+    priorityMicroLamports,
+    slippageBps,
+    hint,
+    validationErrors,
+    onLaneChange,
+    onSimulationPreferenceChange,
+    onPriorityLevelChange,
+  } = props;
+  return (
+    <div className="rounded border border-border bg-subtle px-3 py-2 text-xs space-y-3">
+      <p className="label">EXECUTION_QUALITY</p>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+        <label className="space-y-1">
+          <span className="text-muted text-[10px] uppercase tracking-wider">
+            Lane
+          </span>
+          <select
+            className="input-field !py-2 font-mono"
+            value={lane}
+            onChange={(event) =>
+              onLaneChange(event.target.value as ExecutionLane)
+            }
+          >
+            <option value="fast">fast</option>
+            <option value="protected">protected</option>
+            <option value="safe">safe</option>
+          </select>
+        </label>
+        <label className="space-y-1">
+          <span className="text-muted text-[10px] uppercase tracking-wider">
+            Simulation
+          </span>
+          <select
+            className="input-field !py-2 font-mono"
+            value={simulationPreference}
+            onChange={(event) =>
+              onSimulationPreferenceChange(
+                event.target.value as SimulationPreference,
+              )
+            }
+          >
+            <option value="auto">auto</option>
+            <option value="always">always</option>
+            <option value="never">never</option>
+          </select>
+        </label>
+        <label className="space-y-1">
+          <span className="text-muted text-[10px] uppercase tracking-wider">
+            Priority
+          </span>
+          <select
+            className="input-field !py-2 font-mono"
+            value={priorityLevel}
+            onChange={(event) =>
+              onPriorityLevelChange(event.target.value as PriorityLevel)
+            }
+          >
+            <option value="normal">normal</option>
+            <option value="high">high</option>
+            <option value="urgent">urgent</option>
+          </select>
+        </label>
+      </div>
+      <div className="rounded border border-border/60 bg-paper/70 px-2 py-1.5 text-[10px] text-muted space-y-0.5">
+        <p>Slippage: {slippageBps} bps</p>
+        <p>
+          Priority fee: {priorityMicroLamports.toLocaleString()} u-lamports/CU
+        </p>
+        <p>{hint}</p>
+      </div>
+      {validationErrors.length > 0 ? (
+        <ul className="rounded border border-red-500/40 bg-red-500/10 px-2 py-1.5 text-[11px] text-red-300 space-y-1">
+          {validationErrors.map((error) => (
+            <li key={error}>• {error}</li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
   );
 });
 

--- a/apps/portal/app/terminal/page.tsx
+++ b/apps/portal/app/terminal/page.tsx
@@ -75,6 +75,7 @@ type ExecutionActivityRow = {
   leg: string;
   status: string;
   signature: string | null;
+  qualitySummary: string;
 };
 
 type LadderPrefill = {
@@ -677,6 +678,7 @@ function ControlRoom() {
           leg: `${trade.inputSymbol} -> ${trade.outputSymbol}`,
           status: trade.status,
           signature: trade.signature,
+          qualitySummary: `lane ${trade.lane} • sim ${trade.simulationPreference} • slip ${trade.slippageBps} bps • prio ${trade.priorityLevel}`,
         };
         return [entry, ...current].slice(0, 30);
       });
@@ -1680,6 +1682,9 @@ const PositionsOrdersFillsPanel = memo(
                     </p>
                     <p className="text-[10px] text-muted">
                       {new Date(entry.ts).toLocaleTimeString()}
+                    </p>
+                    <p className="text-[10px] text-muted truncate">
+                      {entry.qualitySummary}
                     </p>
                   </div>
                   <div className="text-right">

--- a/apps/worker/src/execution/submit_contract.ts
+++ b/apps/worker/src/execution/submit_contract.ts
@@ -98,7 +98,9 @@ function parsePrivyExecute(value: unknown): {
   };
   options?: {
     simulateOnly?: boolean;
+    requireSimulation?: boolean;
     dryRun?: boolean;
+    priorityMicroLamports?: number;
     commitment?: "processed" | "confirmed" | "finalized";
     orderType?: "market" | "limit" | "trigger";
     timeInForce?: "gtc" | "ioc" | "fok";
@@ -157,7 +159,9 @@ function parsePrivyExecute(value: unknown): {
   const options = isRecord(value.options) ? value.options : {};
   const optionKeys = new Set([
     "simulateOnly",
+    "requireSimulation",
     "dryRun",
+    "priorityMicroLamports",
     "commitment",
     "orderType",
     "timeInForce",
@@ -178,8 +182,24 @@ function parsePrivyExecute(value: unknown): {
   ) {
     return null;
   }
+  if (
+    options.requireSimulation !== undefined &&
+    typeof options.requireSimulation !== "boolean"
+  ) {
+    return null;
+  }
   if (options.dryRun !== undefined && typeof options.dryRun !== "boolean") {
     return null;
+  }
+  if (options.priorityMicroLamports !== undefined) {
+    const priorityMicroLamports = Number(options.priorityMicroLamports);
+    if (
+      !Number.isInteger(priorityMicroLamports) ||
+      priorityMicroLamports < 0 ||
+      priorityMicroLamports > 2_000_000
+    ) {
+      return null;
+    }
   }
   if (
     options.commitment !== undefined &&
@@ -262,8 +282,16 @@ function parsePrivyExecute(value: unknown): {
             ...(options.simulateOnly !== undefined
               ? { simulateOnly: options.simulateOnly as boolean }
               : {}),
+            ...(options.requireSimulation !== undefined
+              ? { requireSimulation: options.requireSimulation as boolean }
+              : {}),
             ...(options.dryRun !== undefined
               ? { dryRun: options.dryRun as boolean }
+              : {}),
+            ...(options.priorityMicroLamports !== undefined
+              ? {
+                  priorityMicroLamports: Number(options.priorityMicroLamports),
+                }
               : {}),
             ...(options.commitment !== undefined
               ? {
@@ -342,7 +370,9 @@ export type ExecSubmitRequestV1 = {
     };
     options?: {
       simulateOnly?: boolean;
+      requireSimulation?: boolean;
       dryRun?: boolean;
+      priorityMicroLamports?: number;
       commitment?: "processed" | "confirmed" | "finalized";
       orderType?: "market" | "limit" | "trigger";
       timeInForce?: "gtc" | "ioc" | "fok";

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1244,11 +1244,25 @@ const worker = {
         ) {
           const swap = parsed.value.privyExecute.swap;
           const options = parsed.value.privyExecute.options ?? {};
+          const requestedRequireSimulation =
+            typeof options.requireSimulation === "boolean"
+              ? options.requireSimulation
+              : null;
+          const effectiveRequireSimulation =
+            submitPolicyRuntime?.requireSimulation === true ||
+            requestedRequireSimulation === true;
           const executionParams: Record<string, unknown> = {
             lane: laneResolution.lane,
           };
-          if (submitPolicyRuntime?.requireSimulation) {
+          if (requestedRequireSimulation === false) {
+            executionParams.requireSimulation = false;
+          }
+          if (effectiveRequireSimulation) {
             executionParams.requireSimulation = true;
+          }
+          if (typeof options.priorityMicroLamports === "number") {
+            executionParams.priorityMicroLamports =
+              options.priorityMicroLamports;
           }
           const execution = {
             adapter: laneResolution.adapter,
@@ -1266,10 +1280,21 @@ const worker = {
 
           const attemptId = newExecutionAttemptId();
           const attemptStartedAt = new Date().toISOString();
+          const qualityMetadata = {
+            lane: laneResolution.lane,
+            slippageBps: swap.slippageBps,
+            requestedRequireSimulation,
+            effectiveRequireSimulation,
+            priorityMicroLamports:
+              typeof options.priorityMicroLamports === "number"
+                ? options.priorityMicroLamports
+                : null,
+          };
           let providerResponse: Record<string, unknown> | null = {
             route: laneResolution.adapter,
             lane: laneResolution.lane,
             mode: parsed.value.mode,
+            quality: qualityMetadata,
           };
 
           try {
@@ -1405,6 +1430,7 @@ const worker = {
                 route: laneResolution.adapter,
                 resultStatus: result.status,
                 outcome: terminalStatus,
+                quality: qualityMetadata,
                 quote: {
                   inputMint: swap.inputMint,
                   outputMint: swap.outputMint,
@@ -1474,6 +1500,7 @@ const worker = {
                 mode: parsed.value.mode,
                 route: laneResolution.adapter,
                 outcome: terminalStatus,
+                quality: qualityMetadata,
               },
               readyAt: failedAt,
             });

--- a/tests/unit/portal_terminal_trade_ticket_validation.test.ts
+++ b/tests/unit/portal_terminal_trade_ticket_validation.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { validateOrderConfig } from "../../apps/portal/app/terminal/components/trade-ticket-modal";
+import {
+  validateExecutionQualityConfig,
+  validateOrderConfig,
+} from "../../apps/portal/app/terminal/components/trade-ticket-modal";
 
 describe("portal terminal advanced trade ticket validation", () => {
   test("rejects invalid limit and post-only combinations", () => {
@@ -33,6 +36,28 @@ describe("portal terminal advanced trade ticket validation", () => {
       takeProfitPriceAtomic: "1100000",
       stopLossPriceAtomic: "850000",
       bracketEnabled: true,
+    });
+    expect(errors).toHaveLength(0);
+  });
+
+  test("blocks invalid safe lane + no-simulation quality combo", () => {
+    const errors = validateExecutionQualityConfig({
+      lane: "safe",
+      simulationPreference: "never",
+      slippageBps: 50,
+      priorityMicroLamports: 5000,
+    });
+    expect(errors).toContain(
+      "Safe lane requires simulation (choose auto or always).",
+    );
+  });
+
+  test("accepts valid execution quality controls", () => {
+    const errors = validateExecutionQualityConfig({
+      lane: "protected",
+      simulationPreference: "always",
+      slippageBps: 120,
+      priorityMicroLamports: 200000,
     });
     expect(errors).toHaveLength(0);
   });

--- a/tests/unit/worker_exec_submit_contract_privy.test.ts
+++ b/tests/unit/worker_exec_submit_contract_privy.test.ts
@@ -21,7 +21,9 @@ const VALID_PRIVY_SUBMIT = {
     },
     options: {
       simulateOnly: true,
+      requireSimulation: true,
       dryRun: false,
+      priorityMicroLamports: 50000,
       commitment: "confirmed",
     },
   },
@@ -36,6 +38,10 @@ describe("exec submit contract: privy_execute", () => {
     expect(parsed.value.privyExecute?.intentType).toBe("swap");
     expect(parsed.value.privyExecute?.swap.amountAtomic).toBe("1000000");
     expect(parsed.value.privyExecute?.options?.simulateOnly).toBe(true);
+    expect(parsed.value.privyExecute?.options?.requireSimulation).toBe(true);
+    expect(parsed.value.privyExecute?.options?.priorityMicroLamports).toBe(
+      50000,
+    );
     expect(parsed.value.privyExecute?.options?.commitment).toBe("confirmed");
     expect(parsed.metadataForStorage).toEqual({
       source: "terminal-ui",
@@ -105,6 +111,21 @@ describe("exec submit contract: privy_execute", () => {
       },
     });
     expect(invalidOptionShape).toEqual({
+      ok: false,
+      error: "invalid-request",
+    });
+
+    const invalidPriorityBounds = parseExecSubmitPayload({
+      ...VALID_PRIVY_SUBMIT,
+      privyExecute: {
+        ...VALID_PRIVY_SUBMIT.privyExecute,
+        options: {
+          ...VALID_PRIVY_SUBMIT.privyExecute.options,
+          priorityMicroLamports: 2_000_001,
+        },
+      },
+    });
+    expect(invalidPriorityBounds).toEqual({
       ok: false,
       error: "invalid-request",
     });


### PR DESCRIPTION
## Summary\n- add lane/simulation/priority execution quality controls to the terminal trade ticket\n- map controls one-to-one into  payload fields for privy execution\n- add guardrails for invalid lane-policy combinations and surface quality metadata in recent activity\n- extend submit contract validation + unit tests for new quality option fields\n\n## Testing\n- bun run lint\n- bun run typecheck\n- bun test tests/unit/portal_terminal_trade_ticket_validation.test.ts tests/unit/worker_exec_submit_contract_privy.test.ts\n- bun test tests/unit/worker_x402_exec_submit_route.test.ts\n\nCloses #155