### PR TITLE
TERM-018: add Degen mode modules and risk confirmations

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ It provides one execution fabric for:
 - Global terminal status bar for stream/API/lane health, data staleness badges, and diagnostics links
 - Keyboard-first controls with configurable hotkey profiles, panel focus shortcuts, and command palette
 - Custom-mode workspace presets with module visibility toggles and per-workspace layout persistence
+- Degen mode module pack (watchlist + event hooks) with mandatory risk acknowledgement before submit
 - Account-level Privy wallet model (one wallet per user)
 - x402 paid APIs (`/api/x402/read/*`, `/api/x402/exec/submit`)
 - Execution API scaffold:

--- a/apps/portal/app/terminal/components/dashboard-grid.tsx
+++ b/apps/portal/app/terminal/components/dashboard-grid.tsx
@@ -57,6 +57,8 @@ const DEFAULT_DASHBOARD_LAYOUTS: Record<LayoutBreakpoint, Layout[]> = {
     { i: "macro_etf", x: 0, y: 9, w: 4, h: 3 },
     { i: "macro_stablecoin", x: 4, y: 9, w: 4, h: 3 },
     { i: "macro_oil", x: 8, y: 9, w: 4, h: 3 },
+    { i: "degen_watchlist", x: 0, y: 12, w: 6, h: 3 },
+    { i: "degen_event_hooks", x: 6, y: 12, w: 6, h: 3 },
   ],
   md: [
     { i: "chart", x: 0, y: 0, w: 6, h: 6 },
@@ -70,6 +72,8 @@ const DEFAULT_DASHBOARD_LAYOUTS: Record<LayoutBreakpoint, Layout[]> = {
     { i: "macro_etf", x: 5, y: 9, w: 5, h: 3 },
     { i: "macro_stablecoin", x: 0, y: 12, w: 5, h: 3 },
     { i: "macro_oil", x: 5, y: 12, w: 5, h: 3 },
+    { i: "degen_watchlist", x: 0, y: 15, w: 5, h: 3 },
+    { i: "degen_event_hooks", x: 5, y: 15, w: 5, h: 3 },
   ],
   sm: [
     { i: "chart", x: 0, y: 0, w: 6, h: 5 },
@@ -83,6 +87,8 @@ const DEFAULT_DASHBOARD_LAYOUTS: Record<LayoutBreakpoint, Layout[]> = {
     { i: "macro_etf", x: 0, y: 23, w: 6, h: 3 },
     { i: "macro_stablecoin", x: 0, y: 26, w: 6, h: 3 },
     { i: "macro_oil", x: 0, y: 29, w: 6, h: 3 },
+    { i: "degen_watchlist", x: 0, y: 32, w: 6, h: 3 },
+    { i: "degen_event_hooks", x: 0, y: 35, w: 6, h: 3 },
   ],
 };
 

--- a/apps/portal/app/terminal/components/degen-event-hooks-widget.tsx
+++ b/apps/portal/app/terminal/components/degen-event-hooks-widget.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { BTN_PRIMARY, BTN_SECONDARY } from "../../lib";
+import { createTradeIntent, type TradeIntent } from "./trade-intent";
+import type { PairId } from "./trade-pairs";
+
+type DegenEventHooksWidgetProps = {
+  selectedPairId: PairId;
+  tradingEnabled: boolean;
+  onTradeAction?: (intent: TradeIntent) => void;
+};
+
+type EventHook = {
+  id: string;
+  title: string;
+  window: string;
+  risk: "moderate" | "high" | "extreme";
+  pairId: PairId;
+  buyReason: string;
+  sellReason: string;
+};
+
+const EVENT_HOOKS: readonly EventHook[] = [
+  {
+    id: "us-cpi",
+    title: "US CPI Print",
+    window: "Next high-impact macro window",
+    risk: "high",
+    pairId: "SOL/USDC",
+    buyReason: "Macro upside momentum hook",
+    sellReason: "Macro downside hedge hook",
+  },
+  {
+    id: "solana-upgrade",
+    title: "Solana Ecosystem Upgrade",
+    window: "Pending release-cycle catalyst",
+    risk: "extreme",
+    pairId: "JUP/USDC",
+    buyReason: "Event-driven upside breakout hook",
+    sellReason: "Event-failure unwind hook",
+  },
+  {
+    id: "meme-rotation",
+    title: "Meme Rotation Pulse",
+    window: "Realtime social momentum spikes",
+    risk: "extreme",
+    pairId: "WIF/USDC",
+    buyReason: "Momentum continuation hook",
+    sellReason: "Momentum exhaustion hedge hook",
+  },
+];
+
+function riskClass(level: EventHook["risk"]): string {
+  if (level === "moderate") {
+    return "border-amber-500/30 bg-amber-500/10 text-amber-200";
+  }
+  if (level === "high") {
+    return "border-orange-500/40 bg-orange-500/10 text-orange-200";
+  }
+  return "border-red-500/40 bg-red-500/10 text-red-200";
+}
+
+export function DegenEventHooksWidget(props: DegenEventHooksWidgetProps) {
+  const { selectedPairId, tradingEnabled, onTradeAction } = props;
+
+  return (
+    <div className="flex h-full flex-col bg-surface">
+      <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
+        <p className="label dashboard-drag-handle cursor-move">EVENT HOOKS</p>
+        <span className="text-[10px] text-muted uppercase tracking-wider">
+          Prediction scaffolds
+        </span>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        <p className="rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-[11px] text-amber-200">
+          Hook templates only. Always validate thesis and liquidity before
+          dispatch.
+        </p>
+        <div className="mt-2 space-y-1.5">
+          {EVENT_HOOKS.map((item) => {
+            const pairId = item.pairId ?? selectedPairId;
+            return (
+              <div
+                key={item.id}
+                className="rounded border border-border bg-paper p-2"
+              >
+                <div className="mb-1 flex items-start justify-between gap-2">
+                  <div>
+                    <p className="text-xs font-semibold text-ink">
+                      {item.title}
+                    </p>
+                    <p className="text-[11px] text-muted">{item.window}</p>
+                  </div>
+                  <span
+                    className={`rounded border px-1.5 py-0.5 text-[10px] uppercase tracking-wider ${riskClass(item.risk)}`}
+                  >
+                    {item.risk}
+                  </span>
+                </div>
+                <p className="text-[11px] text-muted">
+                  Trade pair hook: {pairId}
+                </p>
+                <div className="mt-2 flex items-center gap-1.5">
+                  <button
+                    className={`${BTN_PRIMARY} h-6 px-2 text-[10px]`}
+                    onClick={() => {
+                      if (!onTradeAction || !tradingEnabled) return;
+                      onTradeAction(
+                        createTradeIntent("buy", "DEGEN_EVENT_HOOK", pairId, {
+                          reason: `${item.title}: ${item.buyReason}`,
+                        }),
+                      );
+                    }}
+                    type="button"
+                    disabled={!tradingEnabled || !onTradeAction}
+                  >
+                    Scenario Buy
+                  </button>
+                  <button
+                    className={`${BTN_SECONDARY} h-6 px-2 text-[10px]`}
+                    onClick={() => {
+                      if (!onTradeAction || !tradingEnabled) return;
+                      onTradeAction(
+                        createTradeIntent("sell", "DEGEN_EVENT_HOOK", pairId, {
+                          reason: `${item.title}: ${item.sellReason}`,
+                        }),
+                      );
+                    }}
+                    type="button"
+                    disabled={!tradingEnabled || !onTradeAction}
+                  >
+                    Scenario Sell
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/portal/app/terminal/components/degen-watchlist-widget.tsx
+++ b/apps/portal/app/terminal/components/degen-watchlist-widget.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { BTN_PRIMARY, BTN_SECONDARY } from "../../lib";
+import type { MarketState } from "./sol-market-feed";
+import { createTradeIntent, type TradeIntent } from "./trade-intent";
+import type { PairId } from "./trade-pairs";
+
+const WATCHLIST: readonly PairId[] = [
+  "BONK/USDC",
+  "WIF/USDC",
+  "JUP/USDC",
+  "RAY/USDC",
+  "SOL/USDC",
+];
+
+const RISK_SCORE: Record<PairId, "elevated" | "high" | "extreme"> = {
+  "BONK/USDC": "extreme",
+  "WIF/USDC": "extreme",
+  "JUP/USDC": "high",
+  "RAY/USDC": "high",
+  "SOL/USDC": "elevated",
+  "SOL/USDT": "elevated",
+  "USDC/USDT": "elevated",
+  "USDC/PYUSD": "elevated",
+  "USDC/USD1": "elevated",
+  "USDC/USDG": "elevated",
+  "SOL/JITOSOL": "elevated",
+  "SOL/MSOL": "elevated",
+  "SOL/JUPSOL": "elevated",
+  "JTO/USDC": "high",
+  "PYTH/USDC": "high",
+};
+
+type DegenWatchlistWidgetProps = {
+  selectedPairId: PairId;
+  market: MarketState;
+  tradingEnabled: boolean;
+  onPairFocus: (pairId: PairId) => void;
+  onTradeAction?: (intent: TradeIntent) => void;
+};
+
+function riskClass(level: "elevated" | "high" | "extreme"): string {
+  if (level === "elevated")
+    return "border-amber-500/30 bg-amber-500/10 text-amber-200";
+  if (level === "high")
+    return "border-orange-500/40 bg-orange-500/10 text-orange-200";
+  return "border-red-500/40 bg-red-500/10 text-red-200";
+}
+
+function formatPriceUi(value: number): string {
+  if (!Number.isFinite(value)) return "--";
+  if (value >= 1000)
+    return `$${value.toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+  if (value >= 1) return `$${value.toFixed(4)}`;
+  return `$${value.toFixed(6)}`;
+}
+
+export function DegenWatchlistWidget(props: DegenWatchlistWidgetProps) {
+  const { selectedPairId, market, tradingEnabled, onPairFocus, onTradeAction } =
+    props;
+
+  return (
+    <div className="flex h-full flex-col bg-surface">
+      <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
+        <p className="label dashboard-drag-handle cursor-move">
+          DEGEN WATCHLIST
+        </p>
+        <span className="text-[10px] text-muted uppercase tracking-wider">
+          Rapid rotation
+        </span>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        <div className="space-y-1.5">
+          {WATCHLIST.map((pairId) => {
+            const isFocused = pairId === selectedPairId;
+            const risk = RISK_SCORE[pairId] ?? "high";
+            const price = isFocused ? market.latestPrice : null;
+            const change24h = isFocused ? market.change24hPct : null;
+            return (
+              <div
+                key={pairId}
+                className="rounded border border-border bg-paper p-2"
+              >
+                <div className="mb-1 flex items-center justify-between gap-2">
+                  <button
+                    className="text-left text-xs font-semibold text-ink underline-offset-2 hover:underline"
+                    onClick={() => onPairFocus(pairId)}
+                    type="button"
+                  >
+                    {pairId}
+                  </button>
+                  <span
+                    className={`rounded border px-1.5 py-0.5 text-[10px] uppercase tracking-wider ${riskClass(risk)}`}
+                  >
+                    {risk}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between gap-3 text-[11px] text-muted">
+                  <span>
+                    Price:{" "}
+                    {price !== null ? formatPriceUi(price) : "Focus pair"}
+                  </span>
+                  <span
+                    className={
+                      change24h === null
+                        ? "text-muted"
+                        : change24h >= 0
+                          ? "text-emerald-300"
+                          : "text-red-300"
+                    }
+                  >
+                    {change24h === null
+                      ? "24h --"
+                      : `24h ${change24h >= 0 ? "+" : ""}${change24h.toFixed(2)}%`}
+                  </span>
+                </div>
+                <div className="mt-2 flex items-center gap-1.5">
+                  <button
+                    className={`${BTN_PRIMARY} h-6 px-2 text-[10px]`}
+                    onClick={() => {
+                      if (!onTradeAction || !tradingEnabled) return;
+                      onTradeAction(
+                        createTradeIntent("buy", "DEGEN_WATCHLIST", pairId, {
+                          reason: `Volatility breakout watch (${risk})`,
+                        }),
+                      );
+                    }}
+                    type="button"
+                    disabled={!tradingEnabled || !onTradeAction}
+                  >
+                    Fast Buy
+                  </button>
+                  <button
+                    className={`${BTN_SECONDARY} h-6 px-2 text-[10px]`}
+                    onClick={() => {
+                      if (!onTradeAction || !tradingEnabled) return;
+                      onTradeAction(
+                        createTradeIntent("sell", "DEGEN_WATCHLIST", pairId, {
+                          reason: `Volatility hedge watch (${risk})`,
+                        }),
+                      );
+                    }}
+                    type="button"
+                    disabled={!tradingEnabled || !onTradeAction}
+                  >
+                    Fast Sell
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/portal/app/terminal/components/trade-ticket-modal.tsx
+++ b/apps/portal/app/terminal/components/trade-ticket-modal.tsx
@@ -30,6 +30,12 @@ type TradeTicketModalProps = {
   walletAddress: string | null;
   tokenBalancesByMint?: Record<string, string> | null;
   riskSnapshot?: AccountRiskSnapshot | null;
+  riskAcknowledgement?: {
+    required: boolean;
+    title?: string;
+    message?: string;
+    confirmationLabel?: string;
+  };
   hotkeyBindings?: TradeTicketHotkeyBindings;
   getAccessToken: () => Promise<string | null>;
   onClose: () => void;
@@ -379,6 +385,7 @@ export function TradeTicketModal({
   walletAddress,
   tokenBalancesByMint,
   riskSnapshot,
+  riskAcknowledgement,
   hotkeyBindings = DEFAULT_TRADE_TICKET_HOTKEY_BINDINGS,
   getAccessToken,
   onClose,
@@ -410,6 +417,7 @@ export function TradeTicketModal({
     "idle" | "submitting" | "tracking" | "error"
   >("idle");
   const [submitMessage, setSubmitMessage] = useState<string | null>(null);
+  const [riskConfirmed, setRiskConfirmed] = useState(false);
   const [isQuoteTransitionPending, startQuoteTransition] = useTransition();
 
   const quoteAbortRef = useRef<AbortController | null>(null);
@@ -489,6 +497,7 @@ export function TradeTicketModal({
     setQuote(EMPTY_QUOTE);
     setSubmitStatus("idle");
     setSubmitMessage(null);
+    setRiskConfirmed(false);
   }, [open, intent]);
 
   const deferredAmountUi = useDeferredValue(amountUi);
@@ -754,6 +763,14 @@ export function TradeTicketModal({
       setSubmitMessage(preSubmitRisk.message ?? "risk-guard-blocked");
       return;
     }
+    if (riskAcknowledgement?.required && !riskConfirmed) {
+      setSubmitStatus("error");
+      setSubmitMessage(
+        riskAcknowledgement.message ??
+          "degen-risk-confirmation-required-before-submit",
+      );
+      return;
+    }
     if (!walletAddress) {
       setSubmitStatus("error");
       setSubmitMessage("wallet-unavailable");
@@ -980,6 +997,9 @@ export function TradeTicketModal({
     orderType,
     orderValidationErrors,
     preSubmitRisk,
+    riskAcknowledgement?.message,
+    riskAcknowledgement?.required,
+    riskConfirmed,
     executionLane,
     executionQualityErrors,
     postOnly,
@@ -1037,6 +1057,7 @@ export function TradeTicketModal({
     submitStatus !== "tracking" &&
     quote.status === "ready" &&
     Boolean(quote.inAmountAtomic) &&
+    (!riskAcknowledgement?.required || riskConfirmed) &&
     orderValidationErrors.length < 1 &&
     executionQualityErrors.length < 1 &&
     !preSubmitRisk.blocked;
@@ -1135,6 +1156,15 @@ export function TradeTicketModal({
             snapshot={riskSnapshot ?? null}
             preSubmitRisk={preSubmitRisk}
           />
+          {riskAcknowledgement?.required ? (
+            <DegenRiskAcknowledgeCard
+              title={riskAcknowledgement.title}
+              message={riskAcknowledgement.message}
+              confirmationLabel={riskAcknowledgement.confirmationLabel}
+              confirmed={riskConfirmed}
+              onConfirmedChange={setRiskConfirmed}
+            />
+          ) : null}
           <TradeInputsSection
             amountUi={amountUi}
             amountPresets={amountPresets}
@@ -1330,6 +1360,38 @@ const TradeRiskContextCard = memo(function TradeRiskContextCard(props: {
           {preSubmitRisk.message}
         </p>
       ) : null}
+    </div>
+  );
+});
+
+const DegenRiskAcknowledgeCard = memo(function DegenRiskAcknowledgeCard(props: {
+  title?: string;
+  message?: string;
+  confirmationLabel?: string;
+  confirmed: boolean;
+  onConfirmedChange: (next: boolean) => void;
+}) {
+  const { title, message, confirmationLabel, confirmed, onConfirmedChange } =
+    props;
+  return (
+    <div className="rounded border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-100">
+      <p className="label">{title ?? "DEGEN_RISK_ACKNOWLEDGEMENT"}</p>
+      <p className="mt-1 text-[11px]">
+        {message ??
+          "This path is configured for high-volatility execution. Confirm risk posture before dispatch."}
+      </p>
+      <label className="mt-2 inline-flex items-center gap-1.5 text-[11px]">
+        <input
+          className="h-3.5 w-3.5 accent-red-500"
+          type="checkbox"
+          checked={confirmed}
+          onChange={(event) => onConfirmedChange(event.target.checked)}
+        />
+        <span>
+          {confirmationLabel ??
+            "I understand this is Degen mode and accept higher execution risk."}
+        </span>
+      </label>
     </div>
   );
 });

--- a/apps/portal/app/terminal/components/workspace-presets.ts
+++ b/apps/portal/app/terminal/components/workspace-presets.ts
@@ -26,6 +26,8 @@ export const CUSTOM_WORKSPACE_MODULES: readonly TerminalModule[] = [
   "macro_etf",
   "macro_stablecoin",
   "macro_oil",
+  "degen_watchlist",
+  "degen_event_hooks",
 ];
 
 export function defaultWorkspaceModules(): WorkspaceModuleVisibility {
@@ -37,6 +39,8 @@ export function defaultWorkspaceModules(): WorkspaceModuleVisibility {
     macro_etf: true,
     macro_stablecoin: true,
     macro_oil: true,
+    degen_watchlist: true,
+    degen_event_hooks: true,
   };
 }
 
@@ -54,6 +58,8 @@ export function sanitizeWorkspaceModules(
     macro_etf: record.macro_etf === true,
     macro_stablecoin: record.macro_stablecoin === true,
     macro_oil: record.macro_oil === true,
+    degen_watchlist: record.degen_watchlist === true,
+    degen_event_hooks: record.degen_event_hooks === true,
   };
 
   if (Object.values(next).some(Boolean)) return next;

--- a/apps/portal/app/terminal/page.tsx
+++ b/apps/portal/app/terminal/page.tsx
@@ -24,6 +24,8 @@ import {
   DashboardGrid,
   hasCustomDashboardGridLayouts,
 } from "./components/dashboard-grid";
+import { DegenEventHooksWidget } from "./components/degen-event-hooks-widget";
+import { DegenWatchlistWidget } from "./components/degen-watchlist-widget";
 import {
   buildDepthChartModel,
   findNearestDepthPoint,
@@ -214,6 +216,8 @@ const CUSTOM_MODULE_LABELS: Record<TerminalModule, string> = {
   macro_etf: "Macro ETF",
   macro_stablecoin: "Stablecoin",
   macro_oil: "Oil",
+  degen_watchlist: "Degen Watchlist",
+  degen_event_hooks: "Event Hooks",
 };
 
 function buildModeLayoutStorageKey(input: {
@@ -434,6 +438,7 @@ function ControlRoom() {
     [activeCustomWorkspace.modules],
   );
   const isCustomMode = terminalMode === "custom";
+  const isDegenMode = terminalMode === "degen";
   const canQuickTrade = modeAllowsAction(terminalMode, "quick_trade");
   const canMacroTrade = modeAllowsAction(terminalMode, "macro_trade");
   const canLayoutEdit = modeAllowsAction(terminalMode, "layout_edit");
@@ -458,6 +463,12 @@ function ControlRoom() {
   const showMacroOilModule =
     modeShowsModule(terminalMode, "macro_oil") &&
     (!isCustomMode || customWorkspaceModules.macro_oil);
+  const showDegenWatchlistModule =
+    modeShowsModule(terminalMode, "degen_watchlist") &&
+    (!isCustomMode || customWorkspaceModules.degen_watchlist);
+  const showDegenEventHooksModule =
+    modeShowsModule(terminalMode, "degen_event_hooks") &&
+    (!isCustomMode || customWorkspaceModules.degen_event_hooks);
   const layoutStorageKey = useMemo(
     () =>
       buildModeLayoutStorageKey({
@@ -1523,6 +1534,18 @@ function ControlRoom() {
           walletAddress={wallet?.walletAddress ?? null}
           tokenBalancesByMint={tokenBalancesByMint}
           riskSnapshot={accountRiskSnapshot}
+          riskAcknowledgement={
+            isDegenMode
+              ? {
+                  required: true,
+                  title: "DEGEN_MODE_CONFIRMATION",
+                  message:
+                    "Degen mode enables rapid volatility execution. Confirm risk acknowledgement before submit.",
+                  confirmationLabel:
+                    "I confirm this order is intentionally high risk.",
+                }
+              : undefined
+          }
           hotkeyBindings={tradeTicketHotkeys}
           getAccessToken={getAccessToken}
           onClose={() => setTradeOpen(false)}
@@ -1556,6 +1579,26 @@ function ControlRoom() {
                 realtime={realtimeTransport}
                 market={marketFeed}
               />
+              {isDegenMode ? (
+                <div className="rounded border border-red-500/40 bg-gradient-to-r from-red-500/15 via-orange-500/10 to-transparent px-3 py-2 text-[11px] text-red-100">
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="font-semibold uppercase tracking-wider">
+                      Degen Mode Active
+                    </p>
+                    <button
+                      className={cn(BTN_SECONDARY, "h-6 px-2 text-[10px]")}
+                      onClick={() => handleTerminalModeChange("regular")}
+                      type="button"
+                    >
+                      Exit Degen
+                    </button>
+                  </div>
+                  <p className="mt-1 text-red-200/90">
+                    High-volatility modules are enabled. Trade ticket execution
+                    requires explicit risk acknowledgement.
+                  </p>
+                </div>
+              ) : null}
               <div className="relative min-h-0 flex-1">
                 <div className="pointer-events-none absolute left-2 top-2 z-20 hidden sm:flex sm:items-center sm:gap-1.5">
                   <div
@@ -1829,6 +1872,32 @@ function ControlRoom() {
                   {showMacroOilModule ? (
                     <div key="macro_oil" className="overflow-hidden">
                       <MacroOilWidget />
+                    </div>
+                  ) : null}
+                  {showDegenWatchlistModule ? (
+                    <div
+                      key="degen_watchlist"
+                      className="flex flex-col overflow-hidden bg-surface"
+                    >
+                      <DegenWatchlistWidget
+                        selectedPairId={selectedPairId}
+                        market={marketFeed}
+                        tradingEnabled={canQuickTrade}
+                        onPairFocus={handlePairChange}
+                        onTradeAction={openTradeTicket}
+                      />
+                    </div>
+                  ) : null}
+                  {showDegenEventHooksModule ? (
+                    <div
+                      key="degen_event_hooks"
+                      className="flex flex-col overflow-hidden bg-surface"
+                    >
+                      <DegenEventHooksWidget
+                        selectedPairId={selectedPairId}
+                        tradingEnabled={canQuickTrade}
+                        onTradeAction={openTradeTicket}
+                      />
                     </div>
                   ) : null}
                 </DashboardGrid>

--- a/apps/portal/app/terminal/terminal-modes.ts
+++ b/apps/portal/app/terminal/terminal-modes.ts
@@ -12,7 +12,9 @@ export type TerminalModule =
   | "macro_fred"
   | "macro_etf"
   | "macro_stablecoin"
-  | "macro_oil";
+  | "macro_oil"
+  | "degen_watchlist"
+  | "degen_event_hooks";
 
 export type TerminalAction = "quick_trade" | "macro_trade" | "layout_edit";
 
@@ -48,6 +50,8 @@ const TERMINAL_MODE_CAPABILITIES: Record<
       "macro_etf",
       "macro_stablecoin",
       "macro_oil",
+      "degen_watchlist",
+      "degen_event_hooks",
     ],
     actions: {
       quick_trade: true,
@@ -66,6 +70,8 @@ const TERMINAL_MODE_CAPABILITIES: Record<
       "macro_etf",
       "macro_stablecoin",
       "macro_oil",
+      "degen_watchlist",
+      "degen_event_hooks",
     ],
     actions: {
       quick_trade: true,

--- a/tests/unit/portal_terminal_modes.test.ts
+++ b/tests/unit/portal_terminal_modes.test.ts
@@ -58,8 +58,11 @@ describe("portal terminal modes", () => {
     expect(modeShowsModule("regular", "macro_stablecoin")).toBe(false);
     expect(modeShowsModule("regular", "macro_radar")).toBe(true);
     expect(modeAllowsAction("regular", "macro_trade")).toBe(false);
+    expect(modeShowsModule("regular", "degen_watchlist")).toBe(false);
 
     expect(modeShowsModule("degen", "macro_stablecoin")).toBe(true);
+    expect(modeShowsModule("degen", "degen_watchlist")).toBe(true);
+    expect(modeShowsModule("degen", "degen_event_hooks")).toBe(true);
     expect(modeAllowsAction("degen", "macro_trade")).toBe(true);
     expect(modeAllowsAction("degen", "layout_edit")).toBe(true);
   });


### PR DESCRIPTION
## Summary
- add Degen mode module pack with high-volatility watchlist and event/prediction hook widgets
- make Degen mode visually distinct with a dedicated warning banner and explicit exit control
- require mandatory risk acknowledgement in trade ticket before Degen-mode execution can submit
- extend mode/custom-module capabilities and default layouts to include new Degen panels

## Testing
- bun run lint
- bun run typecheck
- bun test tests/unit/portal_terminal_modes.test.ts tests/unit/portal_terminal_workspace_presets.test.ts tests/unit/portal_terminal_hotkeys.test.ts tests/unit/portal_terminal_status_bar.test.ts tests/unit/portal_terminal_execution_inspector.test.ts tests/unit/portal_terminal_account_risk.test.ts tests/unit/worker_x402_exec_health_route.test.ts
- cd apps/portal && bun run build

Closes #164
