### PR TITLE
feat: TERM-011 open orders management panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It provides one execution fabric for:
 - Advanced trade ticket with market/limit/trigger modes, TIF/flags, quantity modes, and TP/SL bracket validation
 - Execution quality controls in ticket (lane, simulation preference, slippage, priority fee hints) with terminal activity surfacing
 - Live positions panel with session PnL/risk badges and quick reduce/close actions wired to execution intents
+- Open orders panel with pending/working/partial state, amend/cancel flows, and execute-now actions
 - Account-level Privy wallet model (one wallet per user)
 - x402 paid APIs (`/api/x402/read/*`, `/api/x402/exec/submit`)
 - Execution API scaffold:

--- a/apps/portal/app/terminal/components/open-orders.ts
+++ b/apps/portal/app/terminal/components/open-orders.ts
@@ -28,15 +28,13 @@ export function queueOpenOrder(
   current: readonly OpenOrderRow[],
   order: QueuedTerminalOrder,
 ): OpenOrderRow[] {
-  return [
-    {
-      ...order,
-      status: "pending",
-      initialAmountUi: order.amountUi,
-      lastError: null,
-    },
-    ...current,
-  ].slice(0, 64);
+  const nextOrder: OpenOrderRow = {
+    ...order,
+    status: "pending",
+    initialAmountUi: order.amountUi,
+    lastError: null,
+  };
+  return [nextOrder, ...current].slice(0, 64);
 }
 
 export function promotePendingOrders(

--- a/apps/portal/app/terminal/components/open-orders.ts
+++ b/apps/portal/app/terminal/components/open-orders.ts
@@ -184,6 +184,13 @@ export function executeOpenOrderSlice(input: {
       next: [...input.current],
     };
   }
+  if (target.status === "cancelled" || target.status === "failed") {
+    return {
+      ok: false,
+      error: "order-not-executable",
+      next: [...input.current],
+    };
+  }
   const remaining = parseOrderAmountUi(target.remainingAmountUi);
   if (remaining === null) {
     const error = "invalid-order-amount";

--- a/apps/portal/app/terminal/components/open-orders.ts
+++ b/apps/portal/app/terminal/components/open-orders.ts
@@ -1,0 +1,221 @@
+import type { QueuedTerminalOrder } from "./trade-ticket-modal";
+
+export type OpenOrderStatus =
+  | "pending"
+  | "working"
+  | "partial"
+  | "failed"
+  | "cancelled";
+
+export type OpenOrderRow = QueuedTerminalOrder & {
+  status: OpenOrderStatus;
+  initialAmountUi: string;
+  lastError: string | null;
+};
+
+export function formatOrderAmountUi(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "";
+  return value.toFixed(6).replace(/\.?0+$/, "");
+}
+
+export function parseOrderAmountUi(value: string): number | null {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+export function queueOpenOrder(
+  current: readonly OpenOrderRow[],
+  order: QueuedTerminalOrder,
+): OpenOrderRow[] {
+  return [
+    {
+      ...order,
+      status: "pending",
+      initialAmountUi: order.amountUi,
+      lastError: null,
+    },
+    ...current,
+  ].slice(0, 64);
+}
+
+export function promotePendingOrders(
+  current: readonly OpenOrderRow[],
+  now: number,
+  minPendingMs = 1500,
+): OpenOrderRow[] {
+  let changed = false;
+  const next = current.map((order) => {
+    if (order.status !== "pending") return order;
+    if (now - order.createdAt < minPendingMs) return order;
+    changed = true;
+    return {
+      ...order,
+      status: "working" as const,
+      updatedAt: now,
+    };
+  });
+  return changed ? next : [...current];
+}
+
+export function cancelOpenOrder(
+  current: readonly OpenOrderRow[],
+  orderId: string,
+  now: number,
+): OpenOrderRow[] {
+  return current.map((order) =>
+    order.id === orderId
+      ? {
+          ...order,
+          status: "cancelled",
+          updatedAt: now,
+          lastError: null,
+        }
+      : order,
+  );
+}
+
+export function cancelAllOpenOrders(
+  current: readonly OpenOrderRow[],
+  now: number,
+): OpenOrderRow[] {
+  return current.map((order) => ({
+    ...order,
+    status: "cancelled",
+    updatedAt: now,
+    lastError: null,
+  }));
+}
+
+export function setOrderError(
+  current: readonly OpenOrderRow[],
+  orderId: string,
+  error: string,
+  now: number,
+): OpenOrderRow[] {
+  return current.map((order) =>
+    order.id === orderId
+      ? {
+          ...order,
+          status: "failed",
+          updatedAt: now,
+          lastError: error,
+        }
+      : order,
+  );
+}
+
+export function amendOpenOrder(input: {
+  current: readonly OpenOrderRow[];
+  orderId: string;
+  amountUi: string;
+  priceUi: string;
+  now: number;
+}):
+  | { ok: true; next: OpenOrderRow[] }
+  | { ok: false; error: string; next: OpenOrderRow[] } {
+  const amount = parseOrderAmountUi(input.amountUi.trim());
+  if (amount === null) {
+    return {
+      ok: false,
+      error: "invalid-amend-amount",
+      next: setOrderError(
+        input.current,
+        input.orderId,
+        "invalid-amend-amount",
+        input.now,
+      ),
+    };
+  }
+  const nextAmountUi = formatOrderAmountUi(amount);
+  const normalizedPrice = input.priceUi.trim();
+  if (!normalizedPrice || Number(normalizedPrice) <= 0) {
+    const target = input.current.find((order) => order.id === input.orderId);
+    const error =
+      target?.orderType === "limit"
+        ? "invalid-limit-price"
+        : "invalid-trigger-price";
+    return {
+      ok: false,
+      error,
+      next: setOrderError(input.current, input.orderId, error, input.now),
+    };
+  }
+
+  return {
+    ok: true,
+    next: input.current.map((order) =>
+      order.id === input.orderId
+        ? {
+            ...order,
+            amountUi: nextAmountUi,
+            remainingAmountUi: nextAmountUi,
+            status: "working",
+            updatedAt: input.now,
+            lastError: null,
+            limitPriceUi: order.orderType === "limit" ? normalizedPrice : null,
+            triggerPriceUi:
+              order.orderType === "trigger" ? normalizedPrice : null,
+          }
+        : order,
+    ),
+  };
+}
+
+export function executeOpenOrderSlice(input: {
+  current: readonly OpenOrderRow[];
+  orderId: string;
+  fraction: 0.5 | 1;
+  now: number;
+}):
+  | {
+      ok: true;
+      executeAmountUi: string;
+      next: OpenOrderRow[];
+    }
+  | {
+      ok: false;
+      error: string;
+      next: OpenOrderRow[];
+    } {
+  const target = input.current.find((order) => order.id === input.orderId);
+  if (!target) {
+    return {
+      ok: false,
+      error: "order-not-found",
+      next: [...input.current],
+    };
+  }
+  const remaining = parseOrderAmountUi(target.remainingAmountUi);
+  if (remaining === null) {
+    const error = "invalid-order-amount";
+    return {
+      ok: false,
+      error,
+      next: setOrderError(input.current, input.orderId, error, input.now),
+    };
+  }
+  const executeAmount =
+    input.fraction === 1 ? remaining : Math.max(remaining * 0.5, 0.0001);
+  const executeAmountUi = formatOrderAmountUi(executeAmount);
+  const nextRemaining = Math.max(0, remaining - executeAmount);
+  const nextRemainingUi = formatOrderAmountUi(nextRemaining);
+
+  return {
+    ok: true,
+    executeAmountUi,
+    next: input.current.flatMap((order) => {
+      if (order.id !== input.orderId) return [order];
+      if (nextRemaining <= 0.000001) return [];
+      return [
+        {
+          ...order,
+          remainingAmountUi: nextRemainingUi,
+          status: "partial",
+          updatedAt: input.now,
+          lastError: null,
+        },
+      ];
+    }),
+  };
+}

--- a/apps/portal/app/terminal/components/trade-ticket-modal.tsx
+++ b/apps/portal/app/terminal/components/trade-ticket-modal.tsx
@@ -27,6 +27,7 @@ type TradeTicketModalProps = {
   getAccessToken: () => Promise<string | null>;
   onClose: () => void;
   onTradeComplete?: (trade: TradeTicketCompletion) => void;
+  onOrderQueued?: (order: QueuedTerminalOrder) => void;
 };
 
 export type TradeTicketCompletion = {
@@ -48,6 +49,26 @@ export type TradeTicketCompletion = {
   slippageBps: number;
   priorityLevel: PriorityLevel;
   priorityMicroLamports: number;
+};
+
+export type QueuedTerminalOrder = {
+  id: string;
+  createdAt: number;
+  updatedAt: number;
+  pairId: TradeIntent["pairId"];
+  direction: TradeIntent["direction"];
+  source: string;
+  reason: string;
+  orderType: "limit" | "trigger";
+  timeInForce: TimeInForce;
+  amountUi: string;
+  remainingAmountUi: string;
+  slippageBps: number;
+  lane: ExecutionLane;
+  simulationPreference: SimulationPreference;
+  priorityLevel: PriorityLevel;
+  limitPriceUi: string | null;
+  triggerPriceUi: string | null;
 };
 
 type QuoteState = {
@@ -316,6 +337,7 @@ export function TradeTicketModal({
   getAccessToken,
   onClose,
   onTradeComplete,
+  onOrderQueued,
 }: TradeTicketModalProps) {
   const [amountUi, setAmountUi] = useState("");
   const [slippageInput, setSlippageInput] = useState("50");
@@ -719,6 +741,49 @@ export function TradeTicketModal({
       ...(takeProfitPriceAtomic ? { takeProfitPriceAtomic } : {}),
       ...(stopLossPriceAtomic ? { stopLossPriceAtomic } : {}),
     };
+
+    if (orderType === "limit" || orderType === "trigger") {
+      if (!onOrderQueued) {
+        setSubmitStatus("error");
+        setSubmitMessage("open-orders-panel-unavailable");
+        return;
+      }
+      const amountForOrder = amountUi.trim();
+      if (!amountForOrder) {
+        setSubmitStatus("error");
+        setSubmitMessage("order-amount-required");
+        return;
+      }
+      const now = Date.now();
+      onOrderQueued({
+        id: crypto.randomUUID(),
+        createdAt: now,
+        updatedAt: now,
+        pairId: intent.pairId,
+        direction: intent.direction,
+        source: intent.source,
+        reason: intent.reason,
+        orderType,
+        timeInForce,
+        amountUi: amountForOrder,
+        remainingAmountUi: amountForOrder,
+        slippageBps: boundedSlippageBps,
+        lane: executionLane,
+        simulationPreference,
+        priorityLevel,
+        limitPriceUi:
+          orderType === "limit" ? limitPriceUi.trim() || null : null,
+        triggerPriceUi:
+          orderType === "trigger" ? triggerPriceUi.trim() || null : null,
+      });
+      closeModal();
+      toast.success(`${orderType.toUpperCase()} order queued`, {
+        description: `${intent.pairId} • ${amountForOrder} ${intent.inputSymbol}`,
+        position: "bottom-right",
+        duration: 3500,
+      });
+      return;
+    }
     setSubmitStatus("submitting");
     setSubmitMessage(null);
     let execToastId: string | number | null = null;
@@ -845,11 +910,14 @@ export function TradeTicketModal({
       setSubmitMessage(message);
     }
   }, [
+    amountUi,
     closeModal,
     dismissExecuteToast,
     getAccessToken,
     intent,
     limitPriceAtomic,
+    limitPriceUi,
+    onOrderQueued,
     onTradeComplete,
     orderType,
     orderValidationErrors,
@@ -869,6 +937,7 @@ export function TradeTicketModal({
     takeProfitPriceAtomic,
     timeInForce,
     triggerPriceAtomic,
+    triggerPriceUi,
     walletAddress,
   ]);
 

--- a/apps/portal/app/terminal/components/trade-ticket-modal.tsx
+++ b/apps/portal/app/terminal/components/trade-ticket-modal.tsx
@@ -33,6 +33,8 @@ type TradeTicketModalProps = {
 export type TradeTicketCompletion = {
   pairId: TradeIntent["pairId"];
   direction: TradeIntent["direction"];
+  source: string;
+  reason: string;
   inputMint: string;
   outputMint: string;
   inputSymbol: string;
@@ -858,6 +860,8 @@ export function TradeTicketModal({
       onTradeComplete?.({
         pairId: intent.pairId,
         direction: intent.direction,
+        source: intent.source,
+        reason: intent.reason,
         inputMint: intent.inputMint,
         outputMint: intent.outputMint,
         inputSymbol: intent.inputSymbol,

--- a/apps/portal/app/terminal/page.tsx
+++ b/apps/portal/app/terminal/page.tsx
@@ -209,6 +209,18 @@ function isTypingTarget(target: EventTarget | null): boolean {
   return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
 }
 
+function parseOpenOrderExecutionMarker(reason: string): {
+  orderId: string;
+  fraction: 0.5 | 1;
+} | null {
+  const match = reason.match(/\[order:([A-Za-z0-9_-]+);fraction:(0\.5|1)\]/);
+  if (!match) return null;
+  const orderId = match[1] ?? "";
+  const fraction = match[2] === "0.5" ? 0.5 : 1;
+  if (!orderId) return null;
+  return { orderId, fraction };
+}
+
 export default function AppPage() {
   if (!process.env.NEXT_PUBLIC_PRIVY_APP_ID) {
     return (
@@ -620,20 +632,32 @@ function ControlRoom() {
         return;
       }
 
+      const now = Date.now();
       openTradeTicket(
         createTradeIntent(
           target.direction,
           "OPEN_ORDERS_PANEL",
           target.pairId,
           {
-            reason: `${target.orderType.toUpperCase()} order manual execution`,
+            reason: `${target.orderType.toUpperCase()} order manual execution [order:${target.id};fraction:${input.fraction}]`,
             amountUi: execution.executeAmountUi,
             slippageBps: target.slippageBps,
           },
         ),
       );
 
-      setOpenOrders(execution.next);
+      setOpenOrders((current) =>
+        current.map((order) =>
+          order.id === input.orderId
+            ? {
+                ...order,
+                status: "working",
+                updatedAt: now,
+                lastError: null,
+              }
+            : order,
+        ),
+      );
     },
     [openOrders, openTradeTicket],
   );
@@ -779,6 +803,18 @@ function ControlRoom() {
   const handleTradeComplete = useCallback(
     (trade: TradeTicketCompletion): void => {
       applyOptimisticTradeBalances(trade);
+      const openOrderExecution = parseOpenOrderExecutionMarker(trade.reason);
+      if (openOrderExecution) {
+        setOpenOrders(
+          (current) =>
+            executeOpenOrderSlice({
+              current,
+              orderId: openOrderExecution.orderId,
+              fraction: openOrderExecution.fraction,
+              now: Date.now(),
+            }).next,
+        );
+      }
       setRecentExecutions((current) => {
         const entry: ExecutionActivityRow = {
           id: crypto.randomUUID(),
@@ -2003,13 +2039,20 @@ const PositionsOrdersFillsPanel = memo(
                       className={cn(
                         BTN_SECONDARY,
                         "h-6 rounded px-2 text-[10px] uppercase tracking-wider",
-                        !tradingEnabled && "opacity-60 pointer-events-none",
+                        (!tradingEnabled ||
+                          order.status === "cancelled" ||
+                          order.status === "failed") &&
+                          "opacity-60 pointer-events-none",
                       )}
                       onClick={() =>
                         onExecuteOrder({ orderId: order.id, fraction: 0.5 })
                       }
                       type="button"
-                      disabled={!tradingEnabled}
+                      disabled={
+                        !tradingEnabled ||
+                        order.status === "cancelled" ||
+                        order.status === "failed"
+                      }
                     >
                       Exec 50%
                     </button>
@@ -2017,13 +2060,20 @@ const PositionsOrdersFillsPanel = memo(
                       className={cn(
                         BTN_SECONDARY,
                         "h-6 rounded px-2 text-[10px] uppercase tracking-wider",
-                        !tradingEnabled && "opacity-60 pointer-events-none",
+                        (!tradingEnabled ||
+                          order.status === "cancelled" ||
+                          order.status === "failed") &&
+                          "opacity-60 pointer-events-none",
                       )}
                       onClick={() =>
                         onExecuteOrder({ orderId: order.id, fraction: 1 })
                       }
                       type="button"
-                      disabled={!tradingEnabled}
+                      disabled={
+                        !tradingEnabled ||
+                        order.status === "cancelled" ||
+                        order.status === "failed"
+                      }
                     >
                       Execute all
                     </button>

--- a/apps/portal/app/terminal/page.tsx
+++ b/apps/portal/app/terminal/page.tsx
@@ -32,6 +32,16 @@ import { MacroFredWidget } from "./components/macro-fred-widget";
 import { MacroOilWidget } from "./components/macro-oil-widget";
 import { MacroRadarWidget } from "./components/macro-radar-widget";
 import { MacroStablecoinWidget } from "./components/macro-stablecoin-widget";
+import {
+  amendOpenOrder as applyAmendOpenOrder,
+  cancelAllOpenOrders as applyCancelAllOpenOrders,
+  cancelOpenOrder as applyCancelOpenOrder,
+  executeOpenOrderSlice,
+  type OpenOrderRow,
+  type OpenOrderStatus,
+  promotePendingOrders,
+  queueOpenOrder,
+} from "./components/open-orders";
 import { buildOrderbookLadder } from "./components/orderbook-ladder";
 import {
   type RealtimeTradeTick,
@@ -52,7 +62,10 @@ import {
   SUPPORTED_PAIRS,
   TOKEN_CONFIGS,
 } from "./components/trade-pairs";
-import type { TradeTicketCompletion } from "./components/trade-ticket-modal";
+import type {
+  QueuedTerminalOrder,
+  TradeTicketCompletion,
+} from "./components/trade-ticket-modal";
 import {
   countMissingTradeTicks,
   filterTradeTicks,
@@ -259,6 +272,7 @@ function ControlRoom() {
   const [recentExecutions, setRecentExecutions] = useState<
     ExecutionActivityRow[]
   >([]);
+  const [openOrders, setOpenOrders] = useState<OpenOrderRow[]>([]);
   const [ladderPrefill, setLadderPrefill] = useState<LadderPrefill | null>(
     null,
   );
@@ -547,6 +561,92 @@ function ControlRoom() {
     [hasWallet],
   );
 
+  const handleOrderQueued = useCallback((order: QueuedTerminalOrder): void => {
+    setOpenOrders((current) => queueOpenOrder(current, order));
+  }, []);
+
+  const cancelOpenOrder = useCallback((orderId: string): void => {
+    setOpenOrders((current) =>
+      applyCancelOpenOrder(current, orderId, Date.now()),
+    );
+  }, []);
+
+  const cancelAllOpenOrders = useCallback((): void => {
+    if (openOrders.length === 0) return;
+    setOpenOrders((current) => applyCancelAllOpenOrders(current, Date.now()));
+  }, [openOrders.length]);
+
+  const amendOpenOrder = useCallback(
+    (orderId: string): void => {
+      const target = openOrders.find((order) => order.id === orderId);
+      if (!target) return;
+
+      const amountRaw = window.prompt(
+        "Amend remaining amount",
+        target.remainingAmountUi,
+      );
+      if (amountRaw === null) return;
+      const nextPriceRaw =
+        target.orderType === "limit"
+          ? window.prompt("Amend limit price", target.limitPriceUi ?? "")
+          : window.prompt("Amend trigger price", target.triggerPriceUi ?? "");
+      if (nextPriceRaw === null) return;
+      setOpenOrders(
+        (current) =>
+          applyAmendOpenOrder({
+            current,
+            orderId,
+            amountUi: amountRaw,
+            priceUi: nextPriceRaw,
+            now: Date.now(),
+          }).next,
+      );
+    },
+    [openOrders],
+  );
+
+  const executeOpenOrder = useCallback(
+    (input: { orderId: string; fraction: 0.5 | 1 }): void => {
+      const target = openOrders.find((order) => order.id === input.orderId);
+      if (!target) return;
+      const execution = executeOpenOrderSlice({
+        current: openOrders,
+        orderId: input.orderId,
+        fraction: input.fraction,
+        now: Date.now(),
+      });
+      if (!execution.ok) {
+        setOpenOrders(execution.next);
+        return;
+      }
+
+      openTradeTicket(
+        createTradeIntent(
+          target.direction,
+          "OPEN_ORDERS_PANEL",
+          target.pairId,
+          {
+            reason: `${target.orderType.toUpperCase()} order manual execution`,
+            amountUi: execution.executeAmountUi,
+            slippageBps: target.slippageBps,
+          },
+        ),
+      );
+
+      setOpenOrders(execution.next);
+    },
+    [openOrders, openTradeTicket],
+  );
+
+  useEffect(() => {
+    if (openOrders.length === 0) return;
+    const timer = window.setInterval(() => {
+      const now = Date.now();
+      setOpenOrders((current) => promotePendingOrders(current, now));
+    }, 1000);
+    return () => window.clearInterval(timer);
+  }, [openOrders.length]);
+
   const handleLadderPrefill = useCallback((nextPrefill: LadderPrefill) => {
     setLadderPrefill((current) => {
       if (
@@ -783,6 +883,7 @@ function ControlRoom() {
           getAccessToken={getAccessToken}
           onClose={() => setTradeOpen(false)}
           onTradeComplete={handleTradeComplete}
+          onOrderQueued={handleOrderQueued}
         />
       ) : null}
 
@@ -894,11 +995,16 @@ function ControlRoom() {
                   >
                     <PositionsOrdersFillsPanel
                       entries={recentExecutions}
+                      openOrders={openOrders}
                       selectedPairId={selectedPairId}
                       selectedPairMark={marketFeed.latestPrice}
                       tokenBalancesByMint={tokenBalancesByMint}
                       tradingEnabled={canQuickTrade}
                       onQuickAction={openTradeTicket}
+                      onCancelOrder={cancelOpenOrder}
+                      onCancelAllOrders={cancelAllOpenOrders}
+                      onAmendOrder={amendOpenOrder}
+                      onExecuteOrder={executeOpenOrder}
                     />
                   </div>
                 ) : null}
@@ -1662,19 +1768,29 @@ const TradesTapePanel = memo(function TradesTapePanel(props: {
 const PositionsOrdersFillsPanel = memo(
   function PositionsOrdersFillsPanel(props: {
     entries: ExecutionActivityRow[];
+    openOrders: OpenOrderRow[];
     selectedPairId: PairId;
     selectedPairMark: number | null;
     tokenBalancesByMint: Record<string, string>;
     tradingEnabled: boolean;
     onQuickAction: (intent: TradeIntent) => void;
+    onCancelOrder: (orderId: string) => void;
+    onCancelAllOrders: () => void;
+    onAmendOrder: (orderId: string) => void;
+    onExecuteOrder: (input: { orderId: string; fraction: 0.5 | 1 }) => void;
   }) {
     const {
       entries,
+      openOrders,
       selectedPairId,
       selectedPairMark,
       tokenBalancesByMint,
       tradingEnabled,
       onQuickAction,
+      onCancelOrder,
+      onCancelAllOrders,
+      onAmendOrder,
+      onExecuteOrder,
     } = props;
     const markByPair = useMemo(
       () =>
@@ -1776,6 +1892,21 @@ const PositionsOrdersFillsPanel = memo(
       },
       [],
     );
+    const orderStatusClass = useCallback((status: OpenOrderStatus) => {
+      if (status === "pending") {
+        return "border-sky-500/40 bg-sky-500/10 text-sky-300";
+      }
+      if (status === "working") {
+        return "border-emerald-500/40 bg-emerald-500/10 text-emerald-300";
+      }
+      if (status === "partial") {
+        return "border-amber-500/40 bg-amber-500/10 text-amber-300";
+      }
+      if (status === "cancelled") {
+        return "border-border bg-paper text-muted";
+      }
+      return "border-red-500/40 bg-red-500/10 text-red-300";
+    }, []);
 
     return (
       <>
@@ -1811,6 +1942,115 @@ const PositionsOrdersFillsPanel = memo(
             >
               Realized: {formatSignedPnl(totals.realizedPnl)} USDC
             </p>
+          </div>
+          <div className="rounded border border-border bg-subtle p-2">
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-[10px] uppercase tracking-wider text-muted">
+                Open Orders
+              </p>
+              <button
+                className={cn(
+                  BTN_SECONDARY,
+                  "h-6 rounded px-2 text-[10px] uppercase tracking-wider",
+                  openOrders.length === 0 && "opacity-60 pointer-events-none",
+                )}
+                onClick={onCancelAllOrders}
+                type="button"
+                disabled={openOrders.length === 0}
+              >
+                Cancel all
+              </button>
+            </div>
+            <div className="mt-2 space-y-1.5">
+              {openOrders.length === 0 ? (
+                <p className="text-muted">No pending or working orders.</p>
+              ) : null}
+              {openOrders.map((order) => (
+                <div
+                  key={`open-order-${order.id}`}
+                  className="rounded border border-border/60 px-2 py-1.5 space-y-1.5"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="font-mono text-[11px] text-ink truncate">
+                        {order.pairId} • {order.direction.toUpperCase()} •{" "}
+                        {order.orderType.toUpperCase()}
+                      </p>
+                      <p className="text-[10px] text-muted">
+                        Remaining {order.remainingAmountUi} •{" "}
+                        {order.orderType === "limit"
+                          ? `LMT ${order.limitPriceUi ?? "--"}`
+                          : `TRG ${order.triggerPriceUi ?? "--"}`}{" "}
+                        • {order.timeInForce.toUpperCase()}
+                      </p>
+                    </div>
+                    <span
+                      className={cn(
+                        "rounded border px-1.5 py-0.5 text-[10px] uppercase tracking-wider",
+                        orderStatusClass(order.status),
+                      )}
+                    >
+                      {order.status}
+                    </span>
+                  </div>
+                  {order.lastError ? (
+                    <p className="text-[10px] text-red-300">
+                      action-error: {order.lastError}
+                    </p>
+                  ) : null}
+                  <div className="flex flex-wrap gap-1.5">
+                    <button
+                      className={cn(
+                        BTN_SECONDARY,
+                        "h-6 rounded px-2 text-[10px] uppercase tracking-wider",
+                        !tradingEnabled && "opacity-60 pointer-events-none",
+                      )}
+                      onClick={() =>
+                        onExecuteOrder({ orderId: order.id, fraction: 0.5 })
+                      }
+                      type="button"
+                      disabled={!tradingEnabled}
+                    >
+                      Exec 50%
+                    </button>
+                    <button
+                      className={cn(
+                        BTN_SECONDARY,
+                        "h-6 rounded px-2 text-[10px] uppercase tracking-wider",
+                        !tradingEnabled && "opacity-60 pointer-events-none",
+                      )}
+                      onClick={() =>
+                        onExecuteOrder({ orderId: order.id, fraction: 1 })
+                      }
+                      type="button"
+                      disabled={!tradingEnabled}
+                    >
+                      Execute all
+                    </button>
+                    <button
+                      className={cn(
+                        BTN_SECONDARY,
+                        "h-6 rounded px-2 text-[10px] uppercase tracking-wider",
+                      )}
+                      onClick={() => onAmendOrder(order.id)}
+                      type="button"
+                    >
+                      Amend
+                    </button>
+                    <button
+                      className={cn(
+                        BTN_SECONDARY,
+                        "h-6 rounded px-2 text-[10px] uppercase tracking-wider",
+                      )}
+                      onClick={() => onCancelOrder(order.id)}
+                      type="button"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
           <div className="rounded border border-border bg-subtle p-2">
             <p className="text-[10px] uppercase tracking-wider text-muted">

--- a/tests/unit/portal_terminal_open_orders.test.ts
+++ b/tests/unit/portal_terminal_open_orders.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import {
+  amendOpenOrder,
+  cancelAllOpenOrders,
+  cancelOpenOrder,
+  executeOpenOrderSlice,
+  type OpenOrderRow,
+  promotePendingOrders,
+  queueOpenOrder,
+} from "../../apps/portal/app/terminal/components/open-orders";
+import type { QueuedTerminalOrder } from "../../apps/portal/app/terminal/components/trade-ticket-modal";
+
+function queuedOrder(
+  overrides?: Partial<QueuedTerminalOrder>,
+): QueuedTerminalOrder {
+  return {
+    id: overrides?.id ?? "order_1",
+    createdAt: overrides?.createdAt ?? 1000,
+    updatedAt: overrides?.updatedAt ?? 1000,
+    pairId: overrides?.pairId ?? "SOL/USDC",
+    direction: overrides?.direction ?? "buy",
+    source: overrides?.source ?? "TERMINAL",
+    reason: overrides?.reason ?? "test order",
+    orderType: overrides?.orderType ?? "limit",
+    timeInForce: overrides?.timeInForce ?? "gtc",
+    amountUi: overrides?.amountUi ?? "2",
+    remainingAmountUi: overrides?.remainingAmountUi ?? "2",
+    slippageBps: overrides?.slippageBps ?? 50,
+    lane: overrides?.lane ?? "safe",
+    simulationPreference: overrides?.simulationPreference ?? "auto",
+    priorityLevel: overrides?.priorityLevel ?? "normal",
+    limitPriceUi: overrides?.limitPriceUi ?? "100",
+    triggerPriceUi: overrides?.triggerPriceUi ?? null,
+  };
+}
+
+describe("portal terminal open orders lifecycle", () => {
+  test("queues then promotes pending orders", () => {
+    const queued = queueOpenOrder([], queuedOrder());
+    expect(queued).toHaveLength(1);
+    expect(queued[0]?.status).toBe("pending");
+
+    const promoted = promotePendingOrders(queued, 3000, 1000);
+    expect(promoted[0]?.status).toBe("working");
+  });
+
+  test("amend validates amount and price", () => {
+    const current: OpenOrderRow[] = queueOpenOrder([], queuedOrder());
+    const invalid = amendOpenOrder({
+      current,
+      orderId: "order_1",
+      amountUi: "0",
+      priceUi: "100",
+      now: 4000,
+    });
+    expect(invalid.ok).toBe(false);
+    expect(invalid.next[0]?.lastError).toBe("invalid-amend-amount");
+
+    const valid = amendOpenOrder({
+      current,
+      orderId: "order_1",
+      amountUi: "1.5",
+      priceUi: "101.25",
+      now: 5000,
+    });
+    expect(valid.ok).toBe(true);
+    expect(valid.next[0]?.remainingAmountUi).toBe("1.5");
+    expect(valid.next[0]?.limitPriceUi).toBe("101.25");
+    expect(valid.next[0]?.status).toBe("working");
+  });
+
+  test("execute slice updates remaining and supports cancel actions", () => {
+    const current = queueOpenOrder(
+      [],
+      queuedOrder({ amountUi: "4", remainingAmountUi: "4" }),
+    );
+    const slice = executeOpenOrderSlice({
+      current,
+      orderId: "order_1",
+      fraction: 0.5,
+      now: 6000,
+    });
+    expect(slice.ok).toBe(true);
+    if (!slice.ok) return;
+    expect(slice.executeAmountUi).toBe("2");
+    expect(slice.next[0]?.remainingAmountUi).toBe("2");
+    expect(slice.next[0]?.status).toBe("partial");
+
+    const cancelled = cancelOpenOrder(slice.next, "order_1", 7000);
+    expect(cancelled[0]?.status).toBe("cancelled");
+
+    const queuedTwo = queueOpenOrder(
+      slice.next,
+      queuedOrder({ id: "order_2" }),
+    );
+    const cancelledAll = cancelAllOpenOrders(queuedTwo, 8000);
+    expect(cancelledAll.every((order) => order.status === "cancelled")).toBe(
+      true,
+    );
+  });
+});

--- a/tests/unit/portal_terminal_open_orders.test.ts
+++ b/tests/unit/portal_terminal_open_orders.test.ts
@@ -98,4 +98,43 @@ describe("portal terminal open orders lifecycle", () => {
       true,
     );
   });
+
+  test("rejects execute for cancelled or failed orders", () => {
+    const cancelledCurrent = cancelOpenOrder(
+      queueOpenOrder([], queuedOrder()),
+      "order_1",
+      9000,
+    );
+    const cancelledAttempt = executeOpenOrderSlice({
+      current: cancelledCurrent,
+      orderId: "order_1",
+      fraction: 1,
+      now: 9100,
+    });
+    expect(cancelledAttempt.ok).toBe(false);
+    if (cancelledAttempt.ok) return;
+    expect(cancelledAttempt.error).toBe("order-not-executable");
+    expect(cancelledAttempt.next[0]?.status).toBe("cancelled");
+
+    const queuedFailed = queueOpenOrder([], queuedOrder());
+    const firstFailed = queuedFailed[0];
+    if (!firstFailed) throw new Error("expected queued order");
+    const failedCurrent: OpenOrderRow[] = [
+      {
+        ...firstFailed,
+        status: "failed",
+        lastError: "test-failure",
+      },
+    ];
+    const failedAttempt = executeOpenOrderSlice({
+      current: failedCurrent,
+      orderId: "order_1",
+      fraction: 0.5,
+      now: 9200,
+    });
+    expect(failedAttempt.ok).toBe(false);
+    if (failedAttempt.ok) return;
+    expect(failedAttempt.error).toBe("order-not-executable");
+    expect(failedAttempt.next[0]?.status).toBe("failed");
+  });
 });


### PR DESCRIPTION
## Summary
- add open orders lifecycle model (pending/working/partial/failed/cancelled) with deterministic state transitions
- wire limit/trigger submissions from trade ticket into queued open orders instead of immediate dispatch
- implement panel actions for amend, cancel, cancel-all, execute 50%, and execute all
- route execute actions through terminal trade intents so they continue into the shared execution pipeline
- add unit coverage for open-order lifecycle helpers

## Testing
- bun run lint
- bun run typecheck
- bun test tests/unit/portal_terminal_open_orders.test.ts tests/unit/portal_terminal_live_positions.test.ts tests/unit/portal_terminal_trade_ticket_validation.test.ts tests/unit/worker_exec_submit_contract_privy.test.ts

Closes #157
