### PR TITLE
Add production ops control plane and rollback automation

### DIFF
--- a/.github/workflows/ops-dashboard.yml
+++ b/.github/workflows/ops-dashboard.yml
@@ -1,0 +1,88 @@
+name: Ops Dashboard
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */6 * * *'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dashboard:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.0'
+
+      - name: Install deps
+        run: bun install
+
+      - name: Check admin credentials
+        env:
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ADMIN_TOKEN:-}" ]; then
+            echo "::error::Missing required secret ADMIN_TOKEN for ops dashboard."
+            exit 1
+          fi
+
+      - name: Fetch production ops data
+        env:
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p .tmp/ops-dashboard
+
+          curl -fsS \
+            -H "authorization: Bearer ${ADMIN_TOKEN}" \
+            "https://api.trader-ralph.com/api/admin/execution/observability?windowMinutes=360&maxRequests=10000" \
+            > .tmp/ops-dashboard/execution.json
+
+          curl -fsS \
+            -H "authorization: Bearer ${ADMIN_TOKEN}" \
+            "https://api.trader-ralph.com/api/admin/execution/canary" \
+            > .tmp/ops-dashboard/canary.json
+
+          curl -fsS \
+            -H "authorization: Bearer ${ADMIN_TOKEN}" \
+            "https://api.trader-ralph.com/api/admin/ops/controls" \
+            > .tmp/ops-dashboard/controls-envelope.json
+
+          jq '.controls' .tmp/ops-dashboard/controls-envelope.json > .tmp/ops-dashboard/controls.json
+
+      - name: Build ops dashboard
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          args=(
+            --execution .tmp/ops-dashboard/execution.json
+            --canary .tmp/ops-dashboard/canary.json
+            --controls .tmp/ops-dashboard/controls.json
+            --output-json .tmp/ops-dashboard/dashboard.json
+            --output-markdown .tmp/ops-dashboard/dashboard.md
+          )
+
+          if [ -f .harness/runner-heartbeat.json ]; then
+            args+=(--runner-heartbeat .harness/runner-heartbeat.json)
+          fi
+
+          bun run src/bin/ops_dashboard.ts "${args[@]}"
+          cat .tmp/ops-dashboard/dashboard.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload ops dashboard artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ops-dashboard-${{ github.run_id }}
+          path: .tmp/ops-dashboard
+          if-no-files-found: error

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -1,0 +1,196 @@
+name: Rollback Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: Why the rollback is being triggered
+        required: true
+        type: string
+      target_sha:
+        description: Optional commit SHA to redeploy instead of previous main
+        required: false
+        type: string
+      pr_number:
+        description: Optional PR number to comment with rollback results
+        required: false
+        type: string
+      dry_run:
+        description: Resolve and report the rollback target without deploying
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.0'
+
+      - name: Resolve rollback target
+        id: target
+        run: |
+          set -euo pipefail
+
+          git fetch origin main --depth=2
+          PREVIOUS_MAIN_SHA="$(git rev-parse origin/main^)"
+          TARGET_SHA="${{ inputs.target_sha }}"
+
+          if [ -z "${TARGET_SHA}" ]; then
+            TARGET_SHA="${PREVIOUS_MAIN_SHA}"
+          fi
+
+          git cat-file -e "${TARGET_SHA}^{commit}"
+          echo "target_sha=${TARGET_SHA}" >> "$GITHUB_OUTPUT"
+          echo "previous_main_sha=${PREVIOUS_MAIN_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Check production deploy credentials
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+
+          for secret_name in CLOUDFLARE_API_TOKEN VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
+            if [ -z "${!secret_name:-}" ]; then
+              echo "::error::Missing required secret ${secret_name} for production rollback."
+              exit 1
+            fi
+          done
+
+      - name: Install deps
+        run: bun install
+
+      - name: Perform rollback deploy
+        id: rollback
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          TARGET_SHA: ${{ steps.target.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p .tmp/rollback
+
+          if [ "${DRY_RUN}" = "true" ]; then
+            echo "Dry-run only; skipping production deploy."
+            exit 0
+          fi
+
+          git checkout "${TARGET_SHA}"
+
+          cd apps/worker
+          npm install
+          npx wrangler deploy --env production
+          cd ../..
+
+          DEPLOY_OUTPUT="$(
+            npx --yes vercel deploy \
+              --scope guivercelpro \
+              --token "$VERCEL_TOKEN" \
+              --prod \
+              --yes \
+              --build-env "NEXT_PUBLIC_EDGE_API_BASE=https://api.trader-ralph.com" \
+              --build-env "NEXT_PUBLIC_SITE_URL=https://trader-ralph.com"
+          )"
+
+          DEPLOYMENT_URL="$(
+            printf '%s\n' "$DEPLOY_OUTPUT" | grep -Eo 'https://[^ ]+\.vercel\.app' | tail -n 1
+          )"
+
+          if [ -z "${DEPLOYMENT_URL}" ]; then
+            echo "Failed to parse Vercel deployment URL during rollback" >&2
+            printf '%s\n' "$DEPLOY_OUTPUT" >&2
+            exit 1
+          fi
+
+          for domain in trader-ralph.com www.trader-ralph.com api.trader-ralph.com; do
+            npx --yes vercel alias set "${DEPLOYMENT_URL}" "$domain" --scope guivercelpro --token "$VERCEL_TOKEN"
+          done
+
+          curl -fsS -o /dev/null "https://trader-ralph.com"
+          curl -fsS -o /dev/null "https://api.trader-ralph.com/api/health"
+          curl -fsS -o /dev/null "https://api.trader-ralph.com/openapi.json"
+
+      - name: Write rollback summary
+        if: always()
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          ROLLBACK_OUTCOME: ${{ steps.rollback.outcome }}
+          TARGET_SHA: ${{ steps.target.outputs.target_sha }}
+          PREVIOUS_MAIN_SHA: ${{ steps.target.outputs.previous_main_sha }}
+          REASON: ${{ inputs.reason }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p .tmp/rollback
+          STATUS="failed"
+          if [ "${DRY_RUN}" = "true" ]; then
+            STATUS="dry-run"
+          elif [ "${ROLLBACK_OUTCOME}" = "success" ]; then
+            STATUS="success"
+          fi
+
+          bun run src/bin/rollback_summary.ts \
+            --output .tmp/rollback/summary.md \
+            --target-sha "${TARGET_SHA}" \
+            --previous-main-sha "${PREVIOUS_MAIN_SHA}" \
+            --portal-url "https://trader-ralph.com" \
+            --api-url "https://api.trader-ralph.com" \
+            --status "${STATUS}" \
+            --reason "${REASON}"
+
+          cat .tmp/rollback/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload rollback summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-rollback-${{ github.run_id }}
+          path: .tmp/rollback
+          if-no-files-found: error
+
+      - name: Post rollback result to PR
+        if: always() && inputs.pr_number != ''
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+        with:
+          script: |
+            const fs = require("fs");
+            const body = fs.readFileSync(".tmp/rollback/summary.md", "utf8");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.PR_NUMBER),
+              body,
+            });
+
+      - name: Fail when rollback deploy fails
+        if: ${{ inputs.dry_run == false && steps.rollback.outcome != 'success' }}
+        run: |
+          set -euo pipefail
+          echo "::error::Production rollback failed."
+          exit 1

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -93,20 +93,24 @@ jobs:
           set -euo pipefail
 
           mkdir -p .tmp/rollback
+          TARGET_DIR=".tmp/rollback/target"
+          rm -rf "${TARGET_DIR}"
 
           if [ "${DRY_RUN}" = "true" ]; then
             echo "Dry-run only; skipping production deploy."
             exit 0
           fi
 
-          git checkout "${TARGET_SHA}"
+          git worktree add --detach "${TARGET_DIR}" "${TARGET_SHA}"
+          trap 'git worktree remove --force "${TARGET_DIR}"' EXIT
 
-          cd apps/worker
+          cd "${TARGET_DIR}/apps/worker"
           npm install
           npx wrangler deploy --env production
-          cd ../..
+          cd ../../..
 
           DEPLOY_OUTPUT="$(
+            cd "${TARGET_DIR}" && \
             npx --yes vercel deploy \
               --scope guivercelpro \
               --token "$VERCEL_TOKEN" \

--- a/apps/worker/src/execution/canary.ts
+++ b/apps/worker/src/execution/canary.ts
@@ -1,6 +1,10 @@
 import { SOL_MINT, USDC_MINT } from "../defaults";
 import type { JupiterQuoteResponse } from "../jupiter";
 import { JupiterClient } from "../jupiter";
