### PR TITLE
Fix prod health when Loop A is intentionally disabled

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -851,6 +851,11 @@ const worker = {
     await recordEndpointCallSafe(env, request.method, url.pathname);
     try {
       if (request.method === "GET" && url.pathname === "/api/health") {
+        const loopASlotSourceEnabled =
+          String(env.LOOP_A_SLOT_SOURCE_ENABLED ?? "0").trim() === "1";
+        if (!loopASlotSourceEnabled) {
+          return withCors(json({ ok: true }), env);
+        }
         const loopAHealth = await readLoopAHealthFromKv(env);
         if (!loopAHealth) {
           return withCors(json({ ok: true }), env);
@@ -868,7 +873,11 @@ const worker = {
         request.method === "GET" &&
         url.pathname === "/api/x402/exec/health"
       ) {
-        const loopAHealth = await readLoopAHealthFromKv(env);
+        const loopASlotSourceEnabled =
+          String(env.LOOP_A_SLOT_SOURCE_ENABLED ?? "0").trim() === "1";
+        const loopAHealth = loopASlotSourceEnabled
+          ? await readLoopAHealthFromKv(env)
+          : null;
         const opsControls = await readOpsControlSnapshot(env);
         const routing = readExecutionLaneRoutingConfig(
           env,

--- a/tests/unit/worker_loop_a_health.test.ts
+++ b/tests/unit/worker_loop_a_health.test.ts
@@ -227,6 +227,7 @@ describe("worker loop A health + latency telemetry", () => {
 
   test("api health returns loop-a artifact when available", async () => {
     const { env } = createEnv({ withR2: false });
+    env.LOOP_A_SLOT_SOURCE_ENABLED = "1";
     const cursorState = createCursorState({ head: 640, state: 640 });
     await recordLoopAHealthTick(env, {
       ok: true,
@@ -252,5 +253,29 @@ describe("worker loop A health + latency telemetry", () => {
         lastSuccessfulSlot: 640,
       },
     });
+  });
+
+  test("api health ignores stale loop-a errors when slot source is disabled", async () => {
+    const { env } = createEnv({ withR2: false });
+    await recordLoopAHealthTick(env, {
+      ok: false,
+      trigger: "scheduled",
+      startedAtMs: 1000,
+      nowMs: 1300,
+      observedAt: "2026-02-21T12:30:00.000Z",
+      cursorStateFallback: createCursorState({ head: 900, state: 640 }),
+      error: new Error("loop-a-slot-source-disabled"),
+    });
+
+    env.LOOP_A_SLOT_SOURCE_ENABLED = "0";
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/health", { method: "GET" }),
+      env,
+      createExecutionContextStub(),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
   });
 });

--- a/tests/unit/worker_x402_exec_health_route.test.ts
+++ b/tests/unit/worker_x402_exec_health_route.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import worker from "../../apps/worker/src/index";
+import { recordLoopAHealthTick } from "../../apps/worker/src/loop_a/health";
 import type { Env } from "../../apps/worker/src/types";
 
 function createExecutionContextStub(): ExecutionContext {
@@ -7,6 +8,27 @@ function createExecutionContextStub(): ExecutionContext {
     waitUntil(_promise: Promise<unknown>) {},
     passThroughOnException() {},
   } as ExecutionContext;
+}
+
+function createMockKv() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    kv: {
+      get: async (key: string) => store.get(key) ?? null,
+      put: async (key: string, value: string) => {
+        store.set(key, value);
+      },
+      delete: async (key: string) => {
+        store.delete(key);
+      },
+      list: async () => ({
+        keys: [...store.keys()].map((name) => ({ name })),
+        list_complete: true,
+        cursor: "",
+      }),
+    },
+  };
 }
 
 describe("worker x402 exec health route", () => {
@@ -50,5 +72,58 @@ describe("worker x402 exec health route", () => {
     expect(lanes.fast?.enabled).toBe(false);
     expect(lanes.protected?.enabled).toBe(false);
     expect(lanes.safe?.enabled).toBe(false);
+  });
+
+  test("suppresses stale loop-a artifacts when slot source is disabled", async () => {
+    const { kv } = createMockKv();
+    const env = {
+      ALLOWED_ORIGINS: "*",
+      CONFIG_KV: kv as never,
+      LOOP_A_SLOT_SOURCE_ENABLED: "0",
+    } as Env;
+
+    await recordLoopAHealthTick(env, {
+      ok: false,
+      trigger: "scheduled",
+      startedAtMs: 1000,
+      nowMs: 1400,
+      observedAt: "2026-02-21T13:00:00.000Z",
+      cursorStateFallback: {
+        schemaVersion: "v1",
+        updatedAt: "2026-02-21T13:00:00.000Z",
+        headCursor: {
+          processed: 100,
+          confirmed: 100,
+          finalized: 100,
+        },
+        fetchedCursor: {
+          processed: 100,
+          confirmed: 100,
+          finalized: 100,
+        },
+        ingestionCursor: {
+          processed: 100,
+          confirmed: 100,
+          finalized: 100,
+        },
+        stateCursor: {
+          processed: 90,
+          confirmed: 90,
+          finalized: 90,
+        },
+      },
+      error: new Error("loop-a-slot-source-disabled"),
+    });
+
+    const response = await worker.fetch(
+      new Request("https://dev.api.trader-ralph.com/api/x402/exec/health"),
+      env,
+      createExecutionContextStub(),
+    );
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as Record<string, unknown>;
+    expect(payload.ok).toBe(true);
+    expect(payload.loopA).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- treat disabled Loop A as not applicable in the general health route
- suppress stale Loop A artifacts in execution health when the slot source is disabled
- add regression tests for both health surfaces

## Verification
- bun test tests/unit/worker_loop_a_health.test.ts tests/unit/worker_x402_exec_health_route.test.ts tests/unit/worker_cutover_routes.test.ts
- bun run typecheck
- bunx biome check apps/worker/src/index.ts tests/unit/worker_loop_a_health.test.ts tests/unit/worker_x402_exec_health_route.test.ts