### PR TITLE
[Preview Infra] Add per-PR preview deployment for portal and worker

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,0 +1,233 @@
+name: Deploy PR Preview
+
+on:
+  pull_request:
+    branches: [dev, staging, main]
+    types: [opened, synchronize, reopened, closed]
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    environment: dev
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Resolve preview config
+        id: preview
+        run: |
+          set -euo pipefail
+
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          WORKER_NAME="ralph-edge-pr-${PR_NUMBER}"
+          WORKER_HOST="${WORKER_NAME}.gui-bibeau.workers.dev"
+          WORKER_URL="https://${WORKER_HOST}"
+
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "worker_name=${WORKER_NAME}" >> "$GITHUB_OUTPUT"
+          echo "worker_host=${WORKER_HOST}" >> "$GITHUB_OUTPUT"
+          echo "worker_url=${WORKER_URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Check deployment credentials
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+
+          for secret_name in CLOUDFLARE_API_TOKEN VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
+            if [ -z "${!secret_name:-}" ]; then
+              echo "::error::Missing required secret ${secret_name} for PR preview deploys."
+              exit 1
+            fi
+          done
+
+      - name: Deploy portal preview
+        id: portal
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+
+          DEPLOY_OUTPUT="$(
+            npx --yes vercel deploy \
+              --scope guivercelpro \
+              --token "$VERCEL_TOKEN" \
+              --yes \
+              --build-env "NEXT_PUBLIC_EDGE_API_BASE=${{ steps.preview.outputs.worker_url }}" \
+              --build-env "NEXT_PUBLIC_SITE_URL=https://trader-ralph.com"
+          )"
+          DEPLOYMENT_URL="$(
+            printf '%s\n' "$DEPLOY_OUTPUT" | grep -Eo 'https://[^ ]+\.vercel\.app' | tail -n 1
+          )"
+
+          if [ -z "${DEPLOYMENT_URL}" ]; then
+            echo "Failed to parse Vercel preview URL" >&2
+            printf '%s\n' "$DEPLOY_OUTPUT" >&2
+            exit 1
+          fi
+
+          echo "portal_url=${DEPLOYMENT_URL}" >> "$GITHUB_OUTPUT"
+          echo "Preview URL: ${DEPLOYMENT_URL}"
+
+      - name: Deploy preview worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          node scripts/deploy_preview_worker.mjs \
+            --pr-number "${{ steps.preview.outputs.pr_number }}" \
+            --portal-site-url "${{ steps.portal.outputs.portal_url }}"
+
+      - name: Smoke preview stack
+        env:
+          PORTAL_URL: ${{ steps.portal.outputs.portal_url }}
+          WORKER_URL: ${{ steps.preview.outputs.worker_url }}
+          WORKER_HOST: ${{ steps.preview.outputs.worker_host }}
+        run: |
+          set -euo pipefail
+
+          retry() {
+            local attempts="$1"
+            shift
+            local delay="$1"
+            shift
+            local count=1
+            until "$@"; do
+              if [ "$count" -ge "$attempts" ]; then
+                return 1
+              fi
+              count=$((count + 1))
+              sleep "$delay"
+            done
+          }
+
+          retry 12 5 curl -fsS -o /dev/null "$PORTAL_URL"
+          retry 12 5 curl -fsS -o /dev/null "${WORKER_URL}/api/health"
+
+          for path in /api /endpoints.json /endpoints.txt /llms.txt /openapi.json /agent-registry/metadata.json; do
+            retry 12 5 curl -fsS -o /dev/null "${PORTAL_URL}${path}"
+            retry 12 5 curl -fsS -o /dev/null "${WORKER_URL}${path}"
+          done
+
+          curl -fsS "${PORTAL_URL}/endpoints.json" | grep -q "${WORKER_HOST}"
+          curl -fsS "${PORTAL_URL}/agent-registry/metadata.json" | grep -q "${WORKER_HOST}"
+          curl -fsS "${WORKER_URL}/agent-registry/metadata.json" | grep -q "${WORKER_HOST}"
+
+          tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp"' EXIT
+
+          curl -fsSL "${PORTAL_URL}/login" > "${tmp}/login.html"
+          grep -oE '/_next/static/[^" ]+\.js' "${tmp}/login.html" | sort -u > "${tmp}/scripts.txt"
+
+          if [ ! -s "${tmp}/scripts.txt" ]; then
+            echo "No Next.js JS bundle references found on ${PORTAL_URL}/login" >&2
+            exit 1
+          fi
+
+          while read -r script_path; do
+            curl -fsSL "${PORTAL_URL}${script_path}" >> "${tmp}/bundle.js"
+          done < "${tmp}/scripts.txt"
+
+          if ! grep -q "${WORKER_HOST}" "${tmp}/bundle.js"; then
+            echo "Expected preview worker host ${WORKER_HOST} not found in login bundle" >&2
+            exit 1
+          fi
+
+      - name: Write preview metadata
+        run: |
+          cat <<'JSON' > preview-metadata.json
+          {
+            "prNumber": ${{ steps.preview.outputs.pr_number }},
+            "portalUrl": "${{ steps.portal.outputs.portal_url }}",
+            "workerName": "${{ steps.preview.outputs.worker_name }}",
+            "workerUrl": "${{ steps.preview.outputs.worker_url }}"
+          }
+          JSON
+
+      - name: Upload preview metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-preview-${{ steps.preview.outputs.pr_number }}
+          path: preview-metadata.json
+
+      - name: Post preview links
+        uses: actions/github-script@v7
+        env:
+          PORTAL_URL: ${{ steps.portal.outputs.portal_url }}
+          WORKER_NAME: ${{ steps.preview.outputs.worker_name }}
+          WORKER_URL: ${{ steps.preview.outputs.worker_url }}
+        with:
+          script: |
+            const marker = "<!-- pr-preview -->";
+            const body = `${marker}
+            ## PR Preview
+            - Portal: ${process.env.PORTAL_URL}
+            - Worker: ${process.env.WORKER_URL}
+            - Worker name: \`${process.env.WORKER_NAME}\`
+            - Preview metadata artifact: \`pr-preview-${context.payload.pull_request.number}\``;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            const existing = comments.find((comment) =>
+              comment.user?.type === "Bot" && comment.body?.includes(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });
+
+  cleanup-preview:
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    environment: dev
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Delete preview worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          WORKER_NAME="ralph-edge-pr-${{ github.event.pull_request.number }}"
+          cd apps/worker
+          if ! npx wrangler delete "${WORKER_NAME}" --force; then
+            echo "::warning::Failed to delete ${WORKER_NAME}; it may have already been removed."
+          fi

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -86,6 +86,10 @@ jobs:
           echo "portal_url=${DEPLOYMENT_URL}" >> "$GITHUB_OUTPUT"
           echo "Preview URL: ${DEPLOYMENT_URL}"
 
