### PR TITLE
Add autonomous runtime planning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ It provides one execution fabric for:
 - `apps/worker`: Cloudflare Worker API (execution, x402, discovery)
 - `tests/`: unit + integration tests
 - `docs/`: execution contracts, registry runbooks, and metadata
+- `docs/product-specs`, `docs/design-docs`, `docs/reliability`,
+  `docs/exec-plans`: repo-owned product, architecture, runbook, and rollout
+  docs for the autonomous runtime program
 
 ## Repository Contract
 
@@ -20,6 +23,10 @@ It provides one execution fabric for:
   manual issue branches
 - `docs/repository-verification-index.md`: architecture map, invariants,
   environment inventory, rollback steps, and verification playbooks
+- `docs/product-specs/autonomous-runtime-prd.md`: repo-owned product spec for
+  the Rust hot path rollout
+- `docs/design-docs/autonomous-runtime-architecture.md`: system boundary,
+  topology, and state ownership decisions for runtime-rs
 
 ## What Is Live
 

--- a/docs/design-docs/adrs/ADR-0001-runtime-internal-transport.md
+++ b/docs/design-docs/adrs/ADR-0001-runtime-internal-transport.md
@@ -1,0 +1,34 @@
+# ADR-0001: Runtime internal transport
+
+## Status
+
+Accepted on 2026-03-07
+
+## Context
+
+Runtime-rs needs a private coordination path with the Worker for deployment
+control, health, and execution lifecycle data. The repo already has strong HTTP
+tooling, Cloudflare route handling, fixture-driven contract tests, and harness
+proof expectations.
+
+The main choice for v1 is whether to start with HTTP+JSON or jump directly to
+gRPC.
+
+## Decision
+
+Start with service-authenticated HTTP+JSON for all Worker-to-runtime and
+runtime-to-Worker internal APIs.
+
+## Rationale
+
+- It fits the current Worker and Bun tooling immediately.
+- It is easier to inspect in tests, CI logs, and proof artifacts.
+- It keeps internal contracts legible for the harness and for code review.
+- It avoids introducing transport complexity before runtime behavior is proven.
+
+## Consequences
+
+- Internal schemas must be versioned and shared in-repo.
+- Service-auth enforcement is mandatory before the routes are used.
+- If runtime traffic or operability later demands gRPC, that becomes a
+  deliberate follow-up change rather than an assumption in v1.

--- a/docs/design-docs/adrs/ADR-0002-runtime-storage-ownership.md
+++ b/docs/design-docs/adrs/ADR-0002-runtime-storage-ownership.md
@@ -1,0 +1,37 @@
+# ADR-0002: Runtime storage ownership
+
+## Status
+
+Accepted on 2026-03-07
+
+## Context
+
+The Worker already owns public contracts and several Cloudflare-backed data
+surfaces. The autonomous runtime needs its own low-latency, deterministic state
+for deployments, runs, reservations, risk verdicts, and reconciliation.
+
+The choice is whether to extend current Worker persistence for everything or
+give runtime-rs its own canonical store.
+
+## Decision
+
+Use a runtime-owned, single-writer relational store as the canonical home for
+automation state. Keep the Worker as the canonical owner of public execution
+contracts and public read-serving surfaces.
+
+## Rationale
+
+- Strategy execution, reservations, and reconciliation need transactional,
+  regional, low-latency state close to the runtime.
+- The Worker must stay free to serve the public contract boundary without
+  becoming the hot-path source of truth for automation internals.
+- This split lets runtime-rs evolve deterministic automation state without
+  breaking public route guarantees.
+
+## Consequences
+
+- Runtime-rs will need database bootstrap, migrations, backups, and failover
+  planning as part of the Fly foundation work.
+- Public terminal and admin read models may need projections or summaries from
+  runtime state into current Worker-owned surfaces.
+- Contract tests must prove that runtime and Worker views remain coherent.

