### PR TITLE
[Docs] Add WORKFLOW.md and repository verification index

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ It provides one execution fabric for:
 - `tests/`: unit + integration tests
 - `docs/`: execution contracts, registry runbooks, and metadata
 
+## Repository Contract
+
+- `WORKFLOW.md`: repo-owned execution contract for future issue runners and
+  manual issue branches
+- `docs/repository-verification-index.md`: architecture map, invariants,
+  environment inventory, rollback steps, and verification playbooks
+
 ## What Is Live
 
 - Terminal UI at `/terminal`

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,0 +1,137 @@
+---
+version: 1
+tracker:
+  kind: github
+  repository: GuiBibeau/serious-trader-ralph
+  ready_labels:
+    - harness
+    - agent-ready
+  exclude_labels:
+    - blocked
+    - agent-running
+    - human-review
+branching:
+  branch_prefix: codex/
+  branch_format: codex/issue-<number>-<slug>
+  default_pr_base: dev
+validation:
+  default:
+    - bun run lint
+    - bun run typecheck
+  docs_only:
+    - bun run lint
+proof_bundle:
+  required:
+    - summary_of_changes
+    - validation_commands_and_results
+    - preview_or_local_urls
+    - browser_artifacts_for_ui_changes
+    - benchmark_delta_for_performance_sensitive_changes
+    - risk_notes_and_follow_ups
+approval:
+  posture: high-trust repo-owned execution with mandatory human review before merge
+secrets:
+  never_commit:
+    - .env*
+    - apps/worker/.dev.vars
+    - wallet private keys
+    - API tokens
+  approved_sources:
+    - GitHub Actions secrets
+    - Cloudflare Wrangler secrets
+    - Vercel environment variables
+---
+
+# Trader Ralph Execution Contract
+
+This file is the repo-owned contract for future issue runners and for humans
+working the harness backlog manually. It defines how work is selected, how code
+is validated, and what evidence must be attached before a PR is ready for
+review.
+
+## Eligible Work
+
+Take an issue only when all of the following are true:
+
+- It is in `GuiBibeau/serious-trader-ralph`.
+- It includes both `harness` and `agent-ready`.
+- It does not include `blocked`, `agent-running`, or `human-review`.
+
+When a run starts, add `agent-running`. When the PR is ready for review, remove
+`agent-running` and add `human-review`.
+
+## Branching and PR Rules
+
+- Branch names must follow `codex/issue-<number>-<slug>`.
+- Include `Fixes #<issue-number>` in the PR body when the work should close the
+  issue on merge.
+- Until issue `#241` lands, open PRs against `dev` because the current deploy
+  lane model is still `feature/codex -> dev -> staging -> main`.
+- After issue `#241` lands, switch the default PR base to `main` and treat
+  `dev` as an optional soak lane only.
+- Do not push directly to `dev`, `staging`, or `main`.
+
+## Validation Requirements
+
+Always run the smallest relevant validation set and report the exact commands in
+the PR summary.
+
+Default validation:
+
+```bash
+bun run lint
+bun run typecheck
+```
+
+Use a narrower set only when the issue is documentation-only or when a more
+focused test suite is clearly sufficient. Examples:
+
+- docs-only: `bun run lint`
+- worker changes: add `bun run test:unit` and the most relevant integration
+  suite
+- portal or terminal changes: add `bun run test:e2e` and browser proof once the
+  proof harness exists
+- deployment or environment changes: include the relevant smoke checks and any
+  branch-specific verification notes
+
+## Proof Bundle Requirements
+
+Every PR must include a proof bundle in its summary comment or description. The
+bundle must include:
+
+1. A short change summary.
+2. The exact validation commands run and whether they passed.
+3. The preview URL or local harness URLs used for verification.
+4. Browser screenshots, traces, or videos for UI-affecting changes.
+5. Benchmark deltas for performance-sensitive changes.
+6. Risk notes, follow-ups, and anything intentionally deferred.
+
+If a proof item is not applicable, say so explicitly instead of omitting it.
+
+## Approval Posture
+
+- This repo is operated in a high-trust mode for engineering execution.
+- Human review is still mandatory before merge.
+- Stop at `human-review`; do not auto-merge unless the repo policy changes in a
+  later issue.
+- Prefer reversible changes and call out any deployment or rollout risk in the
+  PR summary.
+
+## Secret Boundaries
+
+- Never commit `.env` files, `.dev.vars`, private keys, tokens, or customer
+  data.
+- Use GitHub Actions secrets, Cloudflare secrets, and Vercel environment
+  variables for deployment-time configuration.
+- Local verification may read from approved local secret stores, but those
+  values must never be copied into tracked files, issue comments, PR comments,
+  or logs.
+
+## Repository-Specific Guardrails
+
+- The public API boundary is the Cloudflare Worker in `apps/worker`.
+- Existing x402 and execution endpoint contracts must remain stable unless the
+  issue explicitly calls for a contract change.
+- Prefer issue-by-issue PRs with focused scope and explicit dependency handling.
+- When deploy behavior changes, include CI and environment changes in the same
+  PR so the lane configuration does not drift.