+import {
+  executionLaneRuntimeControlsFromSnapshot,
+  readOpsControlSnapshot,
+} from "../ops_controls";
 import { enforcePolicy, normalizePolicy } from "../policy";
 import { createPrivySolanaWallet, getPrivyWalletAddressById } from "../privy";
 import { SolanaRpc } from "../solana_rpc";
@@ -604,6 +608,7 @@ export async function runExecutionCanary(input: {
   const { env, triggerSource } = input;
   const config = readExecutionCanaryConfig(env);
   const state = await getExecutionCanaryState(env.WAITLIST_DB);
+  const opsControls = await readOpsControlSnapshot(env);
 
   if (!config.enabled) {
     return {
@@ -613,6 +618,18 @@ export async function runExecutionCanary(input: {
       run: null,
       state,
       error: "execution-canary-disabled-by-config",
+    };
+  }
+  if (!opsControls.canary.enabled) {
+    return {
+      ok: false,
+      status: "disabled",
+      triggerSource,
+      run: null,
+      state,
+      error:
+        opsControls.canary.disabledReason ??
+        "execution-canary-disabled-by-operator",
     };
   }
   if (state?.disabled) {
@@ -669,6 +686,7 @@ export async function runExecutionCanary(input: {
     requestedLane: "safe",
     mode: "privy_execute",
     actorType: "api_key_actor",
+    runtimeControls: executionLaneRuntimeControlsFromSnapshot(opsControls),
   });
   if (!laneResolution.ok) {
     return await finalizeCanaryRun(env, {

--- a/apps/worker/src/execution/lane_resolver.ts
+++ b/apps/worker/src/execution/lane_resolver.ts
@@ -1,3 +1,4 @@
+import type { ExecutionLaneRuntimeControls } from "../ops_controls";
 import type { Env } from "../types";
 import type {
   ExecutionActorType,
@@ -62,18 +63,41 @@ export type ExecutionLaneRoutingConfig = {
   adapters: Record<ExecutionLane, string>;
   enabled: Record<ExecutionLane, boolean>;
   allowAnonymousSafe: boolean;
+  mappedBy: "env" | "ops-control";
+  executionEnabled: boolean;
+  executionDisabledReason: string | null;
 };
 
 export function readExecutionLaneRoutingConfig(
   env: Env,
+  runtimeControls?: ExecutionLaneRuntimeControls,
 ): ExecutionLaneRoutingConfig {
+  const envEnabled = resolveLaneEnabledFlags(env);
+  const globalExecutionEnabled = runtimeControls?.executionEnabled ?? true;
+  const laneEnabledOverrides = runtimeControls?.laneEnabledOverrides ?? {};
   return {
     adapters: resolveLaneAdapters(env),
-    enabled: resolveLaneEnabledFlags(env),
+    enabled: {
+      fast:
+        globalExecutionEnabled &&
+        envEnabled.fast &&
+        (laneEnabledOverrides.fast ?? true),
+      protected:
+        globalExecutionEnabled &&
+        envEnabled.protected &&
+        (laneEnabledOverrides.protected ?? true),
+      safe:
+        globalExecutionEnabled &&
+        envEnabled.safe &&
+        (laneEnabledOverrides.safe ?? true),
+    },
     allowAnonymousSafe: readBooleanFlag(
       env.EXEC_LANE_SAFE_ALLOW_ANONYMOUS,
       false,
     ),
+    mappedBy: runtimeControls?.mappedBy ?? "env",
+    executionEnabled: globalExecutionEnabled,
+    executionDisabledReason: runtimeControls?.executionDisabledReason ?? null,
   };
 }
 
@@ -95,14 +119,24 @@ export function resolveExecutionLane(input: {
   requestedLane: ExecutionLane;
   mode: ExecutionMode;
   actorType: ExecutionActorType;
+  runtimeControls?: ExecutionLaneRuntimeControls;
 }): LaneResolveResult {
-  const routing = readExecutionLaneRoutingConfig(input.env);
+  const routing = readExecutionLaneRoutingConfig(
+    input.env,
+    input.runtimeControls,
+  );
 
   if (!routing.enabled[input.requestedLane]) {
+    const reason =
+      !routing.executionEnabled && routing.executionDisabledReason
+        ? routing.executionDisabledReason
+        : !routing.executionEnabled
+          ? "execution-disabled-by-operator"
+          : "lane-disabled-by-operator";
     return {
       ok: false,
       error: "unsupported-lane",
-      reason: "lane-disabled-by-operator",
+      reason,
     };
   }
 
@@ -132,7 +166,8 @@ export function resolveExecutionLane(input: {
       adapter: routing.adapters[input.requestedLane],
       requestedByMode: input.mode,
       requestedByActor: input.actorType,
-      mappedBy: "env",
+      mappedBy: routing.mappedBy,
+      executionEnabled: routing.executionEnabled,
     },
   };
 }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -115,6 +115,13 @@ import {
 } from "./macro_sources";
 import { computeMarketIndicators } from "./market_indicators";
 import {
+  executionLaneRuntimeControlsFromSnapshot,
+  type OpsControlPatch,
+  readOpsControlSnapshot,
+  resetOpsControlSnapshot,
+  writeOpsControlSnapshot,
+} from "./ops_controls";
+import {
   fetchPerpsFundingSurface,
   fetchPerpsOpenInterestSurface,
   fetchPerpsVenueScore,
@@ -333,6 +340,11 @@ function readNumberEnv(
   return Math.min(max, Math.max(min, parsed));
 }
 
+function readOptionalString(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return normalized ? normalized : null;
+}
+
 function parsePositiveIntParam(
   raw: string | null,
   fallback: number,
@@ -346,6 +358,65 @@ function parsePositiveIntParam(
 
 function shouldSyncExecutePrivySubmit(env: Env): boolean {
   return readBooleanEnv(env.EXEC_PRIVY_SYNC_SUBMIT_ENABLED, false);
+}
+
+function parseOpsControlPatch(
+  value: unknown,
+): OpsControlPatch | { error: string } {
+  if (!isRecord(value)) {
+    return { error: "invalid-ops-control-payload" };
+  }
+
+  const patch: OpsControlPatch = {
+    updatedBy: readOptionalString(value.updatedBy) ?? "admin-route",
+  };
+
+  if (isRecord(value.execution)) {
+    patch.execution = {};
+    if (value.execution.enabled !== undefined) {
+      patch.execution.enabled = readBooleanEnv(value.execution.enabled, true);
+    }
+    if (value.execution.disabledReason !== undefined) {
+      patch.execution.disabledReason = readOptionalString(
+        value.execution.disabledReason,
+      );
+    }
+    if (isRecord(value.execution.lanes)) {
+      patch.execution.lanes = {};
+      if (value.execution.lanes.fast !== undefined) {
+        patch.execution.lanes.fast = readBooleanEnv(
+          value.execution.lanes.fast,
+          true,
+        );
+      }
+      if (value.execution.lanes.protected !== undefined) {
+        patch.execution.lanes.protected = readBooleanEnv(
+          value.execution.lanes.protected,
+          true,
+        );
+      }
+      if (value.execution.lanes.safe !== undefined) {
+        patch.execution.lanes.safe = readBooleanEnv(
+          value.execution.lanes.safe,
+          true,
+        );
+      }
+    }
+  }
+
+  if (isRecord(value.canary)) {
+    patch.canary = {};
+    if (value.canary.enabled !== undefined) {
+      patch.canary.enabled = readBooleanEnv(value.canary.enabled, true);
+    }
+    if (value.canary.disabledReason !== undefined) {
+      patch.canary.disabledReason = readOptionalString(
+        value.canary.disabledReason,
+      );
+    }
+  }
+
+  return patch;
 }
 
 function newExecutionAttemptId(): string {
@@ -801,7 +872,11 @@ const worker = {
         url.pathname === "/api/x402/exec/health"
       ) {
         const loopAHealth = await readLoopAHealthFromKv(env);
-        const routing = readExecutionLaneRoutingConfig(env);
+        const opsControls = await readOpsControlSnapshot(env);
+        const routing = readExecutionLaneRoutingConfig(
+          env,
+          executionLaneRuntimeControlsFromSnapshot(opsControls),
+        );
         const hasLaneOnline =
           routing.enabled.fast ||
           routing.enabled.protected ||
@@ -814,6 +889,9 @@ const worker = {
               ok: true,
             },
             loopA: loopAHealth ?? null,
+            controls: {
+              execution: opsControls.execution,
+            },
             lanes: {
               fast: {
                 enabled: routing.enabled.fast,
@@ -1046,6 +1124,9 @@ const worker = {
           requestedLane: parsed.value.lane,
           mode: parsed.value.mode,
           actorType,
+          runtimeControls: executionLaneRuntimeControlsFromSnapshot(
+            await readOpsControlSnapshot(env),
+          ),
         });
         if (!laneResolution.ok) {
           return withCors(
@@ -1901,6 +1982,147 @@ const worker = {
             : "manual";
         return withCors(
           json(await runExecutionCanary({ env, triggerSource })),
+          env,
+        );
+      }
+
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/admin/ops/controls"
+      ) {
+        const auth = authorizeAdminRoute(request, env);
+        if (!auth.ok) {
+          return withCors(
+            json({ ok: false, error: auth.error }, { status: auth.status }),
+            env,
+          );
+        }
+        return withCors(
+          json({
+            ok: true,
+            controls: await readOpsControlSnapshot(env),
+          }),
+          env,
+        );
+      }
+
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/admin/ops/controls"
+      ) {
+        const auth = authorizeAdminRoute(request, env);
+        if (!auth.ok) {
+          return withCors(
+            json({ ok: false, error: auth.error }, { status: auth.status }),
+            env,
+          );
+        }
+        const payload = (await request.json().catch(() => null)) as unknown;
+        const parsedPatch = parseOpsControlPatch(payload);
+        if ("error" in parsedPatch) {
+          return withCors(
+            json({ ok: false, error: parsedPatch.error }, { status: 400 }),
+            env,
+          );
+        }
+        try {
+          const controls = await writeOpsControlSnapshot(env, parsedPatch);
+          return withCors(json({ ok: true, controls }), env);
+        } catch (error) {
+          return withCors(
+            json(
+              {
+                ok: false,
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "ops-control-write-failed",
+              },
+              { status: 503 },
+            ),
+            env,
+          );
+        }
+      }
+
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/admin/ops/controls/reset"
+      ) {
+        const auth = authorizeAdminRoute(request, env);
+        if (!auth.ok) {
+          return withCors(
+            json({ ok: false, error: auth.error }, { status: auth.status }),
+            env,
+          );
+        }
+        try {
+          const controls = await resetOpsControlSnapshot(env, "admin-reset");
+          return withCors(json({ ok: true, controls }), env);
+        } catch (error) {
+          return withCors(
+            json(
+              {
+                ok: false,
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "ops-control-reset-failed",
+              },
+              { status: 503 },
+            ),
+            env,
+          );
+        }
+      }
+
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/admin/ops/dashboard"
+      ) {
+        const auth = authorizeAdminRoute(request, env);
+        if (!auth.ok) {
+          return withCors(
+            json({ ok: false, error: auth.error }, { status: auth.status }),
+            env,
+          );
+        }
+        const defaultWindowMinutes = Math.floor(
+          readNumberEnv(env.EXEC_OBS_DEFAULT_WINDOW_MINUTES, 60, 5, 10_080),
+        );
+        const defaultMaxRequests = Math.floor(
+          readNumberEnv(env.EXEC_OBS_MAX_REQUESTS, 5_000, 100, 20_000),
+        );
+        const windowMinutes = parsePositiveIntParam(
+          url.searchParams.get("windowMinutes"),
+          defaultWindowMinutes,
+          5,
+          10_080,
+        );
+        const maxRequests = parsePositiveIntParam(
+          url.searchParams.get("maxRequests"),
+          defaultMaxRequests,
+          100,
+          20_000,
+        );
+        const [controls, execution, canary] = await Promise.all([
+          readOpsControlSnapshot(env),
+          readExecutionObservabilitySnapshot({
+            db: env.WAITLIST_DB,
+            windowMinutes,
+            maxRequests,
+            thresholds: readExecObservabilityThresholds(env),
+          }),
+          readExecutionCanarySnapshot(env),
+        ]);
+        return withCors(
+          json({
+            ok: true,
+            now: new Date().toISOString(),
+            controls,
+            execution,
+            canary,
+          }),
           env,
         );
       }

--- a/apps/worker/src/ops_controls.ts
+++ b/apps/worker/src/ops_controls.ts
@@ -1,0 +1,253 @@
+import type { ExecutionLane } from "./execution/repository";
+import type { Env } from "./types";
+
+const OPS_CONTROL_KV_KEY = "ops:controls:v1";
+const EXECUTION_LANES: ExecutionLane[] = ["fast", "protected", "safe"];
+
+type OpsControlJson = Record<string, unknown>;
+
+export type OpsControlSnapshot = {
+  schemaVersion: "v1";
+  execution: {
+    enabled: boolean;
+    disabledReason: string | null;
+    lanes: Record<ExecutionLane, boolean>;
+  };
+  canary: {
+    enabled: boolean;
+    disabledReason: string | null;
+  };
+  metadata: {
+    source: "default" | "kv";
+    updatedAt: string | null;
+    updatedBy: string | null;
+  };
+};
+
+export type OpsControlPatch = {
+  execution?: {
+    enabled?: boolean;
+    disabledReason?: string | null;
+    lanes?: Partial<Record<ExecutionLane, boolean>>;
+  };
+  canary?: {
+    enabled?: boolean;
+    disabledReason?: string | null;
+  };
+  updatedAt?: string;
+  updatedBy?: string | null;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readBoolean(value: unknown, fallback: boolean): boolean {
+  if (typeof value === "boolean") return value;
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  if (!normalized) return fallback;
+  if (normalized === "1" || normalized === "true" || normalized === "on") {
+    return true;
+  }
+  if (normalized === "0" || normalized === "false" || normalized === "off") {
+    return false;
+  }
+  return fallback;
+}
+
+function readStringOrNull(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return normalized ? normalized : null;
+}
+
+function defaultOpsControlSnapshot(): OpsControlSnapshot {
+  return {
+    schemaVersion: "v1",
+    execution: {
+      enabled: true,
+      disabledReason: null,
+      lanes: {
+        fast: true,
+        protected: true,
+        safe: true,
+      },
+    },
+    canary: {
+      enabled: true,
+      disabledReason: null,
+    },
+    metadata: {
+      source: "default",
+      updatedAt: null,
+      updatedBy: null,
+    },
+  };
+}
+
+function mergeLaneFlags(
+  current: Record<ExecutionLane, boolean>,
+  input: unknown,
+): Record<ExecutionLane, boolean> {
+  if (!isRecord(input)) return current;
+  return {
+    fast: readBoolean(input.fast, current.fast),
+    protected: readBoolean(input.protected, current.protected),
+    safe: readBoolean(input.safe, current.safe),
+  };
+}
+
+function normalizeOpsControlSnapshot(
+  value: unknown,
+  source: "default" | "kv",
+): OpsControlSnapshot {
+  const fallback = defaultOpsControlSnapshot();
+  if (!isRecord(value)) {
+    return {
+      ...fallback,
+      metadata: {
+        ...fallback.metadata,
+        source,
+      },
+    };
+  }
+  const execution = isRecord(value.execution) ? value.execution : {};
+  const canary = isRecord(value.canary) ? value.canary : {};
+  const metadata = isRecord(value.metadata) ? value.metadata : {};
+  return {
+    schemaVersion: "v1",
+    execution: {
+      enabled: readBoolean(execution.enabled, fallback.execution.enabled),
+      disabledReason:
+        readStringOrNull(execution.disabledReason) ??
+        fallback.execution.disabledReason,
+      lanes: mergeLaneFlags(fallback.execution.lanes, execution.lanes),
+    },
+    canary: {
+      enabled: readBoolean(canary.enabled, fallback.canary.enabled),
+      disabledReason:
+        readStringOrNull(canary.disabledReason) ??
+        fallback.canary.disabledReason,
+    },
+    metadata: {
+      source,
+      updatedAt: readStringOrNull(metadata.updatedAt),
+      updatedBy: readStringOrNull(metadata.updatedBy),
+    },
+  };
+}
+
+async function readOpsControlRaw(env: Env): Promise<OpsControlJson | null> {
+  if (!env.CONFIG_KV || typeof env.CONFIG_KV.get !== "function") {
+    return null;
+  }
+  const raw = await env.CONFIG_KV.get(OPS_CONTROL_KV_KEY, "json");
+  if (typeof raw === "string" && raw.trim()) {
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      return isRecord(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+  return isRecord(raw) ? raw : null;
+}
+
+export async function readOpsControlSnapshot(
+  env: Env,
+): Promise<OpsControlSnapshot> {
+  const raw = await readOpsControlRaw(env);
+  return normalizeOpsControlSnapshot(raw, raw ? "kv" : "default");
+}
+
+export async function writeOpsControlSnapshot(
+  env: Env,
+  patch: OpsControlPatch,
+): Promise<OpsControlSnapshot> {
+  if (!env.CONFIG_KV || typeof env.CONFIG_KV.put !== "function") {
+    throw new Error("ops-control-kv-missing");
+  }
+  const current = await readOpsControlSnapshot(env);
+  const nextExecutionEnabled =
+    patch.execution?.enabled ?? current.execution.enabled;
+  const nextCanaryEnabled = patch.canary?.enabled ?? current.canary.enabled;
+  const next: OpsControlSnapshot = {
+    schemaVersion: "v1",
+    execution: {
+      enabled: nextExecutionEnabled,
+      disabledReason:
+        patch.execution?.disabledReason !== undefined
+          ? readStringOrNull(patch.execution.disabledReason)
+          : nextExecutionEnabled
+            ? null
+            : current.execution.disabledReason,
+      lanes: {
+        ...current.execution.lanes,
+        ...(patch.execution?.lanes ?? {}),
+      },
+    },
+    canary: {
+      enabled: nextCanaryEnabled,
+      disabledReason:
+        patch.canary?.disabledReason !== undefined
+          ? readStringOrNull(patch.canary.disabledReason)
+          : nextCanaryEnabled
+            ? null
+            : current.canary.disabledReason,
+    },
+    metadata: {
+      source: "kv",
+      updatedAt: readStringOrNull(patch.updatedAt) ?? new Date().toISOString(),
+      updatedBy: readStringOrNull(patch.updatedBy),
+    },
+  };
+  await env.CONFIG_KV.put(OPS_CONTROL_KV_KEY, JSON.stringify(next));
+  return next;
+}
+
+export async function resetOpsControlSnapshot(
+  env: Env,
+  updatedBy?: string | null,
+): Promise<OpsControlSnapshot> {
+  return await writeOpsControlSnapshot(env, {
+    execution: {
+      enabled: true,
+      disabledReason: null,
+      lanes: {
+        fast: true,
+        protected: true,
+        safe: true,
+      },
+    },
+    canary: {
+      enabled: true,
+      disabledReason: null,
+    },
+    updatedBy: updatedBy ?? null,
+  });
+}
+
+export type ExecutionLaneRuntimeControls = {
+  executionEnabled: boolean;
+  executionDisabledReason: string | null;
+  laneEnabledOverrides: Record<ExecutionLane, boolean>;
+  mappedBy: "env" | "ops-control";
+};
+
+export function executionLaneRuntimeControlsFromSnapshot(
+  snapshot: OpsControlSnapshot,
+): ExecutionLaneRuntimeControls {
+  return {
+    executionEnabled: snapshot.execution.enabled,
+    executionDisabledReason: snapshot.execution.disabledReason,
+    laneEnabledOverrides: EXECUTION_LANES.reduce(
+      (acc, lane) => {
+        acc[lane] = snapshot.execution.lanes[lane];
+        return acc;
+      },
+      {} as Record<ExecutionLane, boolean>,
+    ),
+    mappedBy: snapshot.metadata.source === "kv" ? "ops-control" : "env",
+  };
+}

--- a/apps/worker/src/ops_controls.ts
+++ b/apps/worker/src/ops_controls.ts
@@ -142,16 +142,20 @@ async function readOpsControlRaw(env: Env): Promise<OpsControlJson | null> {
   if (!env.CONFIG_KV || typeof env.CONFIG_KV.get !== "function") {
     return null;
   }
-  const raw = await env.CONFIG_KV.get(OPS_CONTROL_KV_KEY, "json");
-  if (typeof raw === "string" && raw.trim()) {
-    try {
-      const parsed = JSON.parse(raw) as unknown;
-      return isRecord(parsed) ? parsed : null;
-    } catch {
-      return null;
+  try {
+    const raw = await env.CONFIG_KV.get(OPS_CONTROL_KV_KEY, "json");
+    if (typeof raw === "string" && raw.trim()) {
+      try {
+        const parsed = JSON.parse(raw) as unknown;
+        return isRecord(parsed) ? parsed : null;
+      } catch {
+        return null;
+      }
     }
+    return isRecord(raw) ? raw : null;
+  } catch {
+    return null;
   }
-  return isRecord(raw) ? raw : null;
 }
 
 export async function readOpsControlSnapshot(

--- a/docs/execution/observability-v1.md
+++ b/docs/execution/observability-v1.md
@@ -5,6 +5,7 @@ This document defines the Phase 2 observability surface for execution requests.
 ## Endpoint
 
 - `GET /api/admin/execution/observability`
+- `GET /api/admin/ops/dashboard`
 - Auth: `Authorization: Bearer <ADMIN_TOKEN>`
 - Query params:
   - `windowMinutes` (default `60`, min `5`, max `10080`)
@@ -66,12 +67,25 @@ Window tuning env vars:
 
 ## Dashboard Suggestions
 
-Use the endpoint payload to build 4 panels per environment:
+Use the endpoint payload to build 4 core execution panels per environment:
 
 1. Outcome rates (`failRate`, `expiryRate`, `duplicateRate`)
 2. Latency health (`dispatch/landing/finalization` p95)
 3. Lane and mode comparison (`dimensions.lane`, `dimensions.mode`)
 4. Provider quality (`dimensions.provider`)
+
+The repo-level ops dashboard for issue `#238` extends that with:
+
+- execution kill-switch state from `GET /api/admin/ops/controls`
+- canary state and latest runs from `GET /api/admin/execution/canary`
+- preview health summaries derived from PR preview metadata comments
+- runner health from the repo-local heartbeat file when the runner is online
+
+Workflow surface:
+
+- `.github/workflows/ops-dashboard.yml`
+- schedule: every 6 hours
+- output: GitHub Actions summary + `ops-dashboard-<run_id>` artifact
 
 ## Operational Notes
 

--- a/docs/execution/operations-runbook-v1.md
+++ b/docs/execution/operations-runbook-v1.md
@@ -21,11 +21,16 @@ Terminal UX cutover sequencing and cohort-mode gates are documented in
 - Required access:
   - GitHub Actions deploy workflows
   - Cloudflare Worker variables/secrets for target env
-  - `ADMIN_TOKEN` for observability endpoint
+  - `ADMIN_TOKEN` for observability and ops-control endpoints
+
+GitHub workflow surfaces added for issue `#238`:
+
+- `.github/workflows/ops-dashboard.yml`
+- `.github/workflows/rollback-production.yml`
 
 ## Operational Toggles
 
-Lane kill switches (all default enabled):
+Static env defaults (all default enabled):
 
 - `EXEC_LANE_FAST_ENABLED`
 - `EXEC_LANE_PROTECTED_ENABLED`
@@ -47,6 +52,64 @@ Verification coverage:
 
 - `tests/unit/worker_execution_lane_resolver.test.ts`
 - `tests/unit/worker_x402_exec_submit_route.test.ts`
+
+## Runtime Ops Control Plane
+
+The worker now exposes runtime controls backed by `CONFIG_KV`, so operators can
+disable execution or the canary lane without redeploying code.
+
+Routes:
+
+- `GET /api/admin/ops/controls`
+- `POST /api/admin/ops/controls`
+- `POST /api/admin/ops/controls/reset`
+- `GET /api/admin/ops/dashboard`
+
+Disable all execution and the canary lane:
+
+```bash
+curl -fsS -X POST \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$API_BASE/api/admin/ops/controls" \
+  --data '{
+    "updatedBy": "incident-response",
+    "execution": {
+      "enabled": false,
+      "disabledReason": "incident-bridge"
+    },
+    "canary": {
+      "enabled": false,
+      "disabledReason": "incident-bridge"
+    }
+  }'
+```
+
+Disable a single execution lane without redeploy:
+
+```bash
+curl -fsS -X POST \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$API_BASE/api/admin/ops/controls" \
+  --data '{
+    "updatedBy": "incident-response",
+    "execution": {
+      "lanes": {
+        "protected": false
+      },
+      "disabledReason": "provider-outage"
+    }
+  }'
+```
+
+Reset runtime controls:
+
+```bash
+curl -fsS -X POST \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  "$API_BASE/api/admin/ops/controls/reset"
+```
 
 ## Incident Taxonomy Alignment
 
@@ -82,11 +145,21 @@ curl -sS \
   "$API_BASE/api/admin/execution/observability?windowMinutes=30&maxRequests=5000"
 ```
 
-2. Capture current thresholds and lane-level failures.
-3. Choose mitigation: disable lane, reroute adapter, or throttle ingress.
-4. Redeploy worker for target environment.
-5. Verify status with smoke submit + status/receipt polling.
-6. Record timeline and decision in incident log.
+2. Pull the aggregated ops dashboard when you need execution + canary + control
+   state in one payload:
+
+```bash
+curl -sS \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  "$API_BASE/api/admin/ops/dashboard?windowMinutes=120&maxRequests=10000"
+```
+
+3. Capture current thresholds and lane-level failures.
+4. Choose mitigation: disable a lane, disable all execution, disable the canary
+   lane, reroute an adapter, or throttle ingress.
+5. Only redeploy if the issue cannot be mitigated by runtime controls alone.
+6. Verify status with smoke submit + status/receipt polling.
+7. Record timeline and decision in incident log.
 
 ## Runbook A: Provider Outage
 
@@ -99,12 +172,14 @@ Trigger indicators:
 Actions:
 
 1. Identify impacted lane (`fast`, `protected`, `safe`).
-2. Apply kill switch for impacted lane (`EXEC_LANE_<LANE>_ENABLED=0`) to stop new risk.
+2. Apply runtime kill switch for the impacted lane through
+   `/api/admin/ops/controls` to stop new risk.
 3. If failover path is validated, set adapter override (`EXEC_LANE_<LANE>_ADAPTER=<adapter>`).
-4. Redeploy and verify:
+4. Redeploy only if adapter overrides or static env defaults must change.
+5. Verify:
    - disabled lane rejects with `unsupported-lane`
    - unaffected lanes continue to accept submits
-5. Recover by restoring lane enable flag to `1` after health stabilizes.
+6. Recover by restoring runtime controls after health stabilizes.
 
 ## Runbook B: Lane Disable / Failover
 
@@ -113,6 +188,7 @@ Use when one lane degrades but overall service remains healthy.
 Actions:
 
 1. Disable only degraded lane with `EXEC_LANE_<LANE>_ENABLED=0`.
+   Prefer the runtime control plane before touching static env vars.
 2. Keep remaining lanes enabled for partial service continuity.
 3. Update client-facing status note (if needed) that lane is temporarily unavailable.
 4. Re-enable lane only after:
@@ -164,6 +240,22 @@ Actions:
 3. Confirm `/api/x402/exec/receipt/:requestId` returns canonical terminal state.
 
 ## Rollback and Verification Checklist
+
+Production rollback automation:
+
+```bash
+gh workflow run rollback-production.yml \
+  --raw-field reason="post-deploy smoke failure" \
+  --raw-field pr_number="<optional-pr-number>"
+```
+
+Optional dry-run:
+
+```bash
+gh workflow run rollback-production.yml \
+  --raw-field reason="dry run" \
+  --raw-field dry_run=true
+```
 
 - Lane flags restored to intended baseline.
 - Adapter overrides removed if temporary.

--- a/docs/repository-verification-index.md
+++ b/docs/repository-verification-index.md
@@ -62,6 +62,9 @@ Current workflow files:
   - `.github/workflows/deploy-manual.yml`
 - Portal deploys:
   - `.github/workflows/deploy-portal.yml`
+- Ops:
+  - `.github/workflows/ops-dashboard.yml`
+  - `.github/workflows/rollback-production.yml`
 
 Current required secret names:
 
@@ -188,6 +191,30 @@ curl -fsS https://<lane-api-domain>/openapi.json
 For portal builds, also verify that the login bundle points at the intended API
 host for the lane and does not reference an unexpected `workers.dev` host.
 
+### 6a. Ops dashboard verification
+
+The scheduled GitHub workflow `.github/workflows/ops-dashboard.yml` is the
+repo-level dashboard surface for:
+
+- execution outcomes and latency
+- preview health
+- runner health
+- canary status
+- runtime kill-switch state
+
+Manual trigger:
+
+```bash
+gh workflow run ops-dashboard.yml
+```
+
+Expected result:
+
+- workflow summary renders all five sections above
+- uploaded artifact name matches `ops-dashboard-<run_id>`
+- preview health includes every open PR with a `<!-- pr-preview -->` comment
+- runner health reports either a valid heartbeat or `not-configured`
+
 ### 7. Canary verification
 
 Production execution canary behavior:
@@ -261,6 +288,20 @@ Use lane and rollout flags before attempting a broader revert:
 - `EXEC_LANE_SAFE_ENABLED`
 
 Reference: `docs/execution/rollout-plan-v1.md`
+
+### Production rollback automation
+
+When code rollback is required, prefer the automated workflow:
+
+```bash
+gh workflow run rollback-production.yml \
+  --raw-field reason="manual rollback" \
+  --raw-field pr_number="<optional-pr-number>"
+```
+
+This redeploys the previous `main` commit unless an explicit `target_sha` is
+provided. The workflow posts a summary to the run and can also comment on a PR
+when `pr_number` is supplied.
 
 ### Production triage and verification
 

--- a/src/bin/ops_dashboard.ts
+++ b/src/bin/ops_dashboard.ts
@@ -1,0 +1,139 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  buildOpsDashboardMarkdown,
+  normalizeRunnerHealth,
+  type OpsDashboardSnapshot,
+  type PreviewHealthResult,
+  parsePreviewCommentBody,
+} from "../ops/dashboard.js";
+
+function readArg(flag: string): string | null {
+  const index = process.argv.indexOf(flag);
+  if (index < 0) return null;
+  return process.argv[index + 1] ?? null;
+}
+
+function requireArg(flag: string): string {
+  const value = readArg(flag);
+  if (!value) {
+    throw new Error(`missing-arg:${flag}`);
+  }
+  return value;
+}
+
+function readJsonFile(path: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+}
+
+async function fetchJson(url: string, token: string): Promise<unknown> {
+  const response = await fetch(url, {
+    headers: {
+      authorization: `Bearer ${token}`,
+      accept: "application/vnd.github+json",
+      "user-agent": "serious-trader-ralph-ops-dashboard",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`github-fetch-failed:${response.status}`);
+  }
+  return (await response.json()) as unknown;
+}
+
+async function checkUrl(url: string): Promise<boolean> {
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(15_000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function collectPreviewHealth(input: {
+  repo: string | null;
+  githubToken: string | null;
+  apiBase: string;
+}): Promise<PreviewHealthResult[]> {
+  if (!input.repo || !input.githubToken) return [];
+  const [owner, repo] = input.repo.split("/", 2);
+  if (!owner || !repo) return [];
+
+  const pulls = (await fetchJson(
+    `${input.apiBase}/repos/${owner}/${repo}/pulls?state=open&per_page=30`,
+    input.githubToken,
+  )) as unknown[];
+  const results: PreviewHealthResult[] = [];
+
+  for (const pull of pulls) {
+    const prNumber = Number(
+      typeof pull === "object" && pull
+        ? (pull as Record<string, unknown>).number
+        : NaN,
+    );
+    if (!Number.isFinite(prNumber)) continue;
+
+    const comments = (await fetchJson(
+      `${input.apiBase}/repos/${owner}/${repo}/issues/${prNumber}/comments?per_page=100`,
+      input.githubToken,
+    )) as unknown[];
+    const previewComment = comments
+      .filter((comment) => typeof comment === "object" && comment)
+      .map((comment) => (comment as Record<string, unknown>).body)
+      .map((body) => String(body ?? ""))
+      .find((body) => body.includes("<!-- pr-preview -->"));
+    if (!previewComment) continue;
+    const preview = parsePreviewCommentBody(previewComment);
+    if (!preview) continue;
+
+    const [portalOk, workerOk] = await Promise.all([
+      checkUrl(preview.portalUrl),
+      checkUrl(`${preview.workerUrl}/api/health`),
+    ]);
+    results.push({
+      prNumber,
+      portalUrl: preview.portalUrl,
+      workerUrl: preview.workerUrl,
+      workerName: preview.workerName,
+      portalOk,
+      workerOk,
+    });
+  }
+
+  return results;
+}
+
+async function main(): Promise<void> {
+  const executionPath = requireArg("--execution");
+  const canaryPath = requireArg("--canary");
+  const controlsPath = requireArg("--controls");
+  const outputJsonPath = requireArg("--output-json");
+  const outputMarkdownPath = requireArg("--output-markdown");
+  const runnerHeartbeatPath = readArg("--runner-heartbeat");
+  const githubApiBase =
+    readArg("--github-api-base") ?? "https://api.github.com";
+
+  const runner =
+    runnerHeartbeatPath && existsSync(runnerHeartbeatPath)
+      ? normalizeRunnerHealth(readJsonFile(runnerHeartbeatPath))
+      : normalizeRunnerHealth(null);
+  const previews = await collectPreviewHealth({
+    repo: process.env.GITHUB_REPOSITORY ?? null,
+    githubToken: process.env.GITHUB_TOKEN ?? null,
+    apiBase: githubApiBase,
+  });
+
+  const snapshot: OpsDashboardSnapshot = {
+    generatedAt: new Date().toISOString(),
+    execution: readJsonFile(executionPath),
+    canary: readJsonFile(canaryPath),
+    controls: readJsonFile(controlsPath),
+    previews,
+    runner,
+  };
+
+  writeFileSync(outputJsonPath, `${JSON.stringify(snapshot, null, 2)}\n`);
+  writeFileSync(outputMarkdownPath, `${buildOpsDashboardMarkdown(snapshot)}\n`);
+}
+
+await main();

--- a/src/bin/rollback_summary.ts
+++ b/src/bin/rollback_summary.ts
@@ -1,0 +1,42 @@
+import { writeFileSync } from "node:fs";
+import {
+  buildRollbackSummary,
+  resolveRollbackTarget,
+} from "../ops/rollback.js";
+
+function readArg(flag: string): string | null {
+  const index = process.argv.indexOf(flag);
+  if (index < 0) return null;
+  return process.argv[index + 1] ?? null;
+}
+
+function requireArg(flag: string): string {
+  const value = readArg(flag);
+  if (!value) {
+    throw new Error(`missing-arg:${flag}`);
+  }
+  return value;
+}
+
+const output = requireArg("--output");
+const portalUrl = requireArg("--portal-url");
+const apiUrl = requireArg("--api-url");
+const status = requireArg("--status") as "success" | "failed" | "dry-run";
+const reason = requireArg("--reason");
+
+const target = resolveRollbackTarget({
+  requestedSha: readArg("--target-sha"),
+  previousMainSha: readArg("--previous-main-sha"),
+});
+
+writeFileSync(
+  output,
+  `${buildRollbackSummary({
+    targetSha: target.targetSha,
+    source: target.source,
+    portalUrl,
+    apiUrl,
+    status,
+    reason,
+  })}\n`,
+);

--- a/src/ops/dashboard.ts
+++ b/src/ops/dashboard.ts
@@ -1,0 +1,185 @@
+export type PreviewLink = {
+  portalUrl: string;
+  workerUrl: string;
+  workerName: string | null;
+};
+
+export type PreviewHealthResult = {
+  prNumber: number;
+  portalUrl: string;
+  workerUrl: string;
+  workerName: string | null;
+  portalOk: boolean;
+  workerOk: boolean;
+};
+
+export type RunnerHealthSnapshot = {
+  status: string;
+  updatedAt: string | null;
+  concurrency: number | null;
+  activeRuns: number | null;
+  note: string | null;
+};
+
+export type OpsDashboardSnapshot = {
+  generatedAt: string;
+  execution: Record<string, unknown>;
+  canary: Record<string, unknown>;
+  controls: Record<string, unknown>;
+  previews: PreviewHealthResult[];
+  runner: RunnerHealthSnapshot;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return normalized ? normalized : null;
+}
+
+function readNumber(value: unknown): number | null {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function parsePreviewCommentBody(body: string): PreviewLink | null {
+  const portalUrl = body.match(/- Portal:\s*(https?:\/\/\S+)/)?.[1] ?? null;
+  const workerUrl = body.match(/- Worker:\s*(https?:\/\/\S+)/)?.[1] ?? null;
+  const workerName =
+    body.match(/- Worker name:\s*`([^`]+)`/)?.[1]?.trim() ?? null;
+  if (!portalUrl || !workerUrl) return null;
+  return {
+    portalUrl,
+    workerUrl,
+    workerName,
+  };
+}
+
+export function normalizeRunnerHealth(value: unknown): RunnerHealthSnapshot {
+  if (!isRecord(value)) {
+    return {
+      status: "not-configured",
+      updatedAt: null,
+      concurrency: null,
+      activeRuns: null,
+      note: "Runner heartbeat file not found yet.",
+    };
+  }
+  return {
+    status: readString(value.status) ?? "unknown",
+    updatedAt: readString(value.updatedAt),
+    concurrency: readNumber(value.concurrency),
+    activeRuns: readNumber(value.activeRuns),
+    note: readString(value.note),
+  };
+}
+
+export function summarizePreviewHealth(results: PreviewHealthResult[]): {
+  total: number;
+  healthy: number;
+  failing: number;
+} {
+  const total = results.length;
+  const healthy = results.filter(
+    (item) => item.portalOk && item.workerOk,
+  ).length;
+  return {
+    total,
+    healthy,
+    failing: total - healthy,
+  };
+}
+
+function formatExecutionSummary(execution: Record<string, unknown>): string[] {
+  const metrics = isRecord(execution.metrics) ? execution.metrics : {};
+  const alerts = Array.isArray(execution.alerts) ? execution.alerts : [];
+  const failRate = readNumber(metrics.failRate);
+  const expiryRate = readNumber(metrics.expiryRate);
+  const dispatchP95 = readNumber(
+    isRecord(metrics.dispatch) ? metrics.dispatch.p95Ms : null,
+  );
+  const finalizationP95 = readNumber(
+    isRecord(metrics.finalization) ? metrics.finalization.p95Ms : null,
+  );
+  const activeAlerts = alerts
+    .filter((alert) => isRecord(alert) && readString(alert.state) !== "ok")
+    .map((alert) => {
+      const record = alert as Record<string, unknown>;
+      return `${readString(record.id) ?? "unknown"}=${readString(record.state) ?? "unknown"}`;
+    });
+  return [
+    `- failRate: ${failRate ?? "n/a"}`,
+    `- expiryRate: ${expiryRate ?? "n/a"}`,
+    `- dispatch p95 ms: ${dispatchP95 ?? "n/a"}`,
+    `- finalization p95 ms: ${finalizationP95 ?? "n/a"}`,
+    `- alerts: ${activeAlerts.length > 0 ? activeAlerts.join(", ") : "ok-or-insufficient-data"}`,
+  ];
+}
+
+function formatCanarySummary(canary: Record<string, unknown>): string[] {
+  const state = isRecord(canary.state) ? canary.state : {};
+  const latestRuns = Array.isArray(canary.latestRuns) ? canary.latestRuns : [];
+  const latestRun = latestRuns.find(isRecord) ?? null;
+  return [
+    `- enabled by config: ${String(isRecord(canary.config) ? canary.config.enabled : "unknown")}`,
+    `- disabled: ${String(state.disabled ?? false)}`,
+    `- disabledReason: ${readString(state.disabledReason) ?? "n/a"}`,
+    `- latest run status: ${readString(latestRun?.status) ?? "n/a"}`,
+    `- latest reconciliation status: ${readString(latestRun?.reconciliationStatus) ?? "n/a"}`,
+  ];
+}
+
+function formatControlSummary(controls: Record<string, unknown>): string[] {
+  const execution = isRecord(controls.execution) ? controls.execution : {};
+  const canary = isRecord(controls.canary) ? controls.canary : {};
+  const lanes = isRecord(execution.lanes) ? execution.lanes : {};
+  return [
+    `- execution enabled: ${String(execution.enabled ?? true)}`,
+    `- execution disabledReason: ${readString(execution.disabledReason) ?? "n/a"}`,
+    `- lane toggles: fast=${String(lanes.fast ?? true)}, protected=${String(lanes.protected ?? true)}, safe=${String(lanes.safe ?? true)}`,
+    `- canary enabled: ${String(canary.enabled ?? true)}`,
+    `- canary disabledReason: ${readString(canary.disabledReason) ?? "n/a"}`,
+  ];
+}
+
+export function buildOpsDashboardMarkdown(
+  snapshot: OpsDashboardSnapshot,
+): string {
+  const previewSummary = summarizePreviewHealth(snapshot.previews);
+  const previewLines =
+    snapshot.previews.length > 0
+      ? snapshot.previews.map(
+          (preview) =>
+            `- PR #${preview.prNumber}: portal=${preview.portalOk ? "ok" : "down"}, worker=${preview.workerOk ? "ok" : "down"}`,
+        )
+      : ["- No open PR previews discovered."];
+  return [
+    "# Ops Dashboard",
+    "",
+    `Generated at: ${snapshot.generatedAt}`,
+    "",
+    "## Execution",
+    ...formatExecutionSummary(snapshot.execution),
+    "",
+    "## Canary",
+    ...formatCanarySummary(snapshot.canary),
+    "",
+    "## Controls",
+    ...formatControlSummary(snapshot.controls),
+    "",
+    "## Preview Health",
+    `- total previews: ${previewSummary.total}`,
+    `- healthy previews: ${previewSummary.healthy}`,
+    `- failing previews: ${previewSummary.failing}`,
+    ...previewLines,
+    "",
+    "## Runner Health",
+    `- status: ${snapshot.runner.status}`,
+    `- updatedAt: ${snapshot.runner.updatedAt ?? "n/a"}`,
+    `- concurrency: ${snapshot.runner.concurrency ?? "n/a"}`,
+    `- activeRuns: ${snapshot.runner.activeRuns ?? "n/a"}`,
+    `- note: ${snapshot.runner.note ?? "n/a"}`,
+  ].join("\n");
+}

--- a/src/ops/rollback.ts
+++ b/src/ops/rollback.ts
@@ -1,0 +1,44 @@
+export type RollbackTargetResolution = {
+  targetSha: string;
+  source: "input" | "previous-main";
+};
+
+export function resolveRollbackTarget(input: {
+  requestedSha?: string | null;
+  previousMainSha?: string | null;
+}): RollbackTargetResolution {
+  const requested = String(input.requestedSha ?? "").trim();
+  if (requested) {
+    return {
+      targetSha: requested,
+      source: "input",
+    };
+  }
+  const previousMainSha = String(input.previousMainSha ?? "").trim();
+  if (!previousMainSha) {
+    throw new Error("rollback-target-missing");
+  }
+  return {
+    targetSha: previousMainSha,
+    source: "previous-main",
+  };
+}
+
+export function buildRollbackSummary(input: {
+  targetSha: string;
+  source: "input" | "previous-main";
+  portalUrl: string;
+  apiUrl: string;
+  status: "success" | "failed" | "dry-run";
+  reason: string;
+}): string {
+  return [
+    "## Production Rollback",
+    `- status: ${input.status}`,
+    `- targetSha: ${input.targetSha}`,
+    `- source: ${input.source}`,
+    `- portalUrl: ${input.portalUrl}`,
+    `- apiUrl: ${input.apiUrl}`,
+    `- reason: ${input.reason}`,
+  ].join("\n");
+}

--- a/tests/unit/ops_dashboard.test.ts
+++ b/tests/unit/ops_dashboard.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildOpsDashboardMarkdown,
+  normalizeRunnerHealth,
+  parsePreviewCommentBody,
+  summarizePreviewHealth,
+} from "../../src/ops/dashboard";
+
+describe("ops dashboard helpers", () => {
+  test("parses PR preview comment body", () => {
+    const parsed = parsePreviewCommentBody(`<!-- pr-preview -->
+## PR Preview
+- Portal: https://preview.example.com
+- Worker: https://worker.example.workers.dev
+- Worker name: \`ralph-edge-pr-999\`
+`);
+
+    expect(parsed).toEqual({
+      portalUrl: "https://preview.example.com",
+      workerUrl: "https://worker.example.workers.dev",
+      workerName: "ralph-edge-pr-999",
+    });
+  });
+
+  test("normalizes missing runner health to not-configured", () => {
+    expect(normalizeRunnerHealth(null)).toEqual({
+      status: "not-configured",
+      updatedAt: null,
+      concurrency: null,
+      activeRuns: null,
+      note: "Runner heartbeat file not found yet.",
+    });
+  });
+
+  test("builds markdown with execution, preview, and runner sections", () => {
+    const markdown = buildOpsDashboardMarkdown({
+      generatedAt: "2026-03-06T00:00:00.000Z",
+      execution: {
+        metrics: {
+          failRate: 0.01,
+          expiryRate: 0,
+          dispatch: { p95Ms: 120 },
+          finalization: { p95Ms: 640 },
+        },
+        alerts: [{ id: "fail-rate", state: "ok" }],
+      },
+      canary: {
+        config: { enabled: true },
+        state: { disabled: false, disabledReason: null },
+        latestRuns: [{ status: "success", reconciliationStatus: "passed" }],
+      },
+      controls: {
+        execution: {
+          enabled: true,
+          disabledReason: null,
+          lanes: { fast: true, protected: true, safe: true },
+        },
+        canary: {
+          enabled: true,
+          disabledReason: null,
+        },
+      },
+      previews: [
+        {
+          prNumber: 247,
+          portalUrl: "https://preview.example.com",
+          workerUrl: "https://worker.example.workers.dev",
+          workerName: "ralph-edge-pr-247",
+          portalOk: true,
+          workerOk: false,
+        },
+      ],
+      runner: {
+        status: "ok",
+        updatedAt: "2026-03-06T00:05:00.000Z",
+        concurrency: 2,
+        activeRuns: 1,
+        note: null,
+      },
+    });
+
+    expect(markdown).toContain("# Ops Dashboard");
+    expect(markdown).toContain("## Execution");
+    expect(markdown).toContain("## Preview Health");
+    expect(markdown).toContain("PR #247: portal=ok, worker=down");
+    expect(markdown).toContain("## Runner Health");
+  });
+
+  test("summarizes preview health counts", () => {
+    expect(
+      summarizePreviewHealth([
+        {
+          prNumber: 1,
+          portalUrl: "https://a.example.com",
+          workerUrl: "https://a-worker.example.com",
+          workerName: null,
+          portalOk: true,
+          workerOk: true,
+        },
+        {
+          prNumber: 2,
+          portalUrl: "https://b.example.com",
+          workerUrl: "https://b-worker.example.com",
+          workerName: null,
+          portalOk: true,
+          workerOk: false,
+        },
+      ]),
+    ).toEqual({
+      total: 2,
+      healthy: 1,
+      failing: 1,
+    });
+  });
+});

--- a/tests/unit/ops_rollback.test.ts
+++ b/tests/unit/ops_rollback.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildRollbackSummary,
+  resolveRollbackTarget,
+} from "../../src/ops/rollback";
+
+describe("ops rollback helpers", () => {
+  test("prefers an explicit rollback sha", () => {
+    expect(
+      resolveRollbackTarget({
+        requestedSha: "abc123",
+        previousMainSha: "def456",
+      }),
+    ).toEqual({
+      targetSha: "abc123",
+      source: "input",
+    });
+  });
+
+  test("falls back to previous main sha", () => {
+    expect(
+      resolveRollbackTarget({
+        requestedSha: "",
+        previousMainSha: "def456",
+      }),
+    ).toEqual({
+      targetSha: "def456",
+      source: "previous-main",
+    });
+  });
+
+  test("throws when no rollback target is available", () => {
+    expect(() =>
+      resolveRollbackTarget({
+        requestedSha: "",
+        previousMainSha: "",
+      }),
+    ).toThrow("rollback-target-missing");
+  });
+
+  test("builds rollback summary markdown", () => {
+    const summary = buildRollbackSummary({
+      targetSha: "def456",
+      source: "previous-main",
+      portalUrl: "https://trader-ralph.com",
+      apiUrl: "https://api.trader-ralph.com",
+      status: "success",
+      reason: "post-deploy smoke failure",
+    });
+
+    expect(summary).toContain("## Production Rollback");
+    expect(summary).toContain("- status: success");
+    expect(summary).toContain("- targetSha: def456");
+  });
+});

--- a/tests/unit/worker_execution_lane_resolver.test.ts
+++ b/tests/unit/worker_execution_lane_resolver.test.ts
@@ -81,6 +81,48 @@ describe("execution lane resolver", () => {
     expect(disabledProtected.reason).toBe("lane-disabled-by-operator");
   });
 
+  test("supports runtime ops-control overrides without redeploy", () => {
+    const resolved = resolveExecutionLane({
+      env: {} as Env,
+      requestedLane: "safe",
+      mode: "privy_execute",
+      actorType: "privy_user",
+      runtimeControls: {
+        executionEnabled: true,
+        executionDisabledReason: null,
+        laneEnabledOverrides: {
+          fast: true,
+          protected: true,
+          safe: false,
+        },
+        mappedBy: "ops-control",
+      },
+    });
+    expect(resolved.ok).toBe(false);
+    if (resolved.ok) return;
+    expect(resolved.reason).toBe("lane-disabled-by-operator");
+
+    const globallyDisabled = resolveExecutionLane({
+      env: {} as Env,
+      requestedLane: "fast",
+      mode: "relay_signed",
+      actorType: "anonymous_x402",
+      runtimeControls: {
+        executionEnabled: false,
+        executionDisabledReason: "execution-disabled-by-operator",
+        laneEnabledOverrides: {
+          fast: true,
+          protected: true,
+          safe: true,
+        },
+        mappedBy: "ops-control",
+      },
+    });
+    expect(globallyDisabled.ok).toBe(false);
+    if (globallyDisabled.ok) return;
+    expect(globallyDisabled.reason).toBe("execution-disabled-by-operator");
+  });
+
   test("rejects safe lane for relay_signed mode", () => {
     const resolved = resolveExecutionLane({
       env: {} as Env,

--- a/tests/unit/worker_ops_controls_route.test.ts
+++ b/tests/unit/worker_ops_controls_route.test.ts
@@ -1,0 +1,267 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Env } from "../../apps/worker/src/types";
+import {
+  createExecutionContextStub,
+  createWorkerLiveEnv,
+} from "../integration/_worker_live_test_utils";
+
+const worker = (await import("../../apps/worker/src/index")).default;
+
+function createSqliteD1Adapter(db: Database): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          return {
+            async run() {
+              const statement = db.query(sql);
+              const result = statement.run(...(params as never[])) as {
+                changes?: number;
+              };
+              return {
+                meta: {
+                  changes:
+                    typeof result.changes === "number" ? result.changes : 0,
+                },
+              };
+            },
+            async first() {
+              const statement = db.query(sql);
+              return (statement.get(...(params as never[])) as unknown) ?? null;
+            },
+            async all() {
+              const statement = db.query(sql);
+              return {
+                results: (statement.all(...(params as never[])) ??
+                  []) as unknown[],
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+function createOpsEnv(overrides?: Partial<Env>) {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA foreign_keys = ON;");
+
+  for (const migrationName of [
+    "0025_execution_fabric.sql",
+    "0026_execution_canary.sql",
+  ]) {
+    const migrationPath = resolve(
+      import.meta.dir,
+      "..",
+      "..",
+      "apps/worker/migrations",
+      migrationName,
+    );
+    sqlite.exec(readFileSync(migrationPath, "utf8"));
+  }
+
+  const env = createWorkerLiveEnv({
+    overrides: {
+      WAITLIST_DB: createSqliteD1Adapter(sqlite),
+      ADMIN_TOKEN: "admin-secret",
+      EXEC_CANARY_ENABLED: "1",
+      EXEC_CANARY_AUTO_CREATE_WALLET: "0",
+      ...overrides,
+    },
+  });
+
+  return { env, sqlite };
+}
+
+describe("worker ops controls routes", () => {
+  test("requires admin auth for ops controls", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/admin/ops/controls"),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({
+        ok: false,
+        error: "auth-required",
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("applies no-redeploy execution and canary kill switches", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const patchResponse = await worker.fetch(
+        new Request("http://localhost/api/admin/ops/controls", {
+          method: "POST",
+          headers: {
+            authorization: "Bearer admin-secret",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            updatedBy: "test-suite",
+            execution: {
+              enabled: false,
+              disabledReason: "incident-123",
+            },
+            canary: {
+              enabled: false,
+              disabledReason: "incident-123",
+            },
+          }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(patchResponse.status).toBe(200);
+
+      const healthResponse = await worker.fetch(
+        new Request("http://localhost/api/x402/exec/health"),
+        env,
+        createExecutionContextStub(),
+      );
+      const healthPayload = (await healthResponse.json()) as Record<
+        string,
+        unknown
+      >;
+      expect(healthPayload.ok).toBe(false);
+      expect(healthPayload.controls).toMatchObject({
+        execution: {
+          enabled: false,
+          disabledReason: "incident-123",
+        },
+      });
+      expect(healthPayload.lanes).toMatchObject({
+        fast: { enabled: false },
+        protected: { enabled: false },
+        safe: { enabled: false },
+      });
+
+      const canaryResponse = await worker.fetch(
+        new Request("http://localhost/api/admin/execution/canary/run", {
+          method: "POST",
+          headers: {
+            authorization: "Bearer admin-secret",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ trigger: "manual" }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(canaryResponse.status).toBe(200);
+      expect(await canaryResponse.json()).toMatchObject({
+        ok: false,
+        status: "disabled",
+        error: "incident-123",
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("resets ops controls back to baseline", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      await worker.fetch(
+        new Request("http://localhost/api/admin/ops/controls", {
+          method: "POST",
+          headers: {
+            authorization: "Bearer admin-secret",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            execution: {
+              enabled: false,
+              disabledReason: "incident-123",
+              lanes: {
+                safe: false,
+              },
+            },
+            canary: {
+              enabled: false,
+              disabledReason: "incident-123",
+            },
+          }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+
+      const resetResponse = await worker.fetch(
+        new Request("http://localhost/api/admin/ops/controls/reset", {
+          method: "POST",
+          headers: {
+            authorization: "Bearer admin-secret",
+          },
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(resetResponse.status).toBe(200);
+      expect(await resetResponse.json()).toMatchObject({
+        ok: true,
+        controls: {
+          execution: {
+            enabled: true,
+            disabledReason: null,
+            lanes: {
+              fast: true,
+              protected: true,
+              safe: true,
+            },
+          },
+          canary: {
+            enabled: true,
+            disabledReason: null,
+          },
+        },
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("returns aggregated admin ops dashboard", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/admin/ops/dashboard", {
+          headers: {
+            authorization: "Bearer admin-secret",
+          },
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        ok: true,
+        controls: {
+          execution: {
+            enabled: true,
+          },
+        },
+        canary: {
+          ok: true,
+        },
+        execution: {
+          totals: {
+            accepted: 0,
+          },
+        },
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/tests/unit/worker_ops_controls_store.test.ts
+++ b/tests/unit/worker_ops_controls_store.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { readOpsControlSnapshot } from "../../apps/worker/src/ops_controls";
+import type { Env } from "../../apps/worker/src/types";
+
+describe("worker ops controls store", () => {
+  test("falls back to default snapshot when KV reads fail", async () => {
+    const snapshot = await readOpsControlSnapshot({
+      CONFIG_KV: {
+        async get() {
+          throw new Error("kv-temporary-outage");
+        },
+      },
+    } as unknown as Env);
+
+    expect(snapshot).toMatchObject({
+      execution: {
+        enabled: true,
+        lanes: {
+          fast: true,
+          protected: true,
+          safe: true,
+        },
+      },
+      canary: {
+        enabled: true,
+      },
+      metadata: {
+        source: "default",
+      },
+    });
+  });
+});


### PR DESCRIPTION
Fixes #238

## Summary
- add a KV-backed runtime ops control plane for execution and canary kill switches without redeploying code
- expose admin ops controls and dashboard routes, plus a scheduled GitHub ops dashboard workflow and a production rollback workflow
- document the new operational surfaces and add explicit unit coverage for kill-switch, dashboard, and rollback helper paths

## Proof Bundle
### Summary of changes
- Added `/api/admin/ops/controls`, `/api/admin/ops/controls/reset`, and `/api/admin/ops/dashboard`.
- Wired execution submit, execution health, and canary execution through runtime ops controls.
- Added `.github/workflows/ops-dashboard.yml` and `.github/workflows/rollback-production.yml`.

### Validation commands and results
- `bun run lint` ✅
- `bun run typecheck` ✅
- `bun test tests/unit/worker_execution_lane_resolver.test.ts tests/unit/worker_x402_exec_health_route.test.ts tests/unit/worker_ops_controls_route.test.ts tests/unit/ops_dashboard.test.ts tests/unit/ops_rollback.test.ts tests/unit/worker_execution_canary_route.test.ts` ✅
- `bun run test:unit` ✅
- `bun -e 'import { readFileSync } from "node:fs"; import YAML from "yaml"; for (const path of [".github/workflows/ops-dashboard.yml", ".github/workflows/rollback-production.yml"]) { YAML.parse(readFileSync(path, "utf8")); console.log(path); }'` ✅

### Preview or local URLs
- Local verification was route and unit-test driven for the worker/runtime control plane.
- PR preview URLs will be attached by CI after the preview workflow completes.

### Browser artifacts for UI changes
- N/A for local verification. No portal UI surface changed in this PR.
- Playwright remains part of the required CI harness and will publish browser-proof artifacts on this PR.

### Benchmark delta for performance-sensitive changes
- N/A. This PR adds operator control surfaces and workflows rather than changing a measured hot path.

### Risk notes and follow-ups
- The new ops dashboard and post-deploy canary trigger both require `ADMIN_TOKEN` in the GitHub `production` environment and the Cloudflare `ralph-edge` worker secrets before they can operate against production.
- Runner health will report `not-configured` until issue `#239` lands and starts publishing a heartbeat file.
