### PR TITLE
Runner: build GitHub Issues adapter and autonomous execution runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ runs/
 trades/
 tasks/
 .tmp/
+.harness/
 .turbo/
 .vercel

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ bun run harness:up
 bun run harness:status
 bun run harness:down
 bun run harness:proof
+bun run runner:once
 ```
 
 - `harness:up` starts a portal and worker pair with worktree-local ports and
@@ -99,6 +100,10 @@ bun run harness:proof
 - `harness:down` tears down only the active worktree harness state
 - `harness:proof` runs the Playwright browser proof suite against the active
   local harness, or a supplied preview URL via `--base-url`
+- `runner:once` polls GitHub for `harness` + `agent-ready` issues, claims up to
+  two at a time by default, executes Codex in isolated worktrees under
+  `.tmp/runner/worktrees/`, and writes runner heartbeat state to
+  `.harness/runner-heartbeat.json`
 
 ### Worker only
 

--- a/biome.json
+++ b/biome.json
@@ -38,6 +38,7 @@
       "!!**/sessions",
       "!!**/tasks",
       "!!**/trades",
+      "!!**/.harness",
       "!!**/.tmp"
     ]
   }

--- a/docs/repository-verification-index.md
+++ b/docs/repository-verification-index.md
@@ -215,6 +215,23 @@ Expected result:
 - preview health includes every open PR with a `<!-- pr-preview -->` comment
 - runner health reports either a valid heartbeat or `not-configured`
 
+### 6b. Runner verification
+
+Run a single GitHub issue poll:
+
+```bash
+bun run runner:once
+```
+
+Expected result:
+
+- the runner only selects issues carrying both `harness` and `agent-ready`
+- each claimed issue receives `agent-running` while execution is active
+- worktrees are created under `.tmp/runner/worktrees/issue-<number>-<slug>`
+- `.harness/runner-heartbeat.json` updates with current status, concurrency, and
+  active run count
+- successful runs open or update a PR and switch the issue to `human-review`
+
 ### 7. Canary verification
 
 Production execution canary behavior:

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "harness:down": "bun run src/bin/harness.ts down",
     "harness:status": "bun run src/bin/harness.ts status",
     "harness:proof": "bun run src/bin/harness.ts proof",
+    "runner:once": "bun run src/bin/runner.ts once",
+    "runner:start": "bun run src/bin/runner.ts start",
     "build": "bun build src/bin/ralph.ts --outdir dist/bin --target node --format esm",
     "start": "bun dist/bin/ralph.js",
     "dev:local": "NEXT_PUBLIC_EDGE_API_BASE=http://127.0.0.1:8888 NEXT_PUBLIC_SITE_URL=http://localhost:3000 bun run dev",

--- a/src/bin/runner.ts
+++ b/src/bin/runner.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import {
+  formatRunnerSummaries,
+  runRunnerOnce,
+  startRunner,
+} from "../runner/service.js";
+
+type RunnerCommand = "once" | "start";
+
+function parseCommand(argv: string[]): RunnerCommand {
+  const command = (argv[2] ?? "once").trim();
+  if (command === "once" || command === "start") {
+    return command;
+  }
+  throw new Error(
+    "usage: bun run src/bin/runner.ts <once|start> [--concurrency <n>] [--poll-interval-ms <ms>]",
+  );
+}
+
+function parseNumberFlag(
+  argv: string[],
+  flag: "--concurrency" | "--poll-interval-ms",
+): number | undefined {
+  const index = argv.indexOf(flag);
+  if (index === -1) {
+    return undefined;
+  }
+  const value = argv[index + 1];
+  if (!value) {
+    throw new Error(`${flag} requires a value`);
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${flag} must be numeric`);
+  }
+  return parsed;
+}
+
+async function main(): Promise<void> {
+  const command = parseCommand(process.argv);
+  const concurrency = parseNumberFlag(process.argv, "--concurrency");
+  const pollIntervalMs = parseNumberFlag(process.argv, "--poll-interval-ms");
+  if (command === "start") {
+    await startRunner({ concurrency, pollIntervalMs });
+    return;
+  }
+  const results = await runRunnerOnce({ concurrency, pollIntervalMs });
+  console.log(formatRunnerSummaries(results));
+}
+
+void main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/src/runner/comments.ts
+++ b/src/runner/comments.ts
@@ -1,0 +1,44 @@
+import type {
+  RunnerIssue,
+  RunnerPullRequestSummary,
+  RunnerRunSummary,
+} from "./service.js";
+
+export function buildRunnerSuccessComment(input: {
+  issue: RunnerIssue;
+  branch: string;
+  pr: RunnerPullRequestSummary;
+  summary: RunnerRunSummary;
+}): string {
+  const checksLink = input.pr.checksUrl
+    ? `[Latest checks](${input.pr.checksUrl})`
+    : "Latest checks: pending";
+  return [
+    "<!-- harness-runner-status -->",
+    "## Harness Runner Status",
+    `- Issue: #${input.issue.number}`,
+    `- Branch: \`${input.branch}\``,
+    `- PR: ${input.pr.url}`,
+    `- Preview/proof bundle: pending on CI publication`,
+    `- ${checksLink}`,
+    `- Commit: \`${input.summary.commitSha ?? "pending"}\``,
+    "",
+    "CI is expected to attach preview, browser-proof, and artifact links after the PR workflows finish.",
+  ].join("\n");
+}
+
+export function buildRunnerFailureComment(input: {
+  issue: RunnerIssue;
+  branch: string;
+  error: string;
+}): string {
+  return [
+    "<!-- harness-runner-failure -->",
+    "## Harness Runner Failure",
+    `- Issue: #${input.issue.number}`,
+    `- Branch: \`${input.branch}\``,
+    `- Error: ${input.error}`,
+    "",
+    "The runner removed `agent-running` so the issue can be retried after investigation.",
+  ].join("\n");
+}

