### PR TITLE
[Browser Proof] Add Playwright proof flows and artifact capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Optional portal env:
 bun run harness:up
 bun run harness:status
 bun run harness:down
+bun run harness:proof
 ```
 
 - `harness:up` starts a portal and worker pair with worktree-local ports and
@@ -96,6 +97,8 @@ bun run harness:down
 - `harness:status` prints the current local URLs, health, log directory, and
   state file for the active worktree
 - `harness:down` tears down only the active worktree harness state
+- `harness:proof` runs the Playwright browser proof suite against the active
+  local harness, or a supplied preview URL via `--base-url`
 
 ### Worker only
 

--- a/apps/portal/app/lib.ts
+++ b/apps/portal/app/lib.ts
@@ -8,6 +8,10 @@ const SOL_DECIMALS = 9;
 const USDC_DECIMALS = 6;
 const DISPLAY_DECIMALS = 2;
 
+type RuntimeWindow = Window & {
+  __TRADER_RALPH_EDGE_API_BASE__?: string;
+};
+
 export type BalanceResponse = {
   sol: { lamports: string; display?: string };
   usdc: { atomic: string; display?: string };
@@ -76,6 +80,14 @@ export function formatBalanceSummary(
 }
 
 export function apiBase(): string {
+  if (typeof window !== "undefined") {
+    const runtimeOverride = String(
+      (window as RuntimeWindow).__TRADER_RALPH_EDGE_API_BASE__ ?? "",
+    )
+      .trim()
+      .replace(/\/+$/, "");
+    if (runtimeOverride) return runtimeOverride;
+  }
   const configured = (process.env.NEXT_PUBLIC_EDGE_API_BASE ?? "")
     .trim()
     .replace(/\/+$/, "");

--- a/apps/portal/app/proof/browser/page.tsx
+++ b/apps/portal/app/proof/browser/page.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { BTN_PRIMARY, BTN_SECONDARY } from "../../lib";
+import {
+  buildAccountRiskSnapshot,
+  resolveAccountRiskThresholds,
+} from "../../terminal/components/account-risk";
+import { ExecutionInspectorDrawer } from "../../terminal/components/execution-inspector-drawer";
+import { MarketChart } from "../../terminal/components/market-chart";
+import type {
+  MarketPoint,
+  MarketState,
+} from "../../terminal/components/sol-market-feed";
+import { createSolUsdcIntent } from "../../terminal/components/trade-intent";
+import { TOKEN_CONFIGS } from "../../terminal/components/trade-pairs";
+import {
+  type TradeTicketCompletion,
+  TradeTicketModal,
+} from "../../terminal/components/trade-ticket-modal";
+
+type RuntimeWindow = Window & {
+  __TRADER_RALPH_EDGE_API_BASE__?: string;
+};
+
+const PROOF_WALLET = "7YB4proofHarnessWallet111111111111111111111111";
+
+function buildProofMarketState(): MarketState {
+  const now = Date.now();
+  const points: MarketPoint[] = [];
+
+  for (let index = 0; index < 72; index += 1) {
+    const ts = now - (71 - index) * 60 * 60 * 1000;
+    const drift = 164.2 + index * 0.62;
+    const swing = Math.sin(index / 5) * 3.8;
+    const close = Number((drift + swing).toFixed(4));
+    points.push({
+      ts,
+      price: close,
+      kind: "ohlcv",
+      open: Number((close - 0.9).toFixed(4)),
+      high: Number((close + 1.4).toFixed(4)),
+      low: Number((close - 1.8).toFixed(4)),
+      close,
+      volume: 1_200_000 + index * 14_000,
+    });
+  }
+
+  const latest = points.at(-1)?.price ?? 0;
+  const anchor = points.at(-25)?.price ?? latest;
+
+  return {
+    status: "ready",
+    error: null,
+    points,
+    latestPrice: latest,
+    change24hPct: anchor > 0 ? ((latest - anchor) / anchor) * 100 : null,
+    lastUpdatedMs: now,
+    sourcePriority: ["proof-fixture", "playwright-route"],
+    pairId: "SOL/USDC",
+  };
+}
+
+export default function BrowserProofPage() {
+  const [tradeOpen, setTradeOpen] = useState(false);
+  const [inspectorOpen, setInspectorOpen] = useState(false);
+  const [completion, setCompletion] = useState<TradeTicketCompletion | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const runtimeWindow = window as RuntimeWindow;
+    if (!runtimeWindow.__TRADER_RALPH_EDGE_API_BASE__) {
+      runtimeWindow.__TRADER_RALPH_EDGE_API_BASE__ = window.location.origin;
+    }
+  }, []);
+
+  const market = useMemo(() => buildProofMarketState(), []);
+  const intent = useMemo(
+    () =>
+      createSolUsdcIntent("buy", "BROWSER_PROOF", {
+        reason: "Deterministic browser proof flow",
+        amountUi: "50",
+        slippageBps: 50,
+      }),
+    [],
+  );
+  const tokenBalancesByMint = useMemo(
+    () => ({
+      [TOKEN_CONFIGS.USDC.mint]: "250000000",
+      [TOKEN_CONFIGS.SOL.mint]: "5000000000",
+    }),
+    [],
+  );
+  const riskSnapshot = useMemo(
+    () =>
+      buildAccountRiskSnapshot({
+        baseQty: 3.8,
+        quoteQty: 900,
+        markPrice: market.latestPrice,
+        thresholds: resolveAccountRiskThresholds(),
+      }),
+    [market.latestPrice],
+  );
+
+  return (
+    <main
+      className="min-h-screen bg-paper text-ink"
+      data-testid="browser-proof-page"
+    >
+      <section className="mx-auto w-[min(1180px,92vw)] space-y-6 py-10">
+        <header className="card p-6">
+          <p className="label">BROWSER_PROOF</p>
+          <div className="mt-3 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+            <div className="max-w-[700px]">
+              <h1>Harness Browser Proof</h1>
+              <p className="mt-3 text-muted">
+                Deterministic proof surface for Playwright. It reuses the real
+                market chart, trade ticket, and execution inspector components
+                while browser routes stub the execution APIs.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <a className={BTN_SECONDARY} href="/login">
+                View login page
+              </a>
+              <button
+                className={BTN_PRIMARY}
+                data-testid="proof-open-trade"
+                onClick={() => {
+                  setCompletion(null);
+                  setInspectorOpen(false);
+                  setTradeOpen(true);
+                }}
+                type="button"
+              >
+                Open trade ticket
+              </button>
+            </div>
+          </div>
+        </header>
+
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(320px,0.9fr)]">
+          <section className="card p-4" data-testid="proof-market-card">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <div>
+                <p className="label">MARKET_RENDER</p>
+                <h2 className="mt-2">SOL / USDC browser proof chart</h2>
+              </div>
+              <div className="rounded border border-border bg-subtle px-3 py-2 text-right text-xs">
+                <p className="text-muted">Source priority</p>
+                <p className="font-mono">
+                  {market.sourcePriority.join(" -> ")}
+                </p>
+              </div>
+            </div>
+            <MarketChart market={market} pairLabel="SOL / USDC" />
+          </section>
+
+          <section className="card space-y-4 p-6">
+            <div>
+              <p className="label">EXECUTION_PROOF</p>
+              <h2 className="mt-2">Receipt drilldown</h2>
+              <p className="mt-3 text-muted">
+                Submit a mocked trade from the proof ticket, then inspect the
+                terminal receipt snapshot and attempt timeline.
+              </p>
+            </div>
+
+            <div className="rounded border border-border bg-subtle p-4 text-sm">
+              <p className="text-muted">Proof wallet</p>
+              <p className="mt-1 font-mono">
+                {PROOF_WALLET.slice(0, 8)}...{PROOF_WALLET.slice(-8)}
+              </p>
+              <p className="mt-3 text-muted">Balances</p>
+              <p className="mt-1 font-mono">
+                250.000000 USDC · 5.000000000 SOL
+              </p>
+            </div>
+
+            {completion ? (
+              <div
+                className="rounded border border-emerald-500/40 bg-emerald-500/10 p-4"
+                data-testid="proof-trade-completion"
+              >
+                <p className="label">TRADE_COMPLETE</p>
+                <p className="mt-2 font-mono text-sm">
+                  {completion.requestId} • {completion.status}
+                </p>
+                <p className="mt-1 text-sm text-muted">
+                  receipt {completion.receiptId ?? "--"} • provider{" "}
+                  {completion.provider ?? "--"}
+                </p>
+                <p className="mt-1 break-all text-sm text-muted">
+                  signature {completion.signature ?? "--"}
+                </p>
+                <div className="mt-4 flex gap-3">
+                  <button
+                    className={BTN_PRIMARY}
+                    data-testid="proof-open-inspector"
+                    onClick={() => setInspectorOpen(true)}
+                    type="button"
+                  >
+                    Open execution inspector
+                  </button>
+                  <button
+                    className={BTN_SECONDARY}
+                    onClick={() => {
+                      setCompletion(null);
+                      setInspectorOpen(false);
+                      setTradeOpen(true);
+                    }}
+                    type="button"
+                  >
+                    Run again
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="rounded border border-dashed border-border p-4 text-sm text-muted">
+                No execution captured yet. Open the trade ticket to run the
+                deterministic proof flow.
+              </div>
+            )}
+          </section>
+        </div>
+      </section>
+
+      <TradeTicketModal
+        open={tradeOpen}
+        intent={intent}
+        walletAddress={PROOF_WALLET}
+        tokenBalancesByMint={tokenBalancesByMint}
+        riskSnapshot={riskSnapshot}
+        getAccessToken={async () => "proof-access-token"}
+        onClose={() => setTradeOpen(false)}
+        onTradeComplete={(trade) => {
+          setCompletion(trade);
+        }}
+      />
+      <ExecutionInspectorDrawer
+        open={inspectorOpen}
+        requestId={completion?.requestId ?? null}
+        onClose={() => setInspectorOpen(false)}
+      />
+    </main>
+  );
+}

--- a/apps/portal/app/terminal/components/execution-inspector-drawer.tsx
+++ b/apps/portal/app/terminal/components/execution-inspector-drawer.tsx
@@ -322,7 +322,10 @@ export const ExecutionInspectorDrawer = memo(function ExecutionInspectorDrawer(
   if (!open || !requestId) return null;
 
   return (
-    <div className="fixed inset-0 z-[70] flex justify-end bg-black/50 backdrop-blur-[2px]">
+    <div
+      className="fixed inset-0 z-[70] flex justify-end bg-black/50 backdrop-blur-[2px]"
+      data-testid="execution-inspector-drawer"
+    >
       <button
         className="absolute inset-0"
         aria-label="Close execution inspector"

--- a/apps/portal/app/terminal/components/trade-ticket-modal.tsx
+++ b/apps/portal/app/terminal/components/trade-ticket-modal.tsx
@@ -1129,7 +1129,10 @@ export function TradeTicketModal({
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-[6px]">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-[6px]"
+      data-testid="trade-ticket-modal"
+    >
       <button
         aria-label="Close trade ticket"
         className="absolute inset-0"
@@ -1251,6 +1254,7 @@ export function TradeTicketModal({
             </button>
             <button
               className={`${BTN_PRIMARY} !py-2 !px-4 text-xs min-w-[8.5rem]`}
+              data-testid="trade-ticket-submit"
               onClick={() => void executeTrade()}
               type="button"
               disabled={!canExecuteTrade}
@@ -1474,6 +1478,7 @@ const TradeInputsSection = memo(function TradeInputsSection(props: {
           <input
             id="trade-ticket-amount"
             className="input-field !py-2.5 font-mono"
+            data-testid="trade-ticket-amount-input"
             inputMode="decimal"
             placeholder={amountPresets[1] ?? amountPresets[0] ?? "1"}
             value={amountUi}
@@ -1528,6 +1533,7 @@ const TradeInputsSection = memo(function TradeInputsSection(props: {
         <input
           id="trade-ticket-slippage"
           className="input-field !py-2.5 font-mono"
+          data-testid="trade-ticket-slippage-input"
           inputMode="numeric"
           min={1}
           max={5000}
@@ -1695,6 +1701,7 @@ const AdvancedOrderConfigSection = memo(
             </span>
             <select
               className="input-field !py-2 font-mono"
+              data-testid="trade-ticket-order-type"
               value={orderType}
               onChange={(event) =>
                 onOrderTypeChange(event.target.value as OrderType)

--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.15",
+        "@playwright/test": "^1.50.0",
         "@types/node": "^25.2.3",
         "@types/ws": "^8.18.1",
         "ajv": "^8.17.1",
@@ -60,6 +61,7 @@
       "name": "ralph-edge-worker",
       "version": "0.1.0",
       "dependencies": {
+        "@solana/web3.js": "^1.98.4",
         "bs58": "^6.0.0",
         "jose": "^6.1.3",
         "zod": "^4.3.6",
@@ -355,6 +357,8 @@
     "@paulmillr/qr": ["@paulmillr/qr@0.2.1", "", {}, "sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ=="],
 
     "@phosphor-icons/webcomponents": ["@phosphor-icons/webcomponents@2.1.5", "", { "dependencies": { "lit": "^3" } }, "sha512-JcvQkZxvcX2jK+QCclm8+e8HXqtdFW9xV4/kk2aL9Y3dJA2oQVt+pzbv1orkumz3rfx4K9mn9fDoMr1He1yr7Q=="],
+
+    "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 
@@ -1168,6 +1172,10 @@
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
 
+    "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
+
+    "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
+
     "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
 
     "pony-cause": ["pony-cause@2.1.11", "", {}, "sha512-M7LhCsdNbNgiLYiP4WjsfLUuFmCfnjdF6jKe2R9NKl4WFN+HZPGHJZ9lnLP7f9ZnKe3U9nuWD0szirmj+migUg=="],
@@ -1811,6 +1819,8 @@
     "pino/pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
 
     "pino/sonic-boom": ["sonic-boom@4.2.0", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "porto/idb-keyval": ["idb-keyval@6.2.2", "", {}, "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg=="],
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "harness:up": "bun run src/bin/harness.ts up",
     "harness:down": "bun run src/bin/harness.ts down",
     "harness:status": "bun run src/bin/harness.ts status",
+    "harness:proof": "bun run src/bin/harness.ts proof",
     "build": "bun build src/bin/ralph.ts --outdir dist/bin --target node --format esm",
     "start": "bun dist/bin/ralph.js",
     "dev:local": "NEXT_PUBLIC_EDGE_API_BASE=http://127.0.0.1:8888 NEXT_PUBLIC_SITE_URL=http://localhost:3000 bun run dev",
@@ -57,6 +58,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.50.0",
     "@biomejs/biome": "^2.3.15",
     "@types/node": "^25.2.3",
     "@types/ws": "^8.18.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { join } from "node:path";
+import { defineConfig } from "@playwright/test";
+
+const proofOutputDir =
+  process.env.PLAYWRIGHT_PROOF_OUTPUT_DIR?.trim() || ".tmp/harness-proof";
+const proofJsonReport = process.env.PLAYWRIGHT_PROOF_JSON_REPORT?.trim();
+
+export default defineConfig({
+  testDir: "./tests/browser",
+  testMatch: /harness-proof\.spec\.ts/,
+  fullyParallel: false,
+  workers: 1,
+  timeout: 60_000,
+  reporter: proofJsonReport
+    ? [["line"], ["json", { outputFile: proofJsonReport }]]
+    : [["line"]],
+  outputDir: join(proofOutputDir, "test-results"),
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL?.trim() || "http://localhost:3000",
+    browserName: "chromium",
+    headless: true,
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+});

--- a/src/bin/harness.ts
+++ b/src/bin/harness.ts
@@ -3,15 +3,53 @@ import {
   startHarness,
   stopHarness,
 } from "../harness/manager.js";
+import { runHarnessProof } from "../harness/proof.js";
 
-type HarnessCommand = "up" | "down" | "status";
+type HarnessCommand = "up" | "down" | "status" | "proof";
 
 function parseCommand(argv: string[]): HarnessCommand {
   const command = argv[2] as HarnessCommand | undefined;
-  if (command === "up" || command === "down" || command === "status") {
+  if (
+    command === "up" ||
+    command === "down" ||
+    command === "status" ||
+    command === "proof"
+  ) {
     return command;
   }
-  throw new Error("usage: bun run src/bin/harness.ts <up|down|status>");
+  throw new Error(
+    "usage: bun run src/bin/harness.ts <up|down|status|proof> [--base-url <url>] [--output-dir <path>]",
+  );
+}
+
+function parseProofOptions(argv: string[]): {
+  baseUrl?: string;
+  outputDir?: string;
+} {
+  let baseUrl: string | undefined;
+  let outputDir: string | undefined;
+
+  for (let index = 3; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token) continue;
+    if (token === "--base-url") {
+      const value = argv[index + 1];
+      if (!value) throw new Error("--base-url requires a value");
+      baseUrl = value;
+      index += 1;
+      continue;
+    }
+    if (token === "--output-dir") {
+      const value = argv[index + 1];
+      if (!value) throw new Error("--output-dir requires a value");
+      outputDir = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`unknown proof option: ${token}`);
+  }
+
+  return { baseUrl, outputDir };
 }
 
 async function main(): Promise<void> {
@@ -22,6 +60,10 @@ async function main(): Promise<void> {
   }
   if (command === "down") {
     await stopHarness();
+    return;
+  }
+  if (command === "proof") {
+    await runHarnessProof(parseProofOptions(process.argv));
     return;
   }
   await printHarnessStatus();

--- a/src/harness/proof.ts
+++ b/src/harness/proof.ts
@@ -1,0 +1,211 @@
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import {
+  getHarnessStatus,
+  resolveWorktreeId,
+  startHarness,
+  stopHarness,
+} from "./manager.js";
+
+type HarnessProofOptions = {
+  baseUrl?: string;
+  outputDir?: string;
+};
+
+type PlaywrightReport = {
+  stats?: {
+    expected?: number;
+    unexpected?: number;
+    skipped?: number;
+    flaky?: number;
+  };
+};
+
+type HarnessProofSummary = {
+  status: "passed" | "failed";
+  baseUrl: string;
+  startedLocalHarness: boolean;
+  artifactsDir: string;
+  screenshotDir: string;
+  screenshots: string[];
+  playwrightReport: string;
+  summaryJson: string;
+  summaryMarkdown: string;
+  stats: {
+    expected: number;
+    unexpected: number;
+    skipped: number;
+    flaky: number;
+  };
+};
+
+function resolveRepoRoot(cwd = process.cwd()): string {
+  const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+    cwd,
+    encoding: "utf8",
+  });
+  return result.stdout.trim();
+}
+
+function timestampToken(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function normalizeUrl(input: string): string {
+  return input.trim().replace(/\/+$/, "");
+}
+
+function ensurePlaywrightBrowser(root: string): void {
+  const result = spawnSync("bunx", ["playwright", "install", "chromium"], {
+    cwd: root,
+    stdio: "inherit",
+  });
+  if (result.status !== 0) {
+    throw new Error("failed to install Playwright chromium browser");
+  }
+}
+
+function parsePlaywrightReport(
+  reportPath: string,
+): HarnessProofSummary["stats"] {
+  if (!existsSync(reportPath)) {
+    return {
+      expected: 0,
+      unexpected: 0,
+      skipped: 0,
+      flaky: 0,
+    };
+  }
+
+  const report = JSON.parse(
+    readFileSync(reportPath, "utf8"),
+  ) as PlaywrightReport;
+  return {
+    expected: Number(report.stats?.expected ?? 0),
+    unexpected: Number(report.stats?.unexpected ?? 0),
+    skipped: Number(report.stats?.skipped ?? 0),
+    flaky: Number(report.stats?.flaky ?? 0),
+  };
+}
+
+export async function runHarnessProof(
+  options: HarnessProofOptions = {},
+  root = resolveRepoRoot(),
+): Promise<void> {
+  const normalizedRoot = resolve(root);
+  let startedLocalHarness = false;
+  const requestedOutputDir = options.outputDir?.trim();
+
+  try {
+    let baseUrl = options.baseUrl ? normalizeUrl(options.baseUrl) : "";
+    if (!baseUrl) {
+      const initialStatus = await getHarnessStatus(normalizedRoot);
+      if (initialStatus.portalHealth !== "healthy") {
+        await startHarness(normalizedRoot);
+        startedLocalHarness = true;
+      }
+      const status = await getHarnessStatus(normalizedRoot);
+      if (
+        status.portalHealth !== "healthy" ||
+        status.portalUrl === "not-running"
+      ) {
+        throw new Error("local harness portal is not healthy");
+      }
+      baseUrl = normalizeUrl(status.portalUrl);
+    }
+
+    const artifactsDir =
+      requestedOutputDir && requestedOutputDir.length > 0
+        ? resolve(normalizedRoot, requestedOutputDir)
+        : join(
+            normalizedRoot,
+            ".tmp",
+            "harness-proof",
+            `${resolveWorktreeId(normalizedRoot)}-${timestampToken()}`,
+          );
+    const screenshotDir = join(artifactsDir, "screenshots");
+    const reportPath = join(artifactsDir, "playwright-report.json");
+    const summaryJson = join(artifactsDir, "summary.json");
+    const summaryMarkdown = join(artifactsDir, "summary.md");
+
+    mkdirSync(screenshotDir, { recursive: true });
+    ensurePlaywrightBrowser(normalizedRoot);
+
+    const result = spawnSync(
+      "bunx",
+      [
+        "playwright",
+        "test",
+        "tests/browser/harness-proof.spec.ts",
+        "--config",
+        "playwright.config.ts",
+      ],
+      {
+        cwd: normalizedRoot,
+        stdio: "inherit",
+        env: {
+          ...process.env,
+          PLAYWRIGHT_BASE_URL: baseUrl,
+          PLAYWRIGHT_PROOF_OUTPUT_DIR: artifactsDir,
+          PLAYWRIGHT_PROOF_SCREENSHOT_DIR: screenshotDir,
+          PLAYWRIGHT_PROOF_JSON_REPORT: reportPath,
+        },
+      },
+    );
+
+    const screenshots = existsSync(screenshotDir)
+      ? readdirSync(screenshotDir)
+          .filter((entry) => entry.endsWith(".png"))
+          .sort()
+          .map((entry) => join(screenshotDir, entry))
+      : [];
+    const stats = parsePlaywrightReport(reportPath);
+    const summary: HarnessProofSummary = {
+      status: result.status === 0 ? "passed" : "failed",
+      baseUrl,
+      startedLocalHarness,
+      artifactsDir,
+      screenshotDir,
+      screenshots,
+      playwrightReport: reportPath,
+      summaryJson,
+      summaryMarkdown,
+      stats,
+    };
+
+    writeFileSync(summaryJson, JSON.stringify(summary, null, 2), "utf8");
+    writeFileSync(
+      summaryMarkdown,
+      [
+        "# Browser Proof",
+        `- Status: ${summary.status}`,
+        `- Base URL: ${summary.baseUrl}`,
+        `- Started local harness: ${summary.startedLocalHarness ? "yes" : "no"}`,
+        `- Expected tests: ${summary.stats.expected}`,
+        `- Unexpected tests: ${summary.stats.unexpected}`,
+        `- Skipped tests: ${summary.stats.skipped}`,
+        `- Flaky tests: ${summary.stats.flaky}`,
+        `- Screenshot directory: ${summary.screenshotDir}`,
+        `- Playwright report: ${summary.playwrightReport}`,
+      ].join("\n"),
+      "utf8",
+    );
+
+    console.log(JSON.stringify(summary, null, 2));
+
+    if (result.status !== 0) {
+      throw new Error(`browser proof failed; see ${summaryJson}`);
+    }
+  } finally {
+    if (startedLocalHarness) {
+      await stopHarness(normalizedRoot);
+    }
+  }
+}

--- a/tests/browser/harness-proof.spec.ts
+++ b/tests/browser/harness-proof.spec.ts
@@ -1,0 +1,166 @@
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { expect, type Page, test } from "@playwright/test";
+
+const REQUEST_ID = "execreq_proof_001";
+const RECEIPT_ID = "execrcpt_proof_001";
+const SIGNATURE = "5N9B8fQ1harnessProofReceiptSignature1111111111111111111111";
+
+function screenshotPath(name: string): string | null {
+  const screenshotDir = process.env.PLAYWRIGHT_PROOF_SCREENSHOT_DIR?.trim();
+  if (!screenshotDir) return null;
+  mkdirSync(screenshotDir, { recursive: true });
+  return join(screenshotDir, name);
+}
+
+async function captureCheckpoint(page: Page, name: string): Promise<void> {
+  const path = screenshotPath(name);
+  if (!path) return;
+  await page.screenshot({ path, fullPage: true });
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.beforeEach(async ({ page }) => {
+  await page.route("**/api/x402/read/market_jupiter_quote", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: true,
+        quote: {
+          outAmount: "2000000000",
+          priceImpactPct: 0.0018,
+          routePlan: [{ swapInfo: { label: "Jupiter" } }],
+        },
+      }),
+    });
+  });
+
+  await page.route("**/api/x402/exec/submit", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: true,
+        requestId: REQUEST_ID,
+        status: {
+          state: "queued",
+          terminal: false,
+          updatedAt: "2026-03-06T20:45:00.000Z",
+        },
+      }),
+    });
+  });
+
+  await page.route("**/api/x402/exec/status/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: true,
+        requestId: REQUEST_ID,
+        status: {
+          state: "finalized",
+          terminal: true,
+          mode: "privy_execute",
+          lane: "safe",
+          actorType: "user",
+          receivedAt: "2026-03-06T20:45:00.000Z",
+          updatedAt: "2026-03-06T20:45:02.000Z",
+          terminalAt: "2026-03-06T20:45:03.000Z",
+        },
+        events: [
+          {
+            state: "queued",
+            at: "2026-03-06T20:45:00.000Z",
+            provider: "proof-harness",
+            attempt: 1,
+            note: "order accepted",
+          },
+          {
+            state: "finalized",
+            at: "2026-03-06T20:45:03.000Z",
+            provider: "proof-harness",
+            attempt: 1,
+            note: "receipt available",
+          },
+        ],
+        attempts: [
+          {
+            attempt: 1,
+            provider: "proof-harness",
+            state: "finalized",
+            at: "2026-03-06T20:45:03.000Z",
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.route("**/api/x402/exec/receipt/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: true,
+        requestId: REQUEST_ID,
+        ready: true,
+        receipt: {
+          receiptId: RECEIPT_ID,
+          provider: "proof-harness",
+          generatedAt: "2026-03-06T20:45:03.000Z",
+          outcome: {
+            status: "finalized",
+            signature: SIGNATURE,
+            networkFeeLamports: "5000",
+            errorCode: null,
+            errorMessage: null,
+          },
+        },
+      }),
+    });
+  });
+});
+
+test("login page renders", async ({ page }) => {
+  await page.goto("/login");
+  await expect(page.locator("main")).toBeVisible();
+  await expect(page.getByRole("heading").first()).toContainText(
+    /Sign in to Terminal|Sign in unavailable|Missing Privy app id/,
+  );
+  await captureCheckpoint(page, "login-page.png");
+});
+
+test("proof route exercises market render, trade validation, and receipt drilldown", async ({
+  page,
+}) => {
+  await page.goto("/proof/browser");
+
+  await expect(page.getByTestId("browser-proof-page")).toBeVisible();
+  await expect(page.getByTestId("proof-market-card")).toBeVisible();
+  await captureCheckpoint(page, "proof-home.png");
+
+  await page.getByTestId("proof-open-trade").click();
+  await expect(page.getByTestId("trade-ticket-modal")).toBeVisible();
+
+  await page.getByTestId("trade-ticket-order-type").selectOption("trigger");
+  await expect(
+    page.getByText("Trigger orders require a trigger price."),
+  ).toBeVisible();
+  await captureCheckpoint(page, "trade-validation.png");
+
+  await page.getByTestId("trade-ticket-order-type").selectOption("market");
+  await expect(page.getByText("2 SOL")).toBeVisible();
+
+  await page.getByTestId("trade-ticket-submit").click();
+  await expect(page.getByTestId("proof-trade-completion")).toContainText(
+    REQUEST_ID,
+  );
+  await captureCheckpoint(page, "trade-complete.png");
+
+  await page.getByTestId("proof-open-inspector").click();
+  await expect(page.getByTestId("execution-inspector-drawer")).toBeVisible();
+  await expect(page.getByText(RECEIPT_ID)).toBeVisible();
+  await captureCheckpoint(page, "receipt-drawer.png");
+});


### PR DESCRIPTION
## Summary\n- add a harness proof command that boots the local stack when needed and runs Playwright browser checks\n- add a deterministic browser-proof route that reuses the real terminal trade components with stubbed execution APIs\n- capture screenshots and a proof summary artifact for local and preview verification\n\n## Testing\n- bun run lint\n- bun run typecheck\n- bun run harness:proof\n\nCloses #234