--- a/docs/design-docs/adrs/ADR-0003-runtime-region-topology.md
+++ b/docs/design-docs/adrs/ADR-0003-runtime-region-topology.md
@@ -1,0 +1,39 @@
+# ADR-0003: Runtime region topology
+
+## Status
+
+Accepted on 2026-03-07
+
+## Context
+
+The autonomous runtime is stateful and long-lived. It needs durable regional
+placement for feeds, state, and execution coordination, but active/active
+execution would create split-brain risk before leader election and distributed
+locking are mature.
+
+## Decision
+
+Run runtime-rs in a single active Fly region with one warm standby region per
+environment or shard. Do not permit active/active strategy execution in v1.
+
+The initial default topology is:
+
+- active region: `ord`
+- warm standby region: `iad`
+
+These defaults can change per environment if latency measurements or provider
+placement justify it, but the single-writer topology does not change in v1.
+
+## Rationale
+
+- One writer keeps reservations, ledger state, and reconciliation sane.
+- A warm standby gives a clear failover target without normalizing dual writes.
+- The chosen defaults keep the first rollout simple and auditable.
+
+## Consequences
+
+- Failover must be explicit and operator-controlled at first.
+- Runtime health, leader state, and database placement must all be visible in
+  dashboards and rollback notes.
+- Any future active/active work requires a separate ADR and explicit
+  split-brain controls.

--- a/docs/design-docs/adrs/ADR-0004-runtime-wallet-sleeves.md
+++ b/docs/design-docs/adrs/ADR-0004-runtime-wallet-sleeves.md
@@ -1,0 +1,42 @@
+# ADR-0004: Runtime wallet sleeves and netting
+
+## Status
+
+Accepted on 2026-03-07
+
+## Context
+
+Trader Ralph already operates with a one-wallet-per-user model. The autonomous
+runtime still needs deterministic capital attribution so one deployment cannot
+silently consume another deployment's budget.
+
+The open design choice is whether v1 should net capital across strategies or
+isolate capital by deployment.
+
+## Decision
+
+Use logical wallet sleeves with explicit reservations per deployment. Do not
+allow cross-strategy netting in v1.
+
+One physical wallet may back several sleeves, but each sleeve has its own:
+
+- capital ceiling,
+- reservation ledger,
+- risk budget,
+- reconciliation record.
+
+## Rationale
+
+- It preserves the current wallet model while keeping automation accounting
+  deterministic.
+- It is easier to reason about during shadow, paper, and first live canary
+  rollouts.
+- It reduces the blast radius of one bad deployment or reconciliation failure.
+
+## Consequences
+
+- The ledger and risk engine must understand logical sleeves even when on-chain
+  balances sit in one physical wallet.
+- Reconciliation must map chain balances back to sleeve attribution.
+- Shared-wallet netting can be considered later only after sleeve accounting
+  and risk proofs are stable.

