### PR TITLE
TERM-020: accessibility and usability hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ It provides one execution fabric for:
 - Custom-mode workspace presets with module visibility toggles and per-workspace layout persistence
 - Degen mode module pack (watchlist + event hooks) with mandatory risk acknowledgement before submit
 - Virtualized orderbook/tape/fills rendering plus terminal frame/render performance budget instrumentation
+- Accessibility hardening: skip-link navigation, stronger contrast, and keyshortcut metadata on critical actions
 - Account-level Privy wallet model (one wallet per user)
 - x402 paid APIs (`/api/x402/read/*`, `/api/x402/exec/submit`)
 - Execution API scaffold:

--- a/apps/portal/app/globals.css
+++ b/apps/portal/app/globals.css
@@ -10,7 +10,7 @@
   /* Deep background */
   --color-surface: #111111;
   /* Slightly lighter background for cards */
-  --color-muted: #a1a1aa;
+  --color-muted: #cbd5e1;
   /* Muted text */
   --color-border: rgba(255, 255, 255, 0.1);
   --color-border-strong: rgba(255, 255, 255, 0.2);
@@ -95,7 +95,7 @@
     --color-ink: #f0f6fc;
     --color-paper: #0a0a0a;
     --color-surface: #111111;
-    --color-muted: #a1a1aa;
+    --color-muted: #cbd5e1;
     --color-border: rgba(255, 255, 255, 0.1);
     --color-border-strong: rgba(255, 255, 255, 0.2);
     --color-subtle: rgba(255, 255, 255, 0.03);

--- a/apps/portal/app/terminal/components/terminal-hotkeys.ts
+++ b/apps/portal/app/terminal/components/terminal-hotkeys.ts
@@ -163,6 +163,42 @@ export function formatHotkeyChord(chord: string): string {
   return labels.join("+");
 }
 
