### PR TITLE
feat: TERM-010 live positions panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ It provides one execution fabric for:
 - Terminal-grade market chart controls (timeframes, line/candles, mark/index/reference overlays, keyboard cursor nav)
 - Advanced trade ticket with market/limit/trigger modes, TIF/flags, quantity modes, and TP/SL bracket validation
 - Execution quality controls in ticket (lane, simulation preference, slippage, priority fee hints) with terminal activity surfacing
+- Live positions panel with session PnL/risk badges and quick reduce/close actions wired to execution intents
 - Account-level Privy wallet model (one wallet per user)
 - x402 paid APIs (`/api/x402/read/*`, `/api/x402/exec/submit`)
 - Execution API scaffold:

--- a/apps/portal/app/terminal/components/live-positions.ts
+++ b/apps/portal/app/terminal/components/live-positions.ts
@@ -1,0 +1,228 @@
+import { getPairConfig, type PairId, type TokenSymbol } from "./trade-pairs";
+
+export type PositionFill = {
+  id: string;
+  ts: number;
+  pairId: PairId;
+  direction: "buy" | "sell";
+  status: string;
+  signature: string | null;
+  baseFilledUi: number;
+  quoteFilledUi: number;
+  fillPrice: number | null;
+  qualitySummary: string;
+};
+
+export type LivePosition = {
+  pairId: PairId;
+  baseSymbol: TokenSymbol;
+  quoteSymbol: TokenSymbol;
+  sizeBase: number;
+  avgEntry: number | null;
+  mark: number | null;
+  unrealizedPnl: number | null;
+  realizedPnl: number;
+  notional: number | null;
+  leverage: number | null;
+  riskLevel: "low" | "medium" | "high";
+  warning: string | null;
+  lastUpdatedTs: number;
+  qualitySummary: string;
+};
+
+export type LivePositionTotals = {
+  unrealizedPnl: number;
+  realizedPnl: number;
+  notional: number;
+};
+
+function isFillSuccess(fill: PositionFill): boolean {
+  const status = fill.status.trim().toLowerCase();
+  if (!status) return false;
+  return (
+    status === "landed" ||
+    status === "finalized" ||
+    status === "confirmed" ||
+    status === "processed"
+  );
+}
+
+function toFiniteNumber(value: number): number | null {
+  if (!Number.isFinite(value)) return null;
+  return value;
+}
+
+function toNonNegative(value: number): number {
+  if (!Number.isFinite(value) || value < 0) return 0;
+  return value;
+}
+
+function resolveRisk(input: {
+  leverage: number | null;
+  unrealizedPnl: number | null;
+  notional: number | null;
+}): { riskLevel: LivePosition["riskLevel"]; warning: string | null } {
+  const { leverage, unrealizedPnl, notional } = input;
+  if (leverage !== null && leverage >= 2) {
+    return {
+      riskLevel: "high",
+      warning: "High leverage vs quote collateral.",
+    };
+  }
+  if (
+    unrealizedPnl !== null &&
+    notional !== null &&
+    notional > 0 &&
+    unrealizedPnl / notional <= -0.08
+  ) {
+    return {
+      riskLevel: "high",
+      warning: "Unrealized drawdown exceeds 8%.",
+    };
+  }
+  if (leverage !== null && leverage >= 1) {
+    return {
+      riskLevel: "medium",
+      warning: "Exposure is elevated.",
+    };
+  }
+  return {
+    riskLevel: "low",
+    warning: null,
+  };
+}
+
+export function buildLivePositions(input: {
+  fills: readonly PositionFill[];
+  markByPair: Partial<Record<PairId, number | null>>;
+  quoteBalanceBySymbol: Partial<Record<TokenSymbol, number | null>>;
+}): LivePosition[] {
+  const sorted = [...input.fills].sort((a, b) => a.ts - b.ts);
+  const state = new Map<
+    PairId,
+    {
+      sizeBase: number;
+      costQuote: number;
+      realizedPnl: number;
+      lastFillPrice: number | null;
+      lastUpdatedTs: number;
+      qualitySummary: string;
+    }
+  >();
+
+  for (const fill of sorted) {
+    if (!isFillSuccess(fill)) continue;
+    const baseFilled = toNonNegative(fill.baseFilledUi);
+    const quoteFilled = toNonNegative(fill.quoteFilledUi);
+    const derivedPrice =
+      fill.fillPrice !== null
+        ? fill.fillPrice
+        : baseFilled > 0
+          ? quoteFilled / baseFilled
+          : null;
+    if (baseFilled <= 0 || quoteFilled <= 0) continue;
+    if (!Number.isFinite(derivedPrice ?? NaN) || (derivedPrice ?? 0) <= 0) {
+      continue;
+    }
+    const price = derivedPrice as number;
+
+    const current = state.get(fill.pairId) ?? {
+      sizeBase: 0,
+      costQuote: 0,
+      realizedPnl: 0,
+      lastFillPrice: null,
+      lastUpdatedTs: fill.ts,
+      qualitySummary: fill.qualitySummary,
+    };
+
+    if (fill.direction === "buy") {
+      current.sizeBase += baseFilled;
+      current.costQuote += baseFilled * price;
+    } else if (current.sizeBase > 0) {
+      const avgEntry = current.costQuote / current.sizeBase;
+      const closeSize = Math.min(baseFilled, current.sizeBase);
+      current.realizedPnl += (price - avgEntry) * closeSize;
+      current.sizeBase -= closeSize;
+      current.costQuote -= avgEntry * closeSize;
+      if (current.sizeBase <= 1e-9) {
+        current.sizeBase = 0;
+        current.costQuote = 0;
+      }
+    }
+
+    current.lastFillPrice = price;
+    current.lastUpdatedTs = fill.ts;
+    current.qualitySummary = fill.qualitySummary;
+    state.set(fill.pairId, current);
+  }
+
+  const positions: LivePosition[] = [];
+  for (const [pairId, entry] of state.entries()) {
+    if (entry.sizeBase <= 0) continue;
+    const pair = getPairConfig(pairId);
+    const avgEntry =
+      entry.sizeBase > 0 ? entry.costQuote / entry.sizeBase : null;
+    const mark = toFiniteNumber(
+      Number(input.markByPair[pairId] ?? entry.lastFillPrice ?? NaN),
+    );
+    const notional =
+      mark === null ? null : (toFiniteNumber(entry.sizeBase * mark) ?? null);
+    const unrealizedPnl =
+      avgEntry === null || mark === null
+        ? null
+        : toFiniteNumber((mark - avgEntry) * entry.sizeBase);
+    const quoteBalance = toFiniteNumber(
+      Number(input.quoteBalanceBySymbol[pair.quoteSymbol] ?? NaN),
+    );
+    const leverage =
+      quoteBalance && quoteBalance > 0 && notional !== null
+        ? toFiniteNumber(notional / quoteBalance)
+        : null;
+    const risk = resolveRisk({
+      leverage,
+      unrealizedPnl,
+      notional,
+    });
+    positions.push({
+      pairId,
+      baseSymbol: pair.baseSymbol,
+      quoteSymbol: pair.quoteSymbol,
+      sizeBase: entry.sizeBase,
+      avgEntry,
+      mark,
+      unrealizedPnl,
+      realizedPnl: entry.realizedPnl,
+      notional,
+      leverage,
+      riskLevel: risk.riskLevel,
+      warning: risk.warning,
+      lastUpdatedTs: entry.lastUpdatedTs,
+      qualitySummary: entry.qualitySummary,
+    });
+  }
+
+  positions.sort((a, b) => {
+    const aNotional = a.notional ?? 0;
+    const bNotional = b.notional ?? 0;
+    if (aNotional !== bNotional) return bNotional - aNotional;
+    return b.lastUpdatedTs - a.lastUpdatedTs;
+  });
+  return positions;
+}
+
+export function summarizeLivePositions(
+  positions: readonly LivePosition[],
+): LivePositionTotals {
+  return positions.reduce(
+    (acc, position) => ({
+      unrealizedPnl: acc.unrealizedPnl + (position.unrealizedPnl ?? 0),
+      realizedPnl: acc.realizedPnl + position.realizedPnl,
+      notional: acc.notional + (position.notional ?? 0),
+    }),
+    {
+      unrealizedPnl: 0,
+      realizedPnl: 0,
+      notional: 0,
+    },
+  );
+}

