### PR TITLE
TERM-022 Add terminal cutover rollout gates + production runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ bun run dev:local
 Optional portal env:
 
 - `NEXT_PUBLIC_TERMINAL_DEFAULT_MODE=regular|degen|custom`
+- `NEXT_PUBLIC_TERMINAL_ALLOWED_MODES` (CSV from `regular,degen,custom`; default all)
+- `NEXT_PUBLIC_TERMINAL_DEGEN_COHORT=all|onboarded|experienced|degen_acknowledged`
+- `NEXT_PUBLIC_TERMINAL_CUSTOM_COHORT=all|onboarded|experienced|degen_acknowledged`
 - `NEXT_PUBLIC_TERMINAL_RISK_INITIAL_MARGIN_RATIO` (default `0.1`)
 - `NEXT_PUBLIC_TERMINAL_RISK_MAINT_MARGIN_RATIO` (default `0.05`)
 - `NEXT_PUBLIC_TERMINAL_RISK_CONCENTRATION_WARNING` (default `0.55`)
@@ -89,6 +92,7 @@ bun run dev:local
 - Fixtures: `docs/execution/fixtures/*`
 - Operations runbook: `docs/execution/operations-runbook-v1.md`
 - Rollout plan: `docs/execution/rollout-plan-v1.md`
+- Terminal cutover plan: `docs/execution/terminal-cutover-plan-v1.md`
 - Tabletop simulation record: `docs/execution/tabletop-simulation-2026-03-03.md`
 - Fills ledger CSV format: `docs/execution/terminal-fills-ledger-export-v1.md`
 

--- a/apps/portal/app/terminal/components/dashboard-header.tsx
+++ b/apps/portal/app/terminal/components/dashboard-header.tsx
@@ -23,6 +23,7 @@ interface DashboardHeaderProps {
   showFundButton?: boolean;
   showBalance?: boolean;
   terminalMode: TerminalMode;
+  allowedModes?: readonly TerminalMode[];
   terminalModeSaving?: boolean;
   onModeChange?: (mode: TerminalMode) => void;
 }