--- a/docs/design-docs/autonomous-runtime-architecture.md
+++ b/docs/design-docs/autonomous-runtime-architecture.md
@@ -1,0 +1,178 @@
+# Autonomous Runtime Architecture
+
+## Purpose
+
+This document translates the autonomous runtime PRD into a repo-owned technical
+shape that preserves the current harness workflow.
+
+The design goal is simple:
+
+- keep the Worker as the only public edge,
+- keep Bun as the repo and harness control plane,
+- add a Rust hot path without creating a second delivery model.
+
+## System boundaries
+
+| Component | Responsibility | Notes |
+| --- | --- | --- |
+| `apps/portal` | Terminal, operator UI, first-party automation surfaces | Continues to talk only to the Worker |
+| `apps/worker` | Public API boundary, x402, auth-adjacent routes, runtime control routes | Public contracts stay stable |
+| `src/` | Harness commands, runner, local orchestration, proof bundle tooling | Remains the repo-owned operator interface |
+| `services/runtime-rs` | Long-lived automation runtime | Added in `#258` |
+| Runtime relational store | Canonical automation state | Added after Fly foundation lands |
+| Cloudflare D1/KV/R2/DO | Public read models, existing execution data, registry metadata | Remain in place |
+
+## Control and data flow
+
+### Deployment lifecycle
+
+1. A human or future operator surface submits a deployment change to the Worker.
+2. The Worker authenticates the request and stores an auditable control record.
+3. The Worker calls the private runtime control endpoint using service auth.
+4. Runtime-rs persists deployment state and begins or changes execution only
+   after risk and readiness gates pass.
+
+### Run lifecycle
+
+1. Runtime-rs ingests feeds and computes features.
+2. The strategy engine evaluates triggers and produces a deterministic run key.
+3. The risk engine evaluates freshness, exposure, reservation, and lane rules.
+4. The execution planner turns desired state into execution plans.
+5. The exec client coordinates submit, status, and receipt handling through
+   private Worker-facing paths that preserve the existing domain contract.
+6. The reconciler updates runtime state and publishes derived read models as
+   needed for terminal and admin surfaces.
+
+## Runtime modules
+
+### `feed_gateway`
+
+- market data sockets,
+- quote feeds,
+- slot and block notifications,
+- venue and provider health signals.
+
+### `feature_cache`
+
+- rolling market features,
+- freshness timestamps per source,
+- deterministic feature snapshots used by the strategy engine.
+
+### `strategy_engine`
+
+- template registry,
+- deployment lifecycle state machine,
+- deterministic trigger evaluation,
+- canonical run identifiers.
+
+### `portfolio_ledger`
+
+- logical wallet sleeves,
+- reservations,
+- positions,
+- cost basis and PnL attribution,
+- capital availability checks.
+
+### `risk_engine`
+
+- pre-trade notional and concentration checks,
+- stale data rejection,
+- lane and mode safety mapping,
+- stop-trading and kill decisions.
+
+### `execution_planner`
+
+- desired-state delta computation,
+- slice planning,
+- lane selection,
+- safe/protected/fast mapping.
+
+### `exec_client`
+
+- private submit coordination,
+- status and receipt polling,
+- canonical idempotency and retry policy.
+
+### `reconciler`
+
+- wallet state sync,
+- receipt reconciliation,
+- position correction,
+- incident flags when runtime and chain state diverge.
+
+### `ops_server`
+
+- health,
+- readiness,
+- metrics,
+- deployment state,
+- pause, resume, and kill controls.
+
+## Deployment topology
+
+The v1 topology is a single-writer model:
+
+- one active Fly region per environment or shard,
+- one warm standby region,
+- one canonical runtime database placed near the active region,
+- no active/active execution.
+
+Cloudflare remains global for public ingress and read-serving. Runtime-rs stays
+regional and stateful.
+
+## State ownership
+
+| State class | Canonical owner | Replica or projection |
+| --- | --- | --- |
+| Automation deployments, runs, sleeves, reservations, risk verdicts, reconciliation records | Runtime relational store | Worker-readable summaries as needed |
+| Public execution submit, status, and receipt contract | Worker and current execution fabric | Runtime caches for coordination only |
+| Discovery, registry, and public metadata | Worker and repo docs | None |
+| Local feature windows and feed buffers | Runtime memory and local persistence | None |
+
+This split keeps the public contract stable while giving the hot path a
+single-writer source of truth for automation.
+
+## Internal API surface
+
+The first private route family is intentionally small:
+
+- `POST /api/internal/runtime/deployments`
+- `GET /api/internal/runtime/deployments/:id`
+- `POST /api/internal/runtime/deployments/:id/pause`
+- `POST /api/internal/runtime/deployments/:id/resume`
+- `POST /api/internal/runtime/deployments/:id/kill`
+- `GET /api/internal/runtime/runs/:deploymentId`
+- `GET /api/internal/runtime/positions`
+- `GET /api/internal/runtime/pnl`
+- `GET /api/internal/runtime/health`
+
+Transport starts as HTTP+JSON with service auth. Shared schemas and fixtures
+arrive in `#257`.
+
+## Harness compatibility requirements
+
+- `harness:up` must remain backward compatible for portal plus Worker users.
+- Runtime-rs support is optional and off by default until `#260`.
+- `harness:status` will surface runtime-rs health when enabled.
+- `harness:proof` remains the browser proof path for portal and operator flows.
+- The GitHub issue runner remains the only repo-owned execution workflow.
+
+## Failure domains and guardrails
+
+- Region split-brain:
+  one active region, explicit failover, no dual writers.
+- Data staleness:
+  freshness budgets become risk-engine inputs, not UI-only warnings.
+- Contract drift:
+  shared schemas, fixtures, and contract tests are required before Worker and
+  runtime coordination is allowed in production.
+- Capital leakage:
+  logical sleeve reservations prevent one deployment from spending another
+  deployment's capital in v1.
+
+## Related ADRs
+
+- `docs/design-docs/adrs/ADR-0001-runtime-internal-transport.md`
+- `docs/design-docs/adrs/ADR-0002-runtime-storage-ownership.md`
+- `docs/design-docs/adrs/ADR-0003-runtime-region-topology.md`
+- `docs/design-docs/adrs/ADR-0004-runtime-wallet-sleeves.md`

