### PR TITLE
feat: TERM-013 account risk and margin guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ It provides one execution fabric for:
 - Live positions panel with session PnL/risk badges and quick reduce/close actions wired to execution intents
 - Open orders panel with pending/working/partial state, amend/cancel flows, and execute-now actions
 - Fills ledger with request/receipt linkage, side/pair/status/query filters, pagination, and CSV export
+- Account risk panel with equity/margin/concentration/liquidation warnings and pre-submit exposure guardrails
 - Account-level Privy wallet model (one wallet per user)
 - x402 paid APIs (`/api/x402/read/*`, `/api/x402/exec/submit`)
 - Execution API scaffold:
@@ -55,6 +56,13 @@ bun run dev:local
 Optional portal env:
 
 - `NEXT_PUBLIC_TERMINAL_DEFAULT_MODE=regular|degen|custom`
+- `NEXT_PUBLIC_TERMINAL_RISK_INITIAL_MARGIN_RATIO` (default `0.1`)
+- `NEXT_PUBLIC_TERMINAL_RISK_MAINT_MARGIN_RATIO` (default `0.05`)
+- `NEXT_PUBLIC_TERMINAL_RISK_CONCENTRATION_WARNING` (default `0.55`)
+- `NEXT_PUBLIC_TERMINAL_RISK_CONCENTRATION_CRITICAL` (default `0.75`)
+- `NEXT_PUBLIC_TERMINAL_RISK_LIQ_WARNING_BUFFER_PCT` (default `15`)
+- `NEXT_PUBLIC_TERMINAL_RISK_LIQ_CRITICAL_BUFFER_PCT` (default `5`)
+- `NEXT_PUBLIC_TERMINAL_RISK_MIN_EQUITY_QUOTE` (default `25`)
 
 ### Worker only
 