@@ -36,6 +37,7 @@ export function DashboardHeader({
   showFundButton = false,
   showBalance = false,
   terminalMode,
+  allowedModes = TERMINAL_MODE_OPTIONS,
   terminalModeSaving = false,
   onModeChange,
 }: DashboardHeaderProps) {
@@ -63,6 +65,7 @@ export function DashboardHeader({
           <div className="inline-flex h-8 shrink-0 items-center rounded-md border border-border bg-surface p-0.5">
             {TERMINAL_MODE_OPTIONS.map((modeOption) => {
               const active = modeOption === terminalMode;
+              const allowed = allowedModes.includes(modeOption);
               const modeView = getTerminalModeCapabilities(modeOption);
               return (
                 <button
@@ -72,12 +75,21 @@ export function DashboardHeader({
                     active
                       ? "bg-ink text-surface"
                       : "text-muted hover:text-ink hover:bg-paper",
+                    !allowed && !active && "opacity-50 cursor-not-allowed",
                     !onModeChange && "pointer-events-none opacity-60",
                   )}
-                  onClick={() => onModeChange?.(modeOption)}
-                  title={modeView.description}
+                  onClick={() => {
+                    if (!allowed) return;
+                    onModeChange?.(modeOption);
+                  }}
+                  title={
+                    allowed
+                      ? modeView.description
+                      : `${modeView.description} (rollout gated)`
+                  }
                   type="button"
                   aria-pressed={active}
+                  aria-disabled={!allowed}
                 >
                   {modeView.label}
                 </button>

--- a/apps/portal/app/terminal/context.tsx
+++ b/apps/portal/app/terminal/context.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import {
   resolveDefaultTerminalMode,
+  TERMINAL_MODE_OPTIONS,
   type TerminalMode,
 } from "./terminal-modes";
 
@@ -24,6 +25,7 @@ type HeaderState = {
   showBalance: boolean;
   isRefreshing: boolean;
   terminalMode: TerminalMode;
+  terminalAllowedModes: readonly TerminalMode[];
   terminalModeSaving: boolean;
 };
 
@@ -36,6 +38,7 @@ type HeaderActions = {
   setShowFundButton: (show: boolean) => void;
   setShowBalance: (show: boolean) => void;
   setTerminalMode: (mode: TerminalMode) => void;
+  setTerminalAllowedModes: (modes: readonly TerminalMode[]) => void;
   setTerminalModeSaving: (saving: boolean) => void;
   setModeAction: (fn: ((mode: TerminalMode) => void) | null) => void;
 };
@@ -62,6 +65,9 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
   const [terminalMode, setTerminalMode] = useState<TerminalMode>(() =>
     resolveDefaultTerminalMode(process.env.NEXT_PUBLIC_TERMINAL_DEFAULT_MODE),
   );
+  const [terminalAllowedModes, setTerminalAllowedModes] = useState<
+    readonly TerminalMode[]
+  >(TERMINAL_MODE_OPTIONS);
   const [terminalModeSaving, setTerminalModeSaving] = useState(false);
 
   const [onFund, setOnFund] = useState<(() => void) | undefined>(undefined);
@@ -101,6 +107,8 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
       setIsRefreshing,
       terminalMode,
       setTerminalMode,
+      terminalAllowedModes,
+      setTerminalAllowedModes,
       terminalModeSaving,
       setTerminalModeSaving,
       onFund,
@@ -117,6 +125,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
       showBalance,
       isRefreshing,
       terminalMode,
+      terminalAllowedModes,
       terminalModeSaving,
       onFund,
       onRefresh,

--- a/apps/portal/app/terminal/dashboard-shell-client.tsx
+++ b/apps/portal/app/terminal/dashboard-shell-client.tsx
@@ -14,6 +14,7 @@ function ConnectedHeader() {
     showFundButton,
     showBalance,
     terminalMode,
+    terminalAllowedModes,
     terminalModeSaving,
     onModeChange,
   } = useDashboard();
@@ -28,6 +29,7 @@ function ConnectedHeader() {
       showFundButton={showFundButton}
       showBalance={showBalance}
       terminalMode={terminalMode}
+      allowedModes={terminalAllowedModes}
       terminalModeSaving={terminalModeSaving}
       onModeChange={onModeChange}
     />

--- a/apps/portal/app/terminal/page.tsx
+++ b/apps/portal/app/terminal/page.tsx
@@ -123,7 +123,10 @@ import {
 } from "./components/workspace-presets";
 import { useDashboard } from "./context";
 import {
+  coerceTerminalModeForRollout,
+  getRolloutAllowedTerminalModes,
   getTerminalModeCapabilities,
+  isTerminalModeAllowedByRollout,
   mergeProfileWithTerminalMode,
   modeAllowsAction,
   modeShowsModule,
@@ -131,6 +134,7 @@ import {
   readTerminalModeFromProfile,
   resolveDefaultTerminalMode,
   type TerminalMode,
+  type TerminalModeRolloutContext,
   type TerminalModule,
   writeLocalTerminalMode,
 } from "./terminal-modes";
@@ -326,6 +330,24 @@ function parseUserProfile(payload: unknown): Record<string, unknown> | null {
   return isRecord(user.profile) ? user.profile : null;
 }
 
+function parseTerminalRolloutContext(
+  payload: unknown,
+): TerminalModeRolloutContext | null {
+  if (!isRecord(payload)) return null;
+  const user = isRecord(payload.user) ? payload.user : null;
+  const experience = isRecord(payload.experience) ? payload.experience : null;
+  if (!user && !experience) return null;
+  return {
+    experienceLevel:
+      typeof experience?.level === "string" ? experience.level : null,
+    onboardingCompleted: experience?.onboardingCompleted === true,
+    degenAcknowledgedAt:
+      typeof user?.degenAcknowledgedAt === "string"
+        ? user.degenAcknowledgedAt
+        : null,
+  };
+}
+
 function isTypingTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
   if (target.isContentEditable) return true;
@@ -407,6 +429,8 @@ function ControlRoom() {
     string,
     unknown
   > | null>(null);
+  const [terminalRolloutContext, setTerminalRolloutContext] =
+    useState<TerminalModeRolloutContext | null>(null);
   const [recentExecutions, setRecentExecutions] = useState<
     ExecutionActivityRow[]
   >([]);
@@ -429,6 +453,13 @@ function ControlRoom() {
   const panelFocusTimerRef = useRef<number | null>(null);
   const terminalModeRef = useRef<TerminalMode>(terminalMode);
   const fallbackModePersistControllerRef = useRef<AbortController | null>(null);
+  const rolloutAllowedModes = useMemo(
+    () =>
+      getRolloutAllowedTerminalModes({
+        context: terminalRolloutContext,
+      }),
+    [terminalRolloutContext],
+  );
   const modeCapabilities = getTerminalModeCapabilities(terminalMode);
   const activeCustomWorkspace = useMemo(
     () => resolveActiveWorkspace(customWorkspaceStore),
@@ -498,6 +529,16 @@ function ControlRoom() {
   useEffect(() => {
     terminalModeRef.current = terminalMode;
   }, [terminalMode]);
+
+  useEffect(() => {
+    const coerced = coerceTerminalModeForRollout(terminalMode, {
+      context: terminalRolloutContext,
+    });
+    if (coerced === terminalMode) return;
+    setTerminalMode(coerced);
+    writeLocalTerminalMode(coerced);
+    setMessage(`Mode ${terminalMode} is rollout-gated. Using ${coerced}.`);
+  }, [terminalMode, terminalRolloutContext]);
 
   useEffect(
     () => () => {
@@ -813,16 +854,26 @@ function ControlRoom() {
       setWallet(parseAccountWallet(walletRaw));
       const profile = parseUserProfile(payload);
       setUserProfile(profile);
+      const rolloutContext = parseTerminalRolloutContext(payload);
+      setTerminalRolloutContext(rolloutContext);
       const serverMode = readTerminalModeFromProfile(profile);
       const localMode = readLocalTerminalMode();
       const defaultMode = resolveDefaultTerminalMode(
         process.env.NEXT_PUBLIC_TERMINAL_DEFAULT_MODE,
       );
-      const resolvedMode = serverMode ?? localMode ?? defaultMode;
+      const requestedMode = serverMode ?? localMode ?? defaultMode;
+      const resolvedMode = coerceTerminalModeForRollout(requestedMode, {
+        context: rolloutContext,
+      });
       setTerminalMode(resolvedMode);
+      if (resolvedMode !== requestedMode) {
+        setMessage(
+          `Mode ${requestedMode} is rollout-gated. Using ${resolvedMode}.`,
+        );
+      }
       // Keep local fallback synced with chosen mode.
       writeLocalTerminalMode(resolvedMode);
-      if (!serverMode) {
+      if (!serverMode || resolvedMode !== requestedMode) {
         const source = localMode ? "local_fallback" : "default_fallback";
         void persistTerminalMode({
           mode: resolvedMode,
@@ -1144,6 +1195,18 @@ function ControlRoom() {
   const handleTerminalModeChange = useCallback(
     (nextMode: TerminalMode): void => {
       if (nextMode === terminalMode) return;
+      const allowed = isTerminalModeAllowedByRollout(nextMode, {
+        context: terminalRolloutContext,
+      });
+      if (!allowed) {
+        const fallback = coerceTerminalModeForRollout(nextMode, {
+          context: terminalRolloutContext,
+        });
+        setMessage(
+          `Mode ${nextMode} is rollout-gated for your cohort. Available: ${rolloutAllowedModes.join(", ")}. Using ${fallback}.`,
+        );
+        return;
+      }
       const previousMode = terminalMode;
       setTerminalMode(nextMode);
       writeLocalTerminalMode(nextMode);
@@ -1165,7 +1228,13 @@ function ControlRoom() {
           setTerminalModeSaving(false);
         });
     },
-    [persistTerminalMode, terminalMode, userProfile],
+    [
+      persistTerminalMode,
+      rolloutAllowedModes,
+      terminalMode,
+      terminalRolloutContext,
+      userProfile,
+    ],
   );
 
   const triggerRefresh = useCallback(() => {
@@ -1356,6 +1425,7 @@ function ControlRoom() {
     setWalletBalanceError: setGlobalWalletBalanceError,
     setFundAction,
     setTerminalMode: setGlobalTerminalMode,
+    setTerminalAllowedModes: setGlobalTerminalAllowedModes,
     setTerminalModeSaving: setGlobalTerminalModeSaving,
     setModeAction,
     setRefreshAction,
@@ -1374,6 +1444,7 @@ function ControlRoom() {
     }
     setFundAction(wallet ? openFundingModal : null);
     setGlobalTerminalMode(terminalMode);
+    setGlobalTerminalAllowedModes(rolloutAllowedModes);
     setGlobalTerminalModeSaving(terminalModeSaving);
     setModeAction(handleTerminalModeChange);
     setRefreshAction(triggerRefresh);
@@ -1395,6 +1466,7 @@ function ControlRoom() {
     setGlobalWalletBalanceError,
     setFundAction,
     setGlobalTerminalMode,
+    setGlobalTerminalAllowedModes,
     setGlobalTerminalModeSaving,
     setModeAction,
     setRefreshAction,
@@ -1402,6 +1474,7 @@ function ControlRoom() {
     setShowFundButton,
     setShowBalance,
     openFundingModal,
+    rolloutAllowedModes,
     terminalMode,
     terminalModeSaving,
     handleTerminalModeChange,

--- a/apps/portal/app/terminal/terminal-modes.ts
+++ b/apps/portal/app/terminal/terminal-modes.ts
@@ -4,6 +4,19 @@ export const TERMINAL_MODE_STORAGE_KEY = "terminal-mode:v1";
 export const TERMINAL_MODE_OPTIONS = ["regular", "degen", "custom"] as const;
 
 export type TerminalMode = (typeof TERMINAL_MODE_OPTIONS)[number];
+export const TERMINAL_MODE_ROLLOUT_COHORT_OPTIONS = [
+  "all",
+  "onboarded",
+  "experienced",
+  "degen_acknowledged",
+] as const;
+export type TerminalModeRolloutCohort =
+  (typeof TERMINAL_MODE_ROLLOUT_COHORT_OPTIONS)[number];
+export type TerminalModeRolloutContext = {
+  experienceLevel?: string | null;
+  onboardingCompleted?: boolean;
+  degenAcknowledgedAt?: string | null;
+};
 
 export type TerminalModule =
   | "market"
@@ -80,6 +93,115 @@ const TERMINAL_MODE_CAPABILITIES: Record<
     },
   },
 };
+
+function parseModeAllowlist(raw: unknown): readonly TerminalMode[] {
+  const parsed = String(raw ?? "")
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry): entry is TerminalMode => isTerminalMode(entry));
+  if (parsed.length < 1) return TERMINAL_MODE_OPTIONS;
+  const deduped = Array.from(new Set(parsed));
+  if (!deduped.includes("regular")) {
+    deduped.unshift("regular");
+  }
+  return deduped;
+}
+
+function parseRolloutCohort(
+  raw: unknown,
+  fallback: TerminalModeRolloutCohort,
+): TerminalModeRolloutCohort {
+  const normalized = String(raw ?? "")
+    .trim()
+    .toLowerCase();
+  return (TERMINAL_MODE_ROLLOUT_COHORT_OPTIONS as readonly string[]).includes(
+    normalized,
+  )
+    ? (normalized as TerminalModeRolloutCohort)
+    : fallback;
+}
+
+function normalizeExperienceLevel(raw: unknown): string {
+  return String(raw ?? "")
+    .trim()
+    .toLowerCase();
+}
+
+function rolloutCohortAllowsMode(
+  context: TerminalModeRolloutContext | null | undefined,
+  cohort: TerminalModeRolloutCohort,
+): boolean {
+  if (cohort === "all") return true;
+  if (cohort === "onboarded") return context?.onboardingCompleted === true;
+  if (cohort === "experienced") {
+    const level = normalizeExperienceLevel(context?.experienceLevel);
+    return level === "advanced" || level === "degen";
+  }
+  return Boolean(String(context?.degenAcknowledgedAt ?? "").trim());
+}
+
+export function resolveTerminalModeRolloutPolicy(
+  env: Record<string, unknown> = process.env,
+): {
+  allowedModes: readonly TerminalMode[];
+  degenCohort: TerminalModeRolloutCohort;
+  customCohort: TerminalModeRolloutCohort;
+} {
+  return {
+    allowedModes: parseModeAllowlist(env.NEXT_PUBLIC_TERMINAL_ALLOWED_MODES),
+    degenCohort: parseRolloutCohort(
+      env.NEXT_PUBLIC_TERMINAL_DEGEN_COHORT,
+      "all",
+    ),
+    customCohort: parseRolloutCohort(
+      env.NEXT_PUBLIC_TERMINAL_CUSTOM_COHORT,
+      "all",
+    ),
+  };
+}
+
+export function isTerminalModeAllowedByRollout(
+  mode: TerminalMode,
+  input: {
+    context?: TerminalModeRolloutContext | null;
+    env?: Record<string, unknown>;
+  } = {},
+): boolean {
+  const policy = resolveTerminalModeRolloutPolicy(input.env ?? process.env);
+  if (!policy.allowedModes.includes(mode)) return false;
+  if (mode === "degen") {
+    return rolloutCohortAllowsMode(input.context, policy.degenCohort);
+  }
+  if (mode === "custom") {
+    return rolloutCohortAllowsMode(input.context, policy.customCohort);
+  }
+  return true;
+}
+
+export function getRolloutAllowedTerminalModes(
+  input: {
+    context?: TerminalModeRolloutContext | null;
+    env?: Record<string, unknown>;
+  } = {},
+): TerminalMode[] {
+  const allowed = TERMINAL_MODE_OPTIONS.filter((mode) =>
+    isTerminalModeAllowedByRollout(mode, input),
+  );
+  if (allowed.length > 0) return [...allowed];
+  return ["regular"];
+}
+
+export function coerceTerminalModeForRollout(
+  mode: TerminalMode,
+  input: {
+    context?: TerminalModeRolloutContext | null;
+    env?: Record<string, unknown>;
+  } = {},
+): TerminalMode {
+  if (isTerminalModeAllowedByRollout(mode, input)) return mode;
+  const allowed = getRolloutAllowedTerminalModes(input);
+  return allowed.includes("regular") ? "regular" : (allowed[0] ?? "regular");
+}
 
 export function isTerminalMode(value: unknown): value is TerminalMode {
   return (

--- a/docs/execution/operations-runbook-v1.md
+++ b/docs/execution/operations-runbook-v1.md
@@ -9,6 +9,8 @@ This runbook covers Phase 2 execution operations for:
 
 Rollout sequencing and revert gates are documented in
 `docs/execution/rollout-plan-v1.md`.
+Terminal UX cutover sequencing and cohort-mode gates are documented in
+`docs/execution/terminal-cutover-plan-v1.md`.
 
 ## Scope and Preconditions
 

--- a/docs/execution/terminal-cutover-plan-v1.md
+++ b/docs/execution/terminal-cutover-plan-v1.md
@@ -1,0 +1,113 @@
+# Terminal Cutover Plan v1
+
+This document defines production cutover for the terminal UX and execution path.
+
+## Objective
+
+Move terminal UX and execution to production with:
+
+- feature-flagged rollout by mode and user cohort
+- explicit go/no-go gates before each promotion
+- immediate rollback steps that preserve execution data integrity
+
+## Rollout Controls
+
+Terminal mode gates (Portal env):
+
+- `NEXT_PUBLIC_TERMINAL_ALLOWED_MODES`
+  - CSV of globally enabled modes from `regular,degen,custom`
+  - default: all modes
+- `NEXT_PUBLIC_TERMINAL_DEGEN_COHORT`
+  - one of: `all`, `onboarded`, `experienced`, `degen_acknowledged`
+  - default: `all`
+- `NEXT_PUBLIC_TERMINAL_CUSTOM_COHORT`
+  - one of: `all`, `onboarded`, `experienced`, `degen_acknowledged`
+  - default: `all`
+
+Execution actor-segment gates (Worker env):
+
+- `EXEC_ROLLOUT_INTERNAL_ENABLED`
+- `EXEC_ROLLOUT_TRUSTED_ENABLED`
+- `EXEC_ROLLOUT_EXTERNAL_ENABLED`
+
+## Cohort Signals
+
+Cohort evaluation is based on `/api/me` response fields:
+
+- `experience.onboardingCompleted`
+- `experience.level`
+- `user.degenAcknowledgedAt`
+
+Mode fallback rule:
+
+- If selected mode is not allowed for the user cohort, UI coerces to `regular`.
+
+## Promotion Sequence
+
+1. `codex/*` -> `dev`
+2. `dev` -> `staging`
+3. `staging` -> `main`
+
+Do not skip lanes during normal rollout.
+
+## Go/No-Go Gates
+
+All gates must pass before lane promotion:
+
+1. CI gates green:
+   - `lint`
+   - `typecheck`
+   - `unit-tests`
+   - `integration-tests`
+   - `terminal-e2e-tests`
+2. Deploy gates green:
+   - `Deploy (dev|staging|production)`
+   - `Deploy Portal (Vercel)`
+3. Terminal execution checks:
+   - submit -> status -> receipt loop healthy on lane API host
+   - execution inspector shows ordered timeline + receipt outcome
+   - no unexpected increase in `submission-failed` / `expired-blockhash`
+4. UX gates:
+   - mode gating behaves correctly for test cohorts
+   - disallowed mode transitions are blocked and safely coerced
+
+No-go triggers:
+
+- execution failure spike above normal baseline for two consecutive windows
+- receipt readiness regressions (`ready=false` after terminal state)
+- rollout gate misconfiguration causing widespread `policy-denied`
+
+## Rollback Playbook
+
+If regression is detected:
+
+1. Restrict terminal modes immediately:
+   - set `NEXT_PUBLIC_TERMINAL_ALLOWED_MODES=regular`
+2. Restrict risky cohorts:
+   - set `NEXT_PUBLIC_TERMINAL_DEGEN_COHORT=degen_acknowledged`
+   - set `NEXT_PUBLIC_TERMINAL_CUSTOM_COHORT=onboarded`
+3. If execution instability persists, gate actor segments in order:
+   - `EXEC_ROLLOUT_EXTERNAL_ENABLED=0`
+   - `EXEC_ROLLOUT_TRUSTED_ENABLED=0` (if needed)
+4. Re-run smoke checks on lane domains:
+   - `/api/health`
+   - `/api/x402/exec/health`
+   - `/api/x402/exec/status/:requestId`
+   - `/api/x402/exec/receipt/:requestId`
+
+Rollback preserves data because execution requests/events/attempts/receipts are append-only and idempotent.
+
+## Post-Launch Validation Checklist
+
+Run after each promotion and 24h after production cutover:
+
+1. Validate cohort gates with representative accounts:
+   - onboarding incomplete
+   - onboarded intermediate
+   - advanced/degen acknowledged
+2. Verify execution observability snapshots:
+   - landed/finalized rates stable
+   - no abnormal expiry trend
+3. Spot-check canonical receipts and timeline rendering.
+4. Confirm no new CORS/auth regressions on terminal execution routes.
+

--- a/tests/unit/portal_terminal_modes.test.ts
+++ b/tests/unit/portal_terminal_modes.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import {
+  coerceTerminalModeForRollout,
+  getRolloutAllowedTerminalModes,
   getTerminalModeCapabilities,
+  isTerminalModeAllowedByRollout,
   mergeProfileWithTerminalMode,
   modeAllowsAction,
   modeShowsModule,
   readTerminalModeFromProfile,
   resolveDefaultTerminalMode,
+  resolveTerminalModeRolloutPolicy,
 } from "../../apps/portal/app/terminal/terminal-modes";
 
 describe("portal terminal modes", () => {
@@ -65,5 +69,88 @@ describe("portal terminal modes", () => {
     expect(modeShowsModule("degen", "degen_event_hooks")).toBe(true);
     expect(modeAllowsAction("degen", "macro_trade")).toBe(true);
     expect(modeAllowsAction("degen", "layout_edit")).toBe(true);
+  });
+
+  test("parses rollout mode policy with stable regular fallback", () => {
+    const policy = resolveTerminalModeRolloutPolicy({
+      NEXT_PUBLIC_TERMINAL_ALLOWED_MODES: "degen,custom",
+      NEXT_PUBLIC_TERMINAL_DEGEN_COHORT: "experienced",
+      NEXT_PUBLIC_TERMINAL_CUSTOM_COHORT: "onboarded",
+    });
+    expect(policy.allowedModes).toEqual(["regular", "degen", "custom"]);
+    expect(policy.degenCohort).toBe("experienced");
+    expect(policy.customCohort).toBe("onboarded");
+  });
+
+  test("enforces cohort gates for degen/custom modes", () => {
+    const env = {
+      NEXT_PUBLIC_TERMINAL_ALLOWED_MODES: "regular,degen,custom",
+      NEXT_PUBLIC_TERMINAL_DEGEN_COHORT: "experienced",
+      NEXT_PUBLIC_TERMINAL_CUSTOM_COHORT: "onboarded",
+    };
+
+    expect(
+      isTerminalModeAllowedByRollout("regular", {
+        env,
+        context: {
+          onboardingCompleted: false,
+          experienceLevel: "beginner",
+          degenAcknowledgedAt: null,
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      isTerminalModeAllowedByRollout("degen", {
+        env,
+        context: {
+          onboardingCompleted: true,
+          experienceLevel: "intermediate",
+          degenAcknowledgedAt: null,
+        },
+      }),
+    ).toBe(false);
+
+    expect(
+      isTerminalModeAllowedByRollout("degen", {
+        env,
+        context: {
+          onboardingCompleted: true,
+          experienceLevel: "advanced",
+          degenAcknowledgedAt: null,
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      isTerminalModeAllowedByRollout("custom", {
+        env,
+        context: {
+          onboardingCompleted: false,
+          experienceLevel: "advanced",
+          degenAcknowledgedAt: null,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  test("resolves allowed mode list and coerces disallowed mode", () => {
+    const env = {
+      NEXT_PUBLIC_TERMINAL_ALLOWED_MODES: "regular,degen,custom",
+      NEXT_PUBLIC_TERMINAL_DEGEN_COHORT: "degen_acknowledged",
+      NEXT_PUBLIC_TERMINAL_CUSTOM_COHORT: "onboarded",
+    };
+    const context = {
+      onboardingCompleted: true,
+      experienceLevel: "advanced",
+      degenAcknowledgedAt: null,
+    };
+    expect(getRolloutAllowedTerminalModes({ env, context })).toEqual([
+      "regular",
+      "custom",
+    ]);
+    expect(coerceTerminalModeForRollout("degen", { env, context })).toBe(
+      "regular",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add terminal mode rollout gates by user cohort and environment policy
- wire allowed mode visibility into the terminal header controls
- enforce safe mode fallback when a selected mode is rollout-gated
- add a production cutover runbook with explicit go/no-go and rollback criteria

## Rollout Controls Added
- `NEXT_PUBLIC_TERMINAL_ALLOWED_MODES`
- `NEXT_PUBLIC_TERMINAL_DEGEN_COHORT`
- `NEXT_PUBLIC_TERMINAL_CUSTOM_COHORT`

## Validation
- bun run lint
- bun run typecheck
- bun run test:unit
- bun run test:integration

Closes #168