--- a/docs/exec-plans/active/autonomous-runtime-rollout.md
+++ b/docs/exec-plans/active/autonomous-runtime-rollout.md
@@ -1,0 +1,80 @@
+# Autonomous Runtime Rollout Plan
+
+**Status:** Active  
+**Backlog owner:** GitHub issue epic `#255`
+
+## Rollout principles
+
+- Build through the current harness flow only.
+- Do not mark downstream issues `agent-ready` until dependencies are merged and
+  the scope still fits one runner-owned PR.
+- Keep the Worker as the public edge throughout the rollout.
+- Treat shadow, paper, and limited live as distinct gates with proof at each
+  phase.
+
+## Phase map
+
+| Phase | Issues | Deliverables | Exit gate |
+| --- | --- | --- | --- |
+| 0 | `#256`, `#257` | Repo-owned PRD, ADRs, verification docs, canonical protocol plan | Docs merged, no public route change, protocol tests ready to start |
+| 1 | `#258`, `#259`, `#260`, `#261` | Rust workspace, private internal routes, harness compatibility, Fly deploy foundation | Runtime builds, internal auth works, harness remains backward compatible, Fly health path exists |
+| 2 | `#262`, `#263`, `#264` | Feed gateway, feature cache, strategy registry, shadow trigger engine | Deterministic shadow runs, no duplicate run keys, stale-data rules proven |
+| 3 | `#265`, `#266`, `#267` | Ledger, reservations, risk engine, execution planner, paper trading | Paper scorecards stable, unsafe orders rejected, proof bundle artifacts complete |
+| 4 | `#268`, `#269`, `#270`, `#271` | Reconciliation loop, scorecards, ops controls, first live runtime canary | Reconciliation passes, runtime canary stable, rollback controls verified |
+| 5 | `#272`, `#273`, `#274` | Operator visibility, managed template packs 1 and 2 | First live template pack is supportable and incident playbooks are proven |
+| 6 | `#275`, `#276` | Advanced templates and multi-strategy capital coordination | Strategy interaction is stable and capital control remains deterministic |
+
+## Phase-specific rollout notes
+
+### Phase 0
+
+- Docs only.
+- No runtime code path is allowed to affect behavior yet.
+- Merge order is `#256` then `#257`.
+
+### Phase 1
+
+- Keep runtime-rs internal-only.
+- `harness:up` and `harness:down` must remain backward compatible.
+- Stop if Fly deployment requires operational decisions not covered by ADRs.
+
+### Phase 2
+
+- Shadow only.
+- No wallet mutation and no live submit path.
+- Require replayable fixtures for trigger determinism.
+
+### Phase 3
+
+- Paper trading only.
+- Risk rejects, reservations, and planner outputs must be inspectable.
+- Do not promote to live while paper scorecards are unstable.
+
+### Phase 4
+
+- Start with one limited live canary deployment only.
+- Use the safest lane defaults and the smallest practical notional.
+- Keep rollback steps and kill controls visible to operators.
+
+### Phase 5 and 6
+
+- Expand only after the live canary is stable.
+- Re-check issue scope before marking template-pack issues ready for harness
+  execution.
+
+## Rollback posture
+
+- Use runtime pause and kill controls before code rollback.
+- Revert the last merged PR when code rollback is necessary.
+- Do not widen public API exposure as part of rollback.
+
+## Verification expectations
+
+Every issue in this program must preserve:
+
+- `bun run lint`
+- the smallest relevant validation set for the changed surface
+- explicit proof bundle evidence in the PR
+
+UI or operator-surface issues also require browser proof through
+`bun run harness:proof`.