--- a/apps/portal/app/terminal/components/trade-ticket-modal.tsx
+++ b/apps/portal/app/terminal/components/trade-ticket-modal.tsx
@@ -30,12 +30,17 @@ type TradeTicketModalProps = {
 };
 
 export type TradeTicketCompletion = {
+  pairId: TradeIntent["pairId"];
+  direction: TradeIntent["direction"];
   inputMint: string;
   outputMint: string;
   inputSymbol: string;
   outputSymbol: string;
   inAmountAtomic: string;
   outAmountAtomic: string;
+  baseFilledUi: number;
+  quoteFilledUi: number;
+  fillPrice: number | null;
   status: string;
   signature: string | null;
   lane: ExecutionLane;
@@ -120,6 +125,17 @@ function formatAtomicToUi(
   } catch {
     return null;
   }
+}
+
+function atomicToUiNumber(
+  atomicRaw: string | null,
+  decimals: number,
+): number | null {
+  const ui = formatAtomicToUi(atomicRaw, decimals, 9);
+  if (!ui) return null;
+  const parsed = Number(ui);
+  if (!Number.isFinite(parsed)) return null;
+  return parsed;
 }
 
 function toPositiveAtomic(raw: string | null | undefined): string | null {
@@ -764,13 +780,28 @@ export function TradeTicketModal({
         signal: controller.signal,
       });
 
+      const inputUiAmount =
+        atomicToUiNumber(quote.inAmountAtomic, intent.inputDecimals) ?? 0;
+      const outputUiAmount =
+        atomicToUiNumber(quote.outAmountAtomic, intent.outputDecimals) ?? 0;
+      const baseFilledUi =
+        intent.direction === "buy" ? outputUiAmount : inputUiAmount;
+      const quoteFilledUi =
+        intent.direction === "buy" ? inputUiAmount : outputUiAmount;
+      const fillPrice = baseFilledUi > 0 ? quoteFilledUi / baseFilledUi : null;
+
       onTradeComplete?.({
+        pairId: intent.pairId,
+        direction: intent.direction,
         inputMint: intent.inputMint,
         outputMint: intent.outputMint,
         inputSymbol: intent.inputSymbol,
         outputSymbol: intent.outputSymbol,
         inAmountAtomic: quote.inAmountAtomic,
         outAmountAtomic: quote.outAmountAtomic,
+        baseFilledUi,
+        quoteFilledUi,
+        fillPrice,
         status: terminal.status,
         signature: terminal.signature,
         lane: executionLane,

--- a/apps/portal/app/terminal/page.tsx
+++ b/apps/portal/app/terminal/page.tsx
@@ -22,6 +22,11 @@ import {
   buildDepthChartModel,
   findNearestDepthPoint,
 } from "./components/depth-chart";
+import {
+  buildLivePositions,
+  type PositionFill,
+  summarizeLivePositions,
+} from "./components/live-positions";
 import { MacroEtfWidget } from "./components/macro-etf-widget";
 import { MacroFredWidget } from "./components/macro-fred-widget";
 import { MacroOilWidget } from "./components/macro-oil-widget";
@@ -72,7 +77,11 @@ type ExecutionActivityRow = {
   id: string;
   ts: number;
   pairId: PairId;
+  direction: "buy" | "sell";
   leg: string;
+  baseFilledUi: number;
+  quoteFilledUi: number;
+  fillPrice: number | null;
   status: string;
   signature: string | null;
   qualitySummary: string;
@@ -674,8 +683,12 @@ function ControlRoom() {
         const entry: ExecutionActivityRow = {
           id: crypto.randomUUID(),
           ts: Date.now(),
-          pairId: selectedPairId,
+          pairId: trade.pairId,
+          direction: trade.direction,
           leg: `${trade.inputSymbol} -> ${trade.outputSymbol}`,
+          baseFilledUi: trade.baseFilledUi,
+          quoteFilledUi: trade.quoteFilledUi,
+          fillPrice: trade.fillPrice,
           status: trade.status,
           signature: trade.signature,
           qualitySummary: `lane ${trade.lane} • sim ${trade.simulationPreference} • slip ${trade.slippageBps} bps • prio ${trade.priorityLevel}`,
@@ -684,7 +697,7 @@ function ControlRoom() {
       });
       void refreshWalletBalances();
     },
-    [applyOptimisticTradeBalances, refreshWalletBalances, selectedPairId],
+    [applyOptimisticTradeBalances, refreshWalletBalances],
   );
 
   useEffect(() => {
@@ -879,7 +892,14 @@ function ControlRoom() {
                     key="positions"
                     className="flex flex-col overflow-hidden bg-surface"
                   >
-                    <PositionsOrdersFillsPanel entries={recentExecutions} />
+                    <PositionsOrdersFillsPanel
+                      entries={recentExecutions}
+                      selectedPairId={selectedPairId}
+                      selectedPairMark={marketFeed.latestPrice}
+                      tokenBalancesByMint={tokenBalancesByMint}
+                      tradingEnabled={canQuickTrade}
+                      onQuickAction={openTradeTicket}
+                    />
                   </div>
                 ) : null}
 
@@ -1642,8 +1662,121 @@ const TradesTapePanel = memo(function TradesTapePanel(props: {
 const PositionsOrdersFillsPanel = memo(
   function PositionsOrdersFillsPanel(props: {
     entries: ExecutionActivityRow[];
+    selectedPairId: PairId;
+    selectedPairMark: number | null;
+    tokenBalancesByMint: Record<string, string>;
+    tradingEnabled: boolean;
+    onQuickAction: (intent: TradeIntent) => void;
   }) {
-    const { entries } = props;
+    const {
+      entries,
+      selectedPairId,
+      selectedPairMark,
+      tokenBalancesByMint,
+      tradingEnabled,
+      onQuickAction,
+    } = props;
+    const markByPair = useMemo(
+      () =>
+        ({
+          [selectedPairId]: selectedPairMark,
+        }) as Partial<Record<PairId, number | null>>,
+      [selectedPairId, selectedPairMark],
+    );
+    const quoteBalanceBySymbol = useMemo(() => {
+      const balances: Record<string, number | null> = {};
+      for (const [symbol, token] of Object.entries(TOKEN_CONFIGS)) {
+        const formatted = formatAtomicTokenBalance(
+          tokenBalancesByMint[token.mint] ?? "0",
+          token.decimals,
+          9,
+        );
+        const parsed = Number(formatted);
+        balances[symbol] = Number.isFinite(parsed) ? parsed : null;
+      }
+      return balances;
+    }, [tokenBalancesByMint]);
+    const fills = useMemo<PositionFill[]>(
+      () =>
+        entries.map((entry) => ({
+          id: entry.id,
+          ts: entry.ts,
+          pairId: entry.pairId,
+          direction: entry.direction,
+          status: entry.status,
+          signature: entry.signature,
+          baseFilledUi: entry.baseFilledUi,
+          quoteFilledUi: entry.quoteFilledUi,
+          fillPrice: entry.fillPrice,
+          qualitySummary: entry.qualitySummary,
+        })),
+      [entries],
+    );
+    const positions = useMemo(
+      () =>
+        buildLivePositions({
+          fills,
+          markByPair,
+          quoteBalanceBySymbol,
+        }),
+      [fills, markByPair, quoteBalanceBySymbol],
+    );
+    const totals = useMemo(
+      () => summarizeLivePositions(positions),
+      [positions],
+    );
+
+    const formatAmountUi = useCallback((value: number): string => {
+      const normalized = Number.isFinite(value) ? value : 0;
+      return normalized.toFixed(4).replace(/\.?0+$/, "") || "0";
+    }, []);
+
+    const openReduceIntent = useCallback(
+      (pairId: PairId, sizeBase: number) => {
+        if (!tradingEnabled) return;
+        const reduceSize = Math.max(sizeBase * 0.25, 0.0001);
+        onQuickAction(
+          createTradeIntent("sell", "POSITIONS_PANEL", pairId, {
+            reason: `Reduce 25% position size`,
+            amountUi: formatAmountUi(reduceSize),
+          }),
+        );
+      },
+      [formatAmountUi, onQuickAction, tradingEnabled],
+    );
+
+    const openCloseIntent = useCallback(
+      (pairId: PairId, sizeBase: number) => {
+        if (!tradingEnabled) return;
+        onQuickAction(
+          createTradeIntent("sell", "POSITIONS_PANEL", pairId, {
+            reason: "Close full position",
+            amountUi: formatAmountUi(sizeBase),
+          }),
+        );
+      },
+      [formatAmountUi, onQuickAction, tradingEnabled],
+    );
+
+    const formatSignedPnl = useCallback((value: number | null): string => {
+      if (value === null || !Number.isFinite(value)) return "--";
+      const sign = value >= 0 ? "+" : "";
+      return `${sign}${value.toFixed(2)}`;
+    }, []);
+
+    const riskBadgeClass = useCallback(
+      (riskLevel: "low" | "medium" | "high") => {
+        if (riskLevel === "high") {
+          return "border-red-500/40 bg-red-500/10 text-red-300";
+        }
+        if (riskLevel === "medium") {
+          return "border-amber-500/40 bg-amber-500/10 text-amber-300";
+        }
+        return "border-emerald-500/40 bg-emerald-500/10 text-emerald-300";
+      },
+      [],
+    );
+
     return (
       <>
         <div className="flex items-center justify-between border-b border-border bg-surface px-3 py-1.5 shrink-0">
@@ -1657,11 +1790,150 @@ const PositionsOrdersFillsPanel = memo(
         <div className="flex-1 overflow-auto p-3 text-xs space-y-3">
           <div className="rounded border border-border bg-subtle p-2">
             <p className="text-[10px] uppercase tracking-wider text-muted">
-              Open Positions
+              Position Totals (Session)
             </p>
-            <p className="mt-1 text-muted">
-              Position netting is not enabled yet for this lane.
+            <p className="mt-1 font-mono text-ink">
+              Notional: {totals.notional.toFixed(2)} USDC
             </p>
+            <p
+              className={cn(
+                "font-mono",
+                totals.unrealizedPnl >= 0 ? "text-emerald-300" : "text-red-300",
+              )}
+            >
+              Unrealized: {formatSignedPnl(totals.unrealizedPnl)} USDC
+            </p>
+            <p
+              className={cn(
+                "font-mono",
+                totals.realizedPnl >= 0 ? "text-emerald-300" : "text-red-300",
+              )}
+            >
+              Realized: {formatSignedPnl(totals.realizedPnl)} USDC
+            </p>
+          </div>
+          <div className="rounded border border-border bg-subtle p-2">
+            <p className="text-[10px] uppercase tracking-wider text-muted">
+              Live Positions
+            </p>
+            <div className="mt-2 space-y-1.5">
+              {positions.length === 0 ? (
+                <p className="text-muted">
+                  No open position from this session yet.
+                </p>
+              ) : null}
+              {positions.map((position) => (
+                <div
+                  key={`position-${position.pairId}`}
+                  className="rounded border border-border/60 px-2 py-1.5 space-y-1.5"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="font-mono text-[11px] text-ink truncate">
+                        {position.pairId} • {position.sizeBase.toFixed(4)}{" "}
+                        {position.baseSymbol}
+                      </p>
+                      <p className="text-[10px] text-muted">
+                        Entry{" "}
+                        {position.avgEntry === null
+                          ? "--"
+                          : position.avgEntry.toFixed(4)}{" "}
+                        • Mark{" "}
+                        {position.mark === null
+                          ? "--"
+                          : position.mark.toFixed(4)}
+                      </p>
+                    </div>
+                    <span
+                      className={cn(
+                        "rounded border px-1.5 py-0.5 text-[10px] uppercase tracking-wider",
+                        riskBadgeClass(position.riskLevel),
+                      )}
+                    >
+                      {position.riskLevel} risk
+                    </span>
+                  </div>
+                  <div className="grid grid-cols-2 gap-2 text-[10px]">
+                    <p className="text-muted">
+                      Unrealized:{" "}
+                      <span
+                        className={
+                          (position.unrealizedPnl ?? 0) >= 0
+                            ? "text-emerald-300"
+                            : "text-red-300"
+                        }
+                      >
+                        {formatSignedPnl(position.unrealizedPnl)}
+                      </span>
+                    </p>
+                    <p className="text-muted text-right">
+                      Realized:{" "}
+                      <span
+                        className={
+                          position.realizedPnl >= 0
+                            ? "text-emerald-300"
+                            : "text-red-300"
+                        }
+                      >
+                        {formatSignedPnl(position.realizedPnl)}
+                      </span>
+                    </p>
+                    <p className="text-muted">
+                      Leverage:{" "}
+                      <span className="font-mono text-ink">
+                        {position.leverage === null
+                          ? "--"
+                          : `${position.leverage.toFixed(2)}x`}
+                      </span>
+                    </p>
+                    <p className="text-muted text-right truncate">
+                      {position.warning ?? "Risk within normal bounds."}
+                    </p>
+                  </div>
+                  <div className="flex gap-1.5">
+                    <button
+                      className={cn(
+                        BTN_SECONDARY,
+                        "h-6 rounded px-2 text-[10px] uppercase tracking-wider",
+                        !tradingEnabled && "opacity-60 pointer-events-none",
+                      )}
+                      onClick={() =>
+                        openReduceIntent(position.pairId, position.sizeBase)
+                      }
+                      type="button"
+                      disabled={!tradingEnabled}
+                    >
+                      Reduce 25%
+                    </button>
+                    <button
+                      className={cn(
+                        BTN_SECONDARY,
+                        "h-6 rounded px-2 text-[10px] uppercase tracking-wider",
+                        !tradingEnabled && "opacity-60 pointer-events-none",
+                      )}
+                      onClick={() =>
+                        openCloseIntent(position.pairId, position.sizeBase)
+                      }
+                      type="button"
+                      disabled={!tradingEnabled}
+                    >
+                      Close
+                    </button>
+                    <button
+                      className={cn(
+                        BTN_SECONDARY,
+                        "h-6 rounded px-2 text-[10px] uppercase tracking-wider opacity-60",
+                      )}
+                      type="button"
+                      disabled
+                      title="Reverse requires shorting/margin support."
+                    >
+                      Reverse
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
           <div className="rounded border border-border bg-subtle p-2">
             <p className="text-[10px] uppercase tracking-wider text-muted">
@@ -1685,6 +1957,14 @@ const PositionsOrdersFillsPanel = memo(
                     </p>
                     <p className="text-[10px] text-muted truncate">
                       {entry.qualitySummary}
+                    </p>
+                    <p className="text-[10px] text-muted">
+                      {entry.direction.toUpperCase()}{" "}
+                      {entry.baseFilledUi.toFixed(4)}{" "}
+                      {getPairConfig(entry.pairId).baseSymbol} @{" "}
+                      {entry.fillPrice === null
+                        ? "--"
+                        : entry.fillPrice.toFixed(4)}
                     </p>
                   </div>
                   <div className="text-right">

--- a/tests/unit/portal_terminal_live_positions.test.ts
+++ b/tests/unit/portal_terminal_live_positions.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildLivePositions,
+  type PositionFill,
+  summarizeLivePositions,
+} from "../../apps/portal/app/terminal/components/live-positions";
+
+function fill(input: Partial<PositionFill> & { id: string }): PositionFill {
+  return {
+    id: input.id,
+    ts: input.ts ?? 0,
+    pairId: input.pairId ?? "SOL/USDC",
+    direction: input.direction ?? "buy",
+    status: input.status ?? "finalized",
+    signature: input.signature ?? "sig",
+    baseFilledUi: input.baseFilledUi ?? 1,
+    quoteFilledUi: input.quoteFilledUi ?? 100,
+    fillPrice: input.fillPrice ?? 100,
+    qualitySummary: input.qualitySummary ?? "lane safe",
+  };
+}
+
+describe("portal terminal live positions model", () => {
+  test("builds unrealized/realized pnl from fills and mark", () => {
+    const positions = buildLivePositions({
+      fills: [
+        fill({
+          id: "f1",
+          ts: 1,
+          direction: "buy",
+          baseFilledUi: 2,
+          quoteFilledUi: 200,
+          fillPrice: 100,
+        }),
+      ],
+      markByPair: { "SOL/USDC": 110 },
+      quoteBalanceBySymbol: { USDC: 1000 },
+    });
+
+    expect(positions).toHaveLength(1);
+    expect(positions[0]?.pairId).toBe("SOL/USDC");
+    expect(positions[0]?.sizeBase).toBeCloseTo(2, 8);
+    expect(positions[0]?.avgEntry).toBeCloseTo(100, 8);
+    expect(positions[0]?.mark).toBeCloseTo(110, 8);
+    expect(positions[0]?.unrealizedPnl).toBeCloseTo(20, 8);
+    expect(positions[0]?.realizedPnl).toBeCloseTo(0, 8);
+    expect(positions[0]?.leverage).toBeCloseTo(0.22, 8);
+  });
+
+  test("tracks realized pnl after partial close", () => {
+    const positions = buildLivePositions({
+      fills: [
+        fill({
+          id: "f1",
+          ts: 1,
+          direction: "buy",
+          baseFilledUi: 2,
+          quoteFilledUi: 200,
+          fillPrice: 100,
+        }),
+        fill({
+          id: "f2",
+          ts: 2,
+          direction: "sell",
+          baseFilledUi: 1,
+          quoteFilledUi: 120,
+          fillPrice: 120,
+        }),
+      ],
+      markByPair: { "SOL/USDC": 115 },
+      quoteBalanceBySymbol: { USDC: 1000 },
+    });
+    const totals = summarizeLivePositions(positions);
+
+    expect(positions).toHaveLength(1);
+    expect(positions[0]?.sizeBase).toBeCloseTo(1, 8);
+    expect(positions[0]?.avgEntry).toBeCloseTo(100, 8);
+    expect(positions[0]?.realizedPnl).toBeCloseTo(20, 8);
+    expect(positions[0]?.unrealizedPnl).toBeCloseTo(15, 8);
+    expect(totals.realizedPnl).toBeCloseTo(20, 8);
+    expect(totals.unrealizedPnl).toBeCloseTo(15, 8);
+  });
+});


### PR DESCRIPTION
## Summary
- build live positions model from execution fills with realized/unrealized PnL, notional, leverage, and risk badges
- replace placeholder positions panel with actionable reduce/close controls that open execution trade intents
- extend trade completion payload with pair/direction/fill metrics so positions update near-realtime from terminal executions
- add dedicated unit tests for positions math and keep trade-ticket validation coverage green

## Testing
- bun run lint
- bun run typecheck
- bun test tests/unit/portal_terminal_live_positions.test.ts tests/unit/portal_terminal_trade_ticket_validation.test.ts tests/unit/worker_exec_submit_contract_privy.test.ts

Closes #156