+      - name: Install worker deps
+        working-directory: apps/worker
+        run: npm install
+
       - name: Deploy preview worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ bun run agent-registry:sync -- --lane production --step all
   - `dev` -> `dev.trader-ralph.com` and `dev.api.trader-ralph.com`
   - `staging` -> `staging.trader-ralph.com` and `staging.api.trader-ralph.com`
   - `main` -> `trader-ralph.com`, `www.trader-ralph.com`, `api.trader-ralph.com`
+- Internal pull requests also provision a Vercel portal preview and an
+  ephemeral Cloudflare worker named `ralph-edge-pr-<pr-number>`.
 - Cloudflare Worker and Vercel deploys are branch-driven in CI.
 
 ## Tests

--- a/apps/portal/app/api/_agent_registry.ts
+++ b/apps/portal/app/api/_agent_registry.ts
@@ -1,6 +1,7 @@
 import devMetadata from "../../../../docs/agent-registry/metadata.dev.json";
 import productionMetadata from "../../../../docs/agent-registry/metadata.production.json";
 import stagingMetadata from "../../../../docs/agent-registry/metadata.staging.json";
+import { buildDiscoveryUrls, toAbsoluteApiUrl } from "./_discovery";
 
 export type AgentRegistryLane = "dev" | "staging" | "production";
 
