### PR TITLE
TERM-017: add custom workspace preset system

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ It provides one execution fabric for:
 - Execution inspector drawer with timeline, attempts, and terminal receipt payload visibility
 - Global terminal status bar for stream/API/lane health, data staleness badges, and diagnostics links
 - Keyboard-first controls with configurable hotkey profiles, panel focus shortcuts, and command palette
+- Custom-mode workspace presets with module visibility toggles and per-workspace layout persistence
 - Account-level Privy wallet model (one wallet per user)
 - x402 paid APIs (`/api/x402/read/*`, `/api/x402/exec/submit`)
 - Execution API scaffold:

--- a/apps/portal/app/terminal/components/dashboard-grid.tsx
+++ b/apps/portal/app/terminal/components/dashboard-grid.tsx
@@ -1,5 +1,5 @@
 // import RGL from "react-grid-layout"; // Commented out to avoid ESM issues
-import { type ReactNode, useCallback, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
 import "react-grid-layout/css/styles.css";
 import "react-resizable/css/styles.css";
 
@@ -27,9 +27,10 @@ interface DashboardGridProps {
   className?: string;
   onLayoutChange?: (layout: Layout[]) => void;
   allowLayoutEditing?: boolean;
+  storageKey?: string;
 }
 
-const DASHBOARD_LAYOUT_STORAGE_KEY = "dashboard-grid-layouts:v5";
+const DASHBOARD_LAYOUT_STORAGE_KEY = "dashboard-grid-layouts:v6";
 const LAYOUT_BREAKPOINTS = ["lg", "md", "sm"] as const;
 
 type LayoutBreakpoint = (typeof LAYOUT_BREAKPOINTS)[number];
@@ -84,6 +85,12 @@ const DEFAULT_DASHBOARD_LAYOUTS: Record<LayoutBreakpoint, Layout[]> = {
     { i: "macro_oil", x: 0, y: 29, w: 6, h: 3 },
   ],
 };