--- a/src/runner/config.ts
+++ b/src/runner/config.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { parse } from "yaml";
+
+type WorkflowFrontmatter = {
+  tracker?: {
+    repository?: string;
+    ready_labels?: string[];
+    exclude_labels?: string[];
+  };
+  branching?: {
+    branch_prefix?: string;
+    branch_format?: string;
+    default_pr_base?: string;
+  };
+};
+
+export type RunnerWorkflowConfig = {
+  repository: string;
+  readyLabels: string[];
+  excludeLabels: string[];
+  branchPrefix: string;
+  branchFormat: string;
+  defaultPrBase: string;
+};
+
+const DEFAULT_CONFIG: RunnerWorkflowConfig = {
+  repository: "GuiBibeau/serious-trader-ralph",
+  readyLabels: ["harness", "agent-ready"],
+  excludeLabels: ["blocked", "agent-running", "human-review"],
+  branchPrefix: "codex/",
+  branchFormat: "codex/issue-<number>-<slug>",
+  defaultPrBase: "dev",
+};
+
+function coerceStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => String(entry ?? "").trim())
+    .filter((entry) => entry.length > 0);
+}
+
+export function parseWorkflowContract(contents: string): RunnerWorkflowConfig {
+  const match = contents.match(/^---\s*\n([\s\S]*?)\n---\s*\n?/);
+  if (!match) {
+    return { ...DEFAULT_CONFIG };
+  }
+
+  const frontmatter = (parse(match[1]) ?? {}) as WorkflowFrontmatter;
+  return {
+    repository:
+      String(frontmatter.tracker?.repository ?? "").trim() ||
+      DEFAULT_CONFIG.repository,
+    readyLabels:
+      coerceStringList(frontmatter.tracker?.ready_labels).length > 0
+        ? coerceStringList(frontmatter.tracker?.ready_labels)
+        : [...DEFAULT_CONFIG.readyLabels],
+    excludeLabels:
+      coerceStringList(frontmatter.tracker?.exclude_labels).length > 0
+        ? coerceStringList(frontmatter.tracker?.exclude_labels)
+        : [...DEFAULT_CONFIG.excludeLabels],
+    branchPrefix:
+      String(frontmatter.branching?.branch_prefix ?? "").trim() ||
+      DEFAULT_CONFIG.branchPrefix,
+    branchFormat:
+      String(frontmatter.branching?.branch_format ?? "").trim() ||
+      DEFAULT_CONFIG.branchFormat,
+    defaultPrBase:
+      String(frontmatter.branching?.default_pr_base ?? "").trim() ||
+      DEFAULT_CONFIG.defaultPrBase,
+  };
+}
+
+export function loadWorkflowContract(root: string): RunnerWorkflowConfig {
+  const filePath = join(resolve(root), "WORKFLOW.md");
+  const contents = readFileSync(filePath, "utf8");
+  return parseWorkflowContract(contents);
+}

--- a/src/runner/heartbeat.ts
+++ b/src/runner/heartbeat.ts
@@ -1,0 +1,34 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+export type RunnerHeartbeat = {
+  status: string;
+  updatedAt: string;
+  concurrency: number;
+  activeRuns: number;
+  note: string;
+};
+
+export function resolveRunnerHeartbeatPath(root: string): string {
+  return join(resolve(root), ".harness", "runner-heartbeat.json");
+}
+
+export function writeRunnerHeartbeat(
+  root: string,
+  heartbeat: Omit<RunnerHeartbeat, "updatedAt"> & { updatedAt?: string },
+): RunnerHeartbeat {
+  const normalized: RunnerHeartbeat = {
+    ...heartbeat,
+    updatedAt: heartbeat.updatedAt ?? new Date().toISOString(),
+  };
+  const filePath = resolveRunnerHeartbeatPath(root);
+  mkdirSync(join(resolve(root), ".harness"), { recursive: true });
+  writeFileSync(filePath, JSON.stringify(normalized, null, 2), "utf8");
+  return normalized;
+}
+
+export function readRunnerHeartbeat(root: string): RunnerHeartbeat {
+  return JSON.parse(
+    readFileSync(resolveRunnerHeartbeatPath(root), "utf8"),
+  ) as RunnerHeartbeat;
+}