--- a/docs/product-specs/autonomous-runtime-prd.md
+++ b/docs/product-specs/autonomous-runtime-prd.md
@@ -1,0 +1,219 @@
+# PRD: Trader Ralph Autonomous Runtime
+
+**Status:** Accepted for repo planning  
+**Date:** 2026-03-07  
+**Audience:** product, engineering, infra, ops, and harness execution
+
+## Summary
+
+Trader Ralph already has:
+
+- a public Cloudflare Worker boundary for x402, execution, discovery, and
+  admin-controlled operations,
+- a production terminal and execution UX,
+- a harness-native repo workflow for issue-driven delivery.
+
+What it does not yet have is an always-on automation runtime that can keep
+market connectivity open, evaluate strategies continuously, manage portfolio
+state deterministically, and reconcile live execution results.
+
+The v1 autonomous runtime keeps the current harness architecture intact:
+
+- the Worker stays the only public API boundary,
+- Bun and the current repo tooling stay the control plane,
+- a new Rust service on Fly (`runtime-rs`) becomes the private hot path.
+
+## Problem
+
+Trader Ralph can execute trades and expose intelligence, but it cannot yet run
+production automation with:
+
+- persistent feed connectivity,
+- deterministic deployment and run lifecycles,
+- portfolio ledger and reservation accounting,
+- portfolio-level risk checks,
+- shadow, paper, and live promotion gates,
+- reconciliation and operator controls,
+- repo-owned docs that let the harness build the system safely.
+
+## Goals
+
+### Primary goals
+
+- Support always-on automation with persistent WebSocket and RPC connectivity.
+- Preserve the Worker as the public API boundary.
+- Preserve the current public execution contract:
+  - `POST /api/x402/exec/submit`
+  - `GET /api/x402/exec/status/:requestId`
+  - `GET /api/x402/exec/receipt/:requestId`
+- Reuse the current harness workflow, proof bundle rules, preview path, and
+  canary posture.
+- Make strategy decisions, risk verdicts, and reconciliation outcomes
+  explainable and reproducible.
+
+### Non-goals for v1
+
+- high-frequency or microsecond trading,
+- arbitrary user-authored strategy code,
+- cross-chain automation,
+- replacing the current Worker or terminal stack,
+- changing public x402 or execution contracts without an explicit versioned
+  follow-up issue.
+
+## Product principles
+
+- Public edge stays stable: the Worker remains the public contract boundary.
+- Hot path stays stateful: the live strategy loop runs in a long-lived service,
+  not on the edge.
+- Harness legibility is part of the product: docs, proof bundles, and rollout
+  gates are first-class.
+- One protocol, multiple transports: terminal, x402, and automation share the
+  same domain concepts even when auth and transport differ.
+- Rollback must be faster than rollout: runtime controls must stop unsafe
+  behavior before code rollback is required.
+
+## Architecture summary
+
+### Cloudflare Worker
+
+Owns:
+
+- public APIs,
+- x402 gating,
+- discovery and registry surfaces,
+- authenticated first-party APIs,
+- public execution contract,
+- internal runtime control endpoints,
+- public read models derived from execution and automation state.
+
+### Bun and the harness
+
+Own:
+
+- `harness:up`, `harness:status`, `harness:proof`,
+- runner workflows and issue orchestration,
+- docs, validation commands, and proof bundles,
+- local orchestration for portal, Worker, and optional runtime-rs integration.
+
+### Rust runtime on Fly
+
+Owns:
+
+- persistent feeds,
+- feature calculation,
+- strategy deployment lifecycle,
+- portfolio ledger and reservations,
+- risk checks,
+- execution planning,
+- reconciliation,
+- runtime-local health and metrics.
+
+## Resolved v1 decisions
+
+The first four architecture decisions are fixed by ADRs in this repo:
+
+- Internal transport starts as service-authenticated HTTP+JSON.
+- Canonical automation state lives in a runtime-owned, single-writer relational
+  store close to the active runtime region.
+- Runtime topology is one active region plus one warm standby per
+  environment/shard, with no active/active execution in v1.
+- Capital is isolated by logical wallet sleeves per deployment with explicit
+  reservations; cross-strategy netting is deferred.
+
+See:
+
+- `docs/design-docs/adrs/ADR-0001-runtime-internal-transport.md`
+- `docs/design-docs/adrs/ADR-0002-runtime-storage-ownership.md`
+- `docs/design-docs/adrs/ADR-0003-runtime-region-topology.md`
+- `docs/design-docs/adrs/ADR-0004-runtime-wallet-sleeves.md`
+
+## Scope
+
+### In scope for v1
+
+- Rust runtime service on Fly.
+- Persistent market data and provider connectivity.
+- Strategy templates:
+  - DCA
+  - threshold rebalance
+  - TWAP entry and exit
+  - trend following
+  - mean reversion
+- Portfolio ledger, reservations, and attribution.
+- Pre-trade and portfolio risk engine.
+- Execution planning and reconciliation.
+- Shadow and paper modes before limited live rollout.
+- Operator controls, dashboards, and kill switches.
+
+### In scope for later phases
+
+- breakout and macro rotation,
+- volatility-target sizing,
+- multi-strategy capital allocation,
+- more advanced perps-native automation.
+
+## Rollout shape
+
+The rollout stays issue-driven and reversible:
+
+| Phase | Backlog issues | Exit gate |
+| --- | --- | --- |
+| Phase 0 | `#256`, `#257` | Docs merged, protocol direction fixed, no public route change |
+| Phase 1 | `#258` to `#261` | Rust skeleton builds, internal auth exists, harness stays compatible, Fly health path exists |
+| Phase 2 | `#262` to `#264` | Feeds and shadow triggers are deterministic and stale-data rules work |
+| Phase 3 | `#265` to `#267` | Ledger, reservations, risk, and paper trading are stable |
+| Phase 4 | `#268` to `#271` | Reconciliation works and one limited live canary is green |
+| Phase 5 | `#272` to `#274` | Operator surfaces and managed templates are stable |
+| Phase 6 | `#275`, `#276` | Advanced templates and capital coordination are stable |
+
+Detailed rollout steps live in
+`docs/exec-plans/active/autonomous-runtime-rollout.md`.
+
+## Success metrics
+
+### Product metrics
+
+- live deployment count,
+- automation notional executed,
+- weekly active automation users,
+- promotion rate from shadow to live.
+
+### Runtime metrics
+
+- trigger-to-submit p95,
+- duplicate-submit rate,
+- stale-feature reject rate,
+- reconciliation error rate,
+- runtime canary pass rate.
+
+### Harness metrics
+
+- issue-to-PR cycle time,
+- proof bundle completion rate,
+- rollback drill success rate,
+- documentation freshness for runtime surfaces.
+
+## Risks and mitigations
+
+- Split-brain across regions:
+  Use one active region plus one warm standby and require explicit leader
+  control before any failover.
+- Contract drift between Worker and runtime:
+  Keep one repo-owned protocol package and shared fixtures.
+- Ops complexity grows too early:
+  Ship one service, one active region, one limited live template, and one
+  rollback path first.
+- Harness drift:
+  Keep the current issue labeling, preview path, and proof bundle rules as the
+  only supported delivery flow.
+
+## Deferred questions
+
+The critical v1 decisions are no longer open. Remaining follow-ups are future
+phase questions, such as:
+
+- when perps-native automation graduates from later phases into the core plan,
+- whether to surface hosted user controls before or after the first template
+  pack is stable,
+- how much existing Bun autopilot logic should be wrapped versus retired once
+  runtime-rs owns the hot path.