+
+const KNOWN_PANEL_IDS = new Set(
+  LAYOUT_BREAKPOINTS.flatMap((breakpoint) =>
+    DEFAULT_DASHBOARD_LAYOUTS[breakpoint].map((entry) => entry.i),
+  ),
+);
 
 const GRID_OVERLAY_STYLES = `
   .react-grid-item.react-grid-placeholder {
@@ -154,28 +161,97 @@ function isDashboardLayoutModified(layouts: unknown): boolean {
   );
 }
 
-function readStoredDashboardLayouts(): unknown | null {
+function resolveLayoutStorageKey(storageKey?: string): string {
+  const normalized = String(storageKey ?? "").trim();
+  return normalized || DASHBOARD_LAYOUT_STORAGE_KEY;
+}
+
+function cloneDefaultDashboardLayouts(): DashboardLayouts {
+  return {
+    lg: DEFAULT_DASHBOARD_LAYOUTS.lg.map((entry) => ({ ...entry })),
+    md: DEFAULT_DASHBOARD_LAYOUTS.md.map((entry) => ({ ...entry })),
+    sm: DEFAULT_DASHBOARD_LAYOUTS.sm.map((entry) => ({ ...entry })),
+  };
+}
+
+function sanitizeLayoutEntry(raw: unknown): Layout | null {
+  if (!raw || typeof raw !== "object") return null;
+  const entry = raw as Record<string, unknown>;
+  const i = String(entry.i ?? "").trim();
+  if (!i || !KNOWN_PANEL_IDS.has(i)) return null;
+  const x = Number(entry.x ?? 0);
+  const y = Number(entry.y ?? 0);
+  const w = Number(entry.w ?? 0);
+  const h = Number(entry.h ?? 0);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+  if (!Number.isFinite(w) || !Number.isFinite(h)) return null;
+  if (w <= 0 || h <= 0) return null;
+
+  return {
+    i,
+    x: Math.max(0, Math.floor(x)),
+    y: Math.max(0, Math.floor(y)),
+    w: Math.max(1, Math.floor(w)),
+    h: Math.max(1, Math.floor(h)),
+  };
+}
+
+function sanitizeDashboardLayouts(layouts: unknown): DashboardLayouts | null {
+  if (!layouts || typeof layouts !== "object") return null;
+  const record = layouts as Record<string, unknown>;
+  const sanitized = cloneDefaultDashboardLayouts();
+
+  for (const breakpoint of LAYOUT_BREAKPOINTS) {
+    const rawEntries = Array.isArray(record[breakpoint])
+      ? record[breakpoint]
+      : [];
+    const entriesById = new Map<string, Layout>();
+
+    for (const rawEntry of rawEntries) {
+      const parsed = sanitizeLayoutEntry(rawEntry);
+      if (!parsed) continue;
+      if (entriesById.has(parsed.i)) continue;
+      entriesById.set(parsed.i, parsed);
+    }
+
+    if (entriesById.size < 1) continue;
+
+    const nextEntries = Array.from(entriesById.values());
+    const missingDefaults = DEFAULT_DASHBOARD_LAYOUTS[breakpoint]
+      .filter((entry) => !entriesById.has(entry.i))
+      .map((entry) => ({ ...entry }));
+    sanitized[breakpoint] = [...nextEntries, ...missingDefaults];
+  }
+
+  return sanitized;
+}
+
+function readStoredDashboardLayouts(
+  storageKey?: string,
+): DashboardLayouts | null {
   if (typeof window === "undefined") return null;
   try {
-    const raw = window.localStorage.getItem(DASHBOARD_LAYOUT_STORAGE_KEY);
+    const raw = window.localStorage.getItem(
+      resolveLayoutStorageKey(storageKey),
+    );
     if (!raw) return null;
-    return JSON.parse(raw);
+    return sanitizeDashboardLayouts(JSON.parse(raw));
   } catch {
     return null;
   }
 }
 
-export function clearDashboardGridLayouts(): void {
+export function clearDashboardGridLayouts(storageKey?: string): void {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.removeItem(DASHBOARD_LAYOUT_STORAGE_KEY);
+    window.localStorage.removeItem(resolveLayoutStorageKey(storageKey));
   } catch {
     // Ignore storage errors.
   }
 }
 
-export function hasCustomDashboardGridLayouts(): boolean {
-  const stored = readStoredDashboardLayouts();
+export function hasCustomDashboardGridLayouts(storageKey?: string): boolean {
+  const stored = readStoredDashboardLayouts(storageKey);
   if (!stored) return false;
   return isDashboardLayoutModified(stored);
 }
@@ -185,41 +261,52 @@ export function DashboardGrid({
   className,
   onLayoutChange,
   allowLayoutEditing = true,
+  storageKey,
 }: DashboardGridProps) {
   // Use the hook to get width
   const { width, containerRef, mounted } = useContainerWidth();
+  const resolvedStorageKey = resolveLayoutStorageKey(storageKey);
 
   const [layouts, setLayouts] = useState<DashboardLayouts>(() => {
-    const stored = readStoredDashboardLayouts();
+    const stored = readStoredDashboardLayouts(resolvedStorageKey);
     if (!stored || !isDashboardLayoutModified(stored)) {
-      clearDashboardGridLayouts();
-      return DEFAULT_DASHBOARD_LAYOUTS as DashboardLayouts;
+      clearDashboardGridLayouts(resolvedStorageKey);
+      return cloneDefaultDashboardLayouts();
     }
 
-    return {
-      ...DEFAULT_DASHBOARD_LAYOUTS,
-      ...(stored as Record<string, unknown>),
-    };
+    return stored;
   });
+
+  useEffect(() => {
+    const stored = readStoredDashboardLayouts(resolvedStorageKey);
+    if (!stored || !isDashboardLayoutModified(stored)) {
+      clearDashboardGridLayouts(resolvedStorageKey);
+      setLayouts(cloneDefaultDashboardLayouts());
+      return;
+    }
+    setLayouts(stored);
+  }, [resolvedStorageKey]);
 
   const handleLayoutChange = useCallback(
     (layout: Layout[], allLayouts: DashboardLayouts) => {
-      setLayouts(allLayouts);
-      if (isDashboardLayoutModified(allLayouts)) {
+      const sanitized =
+        sanitizeDashboardLayouts(allLayouts) ?? cloneDefaultDashboardLayouts();
+      setLayouts(sanitized);
+      if (isDashboardLayoutModified(sanitized)) {
         try {
           window.localStorage.setItem(
-            DASHBOARD_LAYOUT_STORAGE_KEY,
-            JSON.stringify(allLayouts),
+            resolvedStorageKey,
+            JSON.stringify(sanitized),
           );
         } catch {
           // Ignore storage errors and keep in-memory behavior.
         }
       } else {
-        clearDashboardGridLayouts();
+        clearDashboardGridLayouts(resolvedStorageKey);
       }
       if (onLayoutChange) onLayoutChange(layout);
     },
-    [onLayoutChange],
+    [onLayoutChange, resolvedStorageKey],
   );
 
   return (

--- a/apps/portal/app/terminal/components/workspace-presets.ts
+++ b/apps/portal/app/terminal/components/workspace-presets.ts
@@ -1,0 +1,182 @@
+import type { TerminalModule } from "../terminal-modes";
+
+export type WorkspaceModuleVisibility = Record<TerminalModule, boolean>;
+
+export type CustomWorkspacePreset = {
+  id: string;
+  name: string;
+  modules: WorkspaceModuleVisibility;
+  createdAtIso: string;
+  updatedAtIso: string;
+};
+
+export type CustomWorkspaceStore = {
+  activeId: string;
+  presets: CustomWorkspacePreset[];
+};
+
+export const CUSTOM_WORKSPACE_STORAGE_KEY = "terminal.custom.workspaces.v1";
+export const CUSTOM_WORKSPACE_ID_DEFAULT = "default";
+
+export const CUSTOM_WORKSPACE_MODULES: readonly TerminalModule[] = [
+  "market",
+  "wallet",
+  "macro_radar",
+  "macro_fred",
+  "macro_etf",
+  "macro_stablecoin",
+  "macro_oil",
+];
+
+export function defaultWorkspaceModules(): WorkspaceModuleVisibility {
+  return {
+    market: true,
+    wallet: true,
+    macro_radar: true,
+    macro_fred: true,
+    macro_etf: true,
+    macro_stablecoin: true,
+    macro_oil: true,
+  };
+}
+
+export function sanitizeWorkspaceModules(
+  raw: unknown,
+): WorkspaceModuleVisibility {
+  const defaults = defaultWorkspaceModules();
+  if (!raw || typeof raw !== "object") return defaults;
+  const record = raw as Record<string, unknown>;
+  const next: WorkspaceModuleVisibility = {
+    market: record.market === true,
+    wallet: record.wallet === true,
+    macro_radar: record.macro_radar === true,
+    macro_fred: record.macro_fred === true,
+    macro_etf: record.macro_etf === true,
+    macro_stablecoin: record.macro_stablecoin === true,
+    macro_oil: record.macro_oil === true,
+  };
+
+  if (Object.values(next).some(Boolean)) return next;
+  return {
+    ...next,
+    market: true,
+  };
+}
+
+export function createWorkspacePreset(input?: {
+  id?: string;
+  name?: string;
+  modules?: WorkspaceModuleVisibility;
+  nowIso?: string;
+}): CustomWorkspacePreset {
+  const nowIso = input?.nowIso ?? new Date().toISOString();
+  const modules = sanitizeWorkspaceModules(input?.modules ?? null);
+  const id = String(input?.id ?? "").trim() || crypto.randomUUID();
+  const fallbackName =
+    id === CUSTOM_WORKSPACE_ID_DEFAULT ? "Default workspace" : "Workspace";
+  const name = String(input?.name ?? "").trim() || fallbackName;
+  return {
+    id,
+    name,
+    modules,
+    createdAtIso: nowIso,
+    updatedAtIso: nowIso,
+  };
+}
+
+export function createDefaultWorkspaceStore(): CustomWorkspaceStore {
+  const preset = createWorkspacePreset({
+    id: CUSTOM_WORKSPACE_ID_DEFAULT,
+    name: "Default workspace",
+  });
+  return {
+    activeId: preset.id,
+    presets: [preset],
+  };
+}
+
+function sanitizeWorkspacePreset(
+  raw: unknown,
+  index: number,
+): CustomWorkspacePreset | null {
+  if (!raw || typeof raw !== "object") return null;
+  const record = raw as Record<string, unknown>;
+  const fallbackId = `workspace-${index + 1}`;
+  const id = String(record.id ?? fallbackId).trim() || fallbackId;
+  const name = String(record.name ?? "").trim() || `Workspace ${index + 1}`;
+  const createdAtIso = String(record.createdAtIso ?? "").trim();
+  const updatedAtIso = String(record.updatedAtIso ?? "").trim();
+  return {
+    id,
+    name,
+    modules: sanitizeWorkspaceModules(record.modules ?? null),
+    createdAtIso: createdAtIso || new Date().toISOString(),
+    updatedAtIso: updatedAtIso || new Date().toISOString(),
+  };
+}
+
+export function parseCustomWorkspaceStore(raw: unknown): CustomWorkspaceStore {
+  if (!raw || typeof raw !== "object") return createDefaultWorkspaceStore();
+  const record = raw as Record<string, unknown>;
+  const presetsRaw = Array.isArray(record.presets) ? record.presets : [];
+  const unique = new Map<string, CustomWorkspacePreset>();
+
+  presetsRaw.forEach((item, index) => {
+    const parsed = sanitizeWorkspacePreset(item, index);
+    if (!parsed) return;
+    if (unique.has(parsed.id)) return;
+    unique.set(parsed.id, parsed);
+  });
+
+  const presets = Array.from(unique.values());
+  if (presets.length < 1) return createDefaultWorkspaceStore();
+
+  const activeIdRaw = String(record.activeId ?? "").trim();
+  const activeId = unique.has(activeIdRaw) ? activeIdRaw : presets[0].id;
+  return {
+    activeId,
+    presets,
+  };
+}
+
+export function resolveActiveWorkspace(
+  store: CustomWorkspaceStore,
+): CustomWorkspacePreset {
+  const explicit = store.presets.find((item) => item.id === store.activeId);
+  if (explicit) return explicit;
+  const fallback = store.presets[0];
+  if (fallback) return fallback;
+  return createDefaultWorkspaceStore().presets[0];
+}
+
+export function buildCustomWorkspaceLayoutStorageKey(
+  workspaceId: string,
+): string {
+  const normalized = String(workspaceId).trim() || CUSTOM_WORKSPACE_ID_DEFAULT;
+  return `dashboard-grid-layouts:v6:custom:${normalized}`;
+}
+
+export function readCustomWorkspaceStoreFromLocalStorage(): CustomWorkspaceStore {
+  if (typeof window === "undefined") return createDefaultWorkspaceStore();
+  try {
+    const raw = window.localStorage.getItem(CUSTOM_WORKSPACE_STORAGE_KEY);
+    if (!raw) return createDefaultWorkspaceStore();
+    return parseCustomWorkspaceStore(JSON.parse(raw));
+  } catch {
+    return createDefaultWorkspaceStore();
+  }
+}
+
+export function writeCustomWorkspaceStoreToLocalStorage(
+  store: CustomWorkspaceStore,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      CUSTOM_WORKSPACE_STORAGE_KEY,
+      JSON.stringify(store),
+    );
+  } catch {
+    // Ignore storage errors and keep runtime behavior deterministic.
+  }
+}

--- a/apps/portal/app/terminal/page.tsx
+++ b/apps/portal/app/terminal/page.tsx
@@ -104,6 +104,19 @@ import {
   type TapeDisplayMode,
   type TapeSideFilter,
 } from "./components/trades-tape";
+import {
+  buildCustomWorkspaceLayoutStorageKey,
+  CUSTOM_WORKSPACE_ID_DEFAULT,
+  CUSTOM_WORKSPACE_MODULES,
+  type CustomWorkspaceStore,
+  createWorkspacePreset,
+  parseCustomWorkspaceStore,
+  readCustomWorkspaceStoreFromLocalStorage,
+  resolveActiveWorkspace,
+  sanitizeWorkspaceModules,
+  type WorkspaceModuleVisibility,
+  writeCustomWorkspaceStoreToLocalStorage,
+} from "./components/workspace-presets";
 import { useDashboard } from "./context";
 import {
   getTerminalModeCapabilities,
@@ -114,6 +127,7 @@ import {
   readTerminalModeFromProfile,
   resolveDefaultTerminalMode,
   type TerminalMode,
+  type TerminalModule,
   writeLocalTerminalMode,
 } from "./terminal-modes";
 
@@ -191,6 +205,26 @@ const PANEL_ACTION_BY_ID: Record<
   positions: "focusPositions",
   account_risk: "focusRisk",
 };
+
+const CUSTOM_MODULE_LABELS: Record<TerminalModule, string> = {
+  market: "Market",
+  wallet: "Wallet",
+  macro_radar: "Macro Radar",
+  macro_fred: "Macro FRED",
+  macro_etf: "Macro ETF",
+  macro_stablecoin: "Stablecoin",
+  macro_oil: "Oil",
+};
+
+function buildModeLayoutStorageKey(input: {
+  mode: TerminalMode;
+  workspaceId: string;
+}): string {
+  if (input.mode === "custom") {
+    return buildCustomWorkspaceLayoutStorageKey(input.workspaceId);
+  }
+  return `dashboard-grid-layouts:v6:${input.mode}`;
+}
 
 const FundingModal = dynamic(
   () => import("../funding-modal").then((mod) => mod.FundingModal),
@@ -375,6 +409,10 @@ function ControlRoom() {
   const [ladderPrefill, setLadderPrefill] = useState<LadderPrefill | null>(
     null,
   );
+  const [customWorkspaceStore, setCustomWorkspaceStore] =
+    useState<CustomWorkspaceStore>(() =>
+      readCustomWorkspaceStoreFromLocalStorage(),
+    );
   const [focusedPanelId, setFocusedPanelId] =
     useState<TerminalFocusablePanelId | null>(null);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
@@ -387,19 +425,47 @@ function ControlRoom() {
   const terminalModeRef = useRef<TerminalMode>(terminalMode);
   const fallbackModePersistControllerRef = useRef<AbortController | null>(null);
   const modeCapabilities = getTerminalModeCapabilities(terminalMode);
+  const activeCustomWorkspace = useMemo(
+    () => resolveActiveWorkspace(customWorkspaceStore),
+    [customWorkspaceStore],
+  );
+  const customWorkspaceModules = useMemo<WorkspaceModuleVisibility>(
+    () => sanitizeWorkspaceModules(activeCustomWorkspace.modules),
+    [activeCustomWorkspace.modules],
+  );
+  const isCustomMode = terminalMode === "custom";
   const canQuickTrade = modeAllowsAction(terminalMode, "quick_trade");
   const canMacroTrade = modeAllowsAction(terminalMode, "macro_trade");
   const canLayoutEdit = modeAllowsAction(terminalMode, "layout_edit");
-  const showMarketModule = modeShowsModule(terminalMode, "market");
-  const showWalletModule = modeShowsModule(terminalMode, "wallet");
-  const showMacroRadarModule = modeShowsModule(terminalMode, "macro_radar");
-  const showMacroFredModule = modeShowsModule(terminalMode, "macro_fred");
-  const showMacroEtfModule = modeShowsModule(terminalMode, "macro_etf");
-  const showMacroStablecoinModule = modeShowsModule(
-    terminalMode,
-    "macro_stablecoin",
+  const showMarketModule =
+    modeShowsModule(terminalMode, "market") &&
+    (!isCustomMode || customWorkspaceModules.market);
+  const showWalletModule =
+    modeShowsModule(terminalMode, "wallet") &&
+    (!isCustomMode || customWorkspaceModules.wallet);
+  const showMacroRadarModule =
+    modeShowsModule(terminalMode, "macro_radar") &&
+    (!isCustomMode || customWorkspaceModules.macro_radar);
+  const showMacroFredModule =
+    modeShowsModule(terminalMode, "macro_fred") &&
+    (!isCustomMode || customWorkspaceModules.macro_fred);
+  const showMacroEtfModule =
+    modeShowsModule(terminalMode, "macro_etf") &&
+    (!isCustomMode || customWorkspaceModules.macro_etf);
+  const showMacroStablecoinModule =
+    modeShowsModule(terminalMode, "macro_stablecoin") &&
+    (!isCustomMode || customWorkspaceModules.macro_stablecoin);
+  const showMacroOilModule =
+    modeShowsModule(terminalMode, "macro_oil") &&
+    (!isCustomMode || customWorkspaceModules.macro_oil);
+  const layoutStorageKey = useMemo(
+    () =>
+      buildModeLayoutStorageKey({
+        mode: terminalMode,
+        workspaceId: activeCustomWorkspace.id,
+      }),
+    [activeCustomWorkspace.id, terminalMode],
   );
-  const showMacroOilModule = modeShowsModule(terminalMode, "macro_oil");
   const hotkeyProfile = useMemo(
     () => TERMINAL_HOTKEY_PROFILES[hotkeyProfileId],
     [hotkeyProfileId],
@@ -444,10 +510,149 @@ function ControlRoom() {
   }, [tradeOpen]);
 
   const resetDashboardLayout = useCallback(() => {
-    clearDashboardGridLayouts();
+    clearDashboardGridLayouts(layoutStorageKey);
     setHasCustomGridLayout(false);
     setGridRevision((value) => value + 1);
-  }, []);
+  }, [layoutStorageKey]);
+
+  const updateCustomWorkspaceStore = useCallback(
+    (
+      updater: (current: CustomWorkspaceStore) => CustomWorkspaceStore,
+    ): void => {
+      setCustomWorkspaceStore((current) => {
+        const next = parseCustomWorkspaceStore(updater(current));
+        writeCustomWorkspaceStoreToLocalStorage(next);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const setActiveCustomWorkspace = useCallback(
+    (workspaceId: string): void => {
+      updateCustomWorkspaceStore((current) => ({
+        ...current,
+        activeId: workspaceId,
+      }));
+    },
+    [updateCustomWorkspaceStore],
+  );
+
+  const createCustomWorkspace = useCallback((): void => {
+    const suggested = `Workspace ${customWorkspaceStore.presets.length + 1}`;
+    const raw = window.prompt("New workspace name", suggested);
+    if (raw === null) return;
+    const name = raw.trim() || suggested;
+    const nowIso = new Date().toISOString();
+    const preset = createWorkspacePreset({
+      name,
+      nowIso,
+      modules: customWorkspaceModules,
+    });
+    const sourceKey = buildCustomWorkspaceLayoutStorageKey(
+      activeCustomWorkspace.id,
+    );
+    const targetKey = buildCustomWorkspaceLayoutStorageKey(preset.id);
+    if (sourceKey !== targetKey) {
+      try {
+        const source = window.localStorage.getItem(sourceKey);
+        if (source) {
+          window.localStorage.setItem(targetKey, source);
+        } else {
+          clearDashboardGridLayouts(targetKey);
+        }
+      } catch {
+        // Ignore storage failures while still creating preset metadata.
+      }
+    }
+    updateCustomWorkspaceStore((current) => ({
+      ...current,
+      activeId: preset.id,
+      presets: [...current.presets, preset],
+    }));
+    setGridRevision((value) => value + 1);
+  }, [
+    activeCustomWorkspace.id,
+    customWorkspaceModules,
+    customWorkspaceStore.presets.length,
+    updateCustomWorkspaceStore,
+  ]);
+
+  const renameCustomWorkspace = useCallback((): void => {
+    const active = activeCustomWorkspace;
+    const raw = window.prompt("Rename workspace", active.name);
+    if (raw === null) return;
+    const name = raw.trim();
+    if (!name) return;
+    updateCustomWorkspaceStore((current) => ({
+      ...current,
+      presets: current.presets.map((preset) =>
+        preset.id === active.id
+          ? {
+              ...preset,
+              name,
+              updatedAtIso: new Date().toISOString(),
+            }
+          : preset,
+      ),
+    }));
+  }, [activeCustomWorkspace, updateCustomWorkspaceStore]);
+
+  const deleteCustomWorkspace = useCallback((): void => {
+    const active = activeCustomWorkspace;
+    if (active.id === CUSTOM_WORKSPACE_ID_DEFAULT) {
+      window.alert("Default workspace cannot be deleted.");
+      return;
+    }
+    if (customWorkspaceStore.presets.length <= 1) return;
+    const confirmed = window.confirm(
+      `Delete workspace "${active.name}" and its saved layout?`,
+    );
+    if (!confirmed) return;
+    clearDashboardGridLayouts(buildCustomWorkspaceLayoutStorageKey(active.id));
+    updateCustomWorkspaceStore((current) => {
+      const remaining = current.presets.filter(
+        (preset) => preset.id !== active.id,
+      );
+      const fallback =
+        remaining[0] ??
+        createWorkspacePreset({
+          id: CUSTOM_WORKSPACE_ID_DEFAULT,
+          name: "Default workspace",
+        });
+      return {
+        activeId: fallback.id,
+        presets: remaining.length > 0 ? remaining : [fallback],
+      };
+    });
+    setGridRevision((value) => value + 1);
+  }, [
+    activeCustomWorkspace,
+    customWorkspaceStore.presets.length,
+    updateCustomWorkspaceStore,
+  ]);
+
+  const setCustomWorkspaceModuleEnabled = useCallback(
+    (module: TerminalModule, enabled: boolean): void => {
+      if (!isCustomMode) return;
+      updateCustomWorkspaceStore((current) => ({
+        ...current,
+        presets: current.presets.map((preset) => {
+          if (preset.id !== current.activeId) return preset;
+          const nextModules = sanitizeWorkspaceModules({
+            ...preset.modules,
+            [module]: enabled,
+          });
+          return {
+            ...preset,
+            modules: nextModules,
+            updatedAtIso: new Date().toISOString(),
+          };
+        }),
+      }));
+    },
+    [isCustomMode, updateCustomWorkspaceStore],
+  );
 
   const updateHotkeyProfile = useCallback(
     (nextProfile: TerminalHotkeyProfileId): void => {
@@ -502,8 +707,12 @@ function ControlRoom() {
   );
 
   useEffect(() => {
-    setHasCustomGridLayout(hasCustomDashboardGridLayouts());
+    setCustomWorkspaceStore(readCustomWorkspaceStoreFromLocalStorage());
   }, []);
+
+  useEffect(() => {
+    setHasCustomGridLayout(hasCustomDashboardGridLayouts(layoutStorageKey));
+  }, [layoutStorageKey]);
 
   const persistTerminalMode = useCallback(
     async (input: {
@@ -1385,13 +1594,90 @@ function ControlRoom() {
                     </button>
                   </div>
                 )}
+                {isCustomMode ? (
+                  <div className="pointer-events-none absolute right-2 top-10 z-20">
+                    <div className="pointer-events-auto w-[min(380px,90vw)] rounded border border-border/70 bg-paper/90 p-2 text-[11px] text-muted shadow-lg backdrop-blur">
+                      <div className="flex items-center justify-between gap-2">
+                        <p className="label">WORKSPACE_PRESET</p>
+                        <span className="text-[10px]">
+                          {customWorkspaceStore.presets.length} saved
+                        </span>
+                      </div>
+                      <div className="mt-1.5 flex items-center gap-1.5">
+                        <select
+                          className="h-7 min-w-0 flex-1 rounded border border-border bg-paper px-2 text-[11px]"
+                          value={activeCustomWorkspace.id}
+                          onChange={(event) =>
+                            setActiveCustomWorkspace(event.target.value)
+                          }
+                          title="Switch workspace preset"
+                        >
+                          {customWorkspaceStore.presets.map((preset) => (
+                            <option key={preset.id} value={preset.id}>
+                              {preset.name}
+                            </option>
+                          ))}
+                        </select>
+                        <button
+                          className={cn(BTN_SECONDARY, "h-7 px-2 text-[10px]")}
+                          onClick={createCustomWorkspace}
+                          type="button"
+                        >
+                          New
+                        </button>
+                        <button
+                          className={cn(BTN_SECONDARY, "h-7 px-2 text-[10px]")}
+                          onClick={renameCustomWorkspace}
+                          type="button"
+                        >
+                          Rename
+                        </button>
+                        <button
+                          className={cn(BTN_SECONDARY, "h-7 px-2 text-[10px]")}
+                          onClick={deleteCustomWorkspace}
+                          type="button"
+                          disabled={
+                            activeCustomWorkspace.id ===
+                            CUSTOM_WORKSPACE_ID_DEFAULT
+                          }
+                        >
+                          Delete
+                        </button>
+                      </div>
+                      <div className="mt-2 flex flex-wrap gap-1.5">
+                        {CUSTOM_WORKSPACE_MODULES.map((module) => (
+                          <label
+                            key={module}
+                            className="inline-flex items-center gap-1 rounded border border-border bg-surface px-2 py-1 text-[10px] uppercase tracking-wider"
+                          >
+                            <input
+                              className="h-3.5 w-3.5 accent-emerald-500"
+                              type="checkbox"
+                              checked={customWorkspaceModules[module]}
+                              onChange={(event) =>
+                                setCustomWorkspaceModuleEnabled(
+                                  module,
+                                  event.target.checked,
+                                )
+                              }
+                            />
+                            <span>{CUSTOM_MODULE_LABELS[module]}</span>
+                          </label>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
 
                 <DashboardGrid
-                  key={gridRevision}
+                  key={`${layoutStorageKey}:${gridRevision.toString()}`}
                   className="h-full w-full border border-border bg-border pb-1"
                   allowLayoutEditing={canLayoutEdit}
+                  storageKey={layoutStorageKey}
                   onLayoutChange={() =>
-                    setHasCustomGridLayout(hasCustomDashboardGridLayouts())
+                    setHasCustomGridLayout(
+                      hasCustomDashboardGridLayouts(layoutStorageKey),
+                    )
                   }
                 >
                   {showMarketModule ? (

--- a/tests/unit/portal_terminal_workspace_presets.test.ts
+++ b/tests/unit/portal_terminal_workspace_presets.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildCustomWorkspaceLayoutStorageKey,
+  createDefaultWorkspaceStore,
+  parseCustomWorkspaceStore,
+  sanitizeWorkspaceModules,
+} from "../../apps/portal/app/terminal/components/workspace-presets";
+
+describe("portal terminal custom workspace presets", () => {
+  test("sanitizes module visibility with safe fallback", () => {
+    expect(
+      sanitizeWorkspaceModules({
+        market: false,
+        wallet: false,
+        macro_radar: false,
+        macro_fred: false,
+        macro_etf: false,
+        macro_stablecoin: false,
+        macro_oil: false,
+      }).market,
+    ).toBe(true);
+  });
+
+  test("parses and normalizes workspace store payload", () => {
+    const parsed = parseCustomWorkspaceStore({
+      activeId: "ws-2",
+      presets: [
+        {
+          id: "ws-1",
+          name: "Alpha",
+          modules: { market: true },
+        },
+        {
+          id: "ws-2",
+          name: "Beta",
+          modules: { wallet: true, market: false },
+        },
+        {
+          id: "ws-2",
+          name: "Duplicate",
+          modules: { market: true },
+        },
+      ],
+    });
+
+    expect(parsed.presets.length).toBe(2);
+    expect(parsed.activeId).toBe("ws-2");
+    const beta = parsed.presets.find((item) => item.id === "ws-2");
+    expect(beta).toBeDefined();
+    expect(beta?.modules.market).toBe(false);
+    expect(beta?.modules.wallet).toBe(true);
+  });
+
+  test("falls back to default store for invalid data", () => {
+    const parsed = parseCustomWorkspaceStore({
+      activeId: "missing",
+      presets: "bad",
+    });
+    const fallback = createDefaultWorkspaceStore();
+    expect(parsed.activeId).toBe(fallback.activeId);
+    expect(parsed.presets.length).toBe(fallback.presets.length);
+  });
+
+  test("builds stable layout storage key", () => {
+    expect(buildCustomWorkspaceLayoutStorageKey("ws-7")).toBe(
+      "dashboard-grid-layouts:v6:custom:ws-7",
+    );
+    expect(buildCustomWorkspaceLayoutStorageKey("")).toBe(
+      "dashboard-grid-layouts:v6:custom:default",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add Custom mode workspace preset model + local persistence with safe parsing/auto-heal
- add module picker controls for Custom mode (visibility toggles, workspace create/select/rename/delete)
- add per-mode and per-workspace dashboard layout storage keys so regular/degen/custom layouts persist independently
- harden dashboard layout loading with schema sanitization and fallback healing to safe defaults

## Testing
- bun run lint
- bun run typecheck
- bun test tests/unit/portal_terminal_workspace_presets.test.ts tests/unit/portal_terminal_hotkeys.test.ts tests/unit/portal_terminal_status_bar.test.ts tests/unit/portal_terminal_execution_inspector.test.ts tests/unit/portal_terminal_account_risk.test.ts tests/unit/worker_x402_exec_health_route.test.ts
- cd apps/portal && bun run build

Closes #163
