### PR TITLE
feat: TERM-012 fills ledger with receipt linkage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ It provides one execution fabric for:
 - Execution quality controls in ticket (lane, simulation preference, slippage, priority fee hints) with terminal activity surfacing
 - Live positions panel with session PnL/risk badges and quick reduce/close actions wired to execution intents
 - Open orders panel with pending/working/partial state, amend/cancel flows, and execute-now actions
+- Fills ledger with request/receipt linkage, side/pair/status/query filters, pagination, and CSV export
 - Account-level Privy wallet model (one wallet per user)
 - x402 paid APIs (`/api/x402/read/*`, `/api/x402/exec/submit`)
 - Execution API scaffold:
@@ -74,6 +75,7 @@ bun run dev:local
 - Operations runbook: `docs/execution/operations-runbook-v1.md`
 - Rollout plan: `docs/execution/rollout-plan-v1.md`
 - Tabletop simulation record: `docs/execution/tabletop-simulation-2026-03-03.md`
+- Fills ledger CSV format: `docs/execution/terminal-fills-ledger-export-v1.md`
 
 ### x402 API
 

--- a/apps/portal/app/execution-client.ts
+++ b/apps/portal/app/execution-client.ts
@@ -87,8 +87,11 @@ export type ExecutionStatusSnapshot = {
 export type ExecutionReceiptSnapshot = {
   requestId: string;
   ready: boolean;
+  receiptId: string | null;
+  provider: string | null;
   outcomeStatus: string | null;
   signature: string | null;
+  networkFeeLamports: string | null;
   errorCode: string | null;
   errorMessage: string | null;
 };
@@ -97,6 +100,9 @@ export type ExecutionTerminalResult = {
   requestId: string;
   status: string;
   signature: string | null;
+  receiptId: string | null;
+  provider: string | null;
+  networkFeeLamports: string | null;
 };
 
 export type ExecutionTransportRequest = {
@@ -316,6 +322,16 @@ function parseStatusSnapshot(payload: unknown): ExecutionStatusSnapshot {
   };
 }
 
+function parseOptionalAtomicString(value: unknown): string | null {
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return Math.floor(value).toString();
+  }
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed || !/^\d+$/.test(trimmed)) return null;
+  return trimmed;
+}
+
 function parseReceiptSnapshot(payload: unknown): ExecutionReceiptSnapshot {
   if (!isRecord(payload) || payload.ok !== true) {
     throw new ExecutionClientError({
@@ -341,8 +357,11 @@ function parseReceiptSnapshot(payload: unknown): ExecutionReceiptSnapshot {
     return {
       requestId,
       ready: false,
+      receiptId: null,
+      provider: null,
       outcomeStatus: null,
       signature: null,
+      networkFeeLamports: null,
       errorCode: null,
       errorMessage: null,
     };
@@ -350,14 +369,27 @@ function parseReceiptSnapshot(payload: unknown): ExecutionReceiptSnapshot {
 
   const receipt = isRecord(payload.receipt) ? payload.receipt : null;
   const outcome = receipt && isRecord(receipt.outcome) ? receipt.outcome : null;
+  const networkFeeLamports =
+    parseOptionalAtomicString(outcome?.networkFeeLamports) ??
+    parseOptionalAtomicString(outcome?.feeLamports) ??
+    parseOptionalAtomicString(receipt?.networkFeeLamports);
   return {
     requestId,
     ready: true,
+    receiptId:
+      typeof receipt?.receiptId === "string" && receipt.receiptId.trim()
+        ? receipt.receiptId.trim()
+        : null,
+    provider:
+      typeof receipt?.provider === "string" && receipt.provider.trim()
+        ? receipt.provider.trim()
+        : null,
     outcomeStatus: String(outcome?.status ?? "").trim() || null,
     signature:
       typeof outcome?.signature === "string" && outcome.signature.trim()
         ? outcome.signature.trim()
         : null,
+    networkFeeLamports,
     errorCode:
       typeof outcome?.errorCode === "string" && outcome.errorCode.trim()
         ? outcome.errorCode.trim()
@@ -650,6 +682,9 @@ export function createExecutionClient(options: ExecutionClientOptions) {
             requestId: input.requestId,
             status: outcomeStatus,
             signature: receiptSnapshot.signature,
+            receiptId: receiptSnapshot.receiptId,
+            provider: receiptSnapshot.provider,
+            networkFeeLamports: receiptSnapshot.networkFeeLamports,
           };
         }
 

--- a/apps/portal/app/terminal/components/fills-ledger.ts
+++ b/apps/portal/app/terminal/components/fills-ledger.ts
@@ -1,0 +1,138 @@
+import type { PairId } from "./trade-pairs";
+
+export type FillLedgerRow = {
+  id: string;
+  ts: number;
+  requestId: string;
+  receiptId: string | null;
+  pairId: PairId;
+  side: "buy" | "sell";
+  sizeBaseUi: number;
+  quoteFilledUi: number;
+  price: number | null;
+  feeUi: number | null;
+  feeSymbol: string | null;
+  status: string;
+  provider: string | null;
+  signature: string | null;
+};
+
+export type FillLedgerSideFilter = "all" | "buy" | "sell";
+export type FillLedgerStatusFilter = "all" | "successful" | "failed";
+
+export type FillLedgerFilters = {
+  side: FillLedgerSideFilter;
+  pairId: PairId | "all";
+  status: FillLedgerStatusFilter;
+  query: string;
+};
+
+export const FILLS_LEDGER_CSV_COLUMNS = [
+  "timestamp_iso",
+  "request_id",
+  "receipt_id",
+  "pair",
+  "side",
+  "size_base",
+  "quote_notional",
+  "price",
+  "fee",
+  "fee_symbol",
+  "status",
+  "provider",
+  "signature",
+] as const;
+
+function normalizeStatus(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function isSuccessfulStatus(value: string): boolean {
+  const normalized = normalizeStatus(value);
+  return normalized === "landed" || normalized === "finalized";
+}
+
+function normalizeQuery(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function rowMatchesQuery(row: FillLedgerRow, query: string): boolean {
+  if (!query) return true;
+  return (
+    row.requestId.toLowerCase().includes(query) ||
+    row.pairId.toLowerCase().includes(query) ||
+    row.side.toLowerCase().includes(query) ||
+    (row.receiptId ?? "").toLowerCase().includes(query) ||
+    (row.signature ?? "").toLowerCase().includes(query) ||
+    (row.provider ?? "").toLowerCase().includes(query) ||
+    normalizeStatus(row.status).includes(query)
+  );
+}
+
+export function filterFillLedgerRows(
+  rows: readonly FillLedgerRow[],
+  filters: FillLedgerFilters,
+): FillLedgerRow[] {
+  const query = normalizeQuery(filters.query);
+  const output: FillLedgerRow[] = [];
+  for (const row of rows) {
+    if (filters.side !== "all" && row.side !== filters.side) continue;
+    if (filters.pairId !== "all" && row.pairId !== filters.pairId) continue;
+    if (filters.status === "successful" && !isSuccessfulStatus(row.status)) {
+      continue;
+    }
+    if (filters.status === "failed" && isSuccessfulStatus(row.status)) {
+      continue;
+    }
+    if (!rowMatchesQuery(row, query)) continue;
+    output.push(row);
+  }
+  return output;
+}
+
+export function paginateFillLedgerRows(
+  rows: readonly FillLedgerRow[],
+  page: number,
+  pageSize: number,
+): FillLedgerRow[] {
+  if (!Number.isFinite(pageSize) || pageSize <= 0) return [];
+  const normalizedPage =
+    Number.isFinite(page) && page > 0 ? Math.floor(page) : 1;
+  const start = (normalizedPage - 1) * pageSize;
+  if (start >= rows.length) return [];
+  return rows.slice(start, start + pageSize);
+}
+
+function escapeCsvField(value: string): string {
+  if (!/[",\n]/.test(value)) return value;
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+function formatCsvNumber(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "";
+  return value.toString();
+}
+
+export function buildFillLedgerCsv(rows: readonly FillLedgerRow[]): string {
+  const header = FILLS_LEDGER_CSV_COLUMNS.join(",");
+  const lines = rows.map((row) =>
+    [
+      new Date(row.ts).toISOString(),
+      row.requestId,
+      row.receiptId ?? "",
+      row.pairId,
+      row.side,
+      formatCsvNumber(row.sizeBaseUi),
+      formatCsvNumber(row.quoteFilledUi),
+      formatCsvNumber(row.price),
+      formatCsvNumber(row.feeUi),
+      row.feeSymbol ?? "",
+      row.status,
+      row.provider ?? "",
+      row.signature ?? "",
+    ]
+      .map((value) => escapeCsvField(value))
+      .join(","),
+  );
+  return `${header}\n${lines.join("\n")}\n`;
+}

--- a/apps/portal/app/terminal/components/trade-ticket-modal.tsx
+++ b/apps/portal/app/terminal/components/trade-ticket-modal.tsx
@@ -35,6 +35,9 @@ export type TradeTicketCompletion = {
   direction: TradeIntent["direction"];
   source: string;
   reason: string;
+  requestId: string;
+  receiptId: string | null;
+  provider: string | null;
   inputMint: string;
   outputMint: string;
   inputSymbol: string;
@@ -44,6 +47,8 @@ export type TradeTicketCompletion = {
   baseFilledUi: number;
   quoteFilledUi: number;
   fillPrice: number | null;
+  feeUi: number | null;
+  feeSymbol: string | null;
   status: string;
   signature: string | null;
   lane: ExecutionLane;
@@ -157,6 +162,14 @@ function atomicToUiNumber(
   const ui = formatAtomicToUi(atomicRaw, decimals, 9);
   if (!ui) return null;
   const parsed = Number(ui);
+  if (!Number.isFinite(parsed)) return null;
+  return parsed;
+}
+
+function lamportsToSolUi(lamports: string | null): number | null {
+  const formatted = formatAtomicToUi(lamports, 9, 9);
+  if (!formatted) return null;
+  const parsed = Number(formatted);
   if (!Number.isFinite(parsed)) return null;
   return parsed;
 }
@@ -862,6 +875,9 @@ export function TradeTicketModal({
         direction: intent.direction,
         source: intent.source,
         reason: intent.reason,
+        requestId: terminal.requestId,
+        receiptId: terminal.receiptId,
+        provider: terminal.provider,
         inputMint: intent.inputMint,
         outputMint: intent.outputMint,
         inputSymbol: intent.inputSymbol,
@@ -871,6 +887,8 @@ export function TradeTicketModal({
         baseFilledUi,
         quoteFilledUi,
         fillPrice,
+        feeUi: lamportsToSolUi(terminal.networkFeeLamports),
+        feeSymbol: terminal.networkFeeLamports ? "SOL" : null,
         status: terminal.status,
         signature: terminal.signature,
         lane: executionLane,

--- a/apps/portal/app/terminal/page.tsx
+++ b/apps/portal/app/terminal/page.tsx
@@ -23,6 +23,14 @@ import {
   findNearestDepthPoint,
 } from "./components/depth-chart";
 import {
+  buildFillLedgerCsv,
+  type FillLedgerRow,
+  type FillLedgerSideFilter,
+  type FillLedgerStatusFilter,
+  filterFillLedgerRows,
+  paginateFillLedgerRows,
+} from "./components/fills-ledger";
+import {
   buildLivePositions,
   type PositionFill,
   summarizeLivePositions,
@@ -89,13 +97,19 @@ type Balances = BalanceResponse;
 type ExecutionActivityRow = {
   id: string;
   ts: number;
+  requestId: string;
+  receiptId: string | null;
   pairId: PairId;
   direction: "buy" | "sell";
   leg: string;
+  lane: "fast" | "protected" | "safe";
   baseFilledUi: number;
   quoteFilledUi: number;
   fillPrice: number | null;
+  feeUi: number | null;
+  feeSymbol: string | null;
   status: string;
+  provider: string | null;
   signature: string | null;
   qualitySummary: string;
 };
@@ -220,6 +234,8 @@ function parseOpenOrderExecutionMarker(reason: string): {
   if (!orderId) return null;
   return { orderId, fraction };
 }
+
+const FILLS_LEDGER_PAGE_SIZE = 8;
 
 export default function AppPage() {
   if (!process.env.NEXT_PUBLIC_PRIVY_APP_ID) {
@@ -819,17 +835,23 @@ function ControlRoom() {
         const entry: ExecutionActivityRow = {
           id: crypto.randomUUID(),
           ts: Date.now(),
+          requestId: trade.requestId,
+          receiptId: trade.receiptId,
           pairId: trade.pairId,
           direction: trade.direction,
           leg: `${trade.inputSymbol} -> ${trade.outputSymbol}`,
+          lane: trade.lane,
           baseFilledUi: trade.baseFilledUi,
           quoteFilledUi: trade.quoteFilledUi,
           fillPrice: trade.fillPrice,
+          feeUi: trade.feeUi,
+          feeSymbol: trade.feeSymbol,
           status: trade.status,
+          provider: trade.provider,
           signature: trade.signature,
           qualitySummary: `lane ${trade.lane} • sim ${trade.simulationPreference} • slip ${trade.slippageBps} bps • prio ${trade.priorityLevel}`,
         };
-        return [entry, ...current].slice(0, 30);
+        return [entry, ...current].slice(0, 250);
       });
       void refreshWalletBalances();
     },
@@ -1943,6 +1965,80 @@ const PositionsOrdersFillsPanel = memo(
       }
       return "border-red-500/40 bg-red-500/10 text-red-300";
     }, []);
+    const [ledgerSide, setLedgerSide] = useState<FillLedgerSideFilter>("all");
+    const [ledgerPair, setLedgerPair] = useState<PairId | "all">("all");
+    const [ledgerStatus, setLedgerStatus] =
+      useState<FillLedgerStatusFilter>("all");
+    const [ledgerQuery, setLedgerQuery] = useState("");
+    const [ledgerPage, setLedgerPage] = useState(1);
+    const ledgerRows = useMemo<FillLedgerRow[]>(
+      () =>
+        entries.map((entry) => ({
+          id: entry.id,
+          ts: entry.ts,
+          requestId: entry.requestId,
+          receiptId: entry.receiptId,
+          pairId: entry.pairId,
+          side: entry.direction,
+          sizeBaseUi: entry.baseFilledUi,
+          quoteFilledUi: entry.quoteFilledUi,
+          price: entry.fillPrice,
+          feeUi: entry.feeUi,
+          feeSymbol: entry.feeSymbol,
+          status: entry.status,
+          provider: entry.provider,
+          signature: entry.signature,
+        })),
+      [entries],
+    );
+    const filteredLedgerRows = useMemo(
+      () =>
+        filterFillLedgerRows(ledgerRows, {
+          side: ledgerSide,
+          pairId: ledgerPair,
+          status: ledgerStatus,
+          query: ledgerQuery,
+        }),
+      [ledgerPair, ledgerQuery, ledgerRows, ledgerSide, ledgerStatus],
+    );
+    const ledgerPageCount = Math.max(
+      1,
+      Math.ceil(filteredLedgerRows.length / FILLS_LEDGER_PAGE_SIZE),
+    );
+    useEffect(() => {
+      setLedgerPage((current) => Math.min(current, ledgerPageCount));
+    }, [ledgerPageCount]);
+    const pagedLedgerRows = useMemo(
+      () =>
+        paginateFillLedgerRows(
+          filteredLedgerRows,
+          ledgerPage,
+          FILLS_LEDGER_PAGE_SIZE,
+        ),
+      [filteredLedgerRows, ledgerPage],
+    );
+    const exportLedgerCsv = useCallback(() => {
+      if (filteredLedgerRows.length === 0) return;
+      const csv = buildFillLedgerCsv(filteredLedgerRows);
+      const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+      const href = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = href;
+      anchor.download = `terminal-fills-ledger-${new Date().toISOString().replace(/[:.]/g, "-")}.csv`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(href);
+    }, [filteredLedgerRows]);
+    const formatLedgerFee = useCallback((entry: FillLedgerRow): string => {
+      if (entry.feeUi === null || !Number.isFinite(entry.feeUi)) return "--";
+      return `${entry.feeUi.toFixed(6)} ${entry.feeSymbol ?? ""}`.trim();
+    }, []);
+    const shortExecutionId = useCallback((value: string | null): string => {
+      if (!value) return "--";
+      if (value.length <= 16) return value;
+      return `${value.slice(0, 8)}...${value.slice(-6)}`;
+    }, []);
 
     return (
       <>
@@ -2226,47 +2322,181 @@ const PositionsOrdersFillsPanel = memo(
             </div>
           </div>
           <div className="rounded border border-border bg-subtle p-2">
-            <p className="text-[10px] uppercase tracking-wider text-muted">
-              Recent Activity
-            </p>
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-[10px] uppercase tracking-wider text-muted">
+                Fills Ledger
+              </p>
+              <button
+                className={cn(
+                  BTN_SECONDARY,
+                  "h-6 rounded px-2 text-[10px] uppercase tracking-wider",
+                  filteredLedgerRows.length === 0 &&
+                    "opacity-60 pointer-events-none",
+                )}
+                onClick={exportLedgerCsv}
+                type="button"
+                disabled={filteredLedgerRows.length === 0}
+              >
+                Export CSV
+              </button>
+            </div>
+            <div className="mt-2 grid grid-cols-2 gap-1.5 sm:grid-cols-4">
+              <label className="flex flex-col gap-1 text-[10px] uppercase tracking-wider text-muted">
+                Side
+                <select
+                  className="h-7 rounded border border-border bg-paper px-1.5 text-[11px] text-ink"
+                  value={ledgerSide}
+                  onChange={(event) => {
+                    setLedgerSide(event.target.value as FillLedgerSideFilter);
+                    setLedgerPage(1);
+                  }}
+                >
+                  <option value="all">All</option>
+                  <option value="buy">Buy</option>
+                  <option value="sell">Sell</option>
+                </select>
+              </label>
+              <label className="flex flex-col gap-1 text-[10px] uppercase tracking-wider text-muted">
+                Pair
+                <select
+                  className="h-7 rounded border border-border bg-paper px-1.5 text-[11px] text-ink"
+                  value={ledgerPair}
+                  onChange={(event) => {
+                    setLedgerPair(event.target.value as PairId | "all");
+                    setLedgerPage(1);
+                  }}
+                >
+                  <option value="all">All</option>
+                  {SUPPORTED_PAIRS.map((pair) => (
+                    <option key={`ledger-pair-${pair.id}`} value={pair.id}>
+                      {pair.id}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex flex-col gap-1 text-[10px] uppercase tracking-wider text-muted">
+                Status
+                <select
+                  className="h-7 rounded border border-border bg-paper px-1.5 text-[11px] text-ink"
+                  value={ledgerStatus}
+                  onChange={(event) => {
+                    setLedgerStatus(
+                      event.target.value as FillLedgerStatusFilter,
+                    );
+                    setLedgerPage(1);
+                  }}
+                >
+                  <option value="all">All</option>
+                  <option value="successful">Successful</option>
+                  <option value="failed">Failed</option>
+                </select>
+              </label>
+              <label className="flex flex-col gap-1 text-[10px] uppercase tracking-wider text-muted">
+                Search
+                <input
+                  className="h-7 rounded border border-border bg-paper px-1.5 text-[11px] text-ink"
+                  placeholder="request/signature/provider"
+                  value={ledgerQuery}
+                  onChange={(event) => {
+                    setLedgerQuery(event.target.value);
+                    setLedgerPage(1);
+                  }}
+                />
+              </label>
+            </div>
             <div className="mt-2 space-y-1.5">
-              {entries.length === 0 ? (
-                <p className="text-muted">No fills yet in this session.</p>
+              {filteredLedgerRows.length === 0 ? (
+                <p className="text-muted">
+                  No fills match current filters for this session.
+                </p>
               ) : null}
-              {entries.slice(0, 8).map((entry) => (
+              {pagedLedgerRows.map((entry) => (
                 <div
-                  key={entry.id}
+                  key={`fill-ledger-${entry.id}`}
                   className="grid grid-cols-[1fr_auto] gap-2 rounded border border-border/60 px-2 py-1"
                 >
                   <div className="min-w-0">
                     <p className="font-mono text-[11px] text-ink truncate">
-                      {entry.pairId} • {entry.leg}
+                      {entry.pairId} • {entry.side.toUpperCase()}{" "}
+                      {entry.sizeBaseUi.toFixed(4)}{" "}
+                      {getPairConfig(entry.pairId).baseSymbol} @{" "}
+                      {entry.price === null ? "--" : entry.price.toFixed(4)}
                     </p>
                     <p className="text-[10px] text-muted">
-                      {new Date(entry.ts).toLocaleTimeString()}
+                      {new Date(entry.ts).toLocaleTimeString()} • Fee{" "}
+                      {formatLedgerFee(entry)}
                     </p>
                     <p className="text-[10px] text-muted truncate">
-                      {entry.qualitySummary}
-                    </p>
-                    <p className="text-[10px] text-muted">
-                      {entry.direction.toUpperCase()}{" "}
-                      {entry.baseFilledUi.toFixed(4)}{" "}
-                      {getPairConfig(entry.pairId).baseSymbol} @{" "}
-                      {entry.fillPrice === null
-                        ? "--"
-                        : entry.fillPrice.toFixed(4)}
+                      req {shortExecutionId(entry.requestId)} • rcpt{" "}
+                      {shortExecutionId(entry.receiptId)} •{" "}
+                      {entry.provider ?? "provider --"}
                     </p>
                   </div>
-                  <div className="text-right">
-                    <p className="text-[10px] uppercase text-muted">
+                  <div className="flex flex-col items-end gap-1">
+                    <span className="text-[10px] uppercase text-muted">
                       {entry.status}
-                    </p>
-                    <p className="text-[10px] text-muted">
-                      {entry.signature ? "landed" : "tracking"}
-                    </p>
+                    </span>
+                    <a
+                      className="text-[10px] text-ink underline underline-offset-2"
+                      href={`/api/x402/exec/status/${encodeURIComponent(entry.requestId)}`}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Status
+                    </a>
+                    <a
+                      className="text-[10px] text-ink underline underline-offset-2"
+                      href={`/api/x402/exec/receipt/${encodeURIComponent(entry.requestId)}`}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Receipt
+                    </a>
                   </div>
                 </div>
               ))}
+            </div>
+            <div className="mt-2 flex items-center justify-between text-[10px] text-muted">
+              <span>
+                Showing {pagedLedgerRows.length} of {filteredLedgerRows.length}{" "}
+                fills
+              </span>
+              <div className="flex items-center gap-1.5">
+                <button
+                  className={cn(
+                    BTN_SECONDARY,
+                    "h-6 rounded px-2 text-[10px] uppercase tracking-wider",
+                    ledgerPage <= 1 && "opacity-60 pointer-events-none",
+                  )}
+                  onClick={() =>
+                    setLedgerPage((current) => Math.max(1, current - 1))
+                  }
+                  type="button"
+                  disabled={ledgerPage <= 1}
+                >
+                  Prev
+                </button>
+                <span>
+                  Page {ledgerPage} / {ledgerPageCount}
+                </span>
+                <button
+                  className={cn(
+                    BTN_SECONDARY,
+                    "h-6 rounded px-2 text-[10px] uppercase tracking-wider",
+                    ledgerPage >= ledgerPageCount &&
+                      "opacity-60 pointer-events-none",
+                  )}
+                  onClick={() =>
+                    setLedgerPage((current) =>
+                      Math.min(ledgerPageCount, current + 1),
+                    )
+                  }
+                  type="button"
+                  disabled={ledgerPage >= ledgerPageCount}
+                >
+                  Next
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/docs/execution/terminal-fills-ledger-export-v1.md
+++ b/docs/execution/terminal-fills-ledger-export-v1.md
@@ -1,0 +1,29 @@
+# Terminal Fills Ledger Export (v1)
+
+CSV export from the terminal fills ledger is versioned by fixed column order.
+
+## Filename pattern
+
+- `terminal-fills-ledger-<iso-timestamp>.csv`
+
+## Column order (stable)
+
+1. `timestamp_iso`
+2. `request_id`
+3. `receipt_id`
+4. `pair`
+5. `side`
+6. `size_base`
+7. `quote_notional`
+8. `price`
+9. `fee`
+10. `fee_symbol`
+11. `status`
+12. `provider`
+13. `signature`
+
+## Notes
+
+- Values are exported in the terminal's in-memory fill history.
+- CSV escaping follows RFC 4180 style (`"` escaped as `""`).
+- Empty fields are emitted when source data is unavailable.

--- a/tests/unit/portal_execution_client.test.ts
+++ b/tests/unit/portal_execution_client.test.ts
@@ -208,9 +208,12 @@ describe("portal execution client", () => {
             requestId: "execreq_retry1234567890",
             ready: true,
             receipt: {
+              receiptId: "execrcpt_retry123",
+              provider: "jito",
               outcome: {
                 status: "finalized",
                 signature: "sig_retry",
+                networkFeeLamports: "5000",
               },
             },
           },
@@ -235,6 +238,9 @@ describe("portal execution client", () => {
     });
     expect(terminal.status).toBe("finalized");
     expect(terminal.signature).toBe("sig_retry");
+    expect(terminal.receiptId).toBe("execrcpt_retry123");
+    expect(terminal.provider).toBe("jito");
+    expect(terminal.networkFeeLamports).toBe("5000");
     expect(statusCalls).toBe(2);
     expect(receiptCalls).toBe(1);
   });

--- a/tests/unit/portal_terminal_fills_ledger.test.ts
+++ b/tests/unit/portal_terminal_fills_ledger.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildFillLedgerCsv,
+  FILLS_LEDGER_CSV_COLUMNS,
+  type FillLedgerRow,
+  filterFillLedgerRows,
+  paginateFillLedgerRows,
+} from "../../apps/portal/app/terminal/components/fills-ledger";
+
+function row(input: Partial<FillLedgerRow> & { id: string }): FillLedgerRow {
+  return {
+    id: input.id,
+    ts: input.ts ?? 0,
+    requestId: input.requestId ?? `req_${input.id}`,
+    receiptId: input.receiptId ?? `rcpt_${input.id}`,
+    pairId: input.pairId ?? "SOL/USDC",
+    side: input.side ?? "buy",
+    sizeBaseUi: input.sizeBaseUi ?? 1,
+    quoteFilledUi: input.quoteFilledUi ?? 100,
+    price: input.price ?? 100,
+    feeUi: input.feeUi ?? 0.00001,
+    feeSymbol: input.feeSymbol ?? "SOL",
+    status: input.status ?? "finalized",
+    provider: input.provider ?? "helius-sender",
+    signature: input.signature ?? "sig",
+  };
+}
+
+describe("portal terminal fills ledger helpers", () => {
+  test("filters by side, pair, status, and search query", () => {
+    const rows = [
+      row({ id: "1", pairId: "SOL/USDC", side: "buy", provider: "jito" }),
+      row({
+        id: "2",
+        pairId: "SOL/USDT",
+        side: "sell",
+        status: "failed",
+        provider: "helius-sender",
+      }),
+      row({ id: "3", pairId: "USDC/USDT", side: "buy", provider: "jito" }),
+    ];
+
+    const filtered = filterFillLedgerRows(rows, {
+      side: "buy",
+      pairId: "all",
+      status: "successful",
+      query: "jito",
+    });
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map((entry) => entry.id)).toEqual(["1", "3"]);
+
+    const failedOnly = filterFillLedgerRows(rows, {
+      side: "all",
+      pairId: "SOL/USDT",
+      status: "failed",
+      query: "",
+    });
+    expect(failedOnly).toHaveLength(1);
+    expect(failedOnly[0]?.id).toBe("2");
+  });
+
+  test("paginates deterministically", () => {
+    const rows = [row({ id: "1" }), row({ id: "2" }), row({ id: "3" })];
+    expect(paginateFillLedgerRows(rows, 1, 2).map((entry) => entry.id)).toEqual(
+      ["1", "2"],
+    );
+    expect(paginateFillLedgerRows(rows, 2, 2).map((entry) => entry.id)).toEqual(
+      ["3"],
+    );
+    expect(paginateFillLedgerRows(rows, 4, 2)).toEqual([]);
+  });
+
+  test("exports stable csv header and escapes fields", () => {
+    const csv = buildFillLedgerCsv([
+      row({
+        id: "csv",
+        requestId: 'req_"1"',
+        provider: "provider,one",
+        signature: "sig\nline",
+      }),
+    ]);
+    const lines = csv.trimEnd().split("\n");
+    expect(lines[0]).toBe(FILLS_LEDGER_CSV_COLUMNS.join(","));
+    expect(lines[1]).toContain('"req_""1"""');
+    expect(lines[1]).toContain('"provider,one"');
+    expect(lines[1]).toContain('"sig');
+  });
+});


### PR DESCRIPTION
## Summary
- add a terminal fills-ledger model with deterministic filtering, pagination, and stable CSV export helpers
- wire terminal fills to execution request/receipt linkage (requestId, receiptId, provider, optional network fee)
- replace Recent Activity section with a ledger UI including side/pair/status/query filters, page controls, CSV export, and direct status/receipt links
- document CSV schema contract in execution docs and README

## Testing
- bun run lint
- bun run typecheck
- bun test tests/unit/portal_execution_client.test.ts tests/unit/portal_terminal_open_orders.test.ts tests/unit/portal_terminal_live_positions.test.ts tests/unit/portal_terminal_fills_ledger.test.ts tests/unit/portal_terminal_trade_ticket_validation.test.ts
- cd apps/portal && bun run build

Closes #158