--- a/docs/reliability/autonomous-runtime-ops-runbook.md
+++ b/docs/reliability/autonomous-runtime-ops-runbook.md
@@ -1,0 +1,138 @@
+# Autonomous Runtime Ops Runbook
+
+## Purpose
+
+This runbook defines how the autonomous runtime should be operated once runtime
+code lands. During the docs-only phase, it serves as the preflight agreement
+for later implementation issues.
+
+## Operating model
+
+- The Worker remains the public edge and the operator control surface.
+- Runtime-rs is the private hot path running on Fly.
+- Human review remains mandatory before merge and before live promotion.
+- Runtime rollout follows shadow, paper, limited live canary, then broader live
+  template rollout.
+
+## Required controls before any live rollout
+
+- private service-auth between Worker and runtime-rs,
+- runtime health and readiness endpoints,
+- runtime kill switch reachable through the Worker control plane,
+- deployment pause, resume, and kill actions,
+- database backup and restore procedure,
+- region failover checklist,
+- reconciliation mismatch alarm,
+- proof bundle attached to every runtime PR.
+
+## Routine operator actions
+
+### Inspect health
+
+Verify:
+
+- runtime process health,
+- active region and standby region status,
+- provider connectivity,
+- feed freshness,
+- reconciliation backlog,
+- runtime canary status.
+
+### Pause a deployment
+
+Use pause when:
+
+- a strategy is misbehaving but infrastructure is otherwise healthy,
+- a feed is stale for one strategy's market set,
+- capital needs to be reallocated without a full kill.
+
+Expected effect:
+
+- new execution plans stop,
+- reconciliation continues,
+- existing state remains inspectable.
+
+### Kill a deployment
+
+Use kill when:
+
+- risk controls fail open,
+- reconciliation mismatch persists,
+- duplicate submit risk is present,
+- operator confidence in current state is lost.
+
+Expected effect:
+
+- planning and submit stop immediately,
+- deployment state is marked killed,
+- follow-up requires explicit human action.
+
+## Incident classes
+
+### Stale data incident
+
+Symptoms:
+
+- freshness budget breach,
+- risk rejects spike,
+- strategy engine stops promoting runs.
+
+Response:
+
+1. Pause affected deployments.
+2. Confirm provider and socket health.
+3. Keep the runtime canary disabled until freshness is restored.
+
+### Reconciliation incident
+
+Symptoms:
+
+- receipt mismatch,
+- runtime ledger diverges from chain state,
+- sleeve balances no longer explain physical wallet state.
+
+Response:
+
+1. Kill affected deployments.
+2. Freeze further live promotion.
+3. Export reconciliation evidence and compare with chain and Worker receipts.
+
+### Region failover incident
+
+Symptoms:
+
+- active region unhealthy,
+- database unreachable,
+- provider locality degraded beyond budget.
+
+Response:
+
+1. Confirm the active region should be abandoned.
+2. Disable execution in the failing region.
+3. Promote the warm standby only after leader state and database authority are
+   explicit.
+
+## Rollback policy
+
+- Prefer pause or kill controls before code rollback.
+- If code rollback is required, revert the offending PR and redeploy through the
+  same harness flow.
+- Do not shift public traffic directly to runtime-rs in any rollout covered by
+  this runbook; the Worker stays the contract boundary.
+
+## Proof requirements for runtime changes
+
+Every runtime-facing PR should include:
+
+- exact validation commands,
+- local or preview URLs,
+- runtime health or replay evidence when relevant,
+- browser proof for operator-facing UI changes,
+- risk notes and deferred follow-ups.
+
+## References
+
+- `docs/product-specs/autonomous-runtime-prd.md`
+- `docs/design-docs/autonomous-runtime-architecture.md`
+- `docs/exec-plans/active/autonomous-runtime-rollout.md`
+- `docs/repository-verification-index.md`

