### PR TITLE
TERM-016: implement keyboard-first terminal controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ It provides one execution fabric for:
 - Account risk panel with equity/margin/concentration/liquidation warnings and pre-submit exposure guardrails
 - Execution inspector drawer with timeline, attempts, and terminal receipt payload visibility
 - Global terminal status bar for stream/API/lane health, data staleness badges, and diagnostics links
+- Keyboard-first controls with configurable hotkey profiles, panel focus shortcuts, and command palette
 - Account-level Privy wallet model (one wallet per user)
 - x402 paid APIs (`/api/x402/read/*`, `/api/x402/exec/submit`)
 - Execution API scaffold:

--- a/apps/portal/app/terminal/components/terminal-command-palette.tsx
+++ b/apps/portal/app/terminal/components/terminal-command-palette.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { cn } from "../../cn";
+import {
+  formatHotkeyChord,
+  TERMINAL_HOTKEY_PROFILES,
+  type TerminalHotkeyProfileId,
+} from "./terminal-hotkeys";
+
+export type TerminalCommandPaletteCommand = {
+  id: string;
+  title: string;
+  description?: string;
+  hotkey?: string;
+  keywords?: readonly string[];
+  disabled?: boolean;
+  onSelect: () => void;
+};
+
+type TerminalCommandPaletteProps = {
+  open: boolean;
+  commands: readonly TerminalCommandPaletteCommand[];
+  hotkeyProfileId: TerminalHotkeyProfileId;
+  onClose: () => void;
+  onHotkeyProfileChange: (profileId: TerminalHotkeyProfileId) => void;
+};
+
+function filterCommands(
+  commands: readonly TerminalCommandPaletteCommand[],
+  query: string,
+): TerminalCommandPaletteCommand[] {
+  const trimmed = query.trim().toLowerCase();
+  if (!trimmed) return [...commands];
+  return commands.filter((command) => {
+    if (command.title.toLowerCase().includes(trimmed)) return true;
+    if (command.description?.toLowerCase().includes(trimmed)) return true;
+    if (command.hotkey?.toLowerCase().includes(trimmed)) return true;
+    if (
+      command.keywords?.some((keyword) =>
+        keyword.toLowerCase().includes(trimmed),
+      )
+    ) {
+      return true;
+    }
+    return false;
+  });
+}
+
+export function TerminalCommandPalette(props: TerminalCommandPaletteProps) {
+  const { open, commands, hotkeyProfileId, onClose, onHotkeyProfileChange } =
+    props;
+  const [query, setQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const filtered = useMemo(
+    () => filterCommands(commands, query),
+    [commands, query],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    setQuery("");
+    setSelectedIndex(0);
+    window.setTimeout(() => {
+      inputRef.current?.focus();
+    }, 0);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (selectedIndex < filtered.length) return;
+    setSelectedIndex(filtered.length > 0 ? filtered.length - 1 : 0);
+  }, [filtered.length, open, selectedIndex]);
+
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(event: KeyboardEvent): void {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setSelectedIndex((current) =>
+          filtered.length < 1 ? 0 : Math.min(filtered.length - 1, current + 1),
+        );
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setSelectedIndex((current) => Math.max(0, current - 1));
+        return;
+      }
+      if (event.key !== "Enter") return;
+      const selected = filtered[selectedIndex] ?? null;
+      if (!selected || selected.disabled) return;
+      event.preventDefault();
+      selected.onSelect();
+      onClose();
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [filtered, onClose, open, selectedIndex]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[70] flex items-start justify-center bg-black/70 px-4 pt-[8vh] backdrop-blur-[4px]">
+      <button
+        aria-label="Close command palette"
+        className="absolute inset-0"
+        onClick={onClose}
+        type="button"
+      />
+      <div className="relative w-[min(760px,96vw)] rounded-lg border border-border bg-paper shadow-2xl">
+        <div className="border-b border-border px-4 py-3">
+          <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+            <p className="label">COMMAND_PALETTE</p>
+            <span className="text-[10px] text-muted">Esc to close</span>
+          </div>
+          <input
+            ref={inputRef}
+            className="input-field !py-2.5"
+            placeholder="Search actions, panels, or hotkeys"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+          <div className="mt-3 flex flex-wrap items-center gap-1.5">
+            {Object.values(TERMINAL_HOTKEY_PROFILES).map((profile) => {
+              const active = profile.id === hotkeyProfileId;
+              return (
+                <button
+                  key={profile.id}
+                  className={cn(
+                    "rounded border px-2.5 py-1 text-[10px] uppercase tracking-wider",
+                    active
+                      ? "border-emerald-500/50 bg-emerald-500/10 text-emerald-300"
+                      : "border-border text-muted hover:text-ink",
+                  )}
+                  onClick={() => onHotkeyProfileChange(profile.id)}
+                  type="button"
+                >
+                  {profile.label}
+                </button>
+              );
+            })}
+            <span className="text-[10px] text-muted">
+              {TERMINAL_HOTKEY_PROFILES[hotkeyProfileId].description}
+            </span>
+          </div>
+        </div>
+
+        <div className="max-h-[56vh] overflow-y-auto p-2">
+          {filtered.length < 1 ? (
+            <p className="px-2 py-6 text-center text-xs text-muted">
+              No matching commands.
+            </p>
+          ) : (
+            <ul className="space-y-1">
+              {filtered.map((command, index) => {
+                const selected = index === selectedIndex;
+                return (
+                  <li key={command.id}>
+                    <button
+                      className={cn(
+                        "flex w-full items-center justify-between rounded-md border px-3 py-2 text-left transition-colors",
+                        selected
+                          ? "border-emerald-500/50 bg-emerald-500/10"
+                          : "border-border hover:border-border/80 hover:bg-surface",
+                        command.disabled && "cursor-not-allowed opacity-50",
+                      )}
+                      onMouseEnter={() => setSelectedIndex(index)}
+                      onClick={() => {
+                        if (command.disabled) return;
+                        command.onSelect();
+                        onClose();
+                      }}
+                      type="button"
+                      disabled={command.disabled}
+                    >
+                      <span className="min-w-0">
+                        <span className="block truncate text-xs text-ink">
+                          {command.title}
+                        </span>
+                        {command.description ? (
+                          <span className="block truncate text-[11px] text-muted">
+                            {command.description}
+                          </span>
+                        ) : null}
+                      </span>
+                      {command.hotkey ? (
+                        <span className="ml-3 shrink-0 rounded border border-border bg-surface px-2 py-0.5 text-[10px] text-muted">
+                          {formatHotkeyChord(command.hotkey)}
+                        </span>
+                      ) : null}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/portal/app/terminal/components/terminal-hotkeys.ts
+++ b/apps/portal/app/terminal/components/terminal-hotkeys.ts
@@ -1,0 +1,225 @@
+export type TerminalHotkeyAction =
+  | "openPalette"
+  | "quickBuy"
+  | "quickSell"
+  | "focusChart"
+  | "focusOrderbook"
+  | "focusOrderEntry"
+  | "focusTradesTape"
+  | "focusPositions"
+  | "focusRisk"
+  | "resetLayout"
+  | "refreshWallet"
+  | "openFunding"
+  | "tradeSubmit"
+  | "tradeCancel"
+  | "tradePreset1"
+  | "tradePreset2"
+  | "tradePreset3";
+
+export type TerminalHotkeyProfileId = "standard" | "precision";
+
+export type TerminalHotkeyBindings = Record<TerminalHotkeyAction, string>;
+
+export type TerminalHotkeyProfile = {
+  id: TerminalHotkeyProfileId;
+  label: string;
+  description: string;
+  bindings: TerminalHotkeyBindings;
+};
+
+export type HotkeyLikeEvent = {
+  key: string;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  altKey: boolean;
+  shiftKey: boolean;
+};
+
+export const TERMINAL_HOTKEY_PROFILE_STORAGE_KEY = "terminal.hotkey.profile.v1";
+
+export const DEFAULT_TERMINAL_HOTKEY_PROFILE_ID: TerminalHotkeyProfileId =
+  "standard";
+
+const STANDARD_BINDINGS: TerminalHotkeyBindings = {
+  openPalette: "mod+k",
+  quickBuy: "b",
+  quickSell: "s",
+  focusChart: "1",
+  focusOrderbook: "2",
+  focusOrderEntry: "3",
+  focusTradesTape: "4",
+  focusPositions: "5",
+  focusRisk: "6",
+  resetLayout: "r",
+  refreshWallet: "shift+r",
+  openFunding: "f",
+  tradeSubmit: "mod+enter",
+  tradeCancel: "escape",
+  tradePreset1: "alt+1",
+  tradePreset2: "alt+2",
+  tradePreset3: "alt+3",
+};
+
+const PRECISION_BINDINGS: TerminalHotkeyBindings = {
+  openPalette: "mod+k",
+  quickBuy: "shift+b",
+  quickSell: "shift+s",
+  focusChart: "alt+1",
+  focusOrderbook: "alt+2",
+  focusOrderEntry: "alt+3",
+  focusTradesTape: "alt+4",
+  focusPositions: "alt+5",
+  focusRisk: "alt+6",
+  resetLayout: "shift+l",
+  refreshWallet: "shift+r",
+  openFunding: "shift+f",
+  tradeSubmit: "mod+enter",
+  tradeCancel: "escape",
+  tradePreset1: "alt+1",
+  tradePreset2: "alt+2",
+  tradePreset3: "alt+3",
+};
+
+export const TERMINAL_HOTKEY_PROFILES: Record<
+  TerminalHotkeyProfileId,
+  TerminalHotkeyProfile
+> = {
+  standard: {
+    id: "standard",
+    label: "Standard",
+    description: "Fast single-key workflow for active trading.",
+    bindings: STANDARD_BINDINGS,
+  },
+  precision: {
+    id: "precision",
+    label: "Precision",
+    description: "Modifier-heavy bindings to reduce accidental triggers.",
+    bindings: PRECISION_BINDINGS,
+  },
+};
+
+export const TERMINAL_HOTKEY_ACTION_LABELS: Record<
+  TerminalHotkeyAction,
+  string
+> = {
+  openPalette: "Open command palette",
+  quickBuy: "Open buy ticket",
+  quickSell: "Open sell ticket",
+  focusChart: "Focus chart panel",
+  focusOrderbook: "Focus orderbook panel",
+  focusOrderEntry: "Focus order-entry panel",
+  focusTradesTape: "Focus trades tape panel",
+  focusPositions: "Focus positions panel",
+  focusRisk: "Focus account risk panel",
+  resetLayout: "Reset dashboard layout",
+  refreshWallet: "Refresh terminal data",
+  openFunding: "Open funding modal",
+  tradeSubmit: "Submit active trade ticket",
+  tradeCancel: "Cancel active trade ticket",
+  tradePreset1: "Apply preset #1 in trade ticket",
+  tradePreset2: "Apply preset #2 in trade ticket",
+  tradePreset3: "Apply preset #3 in trade ticket",
+};
+
+function normalizeKey(value: string): string {
+  const key = value.trim().toLowerCase();
+  if (!key) return "";
+  if (key === "esc") return "escape";
+  if (key === "return") return "enter";
+  if (key === "spacebar") return "space";
+  if (key === " ") return "space";
+  return key;
+}
+
+export function resolveTerminalHotkeyProfileId(
+  raw: unknown,
+): TerminalHotkeyProfileId {
+  const value = String(raw ?? "")
+    .trim()
+    .toLowerCase();
+  if (value === "standard" || value === "precision") {
+    return value;
+  }
+  return DEFAULT_TERMINAL_HOTKEY_PROFILE_ID;
+}
+
+export function formatHotkeyChord(chord: string): string {
+  const tokens = chord
+    .split("+")
+    .map((token) => token.trim().toLowerCase())
+    .filter(Boolean);
+  const labels = tokens.map((token) => {
+    if (token === "mod") return "Cmd/Ctrl";
+    if (token === "ctrl") return "Ctrl";
+    if (token === "meta") return "Cmd";
+    if (token === "alt") return "Alt";
+    if (token === "shift") return "Shift";
+    if (token === "escape") return "Esc";
+    if (token === "enter") return "Enter";
+    if (token === "space") return "Space";
+    return token.length === 1 ? token.toUpperCase() : token;
+  });
+  return labels.join("+");
+}
+
+export function matchesHotkey(event: HotkeyLikeEvent, chord: string): boolean {
+  const tokens = chord
+    .split("+")
+    .map((token) => token.trim().toLowerCase())
+    .filter(Boolean);
+  if (tokens.length < 1) return false;
+
+  let expectMod = false;
+  let expectCtrl = false;
+  let expectMeta = false;
+  let expectAlt = false;
+  let expectShift = false;
+  let keyToken = "";
+
+  for (const token of tokens) {
+    if (token === "mod") {
+      expectMod = true;
+      continue;
+    }
+    if (token === "ctrl") {
+      expectCtrl = true;
+      continue;
+    }
+    if (token === "meta") {
+      expectMeta = true;
+      continue;
+    }
+    if (token === "alt") {
+      expectAlt = true;
+      continue;
+    }
+    if (token === "shift") {
+      expectShift = true;
+      continue;
+    }
+    keyToken = token;
+  }
+
+  if (!keyToken) return false;
+
+  const eventKey = normalizeKey(event.key);
+  const expectedKey = normalizeKey(keyToken);
+  if (!eventKey || eventKey !== expectedKey) return false;
+
+  const hasMod = event.ctrlKey || event.metaKey;
+  if (expectMod) {
+    if (!hasMod) return false;
+  } else {
+    if (expectCtrl !== event.ctrlKey) return false;
+    if (expectMeta !== event.metaKey) return false;
+  }
+
+  if (expectAlt !== event.altKey) return false;
+  if (expectShift !== event.shiftKey) return false;
+
+  if (expectMod && expectCtrl && !event.ctrlKey) return false;
+  if (expectMod && expectMeta && !event.metaKey) return false;
+
+  return true;
+}

--- a/apps/portal/app/terminal/components/trade-ticket-modal.tsx
+++ b/apps/portal/app/terminal/components/trade-ticket-modal.tsx
@@ -21,6 +21,7 @@ import {
   type AccountRiskSnapshot,
   evaluatePreSubmitRisk,
 } from "./account-risk";
+import { formatHotkeyChord, matchesHotkey } from "./terminal-hotkeys";
 import type { TradeIntent } from "./trade-intent";
 
 type TradeTicketModalProps = {
@@ -29,10 +30,19 @@ type TradeTicketModalProps = {
   walletAddress: string | null;
   tokenBalancesByMint?: Record<string, string> | null;
   riskSnapshot?: AccountRiskSnapshot | null;
+  hotkeyBindings?: TradeTicketHotkeyBindings;
   getAccessToken: () => Promise<string | null>;
   onClose: () => void;
   onTradeComplete?: (trade: TradeTicketCompletion) => void;
   onOrderQueued?: (order: QueuedTerminalOrder) => void;
+};
+
+type TradeTicketHotkeyBindings = {
+  submit: string;
+  cancel: string;
+  preset1: string;
+  preset2: string;
+  preset3: string;
 };
 
 export type TradeTicketCompletion = {
@@ -110,6 +120,13 @@ const MAX_PRIORITY_MICRO_LAMPORTS = 2_000_000;
 const DEFAULT_EXECUTION_LANE: ExecutionLane = "safe";
 const DEFAULT_SIMULATION_PREFERENCE: SimulationPreference = "auto";
 const DEFAULT_PRIORITY_LEVEL: PriorityLevel = "normal";
+const DEFAULT_TRADE_TICKET_HOTKEY_BINDINGS: TradeTicketHotkeyBindings = {
+  submit: "mod+enter",
+  cancel: "escape",
+  preset1: "alt+1",
+  preset2: "alt+2",
+  preset3: "alt+3",
+};
 const PRIORITY_MICRO_LAMPORTS_BY_LEVEL: Record<PriorityLevel, number> = {
   normal: 5_000,
   high: 50_000,
@@ -206,6 +223,13 @@ function toBoundedSlippage(value: string, fallback: number): number {
   const raw = Number(value);
   if (!Number.isFinite(raw)) return fallback;
   return Math.max(1, Math.min(5000, Math.floor(raw)));
+}
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  const tag = target.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
 }
 
 function areQuoteStatesEqual(a: QuoteState, b: QuoteState): boolean {
@@ -355,6 +379,7 @@ export function TradeTicketModal({
   walletAddress,
   tokenBalancesByMint,
   riskSnapshot,
+  hotkeyBindings = DEFAULT_TRADE_TICKET_HOTKEY_BINDINGS,
   getAccessToken,
   onClose,
   onTradeComplete,
@@ -442,15 +467,6 @@ export function TradeTicketModal({
       }
     };
   }, [dismissExecuteToast]);
-
-  useEffect(() => {
-    if (!open) return;
-    function onKeyDown(event: KeyboardEvent): void {
-      if (event.key === "Escape") cancelAndCloseModal();
-    }
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [cancelAndCloseModal, open]);
 
   useEffect(() => {
     if (!open || !intent) return;
@@ -1016,6 +1032,74 @@ export function TradeTicketModal({
     setSlippageInput(MAX_SLIPPAGE_BPS);
   }, []);
 
+  const canExecuteTrade =
+    submitStatus !== "submitting" &&
+    submitStatus !== "tracking" &&
+    quote.status === "ready" &&
+    Boolean(quote.inAmountAtomic) &&
+    orderValidationErrors.length < 1 &&
+    executionQualityErrors.length < 1 &&
+    !preSubmitRisk.blocked;
+
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(event: KeyboardEvent): void {
+      if (matchesHotkey(event, hotkeyBindings.cancel)) {
+        event.preventDefault();
+        cancelAndCloseModal();
+        return;
+      }
+
+      const typing = isTypingTarget(event.target);
+      if (typing && !event.altKey && !event.metaKey && !event.ctrlKey) {
+        return;
+      }
+
+      if (matchesHotkey(event, hotkeyBindings.submit)) {
+        if (!canExecuteTrade) return;
+        event.preventDefault();
+        void executeTrade();
+        return;
+      }
+
+      if (matchesHotkey(event, hotkeyBindings.preset1)) {
+        const preset = amountPresets[0] ?? null;
+        if (!preset) return;
+        event.preventDefault();
+        setAmountUi(preset);
+        return;
+      }
+
+      if (matchesHotkey(event, hotkeyBindings.preset2)) {
+        const preset = amountPresets[1] ?? null;
+        if (!preset) return;
+        event.preventDefault();
+        setAmountUi(preset);
+        return;
+      }
+
+      if (matchesHotkey(event, hotkeyBindings.preset3)) {
+        const preset = amountPresets[2] ?? null;
+        if (!preset) return;
+        event.preventDefault();
+        setAmountUi(preset);
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [
+    amountPresets,
+    cancelAndCloseModal,
+    canExecuteTrade,
+    executeTrade,
+    hotkeyBindings.cancel,
+    hotkeyBindings.preset1,
+    hotkeyBindings.preset2,
+    hotkeyBindings.preset3,
+    hotkeyBindings.submit,
+    open,
+  ]);
+
   if (!intent) return null;
   if (!open) return null;
 
@@ -1133,15 +1217,7 @@ export function TradeTicketModal({
               className={`${BTN_PRIMARY} !py-2 !px-4 text-xs min-w-[8.5rem]`}
               onClick={() => void executeTrade()}
               type="button"
-              disabled={
-                submitStatus === "submitting" ||
-                submitStatus === "tracking" ||
-                quote.status !== "ready" ||
-                !quote.inAmountAtomic ||
-                orderValidationErrors.length > 0 ||
-                executionQualityErrors.length > 0 ||
-                preSubmitRisk.blocked
-              }
+              disabled={!canExecuteTrade}
             >
               {submitStatus === "submitting" || submitStatus === "tracking"
                 ? submitStatus === "tracking"
@@ -1150,6 +1226,13 @@ export function TradeTicketModal({
                 : `Execute ${intent.direction === "buy" ? "Buy" : "Sell"}`}
             </button>
           </div>
+          <p className="text-[10px] text-muted text-right">
+            {formatHotkeyChord(hotkeyBindings.submit)} submit •{" "}
+            {formatHotkeyChord(hotkeyBindings.cancel)} cancel •{" "}
+            {formatHotkeyChord(hotkeyBindings.preset1)}/
+            {formatHotkeyChord(hotkeyBindings.preset2)}/
+            {formatHotkeyChord(hotkeyBindings.preset3)} presets
+          </p>
         </div>
       </div>
     </div>

--- a/apps/portal/app/terminal/page.tsx
+++ b/apps/portal/app/terminal/page.tsx
@@ -69,6 +69,22 @@ import {
   type MarketState,
   useMarketFeed,
 } from "./components/sol-market-feed";
+import {
+  TerminalCommandPalette,
+  type TerminalCommandPaletteCommand,
+} from "./components/terminal-command-palette";
+import {
+  DEFAULT_TERMINAL_HOTKEY_PROFILE_ID,
+  formatHotkeyChord,
+  matchesHotkey,
+  resolveTerminalHotkeyProfileId,
+  TERMINAL_HOTKEY_ACTION_LABELS,
+  TERMINAL_HOTKEY_PROFILE_STORAGE_KEY,
+  TERMINAL_HOTKEY_PROFILES,
+  type TerminalHotkeyAction,
+  type TerminalHotkeyBindings,
+  type TerminalHotkeyProfileId,
+} from "./components/terminal-hotkeys";
 import { TerminalStatusBar } from "./components/terminal-status-bar";
 import { createTradeIntent, type TradeIntent } from "./components/trade-intent";
 import {
@@ -128,6 +144,52 @@ type LadderPrefill = {
   size: number;
   seq: number;
   ts: number;
+};
+
+type TerminalFocusablePanelId =
+  | "chart"
+  | "orderbook"
+  | "order_entry"
+  | "trades_tape"
+  | "positions"
+  | "account_risk";
+
+const FOCUSABLE_PANEL_ORDER: readonly TerminalFocusablePanelId[] = [
+  "chart",
+  "orderbook",
+  "order_entry",
+  "trades_tape",
+  "positions",
+  "account_risk",
+];
+
+const FOCUSABLE_PANEL_LABELS: Record<TerminalFocusablePanelId, string> = {
+  chart: "Chart panel",
+  orderbook: "Orderbook panel",
+  order_entry: "Order entry panel",
+  trades_tape: "Trades tape panel",
+  positions: "Positions panel",
+  account_risk: "Account risk panel",
+};
+
+const PANEL_ACTION_BY_ID: Record<
+  TerminalFocusablePanelId,
+  Extract<
+    TerminalHotkeyAction,
+    | "focusChart"
+    | "focusOrderbook"
+    | "focusOrderEntry"
+    | "focusTradesTape"
+    | "focusPositions"
+    | "focusRisk"
+  >
+> = {
+  chart: "focusChart",
+  orderbook: "focusOrderbook",
+  order_entry: "focusOrderEntry",
+  trades_tape: "focusTradesTape",
+  positions: "focusPositions",
+  account_risk: "focusRisk",
 };
 
 const FundingModal = dynamic(
@@ -313,6 +375,15 @@ function ControlRoom() {
   const [ladderPrefill, setLadderPrefill] = useState<LadderPrefill | null>(
     null,
   );
+  const [focusedPanelId, setFocusedPanelId] =
+    useState<TerminalFocusablePanelId | null>(null);
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  const [hotkeyProfileId, setHotkeyProfileId] =
+    useState<TerminalHotkeyProfileId>(DEFAULT_TERMINAL_HOTKEY_PROFILE_ID);
+  const panelRefs = useRef<
+    Partial<Record<TerminalFocusablePanelId, HTMLDivElement | null>>
+  >({});
+  const panelFocusTimerRef = useRef<number | null>(null);
   const terminalModeRef = useRef<TerminalMode>(terminalMode);
   const fallbackModePersistControllerRef = useRef<AbortController | null>(null);
   const modeCapabilities = getTerminalModeCapabilities(terminalMode);
@@ -329,6 +400,22 @@ function ControlRoom() {
     "macro_stablecoin",
   );
   const showMacroOilModule = modeShowsModule(terminalMode, "macro_oil");
+  const hotkeyProfile = useMemo(
+    () => TERMINAL_HOTKEY_PROFILES[hotkeyProfileId],
+    [hotkeyProfileId],
+  );
+  const hotkeyBindings: TerminalHotkeyBindings = hotkeyProfile.bindings;
+  const panelVisibility = useMemo<Record<TerminalFocusablePanelId, boolean>>(
+    () => ({
+      chart: showMarketModule,
+      orderbook: showMarketModule,
+      order_entry: showMarketModule,
+      trades_tape: showMarketModule,
+      positions: showMarketModule,
+      account_risk: showWalletModule,
+    }),
+    [showMarketModule, showWalletModule],
+  );
 
   useEffect(() => {
     terminalModeRef.current = terminalMode;
@@ -337,15 +424,82 @@ function ControlRoom() {
   useEffect(
     () => () => {
       fallbackModePersistControllerRef.current?.abort();
+      if (panelFocusTimerRef.current !== null) {
+        window.clearTimeout(panelFocusTimerRef.current);
+      }
     },
     [],
   );
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem(
+      TERMINAL_HOTKEY_PROFILE_STORAGE_KEY,
+    );
+    setHotkeyProfileId(resolveTerminalHotkeyProfileId(stored));
+  }, []);
+
+  useEffect(() => {
+    if (!tradeOpen) return;
+    setCommandPaletteOpen(false);
+  }, [tradeOpen]);
 
   const resetDashboardLayout = useCallback(() => {
     clearDashboardGridLayouts();
     setHasCustomGridLayout(false);
     setGridRevision((value) => value + 1);
   }, []);
+
+  const updateHotkeyProfile = useCallback(
+    (nextProfile: TerminalHotkeyProfileId): void => {
+      setHotkeyProfileId(nextProfile);
+      window.localStorage.setItem(
+        TERMINAL_HOTKEY_PROFILE_STORAGE_KEY,
+        nextProfile,
+      );
+    },
+    [],
+  );
+
+  const setPanelRef = useCallback(
+    (panelId: TerminalFocusablePanelId) =>
+      (node: HTMLDivElement | null): void => {
+        panelRefs.current[panelId] = node;
+      },
+    [],
+  );
+
+  const focusPanel = useCallback(
+    (panelId: TerminalFocusablePanelId): boolean => {
+      const node = panelRefs.current[panelId];
+      if (!node) return false;
+      node.focus({ preventScroll: true });
+      node.scrollIntoView({
+        block: "nearest",
+        inline: "nearest",
+        behavior: "smooth",
+      });
+      setFocusedPanelId(panelId);
+      if (panelFocusTimerRef.current !== null) {
+        window.clearTimeout(panelFocusTimerRef.current);
+      }
+      panelFocusTimerRef.current = window.setTimeout(() => {
+        setFocusedPanelId((current) => (current === panelId ? null : current));
+        panelFocusTimerRef.current = null;
+      }, 1600);
+      return true;
+    },
+    [],
+  );
+
+  const panelClassName = useCallback(
+    (panelId: TerminalFocusablePanelId, baseClassName: string) =>
+      cn(
+        baseClassName,
+        "outline-none focus:ring-2 focus:ring-inset focus:ring-emerald-400/80",
+        focusedPanelId === panelId && "ring-2 ring-inset ring-emerald-500/60",
+      ),
+    [focusedPanelId],
+  );
 
   useEffect(() => {
     setHasCustomGridLayout(hasCustomDashboardGridLayouts());
@@ -424,21 +578,6 @@ function ControlRoom() {
     },
     [authenticated, getAccessToken],
   );
-
-  useEffect(() => {
-    function onKeyDown(event: KeyboardEvent): void {
-      if (!canLayoutEdit) return;
-      if (isTypingTarget(event.target)) return;
-      if (event.metaKey || event.ctrlKey || event.altKey) return;
-      if (event.key.toLowerCase() !== "r") return;
-      event.preventDefault();
-      resetDashboardLayout();
-    }
-    window.addEventListener("keydown", onKeyDown);
-    return () => {
-      window.removeEventListener("keydown", onKeyDown);
-    };
-  }, [canLayoutEdit, resetDashboardLayout]);
 
   const refresh = useCallback(async (): Promise<void> => {
     if (!authenticated) return;
@@ -811,6 +950,90 @@ function ControlRoom() {
     void refresh();
   }, [refresh]);
 
+  useEffect(() => {
+    const focusHotkeyActions: Array<{
+      panelId: TerminalFocusablePanelId;
+      action: TerminalHotkeyAction;
+    }> = FOCUSABLE_PANEL_ORDER.map((panelId) => ({
+      panelId,
+      action: PANEL_ACTION_BY_ID[panelId],
+    }));
+
+    function onKeyDown(event: KeyboardEvent): void {
+      if (matchesHotkey(event, hotkeyBindings.openPalette)) {
+        event.preventDefault();
+        setCommandPaletteOpen((current) => !current);
+        return;
+      }
+
+      if (commandPaletteOpen) return;
+      if (tradeOpen) return;
+      if (isTypingTarget(event.target)) return;
+
+      if (matchesHotkey(event, hotkeyBindings.quickBuy)) {
+        if (!canQuickTrade) return;
+        event.preventDefault();
+        openMarketBuyTrade();
+        return;
+      }
+
+      if (matchesHotkey(event, hotkeyBindings.quickSell)) {
+        if (!canQuickTrade) return;
+        event.preventDefault();
+        openMarketSellTrade();
+        return;
+      }
+
+      if (matchesHotkey(event, hotkeyBindings.resetLayout)) {
+        if (!canLayoutEdit) return;
+        event.preventDefault();
+        resetDashboardLayout();
+        return;
+      }
+
+      if (matchesHotkey(event, hotkeyBindings.refreshWallet)) {
+        event.preventDefault();
+        triggerRefresh();
+        return;
+      }
+
+      if (matchesHotkey(event, hotkeyBindings.openFunding)) {
+        if (!wallet) return;
+        event.preventDefault();
+        openFundingModal();
+        return;
+      }
+
+      for (const focusAction of focusHotkeyActions) {
+        if (!panelVisibility[focusAction.panelId]) continue;
+        const chord = hotkeyBindings[focusAction.action];
+        if (!matchesHotkey(event, chord)) continue;
+        event.preventDefault();
+        focusPanel(focusAction.panelId);
+        return;
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [
+    canLayoutEdit,
+    canQuickTrade,
+    commandPaletteOpen,
+    focusPanel,
+    hotkeyBindings,
+    openFundingModal,
+    openMarketBuyTrade,
+    openMarketSellTrade,
+    panelVisibility,
+    resetDashboardLayout,
+    tradeOpen,
+    triggerRefresh,
+    wallet,
+  ]);
+
   const applyOptimisticTradeBalances = useCallback(
     (trade: TradeTicketCompletion): void => {
       const inAmount = parseAtomic(trade.inAmountAtomic);
@@ -963,6 +1186,118 @@ function ControlRoom() {
     triggerRefresh,
   ]);
 
+  const tradeTicketHotkeys = useMemo(
+    () => ({
+      submit: hotkeyBindings.tradeSubmit,
+      cancel: hotkeyBindings.tradeCancel,
+      preset1: hotkeyBindings.tradePreset1,
+      preset2: hotkeyBindings.tradePreset2,
+      preset3: hotkeyBindings.tradePreset3,
+    }),
+    [hotkeyBindings],
+  );
+
+  const commandPaletteCommands = useMemo<
+    TerminalCommandPaletteCommand[]
+  >(() => {
+    const commands: TerminalCommandPaletteCommand[] = [
+      {
+        id: "buy-ticket",
+        title: TERMINAL_HOTKEY_ACTION_LABELS.quickBuy,
+        description: `Open ${selectedPairId} buy ticket`,
+        hotkey: hotkeyBindings.quickBuy,
+        keywords: ["trade", "buy", "execute"],
+        disabled: !canQuickTrade,
+        onSelect: openMarketBuyTrade,
+      },
+      {
+        id: "sell-ticket",
+        title: TERMINAL_HOTKEY_ACTION_LABELS.quickSell,
+        description: `Open ${selectedPairId} sell ticket`,
+        hotkey: hotkeyBindings.quickSell,
+        keywords: ["trade", "sell", "execute"],
+        disabled: !canQuickTrade,
+        onSelect: openMarketSellTrade,
+      },
+      {
+        id: "refresh-data",
+        title: TERMINAL_HOTKEY_ACTION_LABELS.refreshWallet,
+        description: "Reload profile, wallet balances, and mode state",
+        hotkey: hotkeyBindings.refreshWallet,
+        keywords: ["refresh", "wallet", "reload"],
+        onSelect: triggerRefresh,
+      },
+      {
+        id: "open-funding",
+        title: TERMINAL_HOTKEY_ACTION_LABELS.openFunding,
+        description: "Open Privy funding modal",
+        hotkey: hotkeyBindings.openFunding,
+        keywords: ["fund", "wallet", "deposit"],
+        disabled: !wallet,
+        onSelect: openFundingModal,
+      },
+      {
+        id: "reset-layout",
+        title: TERMINAL_HOTKEY_ACTION_LABELS.resetLayout,
+        description: "Reset terminal grid to default panel layout",
+        hotkey: hotkeyBindings.resetLayout,
+        keywords: ["layout", "grid", "reset"],
+        disabled: !canLayoutEdit,
+        onSelect: resetDashboardLayout,
+      },
+    ];
+
+    for (const panelId of FOCUSABLE_PANEL_ORDER) {
+      const action = PANEL_ACTION_BY_ID[panelId];
+      commands.push({
+        id: `focus-${panelId}`,
+        title: TERMINAL_HOTKEY_ACTION_LABELS[action],
+        description: FOCUSABLE_PANEL_LABELS[panelId],
+        hotkey: hotkeyBindings[action],
+        keywords: ["focus", "panel", panelId.replaceAll("_", " ")],
+        disabled: !panelVisibility[panelId],
+        onSelect: () => {
+          focusPanel(panelId);
+        },
+      });
+    }
+
+    commands.push(
+      {
+        id: "profile-standard",
+        title: "Switch hotkeys: Standard",
+        description: TERMINAL_HOTKEY_PROFILES.standard.description,
+        keywords: ["profile", "hotkeys", "standard"],
+        disabled: hotkeyProfileId === "standard",
+        onSelect: () => updateHotkeyProfile("standard"),
+      },
+      {
+        id: "profile-precision",
+        title: "Switch hotkeys: Precision",
+        description: TERMINAL_HOTKEY_PROFILES.precision.description,
+        keywords: ["profile", "hotkeys", "precision"],
+        disabled: hotkeyProfileId === "precision",
+        onSelect: () => updateHotkeyProfile("precision"),
+      },
+    );
+    return commands;
+  }, [
+    canLayoutEdit,
+    canQuickTrade,
+    focusPanel,
+    hotkeyBindings,
+    hotkeyProfileId,
+    openFundingModal,
+    openMarketBuyTrade,
+    openMarketSellTrade,
+    resetDashboardLayout,
+    panelVisibility,
+    selectedPairId,
+    triggerRefresh,
+    updateHotkeyProfile,
+    wallet,
+  ]);
+
   return (
     <>
       {wallet && fundOpen ? (
@@ -979,12 +1314,20 @@ function ControlRoom() {
           walletAddress={wallet?.walletAddress ?? null}
           tokenBalancesByMint={tokenBalancesByMint}
           riskSnapshot={accountRiskSnapshot}
+          hotkeyBindings={tradeTicketHotkeys}
           getAccessToken={getAccessToken}
           onClose={() => setTradeOpen(false)}
           onTradeComplete={handleTradeComplete}
           onOrderQueued={handleOrderQueued}
         />
       ) : null}
+      <TerminalCommandPalette
+        open={commandPaletteOpen}
+        commands={commandPaletteCommands}
+        hotkeyProfileId={hotkeyProfileId}
+        onClose={() => setCommandPaletteOpen(false)}
+        onHotkeyProfileChange={updateHotkeyProfile}
+      />
 
       <section className="flex-1 min-h-0 w-full">
         <div className="w-full h-full min-h-0">
@@ -1005,7 +1348,7 @@ function ControlRoom() {
                 market={marketFeed}
               />
               <div className="relative min-h-0 flex-1">
-                <div className="pointer-events-none absolute left-2 top-2 z-20 hidden sm:block">
+                <div className="pointer-events-none absolute left-2 top-2 z-20 hidden sm:flex sm:items-center sm:gap-1.5">
                   <div
                     className="rounded border border-border/70 bg-paper/90 px-2.5 py-1 text-[11px] text-muted backdrop-blur"
                     title={modeCapabilities.description}
@@ -1015,6 +1358,17 @@ function ControlRoom() {
                       {modeCapabilities.label}
                     </span>
                   </div>
+                  <button
+                    className={cn(
+                      BTN_SECONDARY,
+                      "pointer-events-auto h-7 border-border/70 bg-paper/90 px-2.5 text-[11px] backdrop-blur",
+                    )}
+                    onClick={() => setCommandPaletteOpen(true)}
+                    title="Open command palette"
+                    type="button"
+                  >
+                    Cmd • {formatHotkeyChord(hotkeyBindings.openPalette)}
+                  </button>
                 </div>
                 {hasCustomGridLayout && canLayoutEdit && (
                   <div className="pointer-events-none absolute right-2 top-2 z-20">
@@ -1024,7 +1378,7 @@ function ControlRoom() {
                         "pointer-events-auto h-7 border-border/70 bg-paper/90 px-2.5 text-[11px] backdrop-blur",
                       )}
                       onClick={resetDashboardLayout}
-                      title="Reorganize layout (R)"
+                      title={`Reorganize layout (${formatHotkeyChord(hotkeyBindings.resetLayout)})`}
                       type="button"
                     >
                       Reset layout
@@ -1043,7 +1397,12 @@ function ControlRoom() {
                   {showMarketModule ? (
                     <div
                       key="chart"
-                      className="flex flex-col overflow-hidden bg-surface"
+                      ref={setPanelRef("chart")}
+                      tabIndex={-1}
+                      className={panelClassName(
+                        "chart",
+                        "flex flex-col overflow-hidden bg-surface",
+                      )}
                     >
                       <ChartPanel
                         pairId={selectedPairId}
@@ -1056,7 +1415,12 @@ function ControlRoom() {
                   {showMarketModule ? (
                     <div
                       key="orderbook"
-                      className="flex flex-col overflow-hidden bg-surface"
+                      ref={setPanelRef("orderbook")}
+                      tabIndex={-1}
+                      className={panelClassName(
+                        "orderbook",
+                        "flex flex-col overflow-hidden bg-surface",
+                      )}
                     >
                       <OrderbookDepthPanel
                         market={marketFeed}
@@ -1070,7 +1434,12 @@ function ControlRoom() {
                   {showMarketModule ? (
                     <div
                       key="order_entry"
-                      className="flex flex-col overflow-hidden bg-surface"
+                      ref={setPanelRef("order_entry")}
+                      tabIndex={-1}
+                      className={panelClassName(
+                        "order_entry",
+                        "flex flex-col overflow-hidden bg-surface",
+                      )}
                     >
                       <OrderEntryPanel
                         pairId={selectedPairId}
@@ -1086,7 +1455,12 @@ function ControlRoom() {
                   {showMarketModule ? (
                     <div
                       key="trades_tape"
-                      className="flex flex-col overflow-hidden bg-surface"
+                      ref={setPanelRef("trades_tape")}
+                      tabIndex={-1}
+                      className={panelClassName(
+                        "trades_tape",
+                        "flex flex-col overflow-hidden bg-surface",
+                      )}
                     >
                       <TradesTapePanel realtime={realtimeTransport} />
                     </div>
@@ -1095,7 +1469,12 @@ function ControlRoom() {
                   {showMarketModule ? (
                     <div
                       key="positions"
-                      className="flex flex-col overflow-hidden bg-surface"
+                      ref={setPanelRef("positions")}
+                      tabIndex={-1}
+                      className={panelClassName(
+                        "positions",
+                        "flex flex-col overflow-hidden bg-surface",
+                      )}
                     >
                       <PositionsOrdersFillsPanel
                         entries={recentExecutions}
@@ -1116,7 +1495,12 @@ function ControlRoom() {
                   {showWalletModule ? (
                     <div
                       key="account_risk"
-                      className="flex flex-col overflow-hidden bg-surface"
+                      ref={setPanelRef("account_risk")}
+                      tabIndex={-1}
+                      className={panelClassName(
+                        "account_risk",
+                        "flex flex-col overflow-hidden bg-surface",
+                      )}
                     >
                       <AccountRiskPanel
                         pairId={selectedPairId}

--- a/tests/unit/portal_terminal_hotkeys.test.ts
+++ b/tests/unit/portal_terminal_hotkeys.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import {
+  formatHotkeyChord,
+  matchesHotkey,
+  resolveTerminalHotkeyProfileId,
+} from "../../apps/portal/app/terminal/components/terminal-hotkeys";
+
+describe("portal terminal hotkey helpers", () => {
+  test("matches modifier and simple chords", () => {
+    expect(
+      matchesHotkey(
+        {
+          key: "k",
+          ctrlKey: true,
+          metaKey: false,
+          altKey: false,
+          shiftKey: false,
+        },
+        "mod+k",
+      ),
+    ).toBe(true);
+
+    expect(
+      matchesHotkey(
+        {
+          key: "Enter",
+          ctrlKey: false,
+          metaKey: true,
+          altKey: false,
+          shiftKey: false,
+        },
+        "mod+enter",
+      ),
+    ).toBe(true);
+
+    expect(
+      matchesHotkey(
+        {
+          key: "1",
+          ctrlKey: false,
+          metaKey: false,
+          altKey: true,
+          shiftKey: false,
+        },
+        "alt+1",
+      ),
+    ).toBe(true);
+
+    expect(
+      matchesHotkey(
+        {
+          key: "r",
+          ctrlKey: false,
+          metaKey: false,
+          altKey: false,
+          shiftKey: true,
+        },
+        "r",
+      ),
+    ).toBe(false);
+  });
+
+  test("formats display labels and resolves profile ids", () => {
+    expect(formatHotkeyChord("mod+enter")).toBe("Cmd/Ctrl+Enter");
+    expect(formatHotkeyChord("alt+1")).toBe("Alt+1");
+    expect(resolveTerminalHotkeyProfileId("precision")).toBe("precision");
+    expect(resolveTerminalHotkeyProfileId("unknown")).toBe("standard");
+  });
+});


### PR DESCRIPTION
## Summary
- add a keyboard-first terminal command system with configurable hotkey profiles (`standard` and `precision`)
- add command palette UI for discoverable keyboard actions, panel focus commands, and hotkey profile switching
- wire global hotkeys for buy/sell, panel focus, refresh/funding, and layout reset with input-safe conflict guards
- wire trade-ticket hotkeys for submit, cancel, and amount presets with on-screen shortcut hints

## Testing
- bun run lint
- bun run typecheck
- bun test tests/unit/portal_terminal_hotkeys.test.ts tests/unit/portal_terminal_status_bar.test.ts tests/unit/portal_terminal_execution_inspector.test.ts tests/unit/portal_terminal_account_risk.test.ts tests/unit/worker_x402_exec_health_route.test.ts
- cd apps/portal && bun run build

Closes #162