--- a/docs/repository-verification-index.md
+++ b/docs/repository-verification-index.md
@@ -1,0 +1,241 @@
+# Repository Verification Index
+
+This document is the public-safe starting point for understanding how Trader
+Ralph is put together, what must stay true, which environments exist today, and
+how to verify or roll back the main operating paths.
+
+## Architecture Map
+
+| Surface | Role | Primary paths |
+| --- | --- | --- |
+| Portal | Next.js marketing, login, and terminal UI | `apps/portal` |
+| Worker | Cloudflare Worker API boundary for x402, execution, discovery, and auth-adjacent routes | `apps/worker` |
+| Runtime | Bun CLI, agent runtime, tools, policies, and journals | `src` |
+| Tests | Unit, integration, and terminal execution suites | `tests` |
+| Public contracts | Execution docs, schemas, fixtures, and runbooks | `docs/execution` |
+| Agent registry | Lane metadata and operator runbook | `docs/agent-registry` |
+| Pipeline architecture | Loop A/B/C design and backlog decomposition | `loop-a-loop-b-architecture.md` |
+
+High-level request flow today:
+
+1. The portal reads `NEXT_PUBLIC_EDGE_API_BASE` and talks to the Worker.
+2. The Worker is the public API boundary and enforces x402 and execution
+   contracts.
+3. Execution, telemetry, registry, and loop surfaces persist through Cloudflare
+   resources such as D1, KV, R2, and Durable Objects.
+4. CI and deploy workflows publish branch-specific environments for portal and
+   worker.
+
+## Repo Invariants
+
+These are the invariants that changes should preserve unless the issue
+explicitly calls for a contract break:
+
+- The Cloudflare Worker remains the public API boundary.
+- Existing x402 read routes stay under `POST /api/x402/read/*`.
+- Existing execution routes stay:
+  - `POST /api/x402/exec/submit`
+  - `GET /api/x402/exec/status/:requestId`
+  - `GET /api/x402/exec/receipt/:requestId`
+- The portal must build against explicit `NEXT_PUBLIC_EDGE_API_BASE` and
+  `NEXT_PUBLIC_SITE_URL` values so environment routing stays deterministic.
+- CI-impacting workflow or environment changes must ship in the same PR as the
+  code they support.
+- Secrets never live in tracked files.
+
+## Environment Inventory
+
+Current branch and domain mapping:
+
+| Lane | Branch | Site URL | API URL | Worker name |
+| --- | --- | --- | --- | --- |
+| Dev | `dev` | `https://dev.trader-ralph.com` | `https://dev.api.trader-ralph.com` | `ralph-edge-dev` |
+| Staging | `staging` | `https://staging.trader-ralph.com` | `https://staging.api.trader-ralph.com` | `ralph-edge-staging` |
+| Production | `main` | `https://trader-ralph.com` and `https://www.trader-ralph.com` | `https://api.trader-ralph.com` | `ralph-edge` |
+
+Current workflow files:
+
+- CI: `.github/workflows/ci.yml`
+- Worker deploys:
+  - `.github/workflows/deploy-dev.yml`
+  - `.github/workflows/deploy-staging-production.yml`
+  - `.github/workflows/deploy-manual.yml`
+- Portal deploys:
+  - `.github/workflows/deploy-portal.yml`
+
+Current required secret names:
+
+- Cloudflare: `CLOUDFLARE_API_TOKEN`
+- Vercel: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`
+- Integration and live test inputs vary by suite and may include
+  `RPC_ENDPOINT`, `BALANCE_RPC_ENDPOINT`, `JUPITER_API_KEY`,
+  `WALLET_PRIVATE_KEY`, and provider-specific read keys.
+
+## Verification Playbooks
+
+### 1. Local full-stack verification
+
+```bash
+bun install
+bun run dev:local
+```
+
+Expected local health:
+
+- Portal: `http://localhost:3000`
+- Worker: `http://127.0.0.1:8888/api/health`
+
+Verify:
+
+```bash
+curl -fsS http://127.0.0.1:8888/api/health
+open http://localhost:3000/terminal
+```
+
+### 2. Worker-only verification
+
+```bash
+cd apps/worker
+bun install
+bun run db:migrate:local
+bun run dev:local
+```
+
+Verify:
+
+```bash
+curl -fsS http://127.0.0.1:8888/api/health
+```
+
+### 3. Contract and test verification
+
+Base checks:
+
+```bash
+bun run lint
+bun run typecheck
+```
+
+Execution and runtime checks:
+
+```bash
+bun run test:unit
+bun run test:integration
+bun run test:e2e
+bun run test:integration:worker:live
+```
+
+Use the narrowest relevant subset for focused changes, but record the exact
+commands used in the PR proof bundle.
+
+### 4. x402 and discovery verification
+
+Portal-side discovery:
+
+```bash
+curl -fsS https://dev.trader-ralph.com/api
+curl -fsS https://dev.trader-ralph.com/openapi.json
+curl -fsS https://dev.trader-ralph.com/endpoints.txt
+```
+
+Worker/API-side discovery:
+
+```bash
+curl -fsS https://dev.api.trader-ralph.com/api/health
+curl -fsS https://dev.api.trader-ralph.com/openapi.json
+curl -fsS https://dev.api.trader-ralph.com/agent-registry/metadata.json
+```
+
+x402 gating spot check:
+
+```bash
+curl -i -X POST https://dev.api.trader-ralph.com/api/x402/read/macro_signals
+```
+
+Expected behavior: without `payment-signature`, the route should return `402`
+and a `payment-required` header.
+
+### 5. Agent registry verification
+
+Validate metadata:
+
+```bash
+bun run agent-registry:validate -- --lane dev
+bun run agent-registry:validate -- --lane staging
+bun run agent-registry:validate -- --lane production
+```
+
+Dry-run sync:
+
+```bash
+bun run agent-registry:sync -- --lane dev --step all --dry-run
+bun run agent-registry:sync -- --lane production --step all --dry-run
+```
+
+See also: `docs/agent-registry/runbook.md`
+
+### 6. Deployment smoke verification
+
+Current lane deploys are branch-driven. After a branch deploy completes, verify:
+
+```bash
+curl -fsS https://<lane-site-domain>
+curl -fsS https://<lane-api-domain>/api/health
+curl -fsS https://<lane-api-domain>/openapi.json
+```
+
+For portal builds, also verify that the login bundle points at the intended API
+host for the lane and does not reference an unexpected `workers.dev` host.
+
+### 7. Canary verification
+
+Current state: the dedicated production canary lane is not implemented yet.
+Until issue `#237` lands, use the following temporary substitute after
+production deploys:
+
+1. Run the production execution smoke path described in the execution runbooks.
+2. Check the execution observability endpoint for failures, expiry, and latency
+   regressions.
+3. Confirm status and receipt consistency for the latest execution samples.
+
+When the canary lands, extend this section with the canary wallet, schedule,
+notional limits, and reconciliation checks.
+
+## Rollback Steps
+
+### Code rollback
+
+1. Identify the offending merge or commit.
+2. Open a revert PR against the active lane branch.
+3. Let branch-driven CI and deploy workflows republish the reverted state.
+
+### Execution rollback
+
+Use lane and rollout flags before attempting a broader revert:
+
+- `EXEC_ROLLOUT_INTERNAL_ENABLED`
+- `EXEC_ROLLOUT_TRUSTED_ENABLED`
+- `EXEC_ROLLOUT_EXTERNAL_ENABLED`
+- `EXEC_LANE_FAST_ENABLED`
+- `EXEC_LANE_PROTECTED_ENABLED`
+- `EXEC_LANE_SAFE_ENABLED`
+
+Reference: `docs/execution/rollout-plan-v1.md`
+
+### Production triage and verification
+
+- Check `docs/execution/operations-runbook-v1.md` for request, attempt, and
+  receipt triage.
+- Use `docs/execution/terminal-cutover-plan-v1.md` for execution-specific
+  rollback context.
+- Re-run the lane verification checks after any revert.
+
+## Source Docs by Topic
+
+- Execution API contract: `docs/execution/exec-api-v1.md`
+- Execution observability: `docs/execution/observability-v1.md`
+- Execution operations: `docs/execution/operations-runbook-v1.md`
+- Execution rollout and rollback: `docs/execution/rollout-plan-v1.md`
+- Terminal cutover: `docs/execution/terminal-cutover-plan-v1.md`
+- Agent registry: `docs/agent-registry/runbook.md`
+- Long-form pipeline architecture: `loop-a-loop-b-architecture.md`


### PR DESCRIPTION
Fixes #232

## Summary
- add a repo-owned `WORKFLOW.md` contract for future issue runners and manual issue branches
- add a public-safe repository verification index covering architecture, invariants, environments, rollback, and verification playbooks
- link both documents from the README so reviewers and future automation have a single obvious starting point

## Proof Bundle
- Change summary: documentation-only contract and verification index for harness work
- Validation commands and results:
  - `bun run lint` ✅
  - `bun run typecheck` ✅
- Preview or local URLs: not applicable for this docs-only change
- Browser artifacts: not applicable for this docs-only change
- Benchmark delta: not applicable for this docs-only change
- Risk notes and follow-ups:
  - `WORKFLOW.md` keeps `dev` as the default PR base until issue `#241` removes staging and simplifies the lane model
  - canary verification is documented as a temporary manual substitute until issue `#237` lands