--- a/docs/repository-verification-index.md
+++ b/docs/repository-verification-index.md
@@ -10,7 +10,8 @@ how to verify or roll back the main operating paths.
 | --- | --- | --- |
 | Portal | Next.js marketing, login, and terminal UI | `apps/portal` |
 | Worker | Cloudflare Worker API boundary for x402, execution, discovery, and auth-adjacent routes | `apps/worker` |
-| Runtime | Bun CLI, agent runtime, tools, policies, and journals | `src` |
+| Runtime control plane | Bun CLI, agent runtime, tools, policies, and journals | `src` |
+| Autonomous runtime (planned) | Rust hot path for always-on automation, reconciliation, and portfolio state | `docs/product-specs/autonomous-runtime-prd.md`, `docs/design-docs/autonomous-runtime-architecture.md` |
 | Tests | Unit, integration, and terminal execution suites | `tests` |
 | Public contracts | Execution docs, schemas, fixtures, and runbooks | `docs/execution` |
 | Agent registry | Lane metadata and operator runbook | `docs/agent-registry` |
@@ -32,6 +33,8 @@ These are the invariants that changes should preserve unless the issue
 explicitly calls for a contract break:
 
 - The Cloudflare Worker remains the public API boundary.
+- Autonomous runtime work must preserve the existing harness flow and keep
+  runtime-rs optional until the relevant issue explicitly enables it.
 - Existing x402 read routes stay under `POST /api/x402/read/*`.
 - Existing execution routes stay:
   - `POST /api/x402/exec/submit`