--- a/apps/portal/app/terminal/components/account-risk.ts
+++ b/apps/portal/app/terminal/components/account-risk.ts
@@ -1,0 +1,288 @@
+export type AccountRiskLevel = "low" | "warning" | "critical";
+
+export type AccountRiskThresholds = {
+  initialMarginRatio: number;
+  maintenanceMarginRatio: number;
+  concentrationWarningRatio: number;
+  concentrationCriticalRatio: number;
+  liquidationWarningBufferPct: number;
+  liquidationCriticalBufferPct: number;
+  minEquityToTradeQuote: number;
+};
+
+export type AccountRiskSnapshot = {
+  baseQty: number | null;
+  quoteQty: number | null;
+  markPrice: number | null;
+  exposureNotionalQuote: number | null;
+  equityQuote: number | null;
+  usedMarginQuote: number | null;
+  maintenanceRequirementQuote: number | null;
+  freeCollateralQuote: number | null;
+  maintenanceRatio: number | null;
+  concentrationRatio: number | null;
+  concentrationLevel: AccountRiskLevel;
+  liquidationBufferPct: number | null;
+  liquidationRiskLevel: AccountRiskLevel;
+  warnings: string[];
+  blockNewExposure: boolean;
+  thresholds: AccountRiskThresholds;
+};
+
+export const DEFAULT_ACCOUNT_RISK_THRESHOLDS: AccountRiskThresholds = {
+  initialMarginRatio: 0.1,
+  maintenanceMarginRatio: 0.05,
+  concentrationWarningRatio: 0.55,
+  concentrationCriticalRatio: 0.75,
+  liquidationWarningBufferPct: 15,
+  liquidationCriticalBufferPct: 5,
+  minEquityToTradeQuote: 25,
+};
+
+function clampNumber(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function parseEnvNumber(
+  raw: string | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  if (typeof raw !== "string" || raw.trim() === "") return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return fallback;
+  return clampNumber(parsed, min, max);
+}
+
+export function resolveAccountRiskThresholds(
+  env: Record<string, string | undefined> = process.env,
+): AccountRiskThresholds {
+  const defaults = DEFAULT_ACCOUNT_RISK_THRESHOLDS;
+  return {
+    initialMarginRatio: parseEnvNumber(
+      env.NEXT_PUBLIC_TERMINAL_RISK_INITIAL_MARGIN_RATIO,
+      defaults.initialMarginRatio,
+      0.01,
+      0.9,
+    ),
+    maintenanceMarginRatio: parseEnvNumber(
+      env.NEXT_PUBLIC_TERMINAL_RISK_MAINT_MARGIN_RATIO,
+      defaults.maintenanceMarginRatio,
+      0.005,
+      0.8,
+    ),
+    concentrationWarningRatio: parseEnvNumber(
+      env.NEXT_PUBLIC_TERMINAL_RISK_CONCENTRATION_WARNING,
+      defaults.concentrationWarningRatio,
+      0.1,
+      5,
+    ),
+    concentrationCriticalRatio: parseEnvNumber(
+      env.NEXT_PUBLIC_TERMINAL_RISK_CONCENTRATION_CRITICAL,
+      defaults.concentrationCriticalRatio,
+      0.1,
+      10,
+    ),
+    liquidationWarningBufferPct: parseEnvNumber(
+      env.NEXT_PUBLIC_TERMINAL_RISK_LIQ_WARNING_BUFFER_PCT,
+      defaults.liquidationWarningBufferPct,
+      0.5,
+      100,
+    ),
+    liquidationCriticalBufferPct: parseEnvNumber(
+      env.NEXT_PUBLIC_TERMINAL_RISK_LIQ_CRITICAL_BUFFER_PCT,
+      defaults.liquidationCriticalBufferPct,
+      0.1,
+      100,
+    ),
+    minEquityToTradeQuote: parseEnvNumber(
+      env.NEXT_PUBLIC_TERMINAL_RISK_MIN_EQUITY_QUOTE,
+      defaults.minEquityToTradeQuote,
+      1,
+      1_000_000,
+    ),
+  };
+}
+
+function isFiniteNumber(value: number | null): value is number {
+  return value !== null && Number.isFinite(value);
+}
+
+function normalizeThresholds(
+  input?: Partial<AccountRiskThresholds>,
+): AccountRiskThresholds {
+  const base = DEFAULT_ACCOUNT_RISK_THRESHOLDS;
+  const merged = {
+    ...base,
+    ...(input ?? {}),
+  };
+  const concentrationWarning = clampNumber(
+    merged.concentrationWarningRatio,
+    0.1,
+    5,
+  );
+  const concentrationCritical = clampNumber(
+    Math.max(concentrationWarning, merged.concentrationCriticalRatio),
+    concentrationWarning,
+    10,
+  );
+  const liqWarning = clampNumber(merged.liquidationWarningBufferPct, 0.5, 100);
+  const liqCritical = clampNumber(
+    Math.min(merged.liquidationCriticalBufferPct, liqWarning),
+    0.1,
+    liqWarning,
+  );
+  return {
+    initialMarginRatio: clampNumber(merged.initialMarginRatio, 0.01, 0.9),
+    maintenanceMarginRatio: clampNumber(
+      Math.min(merged.maintenanceMarginRatio, merged.initialMarginRatio),
+      0.005,
+      merged.initialMarginRatio,
+    ),
+    concentrationWarningRatio: concentrationWarning,
+    concentrationCriticalRatio: concentrationCritical,
+    liquidationWarningBufferPct: liqWarning,
+    liquidationCriticalBufferPct: liqCritical,
+    minEquityToTradeQuote: clampNumber(
+      merged.minEquityToTradeQuote,
+      1,
+      1_000_000,
+    ),
+  };
+}
+
+export function buildAccountRiskSnapshot(input: {
+  baseQty: number | null;
+  quoteQty: number | null;
+  markPrice: number | null;
+  thresholds?: Partial<AccountRiskThresholds>;
+}): AccountRiskSnapshot {
+  const thresholds = normalizeThresholds(input.thresholds);
+  const baseQty = isFiniteNumber(input.baseQty) ? input.baseQty : null;
+  const quoteQty = isFiniteNumber(input.quoteQty) ? input.quoteQty : null;
+  const markPrice = isFiniteNumber(input.markPrice) ? input.markPrice : null;
+  if (baseQty === null || quoteQty === null || markPrice === null) {
+    return {
+      baseQty,
+      quoteQty,
+      markPrice,
+      exposureNotionalQuote: null,
+      equityQuote: null,
+      usedMarginQuote: null,
+      maintenanceRequirementQuote: null,
+      freeCollateralQuote: null,
+      maintenanceRatio: null,
+      concentrationRatio: null,
+      concentrationLevel: "low",
+      liquidationBufferPct: null,
+      liquidationRiskLevel: "low",
+      warnings: ["Risk model waiting for complete balance/mark inputs."],
+      blockNewExposure: false,
+      thresholds,
+    };
+  }
+
+  const exposureNotionalQuote = Math.abs(baseQty * markPrice);
+  const equityQuote = quoteQty + baseQty * markPrice;
+  const usedMarginQuote = exposureNotionalQuote * thresholds.initialMarginRatio;
+  const maintenanceRequirementQuote =
+    exposureNotionalQuote * thresholds.maintenanceMarginRatio;
+  const freeCollateralQuote = equityQuote - usedMarginQuote;
+  const maintenanceRatio =
+    maintenanceRequirementQuote > 0
+      ? equityQuote / maintenanceRequirementQuote
+      : null;
+  const concentrationRatio =
+    equityQuote > 0 ? exposureNotionalQuote / equityQuote : null;
+  const liquidationBufferPct =
+    equityQuote > 0
+      ? ((equityQuote - maintenanceRequirementQuote) / equityQuote) * 100
+      : null;
+
+  const concentrationLevel: AccountRiskLevel =
+    concentrationRatio === null
+      ? "low"
+      : concentrationRatio >= thresholds.concentrationCriticalRatio
+        ? "critical"
+        : concentrationRatio >= thresholds.concentrationWarningRatio
+          ? "warning"
+          : "low";
+  const liquidationRiskLevel: AccountRiskLevel =
+    liquidationBufferPct === null
+      ? "low"
+      : liquidationBufferPct <= thresholds.liquidationCriticalBufferPct
+        ? "critical"
+        : liquidationBufferPct <= thresholds.liquidationWarningBufferPct
+          ? "warning"
+          : "low";
+
+  const warnings: string[] = [];
+  if (equityQuote <= thresholds.minEquityToTradeQuote) {
+    warnings.push(
+      `Equity is below ${thresholds.minEquityToTradeQuote.toFixed(2)} quote units.`,
+    );
+  }
+  if (freeCollateralQuote < 0) {
+    warnings.push("Free collateral is negative.");
+  }
+  if (concentrationLevel === "critical") {
+    warnings.push("Position concentration exceeds critical threshold.");
+  } else if (concentrationLevel === "warning") {
+    warnings.push("Position concentration is elevated.");
+  }
+  if (liquidationRiskLevel === "critical") {
+    warnings.push("Liquidation buffer is critically low.");
+  } else if (liquidationRiskLevel === "warning") {
+    warnings.push("Liquidation buffer is tightening.");
+  }
+
+  const blockNewExposure =
+    concentrationLevel === "critical" ||
+    liquidationRiskLevel === "critical" ||
+    freeCollateralQuote < 0 ||
+    equityQuote <= thresholds.minEquityToTradeQuote;
+
+  return {
+    baseQty,
+    quoteQty,
+    markPrice,
+    exposureNotionalQuote,
+    equityQuote,
+    usedMarginQuote,
+    maintenanceRequirementQuote,
+    freeCollateralQuote,
+    maintenanceRatio,
+    concentrationRatio,
+    concentrationLevel,
+    liquidationBufferPct,
+    liquidationRiskLevel,
+    warnings,
+    blockNewExposure,
+    thresholds,
+  };
+}
+
+export function evaluatePreSubmitRisk(input: {
+  snapshot: AccountRiskSnapshot | null | undefined;
+  direction: "buy" | "sell";
+  reduceOnly: boolean;
+}): { blocked: boolean; message: string | null } {
+  if (!input.snapshot) {
+    return { blocked: false, message: null };
+  }
+  if (!input.snapshot.blockNewExposure) {
+    return { blocked: false, message: null };
+  }
+  const warning = input.snapshot.warnings[0] ?? "Risk threshold exceeded.";
+  if (input.direction === "sell" || input.reduceOnly) {
+    return {
+      blocked: false,
+      message: `High risk state: ${warning} New exposure is restricted; reduce-only flow is still allowed.`,
+    };
+  }
+  return {
+    blocked: true,
+    message: `Execution blocked: ${warning}`,
+  };
+}

--- a/apps/portal/app/terminal/components/trade-ticket-modal.tsx
+++ b/apps/portal/app/terminal/components/trade-ticket-modal.tsx
@@ -17,6 +17,10 @@ import {
   newExecutionIdempotencyKey,
 } from "../../execution-client";
 import { apiBase, BTN_PRIMARY, BTN_SECONDARY, isRecord } from "../../lib";
+import {
+  type AccountRiskSnapshot,
+  evaluatePreSubmitRisk,
+} from "./account-risk";
 import type { TradeIntent } from "./trade-intent";
 
 type TradeTicketModalProps = {
@@ -24,6 +28,7 @@ type TradeTicketModalProps = {
   intent: TradeIntent | null;
   walletAddress: string | null;
   tokenBalancesByMint?: Record<string, string> | null;
+  riskSnapshot?: AccountRiskSnapshot | null;
   getAccessToken: () => Promise<string | null>;
   onClose: () => void;
   onTradeComplete?: (trade: TradeTicketCompletion) => void;
@@ -349,6 +354,7 @@ export function TradeTicketModal({
   intent,
   walletAddress,
   tokenBalancesByMint,
+  riskSnapshot,
   getAccessToken,
   onClose,
   onTradeComplete,
@@ -567,6 +573,15 @@ export function TradeTicketModal({
       triggerPriceAtomic,
     ],
   );
+  const preSubmitRisk = useMemo(
+    () =>
+      evaluatePreSubmitRisk({
+        snapshot: riskSnapshot,
+        direction: intent?.direction ?? "buy",
+        reduceOnly,
+      }),
+    [intent?.direction, reduceOnly, riskSnapshot],
+  );
 
   const refreshQuote = useCallback(async (): Promise<void> => {
     if (!intent || !open) return;
@@ -716,6 +731,11 @@ export function TradeTicketModal({
           executionQualityErrors[0] ??
           "invalid-order-config",
       );
+      return;
+    }
+    if (preSubmitRisk.blocked) {
+      setSubmitStatus("error");
+      setSubmitMessage(preSubmitRisk.message ?? "risk-guard-blocked");
       return;
     }
     if (!walletAddress) {
@@ -943,6 +963,7 @@ export function TradeTicketModal({
     onTradeComplete,
     orderType,
     orderValidationErrors,
+    preSubmitRisk,
     executionLane,
     executionQualityErrors,
     postOnly,
@@ -1026,6 +1047,10 @@ export function TradeTicketModal({
 
         <div className="p-6 space-y-4">
           <TradeIdentityCard intent={intent} walletAddress={walletAddress} />
+          <TradeRiskContextCard
+            snapshot={riskSnapshot ?? null}
+            preSubmitRisk={preSubmitRisk}
+          />
           <TradeInputsSection
             amountUi={amountUi}
             amountPresets={amountPresets}
@@ -1114,7 +1139,8 @@ export function TradeTicketModal({
                 quote.status !== "ready" ||
                 !quote.inAmountAtomic ||
                 orderValidationErrors.length > 0 ||
-                executionQualityErrors.length > 0
+                executionQualityErrors.length > 0 ||
+                preSubmitRisk.blocked
               }
             >
               {submitStatus === "submitting" || submitStatus === "tracking"
@@ -1153,6 +1179,74 @@ const TradeIdentityCard = memo(function TradeIdentityCard(props: {
             : "--"}
         </span>
       </div>
+    </div>
+  );
+});
+
+const TradeRiskContextCard = memo(function TradeRiskContextCard(props: {
+  snapshot: AccountRiskSnapshot | null;
+  preSubmitRisk: { blocked: boolean; message: string | null };
+}) {
+  const { snapshot, preSubmitRisk } = props;
+  if (!snapshot) {
+    return (
+      <div className="rounded border border-border bg-subtle px-3 py-2 text-xs text-muted">
+        Risk context unavailable.
+      </div>
+    );
+  }
+
+  const highlightClass =
+    snapshot.liquidationRiskLevel === "critical" ||
+    snapshot.concentrationLevel === "critical"
+      ? "border-red-500/40 bg-red-500/10 text-red-200"
+      : snapshot.liquidationRiskLevel === "warning" ||
+          snapshot.concentrationLevel === "warning"
+        ? "border-amber-500/40 bg-amber-500/10 text-amber-200"
+        : "border-border bg-subtle text-ink";
+  const formatNumber = (value: number | null, digits = 2): string =>
+    value === null || !Number.isFinite(value) ? "--" : value.toFixed(digits);
+
+  return (
+    <div className={`rounded border px-3 py-2 text-xs ${highlightClass}`}>
+      <p className="label">RISK_CONTEXT</p>
+      <div className="mt-1 grid grid-cols-2 gap-x-3 gap-y-1 text-[11px]">
+        <p>
+          Equity:{" "}
+          <span className="font-mono">
+            {formatNumber(snapshot.equityQuote)}
+          </span>
+        </p>
+        <p className="text-right">
+          Used margin:{" "}
+          <span className="font-mono">
+            {formatNumber(snapshot.usedMarginQuote)}
+          </span>
+        </p>
+        <p>
+          Maint ratio:{" "}
+          <span className="font-mono">
+            {formatNumber(snapshot.maintenanceRatio, 2)}x
+          </span>
+        </p>
+        <p className="text-right">
+          Liq buffer:{" "}
+          <span className="font-mono">
+            {formatNumber(snapshot.liquidationBufferPct, 2)}%
+          </span>
+        </p>
+      </div>
+      {preSubmitRisk.message ? (
+        <p
+          className={
+            preSubmitRisk.blocked
+              ? "mt-1.5 text-[11px] text-red-300"
+              : "mt-1.5 text-[11px] text-amber-200"
+          }
+        >
+          {preSubmitRisk.message}
+        </p>
+      ) : null}
     </div>
   );
 });

--- a/apps/portal/app/terminal/page.tsx
+++ b/apps/portal/app/terminal/page.tsx
@@ -14,6 +14,12 @@ import {
 } from "../lib";
 import { PresenceCard } from "../motion";
 import {
+  type AccountRiskLevel,
+  type AccountRiskSnapshot,
+  buildAccountRiskSnapshot,
+  resolveAccountRiskThresholds,
+} from "./components/account-risk";
+import {
   clearDashboardGridLayouts,
   DashboardGrid,
   hasCustomDashboardGridLayouts,
@@ -236,6 +242,7 @@ function parseOpenOrderExecutionMarker(reason: string): {
 }
 
 const FILLS_LEDGER_PAGE_SIZE = 8;
+const ACCOUNT_RISK_THRESHOLDS = resolveAccountRiskThresholds();
 
 export default function AppPage() {
   if (!process.env.NEXT_PUBLIC_PRIVY_APP_ID) {
@@ -572,6 +579,37 @@ function ControlRoom() {
     getAccessToken,
     fallbackPrice: marketFeed.latestPrice,
   });
+  const accountRiskSnapshot = useMemo<AccountRiskSnapshot>(() => {
+    const baseToken = TOKEN_CONFIGS[selectedPair.baseSymbol];
+    const quoteToken = TOKEN_CONFIGS[selectedPair.quoteSymbol];
+    const baseDisplay = formatAtomicTokenBalance(
+      tokenBalancesByMint[baseToken.mint] ?? "0",
+      baseToken.decimals,
+      9,
+    );
+    const quoteDisplay = formatAtomicTokenBalance(
+      tokenBalancesByMint[quoteToken.mint] ?? "0",
+      quoteToken.decimals,
+      9,
+    );
+    const baseQty = Number(baseDisplay);
+    const quoteQty = Number(quoteDisplay);
+    return buildAccountRiskSnapshot({
+      baseQty: Number.isFinite(baseQty) ? baseQty : null,
+      quoteQty: Number.isFinite(quoteQty) ? quoteQty : null,
+      markPrice:
+        marketFeed.latestPrice !== null &&
+        Number.isFinite(marketFeed.latestPrice)
+          ? marketFeed.latestPrice
+          : null,
+      thresholds: ACCOUNT_RISK_THRESHOLDS,
+    });
+  }, [
+    marketFeed.latestPrice,
+    selectedPair.baseSymbol,
+    selectedPair.quoteSymbol,
+    tokenBalancesByMint,
+  ]);
   const handlePairChange = useCallback((nextPairId: PairId): void => {
     setSelectedPairId(nextPairId);
     setLadderPrefill(null);
@@ -938,6 +976,7 @@ function ControlRoom() {
           intent={tradeIntent}
           walletAddress={wallet?.walletAddress ?? null}
           tokenBalancesByMint={tokenBalancesByMint}
+          riskSnapshot={accountRiskSnapshot}
           getAccessToken={getAccessToken}
           onClose={() => setTradeOpen(false)}
           onTradeComplete={handleTradeComplete}
@@ -1077,6 +1116,7 @@ function ControlRoom() {
                       tokenBalancesByMint={tokenBalancesByMint}
                       market={marketFeed}
                       realtime={realtimeTransport}
+                      snapshot={accountRiskSnapshot}
                     />
                   </div>
                 ) : null}
@@ -2510,8 +2550,9 @@ const AccountRiskPanel = memo(function AccountRiskPanel(props: {
   tokenBalancesByMint: Record<string, string>;
   market: MarketState;
   realtime: TerminalRealtimeState;
+  snapshot: AccountRiskSnapshot;
 }) {
-  const { pairId, tokenBalancesByMint, market, realtime } = props;
+  const { pairId, tokenBalancesByMint, market, realtime, snapshot } = props;
   const pair = getPairConfig(pairId);
   const baseToken = TOKEN_CONFIGS[pair.baseSymbol];
   const quoteToken = TOKEN_CONFIGS[pair.quoteSymbol];
@@ -2522,12 +2563,20 @@ const AccountRiskPanel = memo(function AccountRiskPanel(props: {
     quoteAtomic,
     quoteToken.decimals,
   );
-  const baseQty = Number(baseDisplay);
-  const riskExposure =
-    Number.isFinite(baseQty) && Number.isFinite(market.latestPrice ?? NaN)
-      ? baseQty * Number(market.latestPrice)
-      : null;
   const change24h = market.change24hPct ?? null;
+  const formatQuote = (value: number | null): string =>
+    value === null || !Number.isFinite(value)
+      ? "--"
+      : `${value.toFixed(2)} ${quoteToken.symbol}`;
+  const formatRatio = (value: number | null): string =>
+    value === null || !Number.isFinite(value) ? "--" : `${value.toFixed(2)}x`;
+  const formatPct = (value: number | null): string =>
+    value === null || !Number.isFinite(value) ? "--" : `${value.toFixed(2)}%`;
+  const riskClass = (level: AccountRiskLevel): string => {
+    if (level === "critical") return "text-red-300";
+    if (level === "warning") return "text-amber-300";
+    return "text-emerald-300";
+  };
 
   return (
     <>
@@ -2567,13 +2616,28 @@ const AccountRiskPanel = memo(function AccountRiskPanel(props: {
         </div>
         <div className="rounded border border-border bg-subtle px-2 py-1.5">
           <p className="text-[10px] text-muted uppercase tracking-wider">
-            Risk
+            Margin + Exposure
           </p>
           <p className="mt-1 font-mono text-ink">
-            Exposure:{" "}
-            {riskExposure === null || !Number.isFinite(riskExposure)
-              ? "--"
-              : `${riskExposure.toFixed(2)} ${quoteToken.symbol}`}
+            Equity: {formatQuote(snapshot.equityQuote)}
+          </p>
+          <p className="font-mono text-ink">
+            Used margin: {formatQuote(snapshot.usedMarginQuote)}
+          </p>
+          <p className="font-mono text-ink">
+            Free collateral: {formatQuote(snapshot.freeCollateralQuote)}
+          </p>
+          <p className="font-mono text-ink">
+            Maint requirement:{" "}
+            {formatQuote(snapshot.maintenanceRequirementQuote)}
+          </p>
+          <p className="font-mono text-ink">
+            Maintenance ratio: {formatRatio(snapshot.maintenanceRatio)}
+          </p>
+          <p
+            className={cn("font-mono", riskClass(snapshot.concentrationLevel))}
+          >
+            Concentration: {formatPct(snapshot.concentrationRatio)}
           </p>
           <p
             className={cn(
@@ -2587,6 +2651,48 @@ const AccountRiskPanel = memo(function AccountRiskPanel(props: {
           >
             24h change: {change24h === null ? "--" : `${change24h.toFixed(2)}%`}
           </p>
+        </div>
+        <div className="rounded border border-border bg-subtle px-2 py-1.5">
+          <p className="text-[10px] text-muted uppercase tracking-wider">
+            Liquidation Awareness
+          </p>
+          <p
+            className={cn(
+              "mt-1 font-mono",
+              riskClass(snapshot.liquidationRiskLevel),
+            )}
+          >
+            Buffer: {formatPct(snapshot.liquidationBufferPct)}
+          </p>
+          <p
+            className={cn(
+              "font-mono",
+              snapshot.blockNewExposure ? "text-red-300" : "text-emerald-300",
+            )}
+          >
+            New exposure: {snapshot.blockNewExposure ? "restricted" : "allowed"}
+          </p>
+          <p className="text-[10px] text-muted">
+            Thresholds • init{" "}
+            {(snapshot.thresholds.initialMarginRatio * 100).toFixed(1)}% • maint{" "}
+            {(snapshot.thresholds.maintenanceMarginRatio * 100).toFixed(1)}% •
+            conc warn{" "}
+            {(snapshot.thresholds.concentrationWarningRatio * 100).toFixed(0)}%
+          </p>
+          {snapshot.warnings.length === 0 ? (
+            <p className="text-[10px] text-emerald-300">
+              No active risk warnings.
+            </p>
+          ) : (
+            snapshot.warnings.slice(0, 2).map((warning) => (
+              <p
+                key={`risk-warning-${warning}`}
+                className="text-[10px] text-amber-300"
+              >
+                {warning}
+              </p>
+            ))
+          )}
         </div>
       </div>
     </>

--- a/tests/unit/portal_terminal_account_risk.test.ts
+++ b/tests/unit/portal_terminal_account_risk.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildAccountRiskSnapshot,
+  evaluatePreSubmitRisk,
+  resolveAccountRiskThresholds,
+} from "../../apps/portal/app/terminal/components/account-risk";
+
+describe("portal terminal account risk model", () => {
+  test("computes baseline equity/margin metrics", () => {
+    const snapshot = buildAccountRiskSnapshot({
+      baseQty: 2,
+      quoteQty: 800,
+      markPrice: 100,
+    });
+    expect(snapshot.equityQuote).toBeCloseTo(1000, 8);
+    expect(snapshot.usedMarginQuote).toBeCloseTo(20, 8);
+    expect(snapshot.maintenanceRequirementQuote).toBeCloseTo(10, 8);
+    expect(snapshot.freeCollateralQuote).toBeCloseTo(980, 8);
+    expect(snapshot.concentrationLevel).toBe("low");
+    expect(snapshot.liquidationRiskLevel).toBe("low");
+    expect(snapshot.blockNewExposure).toBe(false);
+  });
+
+  test("flags concentration and liquidation critical state", () => {
+    const snapshot = buildAccountRiskSnapshot({
+      baseQty: 10,
+      quoteQty: 1,
+      markPrice: 100,
+      thresholds: {
+        concentrationWarningRatio: 0.4,
+        concentrationCriticalRatio: 0.6,
+        liquidationWarningBufferPct: 20,
+        liquidationCriticalBufferPct: 10,
+      },
+    });
+    expect(snapshot.concentrationLevel).toBe("critical");
+    expect(snapshot.blockNewExposure).toBe(true);
+    expect(snapshot.warnings.length).toBeGreaterThan(0);
+  });
+
+  test("pre-submit guard blocks new buy exposure but allows reduce direction", () => {
+    const snapshot = buildAccountRiskSnapshot({
+      baseQty: 10,
+      quoteQty: 1,
+      markPrice: 100,
+      thresholds: {
+        concentrationWarningRatio: 0.4,
+        concentrationCriticalRatio: 0.6,
+      },
+    });
+    const blocked = evaluatePreSubmitRisk({
+      snapshot,
+      direction: "buy",
+      reduceOnly: false,
+    });
+    expect(blocked.blocked).toBe(true);
+    expect(blocked.message).toContain("Execution blocked");
+
+    const allowedSell = evaluatePreSubmitRisk({
+      snapshot,
+      direction: "sell",
+      reduceOnly: false,
+    });
+    expect(allowedSell.blocked).toBe(false);
+    expect(allowedSell.message).toContain("High risk state");
+  });
+
+  test("reads and clamps configurable thresholds", () => {
+    const thresholds = resolveAccountRiskThresholds({
+      NEXT_PUBLIC_TERMINAL_RISK_INITIAL_MARGIN_RATIO: "0.2",
+      NEXT_PUBLIC_TERMINAL_RISK_MAINT_MARGIN_RATIO: "0.1",
+      NEXT_PUBLIC_TERMINAL_RISK_CONCENTRATION_WARNING: "0.5",
+      NEXT_PUBLIC_TERMINAL_RISK_CONCENTRATION_CRITICAL: "0.7",
+      NEXT_PUBLIC_TERMINAL_RISK_LIQ_WARNING_BUFFER_PCT: "25",
+      NEXT_PUBLIC_TERMINAL_RISK_LIQ_CRITICAL_BUFFER_PCT: "8",
+      NEXT_PUBLIC_TERMINAL_RISK_MIN_EQUITY_QUOTE: "40",
+    });
+    expect(thresholds.initialMarginRatio).toBeCloseTo(0.2, 8);
+    expect(thresholds.maintenanceMarginRatio).toBeCloseTo(0.1, 8);
+    expect(thresholds.concentrationWarningRatio).toBeCloseTo(0.5, 8);
+    expect(thresholds.concentrationCriticalRatio).toBeCloseTo(0.7, 8);
+    expect(thresholds.liquidationWarningBufferPct).toBeCloseTo(25, 8);
+    expect(thresholds.liquidationCriticalBufferPct).toBeCloseTo(8, 8);
+    expect(thresholds.minEquityToTradeQuote).toBeCloseTo(40, 8);
+  });
+});


### PR DESCRIPTION
## Summary
- add a configurable account-risk model (equity, used margin, maintenance requirement/ratio, concentration, liquidation buffer)
- upgrade `ACCOUNT_RISK` panel with continuous risk telemetry and warning thresholds
- wire trade ticket to visible risk context with pre-submit exposure guardrails for high-risk states
- add unit coverage for risk warning logic and threshold configuration

## Testing
- bun run lint
- bun run typecheck
- bun test tests/unit/portal_terminal_account_risk.test.ts tests/unit/portal_terminal_trade_ticket_validation.test.ts tests/unit/portal_terminal_fills_ledger.test.ts tests/unit/portal_execution_client.test.ts tests/unit/portal_terminal_open_orders.test.ts
- cd apps/portal && bun run build

Closes #159