--- a/src/runner/service.ts
+++ b/src/runner/service.ts
@@ -1,5 +1,6 @@
 import { spawn, spawnSync } from "node:child_process";
 import {
+  closeSync,
   existsSync,
   mkdirSync,
   openSync,
@@ -493,6 +494,8 @@ function runLoggedCommand(input: {
       env: process.env,
       stdio: ["ignore", stdoutFd, stderrFd],
     });
+    closeSync(stdoutFd);
+    closeSync(stderrFd);
     child.once("error", (error) => rejectPromise(error));
     child.once("exit", (code) => {
       if (code === 0) {
@@ -648,23 +651,57 @@ async function processIssue(
       JSON.stringify(summary, null, 2),
       "utf8",
     );
-    commentOnIssue(
-      context.root,
-      context.config.repository,
-      context.issue.number,
-      buildRunnerFailureComment({
-        issue: context.issue,
-        branch,
-        error: summary.error ?? "unknown runner error",
-      }),
-    );
-    editIssueLabels(
-      context.root,
-      context.config.repository,
-      context.issue.number,
-      {
-        remove: ["agent-running"],
-      },
+    let cleanupError: string | null = null;
+    try {
+      editIssueLabels(
+        context.root,
+        context.config.repository,
+        context.issue.number,
+        {
+          remove: ["agent-running"],
+        },
+      );
+    } catch (labelError) {
+      cleanupError =
+        labelError instanceof Error ? labelError.message : String(labelError);
+    }
+
+    try {
+      commentOnIssue(
+        context.root,
+        context.config.repository,
+        context.issue.number,
+        buildRunnerFailureComment({
+          issue: context.issue,
+          branch,
+          error: summary.error ?? "unknown runner error",
+        }),
+      );
+    } catch (commentError) {
+      const commentErrorMessage =
+        commentError instanceof Error
+          ? commentError.message
+          : String(commentError);
+      summary.error = [
+        summary.error,
+        `comment-post-failed: ${commentErrorMessage}`,
+      ]
+        .filter((value) => Boolean(value))
+        .join("\n");
+    }
+
+    if (cleanupError) {
+      summary.error = [
+        summary.error,
+        `agent-running-cleanup-failed: ${cleanupError}`,
+      ]
+        .filter((value) => Boolean(value))
+        .join("\n");
+    }
+    writeFileSync(
+      runPaths.summaryFile,
+      JSON.stringify(summary, null, 2),
+      "utf8",
     );
     return summary;
   }

--- a/src/runner/service.ts
+++ b/src/runner/service.ts
@@ -1,0 +1,772 @@
+import { spawn, spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  openSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import {
+  buildRunnerFailureComment,
+  buildRunnerSuccessComment,
+} from "./comments.js";
+import { loadWorkflowContract, type RunnerWorkflowConfig } from "./config.js";
+import { writeRunnerHeartbeat } from "./heartbeat.js";
+
+export type RunnerIssue = {
+  number: number;
+  title: string;
+  body: string;
+  url: string;
+  labels: string[];
+};
+
+export type RunnerPullRequestSummary = {
+  number: number;
+  url: string;
+  checksUrl: string | null;
+};
+
+export type RunnerRunSummary = {
+  status: "success" | "failed" | "idle";
+  issueNumber: number | null;
+  branch: string | null;
+  worktreePath: string | null;
+  logFile: string | null;
+  lastMessageFile: string;
+  commitSha: string | null;
+  prUrl: string | null;
+  error: string | null;
+};
+
+type RunnerJsonIssue = {
+  number: number;
+  title: string;
+  body?: string | null;
+  url: string;
+  labels?: Array<{ name?: string | null }>;
+};
+
+type RunnerJsonPullRequest = {
+  number: number;
+  url: string;
+};
+
+type RunnerOptions = {
+  root?: string;
+  concurrency?: number;
+  pollIntervalMs?: number;
+};
+
+type ProcessIssueContext = {
+  root: string;
+  config: RunnerWorkflowConfig;
+  issue: RunnerIssue;
+};
+
+const DEFAULT_CONCURRENCY = 2;
+const DEFAULT_POLL_INTERVAL_MS = 30_000;
+
+function runCommand(
+  command: string,
+  args: string[],
+  options: {
+    cwd: string;
+    input?: string;
+    env?: NodeJS.ProcessEnv;
+    allowFailure?: boolean;
+  },
+): string {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    env: { ...process.env, ...(options.env ?? {}) },
+    encoding: "utf8",
+    input: options.input,
+  });
+  if (result.status !== 0 && !options.allowFailure) {
+    throw new Error(
+      [result.stdout, result.stderr]
+        .map((chunk) => chunk.trim())
+        .filter((chunk) => chunk.length > 0)
+        .join("\n") || `${command} ${args.join(" ")} failed`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+function runJsonCommand<T>(command: string, args: string[], cwd: string): T {
+  const output = runCommand(command, args, { cwd });
+  return JSON.parse(output) as T;
+}
+
+function resolveRepoRoot(cwd = process.cwd()): string {
+  return runCommand("git", ["rev-parse", "--show-toplevel"], { cwd });
+}
+
+function ensureDirectory(path: string): void {
+  mkdirSync(path, { recursive: true });
+}
+
+function hasAllLabels(issue: RunnerIssue, labels: string[]): boolean {
+  return labels.every((label) => issue.labels.includes(label));
+}
+
+function hasAnyExcludedLabel(issue: RunnerIssue, labels: string[]): boolean {
+  return labels.some((label) => issue.labels.includes(label));
+}
+
+export function selectRunnableIssues(
+  issues: RunnerIssue[],
+  config: RunnerWorkflowConfig,
+): RunnerIssue[] {
+  return issues
+    .filter(
+      (issue) =>
+        hasAllLabels(issue, config.readyLabels) &&
+        !hasAnyExcludedLabel(issue, config.excludeLabels),
+    )
+    .sort((left, right) => left.number - right.number);
+}
+
+export function slugifyIssueTitle(title: string, maxLength = 48): string {
+  const normalized = title
+    .toLowerCase()
+    .replace(/\[[^\]]+\]\s*/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  const trimmed = normalized.slice(0, maxLength).replace(/-+$/g, "");
+  return trimmed || "task";
+}
+
+export function buildIssueBranchName(
+  issue: Pick<RunnerIssue, "number" | "title">,
+  config: RunnerWorkflowConfig,
+): string {
+  return `${config.branchPrefix}issue-${issue.number}-${slugifyIssueTitle(issue.title)}`;
+}
+
+function resolveRunnerRoot(root: string): string {
+  return join(resolve(root), ".tmp", "runner");
+}
+
+function resolveRunRoot(root: string): string {
+  return join(resolveRunnerRoot(root), "runs");
+}
+
+function resolveWorkspaceRoot(root: string): string {
+  return join(resolveRunnerRoot(root), "worktrees");
+}
+
+function resolveIssueWorktreePath(root: string, issue: RunnerIssue): string {
+  return join(
+    resolveWorkspaceRoot(root),
+    `issue-${issue.number}-${slugifyIssueTitle(issue.title, 24)}`,
+  );
+}
+
+function resolveRunPaths(
+  root: string,
+  issue: RunnerIssue,
+): {
+  runDir: string;
+  logFile: string;
+  lastMessageFile: string;
+  summaryFile: string;
+  prBodyFile: string;
+} {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const runDir = join(
+    resolveRunRoot(root),
+    `issue-${issue.number}-${timestamp}`,
+  );
+  return {
+    runDir,
+    logFile: join(runDir, "codex.log"),
+    lastMessageFile: join(runDir, "last-message.md"),
+    summaryFile: join(runDir, "summary.json"),
+    prBodyFile: join(runDir, "pr-body.md"),
+  };
+}
+
+function listOpenIssues(root: string, repository: string): RunnerIssue[] {
+  const issues = runJsonCommand<RunnerJsonIssue[]>(
+    "gh",
+    [
+      "issue",
+      "list",
+      "--repo",
+      repository,
+      "--state",
+      "open",
+      "--limit",
+      "100",
+      "--json",
+      "number,title,body,url,labels",
+    ],
+    root,
+  );
+  return issues.map((issue) => ({
+    number: issue.number,
+    title: issue.title,
+    body: issue.body ?? "",
+    url: issue.url,
+    labels: (issue.labels ?? [])
+      .map((label) => String(label.name ?? "").trim())
+      .filter((label) => label.length > 0),
+  }));
+}
+
+function editIssueLabels(
+  root: string,
+  repository: string,
+  issueNumber: number,
+  changes: { add?: string[]; remove?: string[] },
+): void {
+  const args = ["issue", "edit", String(issueNumber), "--repo", repository];
+  for (const label of changes.add ?? []) {
+    args.push("--add-label", label);
+  }
+  for (const label of changes.remove ?? []) {
+    args.push("--remove-label", label);
+  }
+  runCommand("gh", args, { cwd: root });
+}
+
+function commentOnIssue(
+  root: string,
+  repository: string,
+  issueNumber: number,
+  body: string,
+): void {
+  runCommand(
+    "gh",
+    [
+      "issue",
+      "comment",
+      String(issueNumber),
+      "--repo",
+      repository,
+      "--body",
+      body,
+    ],
+    { cwd: root },
+  );
+}
+
+function commentOnPr(
+  root: string,
+  repository: string,
+  prNumber: number,
+  body: string,
+): void {
+  runCommand(
+    "gh",
+    ["pr", "comment", String(prNumber), "--repo", repository, "--body", body],
+    { cwd: root },
+  );
+}
+
+function findOpenPullRequest(
+  root: string,
+  repository: string,
+  branch: string,
+): RunnerPullRequestSummary | null {
+  const prs = runJsonCommand<RunnerJsonPullRequest[]>(
+    "gh",
+    [
+      "pr",
+      "list",
+      "--repo",
+      repository,
+      "--state",
+      "open",
+      "--head",
+      branch,
+      "--json",
+      "number,url",
+    ],
+    root,
+  );
+  const pr = prs[0];
+  if (!pr) {
+    return null;
+  }
+  return {
+    number: pr.number,
+    url: pr.url,
+    checksUrl: `${pr.url}/checks`,
+  };
+}
+
+function createPullRequest(input: {
+  root: string;
+  repository: string;
+  issue: RunnerIssue;
+  branch: string;
+  prBase: string;
+  prBodyFile: string;
+}): RunnerPullRequestSummary {
+  const title = input.issue.title.replace(/^\[[^\]]+\]\s*/, "").trim();
+  writeFileSync(
+    input.prBodyFile,
+    [
+      `Fixes #${input.issue.number}`,
+      "",
+      "## Summary",
+      "- Implemented by the harness runner in a dedicated worktree.",
+      "- CI and preview workflows will attach proof artifacts on this PR.",
+      "",
+      "## Source issue",
+      `- ${input.issue.url}`,
+    ].join("\n"),
+    "utf8",
+  );
+  const url = runCommand(
+    "gh",
+    [
+      "pr",
+      "create",
+      "--repo",
+      input.repository,
+      "--base",
+      input.prBase,
+      "--head",
+      input.branch,
+      "--title",
+      title,
+      "--body-file",
+      input.prBodyFile,
+    ],
+    { cwd: input.root },
+  )
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.startsWith("https://"));
+  if (!url) {
+    throw new Error("gh pr create did not return a PR URL");
+  }
+  const number = Number(url.match(/\/pull\/(\d+)$/)?.[1] ?? Number.NaN);
+  return {
+    number,
+    url,
+    checksUrl: `${url}/checks`,
+  };
+}
+
+function updatePullRequestBase(
+  root: string,
+  repository: string,
+  prNumber: number,
+  prBase: string,
+): void {
+  runCommand(
+    "gh",
+    ["pr", "edit", String(prNumber), "--repo", repository, "--base", prBase],
+    { cwd: root },
+  );
+}
+
+function remoteBranchExists(root: string, branch: string): boolean {
+  const result = spawnSync(
+    "git",
+    ["ls-remote", "--exit-code", "--heads", "origin", branch],
+    {
+      cwd: root,
+      stdio: "ignore",
+    },
+  );
+  return result.status === 0;
+}
+
+function isGitWorktree(path: string): boolean {
+  const result = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
+    cwd: path,
+    stdio: "ignore",
+  });
+  return result.status === 0;
+}
+
+function ensureWorktreeDependencies(worktreePath: string): void {
+  const rootNodeModules = join(worktreePath, "node_modules");
+  const portalNodeModules = join(
+    worktreePath,
+    "apps",
+    "portal",
+    "node_modules",
+  );
+  const workerNodeModules = join(
+    worktreePath,
+    "apps",
+    "worker",
+    "node_modules",
+  );
+  if (
+    existsSync(rootNodeModules) &&
+    existsSync(portalNodeModules) &&
+    existsSync(workerNodeModules)
+  ) {
+    return;
+  }
+  runCommand("bun", ["install", "--frozen-lockfile"], { cwd: worktreePath });
+}
+
+function ensureIssueWorktree(input: {
+  root: string;
+  issue: RunnerIssue;
+  branch: string;
+  prBase: string;
+}): string {
+  ensureDirectory(resolveWorkspaceRoot(input.root));
+  runCommand("git", ["fetch", "origin", input.prBase], { cwd: input.root });
+  if (remoteBranchExists(input.root, input.branch)) {
+    runCommand("git", ["fetch", "origin", input.branch], { cwd: input.root });
+  }
+
+  const worktreePath = resolveIssueWorktreePath(input.root, input.issue);
+  const startPoint = remoteBranchExists(input.root, input.branch)
+    ? `origin/${input.branch}`
+    : `origin/${input.prBase}`;
+
+  if (!existsSync(worktreePath)) {
+    runCommand(
+      "git",
+      ["worktree", "add", "-B", input.branch, worktreePath, startPoint],
+      { cwd: input.root },
+    );
+  } else if (!isGitWorktree(worktreePath)) {
+    rmSync(worktreePath, { recursive: true, force: true });
+    runCommand(
+      "git",
+      ["worktree", "add", "-B", input.branch, worktreePath, startPoint],
+      { cwd: input.root },
+    );
+  } else if (remoteBranchExists(input.root, input.branch)) {
+    runCommand("git", ["checkout", input.branch], { cwd: worktreePath });
+    runCommand("git", ["reset", "--hard", `origin/${input.branch}`], {
+      cwd: worktreePath,
+    });
+  } else {
+    runCommand(
+      "git",
+      ["checkout", "-B", input.branch, `origin/${input.prBase}`],
+      {
+        cwd: worktreePath,
+      },
+    );
+  }
+
+  ensureWorktreeDependencies(worktreePath);
+  return worktreePath;
+}
+
+function buildRunnerPrompt(
+  issue: RunnerIssue,
+  config: RunnerWorkflowConfig,
+): string {
+  return [
+    `Work GitHub issue #${issue.number} in ${config.repository}.`,
+    "Use WORKFLOW.md in the repo root as the execution contract.",
+    "Make the smallest complete set of code, test, and docs changes needed for the issue.",
+    "Run the narrowest relevant validation commands before stopping.",
+    "Do not open or merge PRs. Do not push. Leave the worktree ready for the runner to commit and push.",
+    "",
+    `Issue title: ${issue.title}`,
+    "",
+    "Issue body:",
+    issue.body.trim() || "(no issue body provided)",
+  ].join("\n");
+}
+
+function runLoggedCommand(input: {
+  command: string;
+  args: string[];
+  cwd: string;
+  logFile: string;
+}): Promise<void> {
+  ensureDirectory(dirname(input.logFile));
+  return new Promise((resolvePromise, rejectPromise) => {
+    const stdoutFd = openSync(input.logFile, "a");
+    const stderrFd = openSync(input.logFile, "a");
+    const child = spawn(input.command, input.args, {
+      cwd: input.cwd,
+      env: process.env,
+      stdio: ["ignore", stdoutFd, stderrFd],
+    });
+    child.once("error", (error) => rejectPromise(error));
+    child.once("exit", (code) => {
+      if (code === 0) {
+        resolvePromise();
+        return;
+      }
+      rejectPromise(
+        new Error(
+          `${input.command} ${input.args.join(" ")} failed with code ${code}`,
+        ),
+      );
+    });
+  });
+}
+
+function commitAndPushWorktree(
+  worktreePath: string,
+  branch: string,
+  issue: RunnerIssue,
+): string {
+  const status = runCommand("git", ["status", "--short"], {
+    cwd: worktreePath,
+  });
+  if (!status) {
+    throw new Error("runner completed without producing any file changes");
+  }
+  runCommand("git", ["add", "-A"], { cwd: worktreePath });
+  runCommand("git", ["commit", "-m", `feat: resolve #${issue.number}`], {
+    cwd: worktreePath,
+  });
+  runCommand("git", ["push", "-u", "origin", branch], { cwd: worktreePath });
+  return runCommand("git", ["rev-parse", "HEAD"], { cwd: worktreePath });
+}
+
+async function processIssue(
+  context: ProcessIssueContext,
+): Promise<RunnerRunSummary> {
+  const branch = buildIssueBranchName(context.issue, context.config);
+  const runPaths = resolveRunPaths(context.root, context.issue);
+  ensureDirectory(runPaths.runDir);
+
+  try {
+    editIssueLabels(
+      context.root,
+      context.config.repository,
+      context.issue.number,
+      {
+        add: ["agent-running"],
+      },
+    );
+
+    const worktreePath = ensureIssueWorktree({
+      root: context.root,
+      issue: context.issue,
+      branch,
+      prBase: context.config.defaultPrBase,
+    });
+
+    await runLoggedCommand({
+      command: "codex",
+      args: [
+        "exec",
+        "--cd",
+        worktreePath,
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--output-last-message",
+        runPaths.lastMessageFile,
+        buildRunnerPrompt(context.issue, context.config),
+      ],
+      cwd: context.root,
+      logFile: runPaths.logFile,
+    });
+
+    const commitSha = commitAndPushWorktree(
+      worktreePath,
+      branch,
+      context.issue,
+    );
+    let pr =
+      findOpenPullRequest(context.root, context.config.repository, branch) ??
+      createPullRequest({
+        root: context.root,
+        repository: context.config.repository,
+        issue: context.issue,
+        branch,
+        prBase: context.config.defaultPrBase,
+        prBodyFile: runPaths.prBodyFile,
+      });
+    updatePullRequestBase(
+      context.root,
+      context.config.repository,
+      pr.number,
+      context.config.defaultPrBase,
+    );
+    pr =
+      findOpenPullRequest(context.root, context.config.repository, branch) ??
+      pr;
+
+    const summary: RunnerRunSummary = {
+      status: "success",
+      issueNumber: context.issue.number,
+      branch,
+      worktreePath,
+      logFile: runPaths.logFile,
+      lastMessageFile: runPaths.lastMessageFile,
+      commitSha,
+      prUrl: pr.url,
+      error: null,
+    };
+    writeFileSync(
+      runPaths.summaryFile,
+      JSON.stringify(summary, null, 2),
+      "utf8",
+    );
+
+    commentOnPr(
+      context.root,
+      context.config.repository,
+      pr.number,
+      buildRunnerSuccessComment({
+        issue: context.issue,
+        branch,
+        pr,
+        summary,
+      }),
+    );
+    editIssueLabels(
+      context.root,
+      context.config.repository,
+      context.issue.number,
+      {
+        add: ["human-review"],
+        remove: ["agent-running"],
+      },
+    );
+    return summary;
+  } catch (error) {
+    const summary: RunnerRunSummary = {
+      status: "failed",
+      issueNumber: context.issue.number,
+      branch,
+      worktreePath: resolveIssueWorktreePath(context.root, context.issue),
+      logFile: runPaths.logFile,
+      lastMessageFile: runPaths.lastMessageFile,
+      commitSha: null,
+      prUrl:
+        findOpenPullRequest(context.root, context.config.repository, branch)
+          ?.url ?? null,
+      error: error instanceof Error ? error.message : String(error),
+    };
+    writeFileSync(
+      runPaths.summaryFile,
+      JSON.stringify(summary, null, 2),
+      "utf8",
+    );
+    commentOnIssue(
+      context.root,
+      context.config.repository,
+      context.issue.number,
+      buildRunnerFailureComment({
+        issue: context.issue,
+        branch,
+        error: summary.error ?? "unknown runner error",
+      }),
+    );
+    editIssueLabels(
+      context.root,
+      context.config.repository,
+      context.issue.number,
+      {
+        remove: ["agent-running"],
+      },
+    );
+    return summary;
+  }
+}
+
+export async function runRunnerOnce(
+  options: RunnerOptions = {},
+): Promise<RunnerRunSummary[]> {
+  const root = resolve(options.root ?? resolveRepoRoot());
+  const config = loadWorkflowContract(root);
+  const concurrency = Math.max(1, options.concurrency ?? DEFAULT_CONCURRENCY);
+  const issues = selectRunnableIssues(
+    listOpenIssues(root, config.repository),
+    config,
+  );
+
+  if (issues.length === 0) {
+    writeRunnerHeartbeat(root, {
+      status: "idle",
+      concurrency,
+      activeRuns: 0,
+      note: "No agent-ready harness issues found.",
+    });
+    return [
+      {
+        status: "idle",
+        issueNumber: null,
+        branch: null,
+        worktreePath: null,
+        logFile: null,
+        lastMessageFile: join(resolveRunRoot(root), "none"),
+        commitSha: null,
+        prUrl: null,
+        error: null,
+      },
+    ];
+  }
+
+  const selectedIssues = issues.slice(0, concurrency);
+  writeRunnerHeartbeat(root, {
+    status: "running",
+    concurrency,
+    activeRuns: selectedIssues.length,
+    note: `Processing issues ${selectedIssues.map((issue) => `#${issue.number}`).join(", ")}.`,
+  });
+
+  const results = await Promise.all(
+    selectedIssues.map((issue) =>
+      processIssue({
+        root,
+        config,
+        issue,
+      }),
+    ),
+  );
+
+  const failures = results.filter((result) => result.status === "failed");
+  writeRunnerHeartbeat(root, {
+    status: failures.length > 0 ? "degraded" : "idle",
+    concurrency,
+    activeRuns: 0,
+    note:
+      failures.length > 0
+        ? `Failures: ${failures.map((result) => `#${result.issueNumber}`).join(", ")}.`
+        : `Completed ${results.length} issue run(s).`,
+  });
+  return results;
+}
+
+export async function startRunner(options: RunnerOptions = {}): Promise<void> {
+  const root = resolve(options.root ?? resolveRepoRoot());
+  const pollIntervalMs = Math.max(
+    5_000,
+    options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+  );
+  while (true) {
+    await runRunnerOnce(options);
+    await new Promise((resolvePromise) =>
+      setTimeout(resolvePromise, pollIntervalMs),
+    );
+    writeRunnerHeartbeat(root, {
+      status: "polling",
+      concurrency: Math.max(1, options.concurrency ?? DEFAULT_CONCURRENCY),
+      activeRuns: 0,
+      note: "Waiting for the next GitHub issue poll.",
+    });
+  }
+}
+
+export function formatRunnerSummaries(results: RunnerRunSummary[]): string {
+  return results
+    .map((result) => {
+      const headline =
+        result.status === "idle"
+          ? "- idle"
+          : `- #${result.issueNumber} ${result.status}`;
+      const branchLine = result.branch ? `  branch: ${result.branch}` : null;
+      const prLine = result.prUrl ? `  pr: ${result.prUrl}` : null;
+      const errorLine = result.error ? `  error: ${result.error}` : null;
+      return [headline, branchLine, prLine, errorLine]
+        .filter((line) => line !== null)
+        .join("\n");
+    })
+    .join("\n");
+}

--- a/tests/unit/runner_config.test.ts
+++ b/tests/unit/runner_config.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import { parseWorkflowContract } from "../../src/runner/config";
+
+test("parseWorkflowContract reads runner settings from frontmatter", () => {
+  const config = parseWorkflowContract(`---
+tracker:
+  repository: GuiBibeau/serious-trader-ralph
+  ready_labels:
+    - harness
+    - agent-ready
+  exclude_labels:
+    - blocked
+branching:
+  branch_prefix: codex/
+  branch_format: codex/issue-<number>-<slug>
+  default_pr_base: dev
+---
+
+# Contract
+`);
+
+  expect(config.repository).toBe("GuiBibeau/serious-trader-ralph");
+  expect(config.readyLabels).toEqual(["harness", "agent-ready"]);
+  expect(config.excludeLabels).toEqual(["blocked"]);
+  expect(config.branchPrefix).toBe("codex/");
+  expect(config.defaultPrBase).toBe("dev");
+});
+
+test("parseWorkflowContract falls back to defaults when frontmatter is absent", () => {
+  const config = parseWorkflowContract("# No frontmatter");
+
+  expect(config.repository).toBe("GuiBibeau/serious-trader-ralph");
+  expect(config.readyLabels).toEqual(["harness", "agent-ready"]);
+  expect(config.excludeLabels).toEqual([
+    "blocked",
+    "agent-running",
+    "human-review",
+  ]);
+});

--- a/tests/unit/runner_heartbeat.test.ts
+++ b/tests/unit/runner_heartbeat.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  readRunnerHeartbeat,
+  resolveRunnerHeartbeatPath,
+  writeRunnerHeartbeat,
+} from "../../src/runner/heartbeat";
+
+const temporaryRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("writeRunnerHeartbeat persists repo-local runner state", () => {
+  const root = mkdtempSync(join(tmpdir(), "runner-heartbeat-"));
+  temporaryRoots.push(root);
+
+  const heartbeat = writeRunnerHeartbeat(root, {
+    status: "running",
+    concurrency: 2,
+    activeRuns: 1,
+    note: "Processing issue #239.",
+  });
+
+  expect(resolveRunnerHeartbeatPath(root)).toBe(
+    join(root, ".harness", "runner-heartbeat.json"),
+  );
+  expect(heartbeat.updatedAt.length).toBeGreaterThan(0);
+  expect(readRunnerHeartbeat(root)).toEqual(heartbeat);
+});

--- a/tests/unit/runner_service.test.ts
+++ b/tests/unit/runner_service.test.ts
@@ -1,0 +1,130 @@
+import { expect, test } from "bun:test";
+import {
+  buildRunnerFailureComment,
+  buildRunnerSuccessComment,
+} from "../../src/runner/comments";
+import {
+  buildIssueBranchName,
+  formatRunnerSummaries,
+  type RunnerIssue,
+  selectRunnableIssues,
+  slugifyIssueTitle,
+} from "../../src/runner/service";
+
+const config = {
+  repository: "GuiBibeau/serious-trader-ralph",
+  readyLabels: ["harness", "agent-ready"],
+  excludeLabels: ["blocked", "agent-running", "human-review"],
+  branchPrefix: "codex/",
+  branchFormat: "codex/issue-<number>-<slug>",
+  defaultPrBase: "dev",
+};
+
+function buildIssue(
+  number: number,
+  title: string,
+  labels: string[],
+): RunnerIssue {
+  return {
+    number,
+    title,
+    body: "",
+    url: `https://github.com/GuiBibeau/serious-trader-ralph/issues/${number}`,
+    labels,
+  };
+}
+
+test("selectRunnableIssues requires all ready labels and excludes blocked states", () => {
+  const issues = [
+    buildIssue(239, "[Runner] Build GitHub Issues adapter", [
+      "harness",
+      "agent-ready",
+    ]),
+    buildIssue(240, "[PR Handoff] Standardize proof", ["harness"]),
+    buildIssue(241, "[Env Simplification] Remove staging", [
+      "harness",
+      "agent-ready",
+      "human-review",
+    ]),
+  ];
+
+  expect(
+    selectRunnableIssues(issues, config).map((issue) => issue.number),
+  ).toEqual([239]);
+});
+
+test("buildIssueBranchName follows the codex issue format", () => {
+  expect(
+    buildIssueBranchName(
+      buildIssue(239, "[Runner] Build GitHub Issues adapter", [
+        "harness",
+        "agent-ready",
+      ]),
+      config,
+    ),
+  ).toBe("codex/issue-239-build-github-issues-adapter");
+});
+
+test("slugifyIssueTitle strips bracket prefixes and punctuation", () => {
+  expect(slugifyIssueTitle("[Ops] Add kill switches & rollback", 64)).toBe(
+    "add-kill-switches-rollback",
+  );
+});
+
+test("runner comments include the key handoff details", () => {
+  const issue = buildIssue(239, "[Runner] Build GitHub Issues adapter", [
+    "harness",
+    "agent-ready",
+  ]);
+
+  const success = buildRunnerSuccessComment({
+    issue,
+    branch: "codex/issue-239-build-github-issues-adapter",
+    pr: {
+      number: 250,
+      url: "https://github.com/GuiBibeau/serious-trader-ralph/pull/250",
+      checksUrl:
+        "https://github.com/GuiBibeau/serious-trader-ralph/pull/250/checks",
+    },
+    summary: {
+      status: "success",
+      issueNumber: 239,
+      branch: "codex/issue-239-build-github-issues-adapter",
+      worktreePath: "/tmp/runner/issue-239",
+      logFile: "/tmp/runner/log.txt",
+      lastMessageFile: "/tmp/runner/last-message.md",
+      commitSha: "abc123",
+      prUrl: "https://github.com/GuiBibeau/serious-trader-ralph/pull/250",
+      error: null,
+    },
+  });
+  const failure = buildRunnerFailureComment({
+    issue,
+    branch: "codex/issue-239-build-github-issues-adapter",
+    error: "codex exec failed",
+  });
+
+  expect(success).toContain("Harness Runner Status");
+  expect(success).toContain("pull/250/checks");
+  expect(success).not.toContain("/tmp/runner");
+  expect(failure).toContain("Harness Runner Failure");
+  expect(failure).toContain("codex exec failed");
+});
+
+test("formatRunnerSummaries prints a compact status list", () => {
+  expect(
+    formatRunnerSummaries([
+      {
+        status: "success",
+        issueNumber: 239,
+        branch: "codex/issue-239-build-github-issues-adapter",
+        worktreePath: "/tmp/runner/issue-239",
+        logFile: "/tmp/runner/log.txt",
+        lastMessageFile: "/tmp/runner/last-message.md",
+        commitSha: "abc123",
+        prUrl: "https://github.com/GuiBibeau/serious-trader-ralph/pull/250",
+        error: null,
+      },
+    ]),
+  ).toContain("#239 success");
+});


### PR DESCRIPTION
Fixes #239

## Summary
- add a repo-owned runner CLI that polls GitHub issues from WORKFLOW.md, claims eligible work, and executes Codex in isolated git worktrees
- add runner heartbeat, PR/issue handoff helpers, and docs/scripts for local verification
- add focused unit coverage for runner config parsing, issue selection, branch naming, comments, and heartbeat persistence

## Validation
- bun run lint
- bun run typecheck
- bun test tests/unit/runner_config.test.ts tests/unit/runner_heartbeat.test.ts tests/unit/runner_service.test.ts
- bun run test:unit
- bun run runner:once