@@ -55,9 +56,20 @@ export function resolveAgentRegistryMetadata(
   generatedAt: string;
 } {
   const lane = laneFromApiOrigin(apiOrigin);
+  const discovery = buildDiscoveryUrls(apiOrigin);
   const metadata = metadataForLane(lane);
   return {
     ...metadata,
+    queryEndpoint: toAbsoluteApiUrl(apiOrigin, "/api/agent/query"),
+    openApiUrl: discovery.openapi,
+    discoveryUrls: {
+      html: discovery.html,
+      json: discovery.json,
+      text: discovery.text,
+      llms: discovery.llms,
+      skills: discovery.skills,
+      metadata: discovery.agentRegistryMetadata,
+    },
     lane,
     generatedAt: new Date().toISOString(),
   };

--- a/apps/portal/app/api/_discovery.ts
+++ b/apps/portal/app/api/_discovery.ts
@@ -43,6 +43,10 @@ function isLocalHostname(hostname: string): boolean {
   );
 }
 
+function isVercelPreviewHostname(hostname: string): boolean {
+  return hostname.endsWith(".vercel.app");
+}
+
 function mapToApiHostname(hostname: string): string {
   if (!hostname) return hostname;
   if (hostname.startsWith("api.") || hostname.includes(".api.")) {
@@ -70,9 +74,14 @@ function resolveApiOrigin(protocolRaw: string, hostRaw: string): string {
   const protocol = normalizeProtocol(protocolRaw);
   const { hostname, port } = parseHost(hostRaw);
   if (!hostname) return "";
+  const configured = configuredApiBase();
 
   if (isLocalHostname(hostname)) {
-    return configuredApiBase() || DEFAULT_LOCAL_API_ORIGIN;
+    return configured || DEFAULT_LOCAL_API_ORIGIN;
+  }
+
+  if (configured && isVercelPreviewHostname(hostname)) {
+    return configured;
   }
 
   const apiHostname = mapToApiHostname(hostname);

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -582,7 +582,7 @@ function readExecObservabilityThresholds(env: Env) {
   };
 }
 
-function resolvePortalOriginForApiHost(hostname: string): string {
+function resolvePortalOriginForApiHost(hostname: string, env: Env): string {
   const normalized = hostname.trim().toLowerCase().split(":")[0] ?? "";
   if (normalized === "dev.api.trader-ralph.com") {
     return "https://dev.trader-ralph.com";
@@ -590,15 +590,22 @@ function resolvePortalOriginForApiHost(hostname: string): string {
   if (normalized === "staging.api.trader-ralph.com") {
     return "https://staging.trader-ralph.com";
   }
+  const configured = String(env.PORTAL_SITE_URL ?? "")
+    .trim()
+    .replace(/\/+$/, "");
+  if (configured) {
+    return configured;
+  }
   return "https://www.trader-ralph.com";
 }
 
 async function proxyPortalDiscovery(
   request: Request,
   pathname: string,
+  env: Env,
 ): Promise<Response> {
   const requestUrl = new URL(request.url);
-  const portalOrigin = resolvePortalOriginForApiHost(requestUrl.host);
+  const portalOrigin = resolvePortalOriginForApiHost(requestUrl.host, env);
   const targetPath = pathname;
   const upstream = await fetch(`${portalOrigin}${targetPath}`, {
     method: "GET",
@@ -760,7 +767,7 @@ const worker = {
     const url = new URL(request.url);
     if (request.method === "GET" && DISCOVERY_DOC_PATHS.has(url.pathname)) {
       await recordEndpointCallSafe(env, request.method, url.pathname);
-      const proxied = await proxyPortalDiscovery(request, url.pathname);
+      const proxied = await proxyPortalDiscovery(request, url.pathname, env);
       return withCors(proxied, env);
     }
     if (url.pathname !== "/api" && !url.pathname.startsWith("/api/")) {

--- a/apps/worker/src/types.ts
+++ b/apps/worker/src/types.ts
@@ -54,6 +54,7 @@ export type Env = {
   LOOP_C_RECOMMENDER_DO?: DurableObjectNamespace;
   EXECUTION_COORDINATOR_DO?: DurableObjectNamespace;
   ALLOWED_ORIGINS?: string;
+  PORTAL_SITE_URL?: string;
   ADMIN_TOKEN?: string;
   PRIVY_APP_ID?: string;
   PRIVY_APP_SECRET?: string;

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -7,6 +7,7 @@ workers_dev = true
 
 [vars]
 ALLOWED_ORIGINS = "*"
+PORTAL_SITE_URL = "https://dev.trader-ralph.com"
 BILLING_MERCHANT_WALLET = "6F6A1zpGpRGmqrXpqgBFYGjC9WFo6iovrRVYoJNBHZqF"
 BILLING_RPC_ENDPOINT = "https://api.devnet.solana.com"
 HELIUS_SENDER_URL = ""
@@ -123,6 +124,7 @@ name = "ralph-edge-staging"
 
 [env.staging.vars]
 ALLOWED_ORIGINS = "*"
+PORTAL_SITE_URL = "https://staging.trader-ralph.com"
 BILLING_MERCHANT_WALLET = "6F6A1zpGpRGmqrXpqgBFYGjC9WFo6iovrRVYoJNBHZqF"
 BILLING_RPC_ENDPOINT = "https://api.mainnet-beta.solana.com"
 HELIUS_SENDER_URL = ""
@@ -220,6 +222,7 @@ name = "ralph-edge"
 
 [env.production.vars]
 ALLOWED_ORIGINS = "*"
+PORTAL_SITE_URL = "https://www.trader-ralph.com"
 BILLING_MERCHANT_WALLET = "6F6A1zpGpRGmqrXpqgBFYGjC9WFo6iovrRVYoJNBHZqF"
 BILLING_RPC_ENDPOINT = "https://api.mainnet-beta.solana.com"
 HELIUS_SENDER_URL = ""

--- a/scripts/deploy_preview_worker.mjs
+++ b/scripts/deploy_preview_worker.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function parseArgs(argv) {
+  let prNumber = "";
+  let portalSiteUrl = "";
+  let dryRun = false;
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--pr-number") {
+      prNumber = String(argv[index + 1] ?? "").trim();
+      index += 1;
+      continue;
+    }
+    if (token === "--portal-site-url") {
+      portalSiteUrl = String(argv[index + 1] ?? "").trim();
+      index += 1;
+      continue;
+    }
+    if (token === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    throw new Error(`unknown argument: ${token}`);
+  }
+
+  if (!/^\d+$/.test(prNumber)) {
+    throw new Error("--pr-number must be a pull request number");
+  }
+
+  if (!portalSiteUrl) {
+    throw new Error("--portal-site-url is required");
+  }
+
+  return {
+    previewName: `ralph-edge-pr-${prNumber}`,
+    portalSiteUrl: portalSiteUrl.replace(/\/+$/, ""),
+    dryRun,
+  };
+}
+
+function firstHeaderIndex(lines) {
+  const index = lines.findIndex((line) => line.trim().startsWith("["));
+  if (index < 0) {
+    throw new Error("failed to find the first TOML section header");
+  }
+  return index;
+}
+
+function collectSection(lines, header) {
+  const index = lines.findIndex((line) => line.trim() === header);
+  if (index < 0) {
+    throw new Error(`missing section ${header} in wrangler.toml`);
+  }
+  const block = [lines[index]];
+  for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+    const line = lines[cursor];
+    if (line.trim().startsWith("[")) break;
+    block.push(line);
+  }
+  return block.join("\n").trimEnd();
+}
+
+function collectSections(lines, header) {
+  const sections = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    if (lines[index].trim() !== header) continue;
+    const block = [lines[index]];
+    for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+      const line = lines[cursor];
+      if (line.trim().startsWith("[")) break;
+      block.push(line);
+      index = cursor;
+    }
+    sections.push(block.join("\n").trimEnd());
+  }
+  if (sections.length < 1) {
+    throw new Error(`missing repeated section ${header} in wrangler.toml`);
+  }
+  return sections;
+}
+
+function renameSectionHeader(section, fromHeader, toHeader) {
+  const [firstLine, ...rest] = section.split("\n");
+  if (firstLine.trim() !== fromHeader) {
+    throw new Error(`expected section ${fromHeader}`);
+  }
+  return [toHeader, ...rest].join("\n");
+}
+
+function upsertStringVar(section, key, value) {
+  const lines = section.split("\n");
+  const pattern = new RegExp(`^${key}\\s*=`);
+  const replacement = `${key} = ${JSON.stringify(value)}`;
+
+  for (let index = 1; index < lines.length; index += 1) {
+    if (pattern.test(lines[index].trim())) {
+      lines[index] = replacement;
+      return lines.join("\n");
+    }
+  }
+
+  lines.push(replacement);
+  return lines.join("\n");
+}
+
+function rewriteSectionPath(section, key, value) {
+  return section
+    .split("\n")
+    .map((line) =>
+      line.trim().startsWith(`${key} =`)
+        ? `${key} = ${JSON.stringify(value)}`
+        : line,
+    )
+    .join("\n");
+}
+
+function buildPreviewConfig(source, previewName, portalSiteUrl, workerRoot) {
+  const lines = source.replace(/\r\n/g, "\n").split("\n");
+  const topLevel = lines.slice(0, firstHeaderIndex(lines)).map((line) => {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("name =")) {
+      return `name = ${JSON.stringify(previewName)}`;
+    }
+    if (trimmed.startsWith("main =")) {
+      return `main = ${JSON.stringify(join(workerRoot, "src", "index.ts"))}`;
+    }
+    if (trimmed.startsWith("workers_dev =")) {
+      return "workers_dev = true";
+    }
+    return line;
+  });
+
+  const vars = upsertStringVar(
+    renameSectionHeader(
+      collectSection(lines, "[env.production.vars]"),
+      "[env.production.vars]",
+      "[vars]",
+    ),
+    "PORTAL_SITE_URL",
+    portalSiteUrl,
+  );
+  const durableObjects = collectSections(lines, "[[durable_objects.bindings]]");
+  const kvNamespaces = collectSections(
+    lines,
+    "[[env.production.kv_namespaces]]",
+  ).map((section) =>
+    renameSectionHeader(
+      section,
+      "[[env.production.kv_namespaces]]",
+      "[[kv_namespaces]]",
+    ),
+  );
+  const d1Databases = collectSections(
+    lines,
+    "[[env.production.d1_databases]]",
+  ).map((section) =>
+    rewriteSectionPath(
+      renameSectionHeader(
+        section,
+        "[[env.production.d1_databases]]",
+        "[[d1_databases]]",
+      ),
+      "migrations_dir",
+      join(workerRoot, "migrations"),
+    ),
+  );
+  const r2Buckets = collectSections(lines, "[[env.production.r2_buckets]]").map(
+    (section) =>
+      renameSectionHeader(
+        section,
+        "[[env.production.r2_buckets]]",
+        "[[r2_buckets]]",
+      ),
+  );
+  const migrations = collectSections(lines, "[[migrations]]");
+
+  return [
+    topLevel.join("\n").trimEnd(),
+    vars,
+    ...durableObjects,
+    ...kvNamespaces,
+    ...d1Databases,
+    ...r2Buckets,
+    ...migrations,
+  ]
+    .filter(Boolean)
+    .join("\n\n")
+    .concat("\n");
+}
+
+function main() {
+  const { previewName, portalSiteUrl, dryRun } = parseArgs(process.argv);
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const workerRoot = join(repoRoot, "apps", "worker");
+  const wranglerSource = readFileSync(
+    join(workerRoot, "wrangler.toml"),
+    "utf8",
+  );
+  const previewConfig = buildPreviewConfig(
+    wranglerSource,
+    previewName,
+    portalSiteUrl,
+    workerRoot,
+  );
+  const tmpDir = mkdtempSync(join(workerRoot, ".wrangler-preview-"));
+  const previewConfigPath = join(tmpDir, "wrangler.preview.toml");
+
+  writeFileSync(previewConfigPath, previewConfig, "utf8");
+
+  try {
+    const args = ["wrangler", "deploy", "--config", previewConfigPath];
+    if (dryRun) args.push("--dry-run");
+    const result = spawnSync("npx", args, {
+      cwd: workerRoot,
+      stdio: "inherit",
+    });
+    if (result.status !== 0) {
+      process.exit(result.status ?? 1);
+    }
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+main();

--- a/scripts/deploy_preview_worker.mjs
+++ b/scripts/deploy_preview_worker.mjs
@@ -85,14 +85,6 @@ function collectSections(lines, header) {
   return sections;
 }
 
-function renameSectionHeader(section, fromHeader, toHeader) {
-  const [firstLine, ...rest] = section.split("\n");
-  if (firstLine.trim() !== fromHeader) {
-    throw new Error(`expected section ${fromHeader}`);
-  }
-  return [toHeader, ...rest].join("\n");
-}
-
 function upsertStringVar(section, key, value) {
   const lines = section.split("\n");
   const pattern = new RegExp(`^${key}\\s*=`);
@@ -137,47 +129,21 @@ function buildPreviewConfig(source, previewName, portalSiteUrl, workerRoot) {
   });
 
   const vars = upsertStringVar(
-    renameSectionHeader(
-      collectSection(lines, "[env.production.vars]"),
-      "[env.production.vars]",
-      "[vars]",
-    ),
+    collectSection(lines, "[vars]"),
     "PORTAL_SITE_URL",
     portalSiteUrl,
   );
   const durableObjects = collectSections(lines, "[[durable_objects.bindings]]");
-  const kvNamespaces = collectSections(
-    lines,
-    "[[env.production.kv_namespaces]]",
-  ).map((section) =>
-    renameSectionHeader(
-      section,
-      "[[env.production.kv_namespaces]]",
-      "[[kv_namespaces]]",
-    ),
-  );
-  const d1Databases = collectSections(
-    lines,
-    "[[env.production.d1_databases]]",
-  ).map((section) =>
-    rewriteSectionPath(
-      renameSectionHeader(
-        section,
-        "[[env.production.d1_databases]]",
-        "[[d1_databases]]",
-      ),
-      "migrations_dir",
-      join(workerRoot, "migrations"),
-    ),
-  );
-  const r2Buckets = collectSections(lines, "[[env.production.r2_buckets]]").map(
+  const kvNamespaces = collectSections(lines, "[[kv_namespaces]]");
+  const d1Databases = collectSections(lines, "[[d1_databases]]").map(
     (section) =>
-      renameSectionHeader(
+      rewriteSectionPath(
         section,
-        "[[env.production.r2_buckets]]",
-        "[[r2_buckets]]",
+        "migrations_dir",
+        join(workerRoot, "migrations"),
       ),
   );
+  const r2Buckets = collectSections(lines, "[[r2_buckets]]");
   const migrations = collectSections(lines, "[[migrations]]");
 
   return [

--- a/tests/unit/portal_agent_registry_metadata_routes.test.ts
+++ b/tests/unit/portal_agent_registry_metadata_routes.test.ts
@@ -50,4 +50,32 @@ describe("portal agent registry metadata routes", () => {
     >;
     expect(aliasPayload.lane).toBe("production");
   });
+
+  test("serves preview metadata against the configured preview worker host", async () => {
+    const originalEdgeApiBase = process.env.NEXT_PUBLIC_EDGE_API_BASE;
+    process.env.NEXT_PUBLIC_EDGE_API_BASE =
+      "https://ralph-edge-pr-235.gui-bibeau.workers.dev";
+
+    try {
+      const response = getMetadata(
+        new Request(
+          "https://serious-trader-ralph-git-codex-issue-235-preview-guivercelpro.vercel.app/agent-registry/metadata.json",
+        ),
+      );
+      expect(response.status).toBe(200);
+      const payload = (await response.json()) as Record<string, unknown>;
+      expect(payload.lane).toBe("production");
+      expect(String(payload.queryEndpoint)).toBe(
+        "https://ralph-edge-pr-235.gui-bibeau.workers.dev/api/agent/query",
+      );
+      expect(String(payload.openApiUrl)).toBe(
+        "https://ralph-edge-pr-235.gui-bibeau.workers.dev/openapi.json",
+      );
+      expect(String(payload.metadataUrl)).toBe(
+        "https://ralph-edge-pr-235.gui-bibeau.workers.dev/agent-registry/metadata.json",
+      );
+    } finally {
+      process.env.NEXT_PUBLIC_EDGE_API_BASE = originalEdgeApiBase;
+    }
+  });
 });

--- a/tests/unit/portal_api_catalog_routes.test.ts
+++ b/tests/unit/portal_api_catalog_routes.test.ts
@@ -155,4 +155,37 @@ describe("portal x402 api catalog routes", () => {
     expect(body.includes("API origin: https://portal.example")).toBe(true);
     expect(body.includes("https://portal.example/openapi.json")).toBe(true);
   });
+
+  test("GET /api/endpoints.json uses the preview worker host on Vercel previews", async () => {
+    const originalEdgeApiBase = process.env.NEXT_PUBLIC_EDGE_API_BASE;
+    process.env.NEXT_PUBLIC_EDGE_API_BASE =
+      "https://ralph-edge-pr-235.gui-bibeau.workers.dev";
+
+    try {
+      const response = getJsonCatalog(
+        new Request(
+          "https://serious-trader-ralph-git-codex-issue-235-preview-guivercelpro.vercel.app/api/endpoints.json",
+        ),
+      );
+      expect(response.status).toBe(200);
+
+      const payload = (await response.json()) as Record<string, unknown>;
+      const runtime = toRecord(payload.runtime);
+      expect(runtime).not.toBeNull();
+      expect(String(runtime?.apiOrigin)).toBe(
+        "https://ralph-edge-pr-235.gui-bibeau.workers.dev",
+      );
+
+      const discovery = toRecord(payload.discovery);
+      expect(discovery).not.toBeNull();
+      expect(String(discovery?.openapi)).toBe(
+        "https://ralph-edge-pr-235.gui-bibeau.workers.dev/openapi.json",
+      );
+      expect(String(discovery?.agentRegistryMetadata)).toBe(
+        "https://ralph-edge-pr-235.gui-bibeau.workers.dev/agent-registry/metadata.json",
+      );
+    } finally {
+      process.env.NEXT_PUBLIC_EDGE_API_BASE = originalEdgeApiBase;
+    }
+  });
 });

--- a/tests/unit/worker_discovery_proxy_routes.test.ts
+++ b/tests/unit/worker_discovery_proxy_routes.test.ts
@@ -75,4 +75,39 @@ describe("worker discovery proxy routes", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  test("proxies preview-worker discovery docs to the configured preview portal", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      expect(url).toBe(
+        "https://serious-trader-ralph-git-codex-issue-235-preview-guivercelpro.vercel.app/openapi.json",
+      );
+      return new Response('{"preview":true}', {
+        status: 200,
+        headers: {
+          "content-type": "application/json; charset=utf-8",
+        },
+      });
+    }) as typeof fetch;
+
+    try {
+      const response = await worker.fetch(
+        new Request(
+          "https://ralph-edge-pr-235.gui-bibeau.workers.dev/openapi.json",
+        ),
+        {
+          ...env,
+          PORTAL_SITE_URL:
+            "https://serious-trader-ralph-git-codex-issue-235-preview-guivercelpro.vercel.app",
+        },
+        createExecutionContextStub(),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.preview).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });


### PR DESCRIPTION
## Summary\n- deploy internal PRs to a Vercel preview that is built against a matching ephemeral Cloudflare worker\n- generate a preview worker config from the production worker bindings so previews expose the right health and discovery surfaces\n- smoke the preview stack, upload preview metadata, and post sticky preview links back to the PR\n\n## Testing\n- bun run lint\n- bun run typecheck\n- bun test tests/unit/worker_discovery_proxy_routes.test.ts tests/unit/portal_agent_registry_metadata_routes.test.ts tests/unit/portal_api_catalog_routes.test.ts\n- node scripts/deploy_preview_worker.mjs --pr-number 235 --portal-site-url https://example.com --dry-run\n- node scripts/deploy_preview_worker.mjs --pr-number 99999 --portal-site-url https://example.com\n- cd apps/worker && npx wrangler delete ralph-edge-pr-99999 --force\n\nCloses #235