@@ -51,6 +54,18 @@ Current branch and domain mapping:
 | --- | --- | --- | --- | --- |
 | Dev | `dev` | `https://dev.trader-ralph.com` | `https://dev.api.trader-ralph.com` | `ralph-edge-dev` |
 | Production | `main` | `https://trader-ralph.com` and `https://www.trader-ralph.com` | `https://api.trader-ralph.com` | `ralph-edge` |
+
+Autonomous runtime planning surfaces:
+
+- Product spec: `docs/product-specs/autonomous-runtime-prd.md`
+- Architecture: `docs/design-docs/autonomous-runtime-architecture.md`
+- ADRs: `docs/design-docs/adrs/`
+- Ops runbook: `docs/reliability/autonomous-runtime-ops-runbook.md`
+- Rollout plan: `docs/exec-plans/active/autonomous-runtime-rollout.md`
+
+The runtime service is not deployed yet. Until `#258` to `#261` land, runtime
+verification is documentation-only and the live stack remains portal plus
+Worker.
 
 Current workflow files:
 
@@ -130,6 +145,22 @@ bun run test:integration:worker:live
 
 Use the narrowest relevant subset for focused changes, but record the exact
 commands used in the PR proof bundle.
+
+### 3a. Autonomous runtime planning verification
+
+For docs-only runtime planning work:
+
+```bash
+bun run lint
+```
+
+Verify:
+
+- the PRD, architecture doc, ADRs, runbook, and rollout plan all agree on the
+  Worker boundary and harness compatibility,
+- the chosen v1 answers for internal transport, storage ownership, region
+  topology, and wallet sleeve model are explicit,
+- no docs introduce secrets or private operational tokens.
 
 ### 4. x402 and discovery verification
 
@@ -326,6 +357,8 @@ when `pr_number` is supplied.
   receipt triage.
 - Use `docs/execution/terminal-cutover-plan-v1.md` for execution-specific
   rollback context.
+- Use `docs/exec-plans/active/autonomous-runtime-rollout.md` for runtime phase
+  gates and rollback posture when runtime-rs work lands.
 - Re-run the lane verification checks after any revert.
 
 ## Source Docs by Topic
@@ -336,4 +369,8 @@ when `pr_number` is supplied.
 - Execution rollout and rollback: `docs/execution/rollout-plan-v1.md`
 - Terminal cutover: `docs/execution/terminal-cutover-plan-v1.md`
 - Agent registry: `docs/agent-registry/runbook.md`
+- Autonomous runtime PRD: `docs/product-specs/autonomous-runtime-prd.md`
+- Autonomous runtime architecture: `docs/design-docs/autonomous-runtime-architecture.md`
+- Autonomous runtime runbook: `docs/reliability/autonomous-runtime-ops-runbook.md`
+- Autonomous runtime rollout plan: `docs/exec-plans/active/autonomous-runtime-rollout.md`
 - Long-form pipeline architecture: `loop-a-loop-b-architecture.md`


### PR DESCRIPTION
Fixes #256

## Summary of changes
- add a repo-owned autonomous runtime PRD under `docs/product-specs`
- add a runtime architecture doc and four ADRs covering internal transport, storage ownership, region topology, and wallet sleeves
- add a runtime ops runbook and active rollout plan
- update the repository verification index and README so the runtime program is part of the existing harness contract

## Validation commands and results
- `bun run lint` ✅

## Preview or local URLs
- Not applicable for this docs-only change.

## Browser artifacts for UI changes
- Not applicable for this docs-only change.

## Benchmark delta for performance-sensitive changes
- Not applicable for this docs-only change.

## Risk notes and follow-ups
- This PR is intentionally docs-only and does not add a runtime code path.
- `#257` should consume these ADR decisions to define the canonical shared schemas and contract tests.
