### PR TITLE
TERM-015: add terminal global health status bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ It provides one execution fabric for:
 - Fills ledger with request/receipt linkage, side/pair/status/query filters, pagination, and CSV export
 - Account risk panel with equity/margin/concentration/liquidation warnings and pre-submit exposure guardrails
 - Execution inspector drawer with timeline, attempts, and terminal receipt payload visibility
+- Global terminal status bar for stream/API/lane health, data staleness badges, and diagnostics links
 - Account-level Privy wallet model (one wallet per user)
 - x402 paid APIs (`/api/x402/read/*`, `/api/x402/exec/submit`)
 - Execution API scaffold:

--- a/apps/portal/app/terminal/components/terminal-status-bar.tsx
+++ b/apps/portal/app/terminal/components/terminal-status-bar.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { memo, useEffect, useMemo, useState } from "react";
+import { cn } from "../../cn";
+import { apiBase, isRecord } from "../../lib";
+import type { TerminalRealtimeState } from "./realtime-transport";
+import type { MarketState } from "./sol-market-feed";
+
+type TerminalStatusBarProps = {
+  realtime: TerminalRealtimeState;
+  market: MarketState;
+};
+
+type LaneHealth = {
+  enabled: boolean;
+  adapter: string | null;
+};
+
+type ExecHealthSnapshot = {
+  ok: boolean;
+  serverNowIso: string | null;
+  lanes: {
+    fast: LaneHealth;
+    protected: LaneHealth;
+    safe: LaneHealth;
+  };
+};
+
+const HEALTH_POLL_MS = 5_000;
+const MARKET_STALE_MS = 20_000;
+const ACCOUNT_STALE_MS = 20_000;
+const TIME_SKEW_WARNING_MS = 5_000;
+
+export function classifyStaleness(
+  lastUpdatedMs: number | null,
+  staleAfterMs: number,
+): "fresh" | "stale" | "missing" {
+  if (!lastUpdatedMs || !Number.isFinite(lastUpdatedMs)) return "missing";
+  return Date.now() - lastUpdatedMs > staleAfterMs ? "stale" : "fresh";
+}
+
+export function computeTimeSkewMs(serverNowIso: string | null): number | null {
+  if (!serverNowIso) return null;
+  const parsed = Date.parse(serverNowIso);
+  if (!Number.isFinite(parsed)) return null;
+  return Date.now() - parsed;
+}
+
+function parseLaneHealth(value: unknown): LaneHealth {
+  if (!isRecord(value)) {
+    return { enabled: false, adapter: null };
+  }
+  return {
+    enabled: value.enabled === true,
+    adapter:
+      typeof value.adapter === "string" && value.adapter.trim()
+        ? value.adapter.trim()
+        : null,
+  };
+}
+
+function parseExecHealthPayload(payload: unknown): ExecHealthSnapshot | null {
+  if (!isRecord(payload)) return null;
+  const lanes = isRecord(payload.lanes) ? payload.lanes : null;
+  if (!lanes) return null;
+  return {
+    ok: payload.ok === true,
+    serverNowIso:
+      typeof payload.now === "string" && payload.now.trim()
+        ? payload.now.trim()
+        : null,
+    lanes: {
+      fast: parseLaneHealth(lanes.fast),
+      protected: parseLaneHealth(lanes.protected),
+      safe: parseLaneHealth(lanes.safe),
+    },
+  };
+}
+
+function healthChipClass(level: "good" | "warn" | "bad"): string {
+  if (level === "good")
+    return "border-emerald-500/40 bg-emerald-500/10 text-emerald-300";
+  if (level === "warn")
+    return "border-amber-500/40 bg-amber-500/10 text-amber-300";
+  return "border-red-500/40 bg-red-500/10 text-red-300";
+}
+
+export const TerminalStatusBar = memo(function TerminalStatusBar(
+  props: TerminalStatusBarProps,
+) {
+  const { realtime, market } = props;
+  const [execHealth, setExecHealth] = useState<ExecHealthSnapshot | null>(null);
+  const [execHealthError, setExecHealthError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadHealth(): Promise<void> {
+      const base = apiBase();
+      if (!base) {
+        if (!cancelled) setExecHealthError("missing NEXT_PUBLIC_EDGE_API_BASE");
+        return;
+      }
+      try {
+        const response = await fetch(`${base}/api/x402/exec/health`, {
+          method: "GET",
+        });
+        const payload = (await response.json().catch(() => null)) as unknown;
+        if (!response.ok) {
+          throw new Error(`health-http-${response.status}`);
+        }
+        const parsed = parseExecHealthPayload(payload);
+        if (!parsed) throw new Error("invalid-health-payload");
+        if (cancelled) return;
+        setExecHealth(parsed);
+        setExecHealthError(null);
+      } catch (error) {
+        if (cancelled) return;
+        setExecHealthError(
+          error instanceof Error ? error.message : "health-fetch-error",
+        );
+      }
+    }
+
+    void loadHealth();
+    const timer = window.setInterval(() => {
+      void loadHealth();
+    }, HEALTH_POLL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, []);
+
+  const marketFreshness = classifyStaleness(
+    market.lastUpdatedMs,
+    MARKET_STALE_MS,
+  );
+  const accountFreshness = classifyStaleness(
+    realtime.account?.ts ?? null,
+    ACCOUNT_STALE_MS,
+  );
+  const timeSkewMs = computeTimeSkewMs(execHealth?.serverNowIso ?? null);
+  const timeSkewLevel: "good" | "warn" =
+    timeSkewMs !== null && Math.abs(timeSkewMs) > TIME_SKEW_WARNING_MS
+      ? "warn"
+      : "good";
+
+  const laneSummary = useMemo(() => {
+    if (!execHealth) return "lanes --";
+    const rows = [
+      `fast:${execHealth.lanes.fast.enabled ? "up" : "down"}`,
+      `prot:${execHealth.lanes.protected.enabled ? "up" : "down"}`,
+      `safe:${execHealth.lanes.safe.enabled ? "up" : "down"}`,
+    ];
+    return rows.join(" ");
+  }, [execHealth]);
+
+  return (
+    <div className="h-8 shrink-0 border border-border bg-surface px-2.5 text-[10px]">
+      <div className="flex h-full items-center justify-between gap-2 overflow-x-auto">
+        <div className="flex items-center gap-1.5 whitespace-nowrap">
+          <span
+            className={cn(
+              "rounded border px-1.5 py-0.5 uppercase tracking-wider",
+              healthChipClass(
+                realtime.health === "live"
+                  ? "good"
+                  : realtime.health === "degraded" ||
+                      realtime.health === "stale"
+                    ? "warn"
+                    : "bad",
+              ),
+            )}
+          >
+            stream {realtime.health}
+          </span>
+          <span
+            className={cn(
+              "rounded border px-1.5 py-0.5 uppercase tracking-wider",
+              healthChipClass(
+                execHealthError
+                  ? "bad"
+                  : execHealth?.ok === false
+                    ? "warn"
+                    : "good",
+              ),
+            )}
+          >
+            api {execHealthError ? "down" : "up"}
+          </span>
+          <span
+            className={cn(
+              "rounded border px-1.5 py-0.5 uppercase tracking-wider",
+              healthChipClass(marketFreshness === "fresh" ? "good" : "warn"),
+            )}
+          >
+            market {marketFreshness}
+          </span>
+          <span
+            className={cn(
+              "rounded border px-1.5 py-0.5 uppercase tracking-wider",
+              healthChipClass(accountFreshness === "fresh" ? "good" : "warn"),
+            )}
+          >
+            account {accountFreshness}
+          </span>
+          <span
+            className={cn(
+              "rounded border px-1.5 py-0.5 uppercase tracking-wider",
+              healthChipClass(timeSkewLevel),
+            )}
+          >
+            clock{" "}
+            {timeSkewMs === null
+              ? "--"
+              : `${Math.round(timeSkewMs / 1000).toString()}s`}
+          </span>
+          <span className="text-muted">{laneSummary}</span>
+          {realtime.reason ? (
+            <span className="text-amber-300 truncate">
+              reason: {realtime.reason}
+            </span>
+          ) : null}
+          {execHealthError ? (
+            <span className="text-red-300 truncate">
+              health: {execHealthError}
+            </span>
+          ) : null}
+        </div>
+        <div className="flex items-center gap-1 whitespace-nowrap">
+          <a
+            className="text-muted underline underline-offset-2"
+            href="/api/x402/exec/health"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Diagnostics
+          </a>
+          <span className="text-muted">|</span>
+          <a
+            className="text-muted underline underline-offset-2"
+            href="/api"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Help
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/apps/portal/app/terminal/page.tsx
+++ b/apps/portal/app/terminal/page.tsx
@@ -69,6 +69,7 @@ import {
   type MarketState,
   useMarketFeed,
 } from "./components/sol-market-feed";
+import { TerminalStatusBar } from "./components/terminal-status-bar";
 import { createTradeIntent, type TradeIntent } from "./components/trade-intent";
 import {
   DEFAULT_PAIR_ID,
@@ -998,164 +999,170 @@ function ControlRoom() {
               <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-accent" />
             </div>
           ) : (
-            <div className="relative h-full">
-              <div className="pointer-events-none absolute left-2 top-2 z-20 hidden sm:block">
-                <div
-                  className="rounded border border-border/70 bg-paper/90 px-2.5 py-1 text-[11px] text-muted backdrop-blur"
-                  title={modeCapabilities.description}
+            <div className="flex h-full min-h-0 flex-col gap-1">
+              <TerminalStatusBar
+                realtime={realtimeTransport}
+                market={marketFeed}
+              />
+              <div className="relative min-h-0 flex-1">
+                <div className="pointer-events-none absolute left-2 top-2 z-20 hidden sm:block">
+                  <div
+                    className="rounded border border-border/70 bg-paper/90 px-2.5 py-1 text-[11px] text-muted backdrop-blur"
+                    title={modeCapabilities.description}
+                  >
+                    Mode:{" "}
+                    <span className="font-semibold text-ink">
+                      {modeCapabilities.label}
+                    </span>
+                  </div>
+                </div>
+                {hasCustomGridLayout && canLayoutEdit && (
+                  <div className="pointer-events-none absolute right-2 top-2 z-20">
+                    <button
+                      className={cn(
+                        BTN_SECONDARY,
+                        "pointer-events-auto h-7 border-border/70 bg-paper/90 px-2.5 text-[11px] backdrop-blur",
+                      )}
+                      onClick={resetDashboardLayout}
+                      title="Reorganize layout (R)"
+                      type="button"
+                    >
+                      Reset layout
+                    </button>
+                  </div>
+                )}
+
+                <DashboardGrid
+                  key={gridRevision}
+                  className="h-full w-full border border-border bg-border pb-1"
+                  allowLayoutEditing={canLayoutEdit}
+                  onLayoutChange={() =>
+                    setHasCustomGridLayout(hasCustomDashboardGridLayouts())
+                  }
                 >
-                  Mode:{" "}
-                  <span className="font-semibold text-ink">
-                    {modeCapabilities.label}
-                  </span>
-                </div>
+                  {showMarketModule ? (
+                    <div
+                      key="chart"
+                      className="flex flex-col overflow-hidden bg-surface"
+                    >
+                      <ChartPanel
+                        pairId={selectedPairId}
+                        market={marketFeed}
+                        onPairChange={handlePairChange}
+                      />
+                    </div>
+                  ) : null}
+
+                  {showMarketModule ? (
+                    <div
+                      key="orderbook"
+                      className="flex flex-col overflow-hidden bg-surface"
+                    >
+                      <OrderbookDepthPanel
+                        market={marketFeed}
+                        realtime={realtimeTransport}
+                        selectedPrefill={ladderPrefill}
+                        onPrefill={handleLadderPrefill}
+                      />
+                    </div>
+                  ) : null}
+
+                  {showMarketModule ? (
+                    <div
+                      key="order_entry"
+                      className="flex flex-col overflow-hidden bg-surface"
+                    >
+                      <OrderEntryPanel
+                        pairId={selectedPairId}
+                        onBuy={openMarketBuyTrade}
+                        onSell={openMarketSellTrade}
+                        tradingEnabled={canQuickTrade}
+                        prefill={ladderPrefill}
+                        onClearPrefill={clearLadderPrefill}
+                      />
+                    </div>
+                  ) : null}
+
+                  {showMarketModule ? (
+                    <div
+                      key="trades_tape"
+                      className="flex flex-col overflow-hidden bg-surface"
+                    >
+                      <TradesTapePanel realtime={realtimeTransport} />
+                    </div>
+                  ) : null}
+
+                  {showMarketModule ? (
+                    <div
+                      key="positions"
+                      className="flex flex-col overflow-hidden bg-surface"
+                    >
+                      <PositionsOrdersFillsPanel
+                        entries={recentExecutions}
+                        openOrders={openOrders}
+                        selectedPairId={selectedPairId}
+                        selectedPairMark={marketFeed.latestPrice}
+                        tokenBalancesByMint={tokenBalancesByMint}
+                        tradingEnabled={canQuickTrade}
+                        onQuickAction={openTradeTicket}
+                        onCancelOrder={cancelOpenOrder}
+                        onCancelAllOrders={cancelAllOpenOrders}
+                        onAmendOrder={amendOpenOrder}
+                        onExecuteOrder={executeOpenOrder}
+                      />
+                    </div>
+                  ) : null}
+
+                  {showWalletModule ? (
+                    <div
+                      key="account_risk"
+                      className="flex flex-col overflow-hidden bg-surface"
+                    >
+                      <AccountRiskPanel
+                        pairId={selectedPairId}
+                        tokenBalancesByMint={tokenBalancesByMint}
+                        market={marketFeed}
+                        realtime={realtimeTransport}
+                        snapshot={accountRiskSnapshot}
+                      />
+                    </div>
+                  ) : null}
+
+                  {showMacroRadarModule ? (
+                    <div key="macro_radar" className="overflow-hidden">
+                      <MacroRadarWidget
+                        onTradeAction={
+                          canMacroTrade ? openTradeTicket : undefined
+                        }
+                      />
+                    </div>
+                  ) : null}
+                  {showMacroFredModule ? (
+                    <div key="macro_fred" className="overflow-hidden">
+                      <MacroFredWidget />
+                    </div>
+                  ) : null}
+                  {showMacroEtfModule ? (
+                    <div key="macro_etf" className="overflow-hidden">
+                      <MacroEtfWidget />
+                    </div>
+                  ) : null}
+                  {showMacroStablecoinModule ? (
+                    <div key="macro_stablecoin" className="overflow-hidden">
+                      <MacroStablecoinWidget
+                        onTradeAction={
+                          canMacroTrade ? openTradeTicket : undefined
+                        }
+                      />
+                    </div>
+                  ) : null}
+                  {showMacroOilModule ? (
+                    <div key="macro_oil" className="overflow-hidden">
+                      <MacroOilWidget />
+                    </div>
+                  ) : null}
+                </DashboardGrid>
               </div>
-              {hasCustomGridLayout && canLayoutEdit && (
-                <div className="pointer-events-none absolute right-2 top-2 z-20">
-                  <button
-                    className={cn(
-                      BTN_SECONDARY,
-                      "pointer-events-auto h-7 border-border/70 bg-paper/90 px-2.5 text-[11px] backdrop-blur",
-                    )}
-                    onClick={resetDashboardLayout}
-                    title="Reorganize layout (R)"
-                    type="button"
-                  >
-                    Reset layout
-                  </button>
-                </div>
-              )}
-
-              <DashboardGrid
-                key={gridRevision}
-                className="w-full h-full border border-border bg-border pb-1"
-                allowLayoutEditing={canLayoutEdit}
-                onLayoutChange={() =>
-                  setHasCustomGridLayout(hasCustomDashboardGridLayouts())
-                }
-              >
-                {showMarketModule ? (
-                  <div
-                    key="chart"
-                    className="flex flex-col overflow-hidden bg-surface"
-                  >
-                    <ChartPanel
-                      pairId={selectedPairId}
-                      market={marketFeed}
-                      onPairChange={handlePairChange}
-                    />
-                  </div>
-                ) : null}
-
-                {showMarketModule ? (
-                  <div
-                    key="orderbook"
-                    className="flex flex-col overflow-hidden bg-surface"
-                  >
-                    <OrderbookDepthPanel
-                      market={marketFeed}
-                      realtime={realtimeTransport}
-                      selectedPrefill={ladderPrefill}
-                      onPrefill={handleLadderPrefill}
-                    />
-                  </div>
-                ) : null}
-
-                {showMarketModule ? (
-                  <div
-                    key="order_entry"
-                    className="flex flex-col overflow-hidden bg-surface"
-                  >
-                    <OrderEntryPanel
-                      pairId={selectedPairId}
-                      onBuy={openMarketBuyTrade}
-                      onSell={openMarketSellTrade}
-                      tradingEnabled={canQuickTrade}
-                      prefill={ladderPrefill}
-                      onClearPrefill={clearLadderPrefill}
-                    />
-                  </div>
-                ) : null}
-
-                {showMarketModule ? (
-                  <div
-                    key="trades_tape"
-                    className="flex flex-col overflow-hidden bg-surface"
-                  >
-                    <TradesTapePanel realtime={realtimeTransport} />
-                  </div>
-                ) : null}
-
-                {showMarketModule ? (
-                  <div
-                    key="positions"
-                    className="flex flex-col overflow-hidden bg-surface"
-                  >
-                    <PositionsOrdersFillsPanel
-                      entries={recentExecutions}
-                      openOrders={openOrders}
-                      selectedPairId={selectedPairId}
-                      selectedPairMark={marketFeed.latestPrice}
-                      tokenBalancesByMint={tokenBalancesByMint}
-                      tradingEnabled={canQuickTrade}
-                      onQuickAction={openTradeTicket}
-                      onCancelOrder={cancelOpenOrder}
-                      onCancelAllOrders={cancelAllOpenOrders}
-                      onAmendOrder={amendOpenOrder}
-                      onExecuteOrder={executeOpenOrder}
-                    />
-                  </div>
-                ) : null}
-
-                {showWalletModule ? (
-                  <div
-                    key="account_risk"
-                    className="flex flex-col overflow-hidden bg-surface"
-                  >
-                    <AccountRiskPanel
-                      pairId={selectedPairId}
-                      tokenBalancesByMint={tokenBalancesByMint}
-                      market={marketFeed}
-                      realtime={realtimeTransport}
-                      snapshot={accountRiskSnapshot}
-                    />
-                  </div>
-                ) : null}
-
-                {showMacroRadarModule ? (
-                  <div key="macro_radar" className="overflow-hidden">
-                    <MacroRadarWidget
-                      onTradeAction={
-                        canMacroTrade ? openTradeTicket : undefined
-                      }
-                    />
-                  </div>
-                ) : null}
-                {showMacroFredModule ? (
-                  <div key="macro_fred" className="overflow-hidden">
-                    <MacroFredWidget />
-                  </div>
-                ) : null}
-                {showMacroEtfModule ? (
-                  <div key="macro_etf" className="overflow-hidden">
-                    <MacroEtfWidget />
-                  </div>
-                ) : null}
-                {showMacroStablecoinModule ? (
-                  <div key="macro_stablecoin" className="overflow-hidden">
-                    <MacroStablecoinWidget
-                      onTradeAction={
-                        canMacroTrade ? openTradeTicket : undefined
-                      }
-                    />
-                  </div>
-                ) : null}
-                {showMacroOilModule ? (
-                  <div key="macro_oil" className="overflow-hidden">
-                    <MacroOilWidget />
-                  </div>
-                ) : null}
-              </DashboardGrid>
             </div>
           )}
         </div>

--- a/apps/worker/src/execution/lane_resolver.ts
+++ b/apps/worker/src/execution/lane_resolver.ts
@@ -58,6 +58,25 @@ function resolveLaneEnabledFlags(env: Env): Record<ExecutionLane, boolean> {
   };
 }
 
+export type ExecutionLaneRoutingConfig = {
+  adapters: Record<ExecutionLane, string>;
+  enabled: Record<ExecutionLane, boolean>;
+  allowAnonymousSafe: boolean;
+};
+
+export function readExecutionLaneRoutingConfig(
+  env: Env,
+): ExecutionLaneRoutingConfig {
+  return {
+    adapters: resolveLaneAdapters(env),
+    enabled: resolveLaneEnabledFlags(env),
+    allowAnonymousSafe: readBooleanFlag(
+      env.EXEC_LANE_SAFE_ALLOW_ANONYMOUS,
+      false,
+    ),
+  };
+}
+
 type LaneResolveResult =
   | {
       ok: true;
@@ -77,14 +96,9 @@ export function resolveExecutionLane(input: {
   mode: ExecutionMode;
   actorType: ExecutionActorType;
 }): LaneResolveResult {
-  const adapters = resolveLaneAdapters(input.env);
-  const enabledFlags = resolveLaneEnabledFlags(input.env);
-  const allowAnonymousSafe = readBooleanFlag(
-    input.env.EXEC_LANE_SAFE_ALLOW_ANONYMOUS,
-    false,
-  );
+  const routing = readExecutionLaneRoutingConfig(input.env);
 
-  if (!enabledFlags[input.requestedLane]) {
+  if (!routing.enabled[input.requestedLane]) {
     return {
       ok: false,
       error: "unsupported-lane",
@@ -100,7 +114,7 @@ export function resolveExecutionLane(input: {
         reason: "lane-not-available-for-relay-signed",
       };
     }
-    if (input.actorType === "anonymous_x402" && !allowAnonymousSafe) {
+    if (input.actorType === "anonymous_x402" && !routing.allowAnonymousSafe) {
       return {
         ok: false,
         error: "unsupported-lane",
@@ -112,10 +126,10 @@ export function resolveExecutionLane(input: {
   return {
     ok: true,
     lane: input.requestedLane,
-    adapter: adapters[input.requestedLane],
+    adapter: routing.adapters[input.requestedLane],
     metadata: {
       lane: input.requestedLane,
-      adapter: adapters[input.requestedLane],
+      adapter: routing.adapters[input.requestedLane],
       requestedByMode: input.mode,
       requestedByActor: input.actorType,
       mappedBy: "env",

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -26,7 +26,10 @@ import {
   readIdempotencyKey,
   reserveExecutionSubmitRequest,
 } from "./execution/idempotency";
-import { resolveExecutionLane } from "./execution/lane_resolver";
+import {
+  readExecutionLaneRoutingConfig,
+  resolveExecutionLane,
+} from "./execution/lane_resolver";
 import {
   DEFAULT_EXECUTION_OBSERVABILITY_THRESHOLDS,
   readExecutionObservabilitySnapshot,
@@ -774,6 +777,44 @@ const worker = {
           json({
             ok: loopAHealth.status !== "error",
             loopA: loopAHealth,
+          }),
+          env,
+        );
+      }
+
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/x402/exec/health"
+      ) {
+        const loopAHealth = await readLoopAHealthFromKv(env);
+        const routing = readExecutionLaneRoutingConfig(env);
+        const hasLaneOnline =
+          routing.enabled.fast ||
+          routing.enabled.protected ||
+          routing.enabled.safe;
+        return withCors(
+          json({
+            ok: hasLaneOnline,
+            now: new Date().toISOString(),
+            api: {
+              ok: true,
+            },
+            loopA: loopAHealth ?? null,
+            lanes: {
+              fast: {
+                enabled: routing.enabled.fast,
+                adapter: routing.adapters.fast,
+              },
+              protected: {
+                enabled: routing.enabled.protected,
+                adapter: routing.adapters.protected,
+              },
+              safe: {
+                enabled: routing.enabled.safe,
+                adapter: routing.adapters.safe,
+                allowAnonymous: routing.allowAnonymousSafe,
+              },
+            },
           }),
           env,
         );

--- a/tests/unit/portal_terminal_status_bar.test.ts
+++ b/tests/unit/portal_terminal_status_bar.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import {
+  classifyStaleness,
+  computeTimeSkewMs,
+} from "../../apps/portal/app/terminal/components/terminal-status-bar";
+
+describe("portal terminal status bar helpers", () => {
+  test("classifies freshness from timestamps", () => {
+    const now = Date.now();
+    const originalNow = Date.now;
+    Date.now = () => now;
+    try {
+      expect(classifyStaleness(now - 1_000, 5_000)).toBe("fresh");
+      expect(classifyStaleness(now - 6_000, 5_000)).toBe("stale");
+      expect(classifyStaleness(null, 5_000)).toBe("missing");
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
+  test("computes server/client clock skew", () => {
+    const now = Date.now();
+    const originalNow = Date.now;
+    Date.now = () => now;
+    try {
+      const serverIso = new Date(now - 2_500).toISOString();
+      expect(computeTimeSkewMs(serverIso)).toBeCloseTo(2_500, -2);
+      expect(computeTimeSkewMs("not-a-date")).toBeNull();
+      expect(computeTimeSkewMs(null)).toBeNull();
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+});

--- a/tests/unit/worker_x402_exec_health_route.test.ts
+++ b/tests/unit/worker_x402_exec_health_route.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import worker from "../../apps/worker/src/index";
+import type { Env } from "../../apps/worker/src/types";
+
+function createExecutionContextStub(): ExecutionContext {
+  return {
+    waitUntil(_promise: Promise<unknown>) {},
+    passThroughOnException() {},
+  } as ExecutionContext;
+}
+
+describe("worker x402 exec health route", () => {
+  test("returns lane availability from routing config", async () => {
+    const env = {
+      ALLOWED_ORIGINS: "*",
+    } as Env;
+    const response = await worker.fetch(
+      new Request("https://dev.api.trader-ralph.com/api/x402/exec/health"),
+      env,
+      createExecutionContextStub(),
+    );
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as Record<string, unknown>;
+    expect(payload.ok).toBe(true);
+    expect(typeof payload.now).toBe("string");
+    expect(payload.lanes).toBeDefined();
+    const lanes = payload.lanes as Record<string, Record<string, unknown>>;
+    expect(lanes.fast?.enabled).toBe(true);
+    expect(lanes.protected?.enabled).toBe(true);
+    expect(lanes.safe?.enabled).toBe(true);
+    expect(typeof lanes.fast?.adapter).toBe("string");
+  });
+
+  test("reflects env-disabled lanes", async () => {
+    const env = {
+      ALLOWED_ORIGINS: "*",
+      EXEC_LANE_FAST_ENABLED: "false",
+      EXEC_LANE_PROTECTED_ENABLED: "0",
+      EXEC_LANE_SAFE_ENABLED: "off",
+    } as Env;
+    const response = await worker.fetch(
+      new Request("https://dev.api.trader-ralph.com/api/x402/exec/health"),
+      env,
+      createExecutionContextStub(),
+    );
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as Record<string, unknown>;
+    expect(payload.ok).toBe(false);
+    const lanes = payload.lanes as Record<string, Record<string, unknown>>;
+    expect(lanes.fast?.enabled).toBe(false);
+    expect(lanes.protected?.enabled).toBe(false);
+    expect(lanes.safe?.enabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a terminal-global status bar for realtime stream health, API health, lane availability, data staleness, and clock skew
- add worker endpoint `GET /api/x402/exec/health` sourced from lane routing config and loop health
- expose lane routing config reader for shared endpoint/runtime use and add targeted unit coverage

## Testing
- bun run lint
- bun run typecheck
- bun test tests/unit/portal_terminal_status_bar.test.ts tests/unit/worker_x402_exec_health_route.test.ts tests/unit/portal_terminal_execution_inspector.test.ts tests/unit/portal_terminal_account_risk.test.ts
- cd apps/portal && bun run build

Closes #161