+export function toAriaKeyShortcuts(chord: string): string {
+  const tokens = chord
+    .split("+")
+    .map((token) => token.trim().toLowerCase())
+    .filter(Boolean);
+  if (tokens.length < 1) return "";
+
+  const modifiers = tokens.filter((token) =>
+    ["mod", "ctrl", "meta", "alt", "shift"].includes(token),
+  );
+  const keyToken = tokens.find(
+    (token) => !["mod", "ctrl", "meta", "alt", "shift"].includes(token),
+  );
+  if (!keyToken) return "";
+
+  const baseKey = keyToken.length === 1 ? keyToken.toUpperCase() : keyToken;
+  const baseMods = modifiers.filter((token) => token !== "mod");
+  const withBaseMods = [...baseMods];
+
+  if (modifiers.includes("mod")) {
+    const ctrlCombo = [...withBaseMods, "Control", baseKey].join("+");
+    const metaCombo = [...withBaseMods, "Meta", baseKey].join("+");
+    return `${ctrlCombo} ${metaCombo}`;
+  }
+
+  const normalizedMods = withBaseMods.map((token) => {
+    if (token === "ctrl") return "Control";
+    if (token === "meta") return "Meta";
+    if (token === "alt") return "Alt";
+    if (token === "shift") return "Shift";
+    return token;
+  });
+
+  return [...normalizedMods, baseKey].join("+");
+}
+
 export function matchesHotkey(event: HotkeyLikeEvent, chord: string): boolean {
   const tokens = chord
     .split("+")

--- a/apps/portal/app/terminal/components/trade-ticket-modal.tsx
+++ b/apps/portal/app/terminal/components/trade-ticket-modal.tsx
@@ -21,7 +21,11 @@ import {
   type AccountRiskSnapshot,
   evaluatePreSubmitRisk,
 } from "./account-risk";
-import { formatHotkeyChord, matchesHotkey } from "./terminal-hotkeys";
+import {
+  formatHotkeyChord,
+  matchesHotkey,
+  toAriaKeyShortcuts,
+} from "./terminal-hotkeys";
 import type { TradeIntent } from "./trade-intent";
 
 type TradeTicketModalProps = {
@@ -1145,6 +1149,7 @@ export function TradeTicketModal({
             onClick={cancelAndCloseModal}
             type="button"
             aria-label="Close"
+            aria-keyshortcuts={toAriaKeyShortcuts(hotkeyBindings.cancel)}
           >
             &times;
           </button>
@@ -1240,6 +1245,7 @@ export function TradeTicketModal({
               className={`${BTN_SECONDARY} !py-2 !px-4 text-xs`}
               onClick={cancelAndCloseModal}
               type="button"
+              aria-keyshortcuts={toAriaKeyShortcuts(hotkeyBindings.cancel)}
             >
               Close
             </button>
@@ -1248,6 +1254,7 @@ export function TradeTicketModal({
               onClick={() => void executeTrade()}
               type="button"
               disabled={!canExecuteTrade}
+              aria-keyshortcuts={toAriaKeyShortcuts(hotkeyBindings.submit)}
             >
               {submitStatus === "submitting" || submitStatus === "tracking"
                 ? submitStatus === "tracking"

--- a/apps/portal/app/terminal/dashboard-shell-client.tsx
+++ b/apps/portal/app/terminal/dashboard-shell-client.tsx
@@ -38,6 +38,12 @@ export function DashboardShellClient({ children }: { children: ReactNode }) {
   return (
     <DashboardProvider>
       <main className="min-h-screen bg-paper text-ink flex flex-col">
+        <a
+          href="#terminal-main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:left-2 focus:top-2 focus:z-50 rounded border border-border bg-paper px-3 py-2 text-xs"
+        >
+          Skip to terminal content
+        </a>
         <ConnectedHeader />
         <div className="flex-1 min-h-0 flex flex-col">{children}</div>
       </main>

--- a/apps/portal/app/terminal/page.tsx
+++ b/apps/portal/app/terminal/page.tsx
@@ -85,6 +85,7 @@ import {
   type TerminalHotkeyAction,
   type TerminalHotkeyBindings,
   type TerminalHotkeyProfileId,
+  toAriaKeyShortcuts,
 } from "./components/terminal-hotkeys";
 import { useTerminalRenderPerformance } from "./components/terminal-performance";
 import { TerminalStatusBar } from "./components/terminal-status-bar";
@@ -1562,7 +1563,7 @@ function ControlRoom() {
         onHotkeyProfileChange={updateHotkeyProfile}
       />
 
-      <section className="flex-1 min-h-0 w-full">
+      <section id="terminal-main-content" className="flex-1 min-h-0 w-full">
         <div className="w-full h-full min-h-0">
           <PresenceCard show={Boolean(message)}>
             <div className="mb-4 rounded-md border-l-4 border-red-500 bg-red-500/10 p-3 text-sm text-red-400">
@@ -1620,6 +1621,9 @@ function ControlRoom() {
                     onClick={() => setCommandPaletteOpen(true)}
                     title="Open command palette"
                     type="button"
+                    aria-keyshortcuts={toAriaKeyShortcuts(
+                      hotkeyBindings.openPalette,
+                    )}
                   >
                     Cmd • {formatHotkeyChord(hotkeyBindings.openPalette)}
                   </button>
@@ -1634,6 +1638,9 @@ function ControlRoom() {
                       onClick={resetDashboardLayout}
                       title={`Reorganize layout (${formatHotkeyChord(hotkeyBindings.resetLayout)})`}
                       type="button"
+                      aria-keyshortcuts={toAriaKeyShortcuts(
+                        hotkeyBindings.resetLayout,
+                      )}
                     >
                       Reset layout
                     </button>
@@ -1776,6 +1783,8 @@ function ControlRoom() {
                         pairId={selectedPairId}
                         onBuy={openMarketBuyTrade}
                         onSell={openMarketSellTrade}
+                        quickBuyShortcut={hotkeyBindings.quickBuy}
+                        quickSellShortcut={hotkeyBindings.quickSell}
                         tradingEnabled={canQuickTrade}
                         prefill={ladderPrefill}
                         onClearPrefill={clearLadderPrefill}
@@ -2370,12 +2379,22 @@ const OrderEntryPanel = memo(function OrderEntryPanel(props: {
   pairId: PairId;
   onBuy: () => void;
   onSell: () => void;
+  quickBuyShortcut?: string;
+  quickSellShortcut?: string;
   tradingEnabled: boolean;
   prefill: LadderPrefill | null;
   onClearPrefill: () => void;
 }) {
-  const { pairId, onBuy, onSell, tradingEnabled, prefill, onClearPrefill } =
-    props;
+  const {
+    pairId,
+    onBuy,
+    onSell,
+    quickBuyShortcut,
+    quickSellShortcut,
+    tradingEnabled,
+    prefill,
+    onClearPrefill,
+  } = props;
   return (
     <>
       <div className="flex items-center justify-between border-b border-border bg-surface px-3 py-1.5 shrink-0">
@@ -2423,6 +2442,16 @@ const OrderEntryPanel = memo(function OrderEntryPanel(props: {
             onClick={onBuy}
             type="button"
             disabled={!tradingEnabled}
+            aria-keyshortcuts={
+              quickBuyShortcut
+                ? toAriaKeyShortcuts(quickBuyShortcut)
+                : undefined
+            }
+            title={
+              quickBuyShortcut
+                ? `Hotkey: ${formatHotkeyChord(quickBuyShortcut)}`
+                : undefined
+            }
           >
             Buy / Lift
           </button>
@@ -2435,6 +2464,16 @@ const OrderEntryPanel = memo(function OrderEntryPanel(props: {
             onClick={onSell}
             type="button"
             disabled={!tradingEnabled}
+            aria-keyshortcuts={
+              quickSellShortcut
+                ? toAriaKeyShortcuts(quickSellShortcut)
+                : undefined
+            }
+            title={
+              quickSellShortcut
+                ? `Hotkey: ${formatHotkeyChord(quickSellShortcut)}`
+                : undefined
+            }
           >
             Sell / Hit
           </button>

--- a/tests/unit/portal_terminal_hotkeys.test.ts
+++ b/tests/unit/portal_terminal_hotkeys.test.ts
@@ -3,6 +3,7 @@ import {
   formatHotkeyChord,
   matchesHotkey,
   resolveTerminalHotkeyProfileId,
+  toAriaKeyShortcuts,
 } from "../../apps/portal/app/terminal/components/terminal-hotkeys";
 
 describe("portal terminal hotkey helpers", () => {
@@ -63,6 +64,8 @@ describe("portal terminal hotkey helpers", () => {
   test("formats display labels and resolves profile ids", () => {
     expect(formatHotkeyChord("mod+enter")).toBe("Cmd/Ctrl+Enter");
     expect(formatHotkeyChord("alt+1")).toBe("Alt+1");
+    expect(toAriaKeyShortcuts("mod+k")).toBe("Control+K Meta+K");
+    expect(toAriaKeyShortcuts("shift+r")).toBe("Shift+R");
     expect(resolveTerminalHotkeyProfileId("precision")).toBe("precision");
     expect(resolveTerminalHotkeyProfileId("unknown")).toBe("standard");
   });


### PR DESCRIPTION
## Summary
- add skip-link navigation and stronger keyboard-only flow affordances for terminal operators
- add ARIA keyshortcuts metadata for critical trading actions (palette, buy/sell, submit/cancel)
- improve dark-mode muted contrast baseline for dense terminal text readability
- expand hotkey unit coverage for accessibility shortcut serialization used by controls

## Testing
- bun run lint
- bun run typecheck
- bun test tests/unit/portal_terminal_hotkeys.test.ts tests/unit/portal_terminal_performance_budget.test.ts tests/unit/portal_terminal_modes.test.ts tests/unit/portal_terminal_workspace_presets.test.ts tests/unit/portal_terminal_status_bar.test.ts tests/unit/portal_terminal_execution_inspector.test.ts tests/unit/portal_terminal_account_risk.test.ts tests/unit/worker_x402_exec_health_route.test.ts
- cd apps/portal && bun run build

Closes #166
