### PR TITLE
Add private runtime service auth and internal routes

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -132,6 +132,7 @@ import { enforcePolicy, normalizePolicy } from "./policy";
 import { createPrivySolanaWallet } from "./privy";
 import { gatherMarketSnapshot } from "./research";
 import { json, okCors, withCors } from "./response";
+import { handleRuntimeInternalRoute } from "./runtime_internal";
 import { SolanaRpc } from "./solana_rpc";
 import type { Env, ExecutionConfig } from "./types";
 import type { UserRow } from "./users_db";
@@ -867,6 +868,15 @@ const worker = {
           }),
           env,
         );
+      }
+
+      const runtimeInternalResponse = await handleRuntimeInternalRoute(
+        request,
+        url,
+        env,
+      );
+      if (runtimeInternalResponse) {
+        return withCors(runtimeInternalResponse, env);
       }
 
       if (

--- a/apps/worker/src/runtime_internal.ts
+++ b/apps/worker/src/runtime_internal.ts
@@ -1,0 +1,428 @@
+import { json } from "./response";
+import {
+  parseRuntimeDeploymentRecord,
+  parseRuntimeExecutionPlan,
+  parseRuntimeLedgerSnapshot,
+  parseRuntimeRunRecord,
+  RUNTIME_PROTOCOL_SCHEMA_VERSION,
+  type RuntimeDeploymentRecord,
+  type RuntimeExecutionPlan,
+  type RuntimeLedgerSnapshot,
+  type RuntimeRunRecord,
+} from "./runtime_contracts";
+import type { Env } from "./types";
+
+const BEARER_RE = /^bearer\s+/i;
+const INTERNAL_RUNTIME_PREFIX = "/api/internal/runtime";
+const INTERNAL_RUNTIME_DEPLOYMENTS_PREFIX = `${INTERNAL_RUNTIME_PREFIX}/deployments/`;
+const INTERNAL_RUNTIME_RUNS_PREFIX = `${INTERNAL_RUNTIME_PREFIX}/runs/`;
+const INTERNAL_RUNTIME_EXECUTION_PLANS_PATH = `${INTERNAL_RUNTIME_PREFIX}/execution-plans`;
+const FIXTURE_TIMESTAMP = "2026-03-07T00:00:00.000Z";
+const FIXTURE_BASE_MINT = "So11111111111111111111111111111111111111112";
+const FIXTURE_QUOTE_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const DEFAULT_RUNTIME_SERVICE = "runtime-rs";
+
+type RuntimeControlAction = "pause" | "resume" | "kill";
+
+function parseBearerToken(value: string | null): string | null {
+  const raw = String(value ?? "").trim();
+  if (!raw) return null;
+  if (!BEARER_RE.test(raw)) return null;
+  return raw.replace(BEARER_RE, "").trim() || null;
+}
+
+function isRuntimeStubModeEnabled(env: Env): boolean {
+  return String(env.RUNTIME_INTERNAL_STUB_MODE ?? "").trim() === "1";
+}
+
+function configuredRuntimeServiceName(env: Env): string {
+  const configured = String(env.RUNTIME_INTERNAL_SERVICE_NAME ?? "").trim();
+  return configured || DEFAULT_RUNTIME_SERVICE;
+}
+
+function readRuntimeServiceBaseUrl(env: Env): string | null {
+  const raw = String(env.RUNTIME_INTERNAL_BASE_URL ?? "").trim();
+  return raw || null;
+}
+
+function authorizeRuntimeServiceRoute(
+  request: Request,
+  env: Env,
+):
+  | { ok: true; service: string }
+  | { ok: false; status: number; error: string } {
+  const configuredToken = String(
+    env.RUNTIME_INTERNAL_SERVICE_TOKEN ?? "",
+  ).trim();
+  if (!configuredToken) {
+    return {
+      ok: false,
+      status: 503,
+      error: "runtime-service-auth-not-configured",
+    };
+  }
+
+  const token = parseBearerToken(request.headers.get("authorization"));
+  if (!token || token !== configuredToken) {
+    return {
+      ok: false,
+      status: 401,
+      error: "auth-required",
+    };
+  }
+
+  return {
+    ok: true,
+    service: configuredRuntimeServiceName(env),
+  };
+}
+
+function createRuntimeDeploymentFixture(
+  deploymentId: string,
+  state: RuntimeDeploymentRecord["state"] = "shadow",
+): RuntimeDeploymentRecord {
+  return parseRuntimeDeploymentRecord({
+    schemaVersion: RUNTIME_PROTOCOL_SCHEMA_VERSION,
+    deploymentId,
+    strategyKey: "dca",
+    sleeveId: "sleeve_alpha",
+    ownerUserId: "user_runtime_fixture",
+    pair: {
+      symbol: "SOL/USDC",
+      baseMint: FIXTURE_BASE_MINT,
+      quoteMint: FIXTURE_QUOTE_MINT,
+    },
+    mode: state === "live" ? "live" : state === "paper" ? "paper" : "shadow",
+    state,
+    lane: "safe",
+    createdAt: FIXTURE_TIMESTAMP,
+    updatedAt: FIXTURE_TIMESTAMP,
+    ...(state === "paused" ? { pausedAt: FIXTURE_TIMESTAMP } : {}),
+    ...(state === "killed" ? { killedAt: FIXTURE_TIMESTAMP } : {}),
+    policy: {
+      maxNotionalUsd: "250.00",
+      dailyLossLimitUsd: "35.00",
+      maxSlippageBps: 50,
+      maxConcurrentRuns: 2,
+      rebalanceToleranceBps: 100,
+    },
+    capital: {
+      allocatedUsd: "1000.00",
+      reservedUsd: "125.00",
+      availableUsd: "875.00",
+    },
+    tags: ["fixture", "internal-route"],
+  });
+}
+
+function createRuntimeRunFixture(deploymentId: string): RuntimeRunRecord {
+  return parseRuntimeRunRecord({
+    schemaVersion: RUNTIME_PROTOCOL_SCHEMA_VERSION,
+    runId: `run_${deploymentId}`,
+    deploymentId,
+    runKey: `${deploymentId}:2026-03-07T00:00:00Z`,
+    trigger: {
+      kind: "operator",
+      source: "runtime-internal-fixture",
+      observedAt: FIXTURE_TIMESTAMP,
+      reason: "fixture-bootstrap",
+    },
+    state: "planned",
+    plannedAt: FIXTURE_TIMESTAMP,
+    updatedAt: FIXTURE_TIMESTAMP,
+    executionPlanId: `plan_${deploymentId}`,
+  });
+}
+
+function createRuntimeLedgerFixture(
+  deploymentId: string,
+): RuntimeLedgerSnapshot {
+  return parseRuntimeLedgerSnapshot({
+    schemaVersion: RUNTIME_PROTOCOL_SCHEMA_VERSION,
+    snapshotId: `ledger_${deploymentId}`,
+    deploymentId,
+    sleeveId: "sleeve_alpha",
+    asOf: FIXTURE_TIMESTAMP,
+    balances: [
+      {
+        mint: FIXTURE_QUOTE_MINT,
+        symbol: "USDC",
+        decimals: 6,
+        freeAtomic: "875000000",
+        reservedAtomic: "125000000",
+        priceUsd: "1.00",
+      },
+      {
+        mint: FIXTURE_BASE_MINT,
+        symbol: "SOL",
+        decimals: 9,
+        freeAtomic: "1500000000",
+        reservedAtomic: "0",
+        priceUsd: "142.00",
+      },
+    ],
+    positions: [
+      {
+        instrumentId: "SOL/USDC",
+        side: "long",
+        quantityAtomic: "1500000000",
+        entryPriceUsd: "140.00",
+        markPriceUsd: "142.00",
+        unrealizedPnlUsd: "3.00",
+      },
+    ],
+    totals: {
+      equityUsd: "1088.00",
+      reservedUsd: "125.00",
+      availableUsd: "963.00",
+      realizedPnlUsd: "10.00",
+      unrealizedPnlUsd: "3.00",
+    },
+  });
+}
+
+async function readJsonBody(request: Request): Promise<unknown> {
+  try {
+    return await request.json();
+  } catch {
+    throw new Error("invalid-json");
+  }
+}
+
+function runtimeInternalUnavailable(env: Env) {
+  return json(
+    {
+      ok: false,
+      error: "runtime-integration-not-configured",
+      stubModeEnabled: isRuntimeStubModeEnabled(env),
+      runtimeBaseUrl: readRuntimeServiceBaseUrl(env),
+    },
+    { status: 503 },
+  );
+}
+
+function buildRuntimeHealthPayload(env: Env, service: string) {
+  return {
+    ok: true,
+    schemaVersion: RUNTIME_PROTOCOL_SCHEMA_VERSION,
+    service: "worker-runtime-bridge",
+    authenticatedService: service,
+    integration: {
+      stubModeEnabled: isRuntimeStubModeEnabled(env),
+      runtimeBaseUrl: readRuntimeServiceBaseUrl(env),
+    },
+    routes: {
+      deployments: `${INTERNAL_RUNTIME_PREFIX}/deployments`,
+      runs: `${INTERNAL_RUNTIME_PREFIX}/runs/:deploymentId`,
+      positions: `${INTERNAL_RUNTIME_PREFIX}/positions`,
+      pnl: `${INTERNAL_RUNTIME_PREFIX}/pnl`,
+      executionPlans: INTERNAL_RUNTIME_EXECUTION_PLANS_PATH,
+      health: `${INTERNAL_RUNTIME_PREFIX}/health`,
+    },
+  };
+}
+
+function mapControlActionToState(
+  action: RuntimeControlAction,
+): RuntimeDeploymentRecord["state"] {
+  if (action === "pause") return "paused";
+  if (action === "resume") return "shadow";
+  return "killed";
+}
+
+function controlActionFromPath(pathname: string): {
+  deploymentId: string;
+  action: RuntimeControlAction;
+} | null {
+  if (!pathname.startsWith(INTERNAL_RUNTIME_DEPLOYMENTS_PREFIX)) return null;
+  const suffix = pathname.slice(INTERNAL_RUNTIME_DEPLOYMENTS_PREFIX.length);
+  const [deploymentId, action] = suffix.split("/");
+  if (!deploymentId) return null;
+  if (action === "pause" || action === "resume" || action === "kill") {
+    return { deploymentId, action };
+  }
+  return null;
+}
+
+export async function handleRuntimeInternalRoute(
+  request: Request,
+  url: URL,
+  env: Env,
+): Promise<Response | null> {
+  const isRuntimeRoute =
+    url.pathname === `${INTERNAL_RUNTIME_PREFIX}/health` ||
+    url.pathname === `${INTERNAL_RUNTIME_PREFIX}/deployments` ||
+    url.pathname === `${INTERNAL_RUNTIME_PREFIX}/positions` ||
+    url.pathname === `${INTERNAL_RUNTIME_PREFIX}/pnl` ||
+    url.pathname === INTERNAL_RUNTIME_EXECUTION_PLANS_PATH ||
+    url.pathname.startsWith(INTERNAL_RUNTIME_DEPLOYMENTS_PREFIX) ||
+    url.pathname.startsWith(INTERNAL_RUNTIME_RUNS_PREFIX);
+  if (!isRuntimeRoute) return null;
+
+  const auth = authorizeRuntimeServiceRoute(request, env);
+  if (!auth.ok) {
+    return json({ ok: false, error: auth.error }, { status: auth.status });
+  }
+
+  if (
+    request.method === "GET" &&
+    url.pathname === `${INTERNAL_RUNTIME_PREFIX}/health`
+  ) {
+    return json(buildRuntimeHealthPayload(env, auth.service));
+  }
+
+  if (!isRuntimeStubModeEnabled(env)) {
+    return runtimeInternalUnavailable(env);
+  }
+
+  if (
+    request.method === "POST" &&
+    url.pathname === `${INTERNAL_RUNTIME_PREFIX}/deployments`
+  ) {
+    let deployment: RuntimeDeploymentRecord;
+    try {
+      const payload = await readJsonBody(request);
+      deployment = parseRuntimeDeploymentRecord(payload);
+    } catch (error) {
+      return json(
+        {
+          ok: false,
+          error: "invalid-runtime-deployment",
+          details: {
+            reason: error instanceof Error ? error.message : "unknown-error",
+          },
+        },
+        { status: 400 },
+      );
+    }
+    return json(
+      {
+        ok: true,
+        status: "accepted",
+        source: "stub",
+        deployment,
+      },
+      { status: 201 },
+    );
+  }
+
+  if (
+    request.method === "GET" &&
+    url.pathname.startsWith(INTERNAL_RUNTIME_DEPLOYMENTS_PREFIX)
+  ) {
+    const suffix = url.pathname.slice(
+      INTERNAL_RUNTIME_DEPLOYMENTS_PREFIX.length,
+    );
+    if (suffix && !suffix.includes("/")) {
+      return json({
+        ok: true,
+        source: "stub",
+        deployment: createRuntimeDeploymentFixture(suffix),
+      });
+    }
+  }
+
+  if (request.method === "POST") {
+    const control = controlActionFromPath(url.pathname);
+    if (control) {
+      return json({
+        ok: true,
+        status: "accepted",
+        source: "stub",
+        action: control.action,
+        deployment: createRuntimeDeploymentFixture(
+          control.deploymentId,
+          mapControlActionToState(control.action),
+        ),
+      });
+    }
+  }
+
+  if (
+    request.method === "GET" &&
+    url.pathname.startsWith(INTERNAL_RUNTIME_RUNS_PREFIX)
+  ) {
+    const deploymentId = url.pathname.slice(
+      INTERNAL_RUNTIME_RUNS_PREFIX.length,
+    );
+    if (!deploymentId) {
+      return json({ ok: false, error: "not-found" }, { status: 404 });
+    }
+    return json({
+      ok: true,
+      source: "stub",
+      deploymentId,
+      runs: [createRuntimeRunFixture(deploymentId)],
+    });
+  }
+
+  if (
+    request.method === "GET" &&
+    url.pathname === `${INTERNAL_RUNTIME_PREFIX}/positions`
+  ) {
+    const deploymentId =
+      url.searchParams.get("deploymentId") ?? "deployment_fixture";
+    return json({
+      ok: true,
+      source: "stub",
+      deploymentId,
+      snapshot: createRuntimeLedgerFixture(deploymentId),
+    });
+  }
+
+  if (
+    request.method === "GET" &&
+    url.pathname === `${INTERNAL_RUNTIME_PREFIX}/pnl`
+  ) {
+    const deploymentId =
+      url.searchParams.get("deploymentId") ?? "deployment_fixture";
+    const snapshot = createRuntimeLedgerFixture(deploymentId);
+    return json({
+      ok: true,
+      source: "stub",
+      deploymentId,
+      asOf: snapshot.asOf,
+      totals: snapshot.totals,
+    });
+  }
+
+  if (
+    request.method === "POST" &&
+    url.pathname === INTERNAL_RUNTIME_EXECUTION_PLANS_PATH
+  ) {
+    let plan: RuntimeExecutionPlan;
+    try {
+      const payload = await readJsonBody(request);
+      plan = parseRuntimeExecutionPlan(payload);
+    } catch (error) {
+      return json(
+        {
+          ok: false,
+          error: "invalid-runtime-execution-plan",
+          details: {
+            reason: error instanceof Error ? error.message : "unknown-error",
+          },
+        },
+        { status: 400 },
+      );
+    }
+    return json(
+      {
+        ok: true,
+        accepted: true,
+        source: "stub",
+        coordination: {
+          planId: plan.planId,
+          deploymentId: plan.deploymentId,
+          runId: plan.runId,
+          mode: plan.mode,
+          lane: plan.lane,
+          sliceCount: plan.slices.length,
+        },
+      },
+      { status: 202 },
+    );
+  }
+
+  return json({ ok: false, error: "not-found" }, { status: 404 });
+}

--- a/apps/worker/src/types.ts
+++ b/apps/worker/src/types.ts
@@ -56,6 +56,10 @@ export type Env = {
   ALLOWED_ORIGINS?: string;
   PORTAL_SITE_URL?: string;
   ADMIN_TOKEN?: string;
+  RUNTIME_INTERNAL_SERVICE_TOKEN?: string;
+  RUNTIME_INTERNAL_SERVICE_NAME?: string;
+  RUNTIME_INTERNAL_BASE_URL?: string;
+  RUNTIME_INTERNAL_STUB_MODE?: string;
   PRIVY_APP_ID?: string;
   PRIVY_APP_SECRET?: string;
   PRIVY_WALLET_ID?: string;

--- a/crates/exec-client/src/lib.rs
+++ b/crates/exec-client/src/lib.rs
@@ -1,18 +1,52 @@
 use protocol::RuntimeExecutionPlan;
 
+pub const RUNTIME_INTERNAL_AUTH_HEADER: &str = "authorization";
+const DEFAULT_RUNTIME_WORKER_API_BASE: &str = "http://127.0.0.1:8888";
+const DEFAULT_RUNTIME_EXECUTION_PLAN_PATH: &str = "/api/internal/runtime/execution-plans";
+const DEFAULT_RUNTIME_HEALTH_PATH: &str = "/api/internal/runtime/health";
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExecClientConfig {
     pub api_base: String,
     pub submit_path: String,
     pub health_path: String,
+    pub service_auth_token: Option<String>,
 }
 
 impl Default for ExecClientConfig {
     fn default() -> Self {
         Self {
-            api_base: "http://127.0.0.1:8888".to_string(),
-            submit_path: "/api/internal/runtime/deployments".to_string(),
-            health_path: "/api/internal/runtime/health".to_string(),
+            api_base: DEFAULT_RUNTIME_WORKER_API_BASE.to_string(),
+            submit_path: DEFAULT_RUNTIME_EXECUTION_PLAN_PATH.to_string(),
+            health_path: DEFAULT_RUNTIME_HEALTH_PATH.to_string(),
+            service_auth_token: None,
+        }
+    }
+}
+
+impl ExecClientConfig {
+    #[must_use]
+    pub fn from_lookup<F>(lookup: F) -> Self
+    where
+        F: Fn(&str) -> Option<String>,
+    {
+        let api_base = lookup("RUNTIME_WORKER_API_BASE")
+            .unwrap_or_else(|| DEFAULT_RUNTIME_WORKER_API_BASE.to_string())
+            .trim_end_matches('/')
+            .to_string();
+        let submit_path = lookup("RUNTIME_WORKER_EXECUTION_PLAN_PATH")
+            .unwrap_or_else(|| DEFAULT_RUNTIME_EXECUTION_PLAN_PATH.to_string());
+        let health_path = lookup("RUNTIME_WORKER_HEALTH_PATH")
+            .unwrap_or_else(|| DEFAULT_RUNTIME_HEALTH_PATH.to_string());
+        let service_auth_token = lookup("RUNTIME_INTERNAL_SERVICE_TOKEN")
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+
+        Self {
+            api_base,
+            submit_path,
+            health_path,
+            service_auth_token,
         }
     }
 }
@@ -29,6 +63,14 @@ impl ExecClient {
     }
 
     #[must_use]
+    pub fn from_lookup<F>(lookup: F) -> Self
+    where
+        F: Fn(&str) -> Option<String>,
+    {
+        Self::new(ExecClientConfig::from_lookup(lookup))
+    }
+
+    #[must_use]
     pub fn submit_url(&self) -> String {
         format!("{}{}", self.config.api_base, self.config.submit_path)
     }
@@ -36,6 +78,27 @@ impl ExecClient {
     #[must_use]
     pub fn health_url(&self) -> String {
         format!("{}{}", self.config.api_base, self.config.health_path)
+    }
+
+    #[must_use]
+    pub fn auth_header_name(&self) -> Option<&'static str> {
+        self.config
+            .service_auth_token
+            .as_ref()
+            .map(|_| RUNTIME_INTERNAL_AUTH_HEADER)
+    }
+
+    #[must_use]
+    pub fn auth_header_value(&self) -> Option<String> {
+        self.config
+            .service_auth_token
+            .as_ref()
+            .map(|token| format!("Bearer {token}"))
+    }
+
+    #[must_use]
+    pub fn has_service_auth(&self) -> bool {
+        self.config.service_auth_token.is_some()
     }
 
     #[must_use]
@@ -73,7 +136,32 @@ mod tests {
         );
         assert_eq!(
             client.submit_reference(&plan),
-            "http://127.0.0.1:8888/api/internal/runtime/deployments#plan_1",
+            "http://127.0.0.1:8888/api/internal/runtime/execution-plans#plan_1",
         );
+        assert_eq!(client.auth_header_name(), None);
+        assert_eq!(client.auth_header_value(), None);
+    }
+
+    #[test]
+    fn loads_service_auth_from_lookup() {
+        let client = ExecClient::from_lookup(|key| match key {
+            "RUNTIME_WORKER_API_BASE" => Some("https://worker.internal/".to_string()),
+            "RUNTIME_INTERNAL_SERVICE_TOKEN" => Some("runtime-secret".to_string()),
+            _ => None,
+        });
+
+        assert_eq!(
+            client.submit_url(),
+            "https://worker.internal/api/internal/runtime/execution-plans",
+        );
+        assert_eq!(
+            client.auth_header_name(),
+            Some(RUNTIME_INTERNAL_AUTH_HEADER),
+        );
+        assert_eq!(
+            client.auth_header_value().as_deref(),
+            Some("Bearer runtime-secret"),
+        );
+        assert!(client.has_service_auth());
     }
 }

--- a/docs/design-docs/autonomous-runtime-architecture.md
+++ b/docs/design-docs/autonomous-runtime-architecture.md
@@ -145,9 +145,11 @@ The first private route family is intentionally small:
 - `GET /api/internal/runtime/positions`
 - `GET /api/internal/runtime/pnl`
 - `GET /api/internal/runtime/health`
+- `POST /api/internal/runtime/execution-plans`
 
 Transport starts as HTTP+JSON with service auth. Shared schemas and fixtures
-arrive in `#257`.
+arrive in `#257`. In `#259`, control and inspection routes are fixture-backed
+stubs until later issues replace them with real runtime integration.
 
 ## Harness compatibility requirements
 

--- a/services/runtime-rs/README.md
+++ b/services/runtime-rs/README.md
@@ -22,6 +22,10 @@ cargo run -p runtime-rs
   Default: `local`
 - `RUNTIME_RS_LOG`
   Default: `info`
+- `RUNTIME_WORKER_API_BASE`
+  Default: `http://127.0.0.1:8888`
+- `RUNTIME_INTERNAL_SERVICE_TOKEN`
+  Shared bearer token used for private runtime-to-Worker requests.
 
 ## Health check
 

--- a/services/runtime-rs/src/lib.rs
+++ b/services/runtime-rs/src/lib.rs
@@ -1,5 +1,5 @@
 use axum::{extract::State, routing::get, Json, Router};
-use exec_client::{ExecClient, ExecClientConfig};
+use exec_client::ExecClient;
 use market_adapters::MarketAdapterHealth;
 use runtime_ops::{health_snapshot, RuntimeConfig};
 use serde::{Deserialize, Serialize};
@@ -17,7 +17,7 @@ impl RuntimeAppState {
     pub fn new(config: RuntimeConfig) -> Self {
         Self {
             config,
-            exec_client: ExecClient::new(ExecClientConfig::default()),
+            exec_client: ExecClient::from_lookup(|key| std::env::var(key).ok()),
             market_adapter_health: MarketAdapterHealth::bootstrap(
                 "bootstrap",
                 "wss://placeholder.invalid/runtime",
@@ -36,6 +36,7 @@ pub struct RuntimeHealthResponse {
     pub protocol_version: String,
     pub bind_address: String,
     pub exec_health_url: String,
+    pub worker_service_auth_configured: bool,
     pub market_adapter_status: String,
     pub supported_strategies: Vec<String>,
 }
@@ -55,6 +56,7 @@ fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
         protocol_version: snapshot.protocol_version,
         bind_address: snapshot.bind_address,
         exec_health_url: state.exec_client.health_url(),
+        worker_service_auth_configured: state.exec_client.has_service_auth(),
         market_adapter_status: state.market_adapter_health.status_label().to_string(),
         supported_strategies: SUPPORTED_STRATEGIES
             .iter()

--- a/src/harness/manager.ts
+++ b/src/harness/manager.ts
@@ -16,6 +16,8 @@ const WORKER_PORT_BASE = 8800;
 const PORT_SCAN_WINDOW = 400;
 const STARTUP_TIMEOUT_MS = 90_000;
 const POLL_INTERVAL_MS = 1_000;
+const DEFAULT_RUNTIME_INTERNAL_SERVICE_TOKEN = "runtime-service-secret";
+const DEFAULT_RUNTIME_INTERNAL_SERVICE_NAME = "runtime-rs";
 
 export type HarnessState = {
   version: 1;
@@ -347,6 +349,13 @@ export async function startHarness(root = resolveRepoRoot()): Promise<void> {
 
   const workerDir = join(root, "apps", "worker");
   const portalDir = join(root, "apps", "portal");
+  const runtimeInternalServiceToken =
+    process.env.RUNTIME_INTERNAL_SERVICE_TOKEN ??
+    DEFAULT_RUNTIME_INTERNAL_SERVICE_TOKEN;
+  const runtimeInternalServiceName =
+    process.env.RUNTIME_INTERNAL_SERVICE_NAME ??
+    DEFAULT_RUNTIME_INTERNAL_SERVICE_NAME;
+  const runtimeInternalStubMode = process.env.RUNTIME_INTERNAL_STUB_MODE ?? "1";
 
   ensureWorkspaceDependencies(root);
   runWorkerMigration(workerDir, paths.workerStateDir);
@@ -363,6 +372,12 @@ export async function startHarness(root = resolveRepoRoot()): Promise<void> {
       "--test-scheduled",
       "--port",
       String(workerPort),
+      "--var",
+      `RUNTIME_INTERNAL_SERVICE_TOKEN:${runtimeInternalServiceToken}`,
+      "--var",
+      `RUNTIME_INTERNAL_SERVICE_NAME:${runtimeInternalServiceName}`,
+      "--var",
+      `RUNTIME_INTERNAL_STUB_MODE:${runtimeInternalStubMode}`,
     ],
     logFile: paths.workerLog,
   });

--- a/tests/integration/_worker_live_test_utils.ts
+++ b/tests/integration/_worker_live_test_utils.ts
@@ -172,6 +172,15 @@ export function createWorkerLiveEnv(options?: {
     BACKTEST_QUEUE: createMockDoNamespace() as never,
     LOGS_BUCKET: createMockR2() as never,
     ALLOWED_ORIGINS: "*",
+    RUNTIME_INTERNAL_SERVICE_TOKEN: readLiveEnv(
+      "RUNTIME_INTERNAL_SERVICE_TOKEN",
+      "runtime-service-secret",
+    ),
+    RUNTIME_INTERNAL_SERVICE_NAME: readLiveEnv(
+      "RUNTIME_INTERNAL_SERVICE_NAME",
+      "runtime-rs",
+    ),
+    RUNTIME_INTERNAL_STUB_MODE: readLiveEnv("RUNTIME_INTERNAL_STUB_MODE", "1"),
     LOOP_ENABLED_DEFAULT: "false",
     X402_NETWORK: readLiveEnv("X402_NETWORK", "solana-devnet"),
     X402_PAY_TO: readLiveEnv("X402_PAY_TO", DEFAULT_MERCHANT_WALLET),

--- a/tests/unit/worker_runtime_internal_routes.test.ts
+++ b/tests/unit/worker_runtime_internal_routes.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createExecutionContextStub,
+  createWorkerLiveEnv,
+} from "../integration/_worker_live_test_utils";
+
+const worker = (await import("../../apps/worker/src/index")).default;
+
+const VALID_RUNTIME_DEPLOYMENT = {
+  schemaVersion: "v1",
+  deploymentId: "deployment_123",
+  strategyKey: "dca",
+  sleeveId: "sleeve_alpha",
+  ownerUserId: "user_123",
+  pair: {
+    symbol: "SOL/USDC",
+    baseMint: "So11111111111111111111111111111111111111112",
+    quoteMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  },
+  mode: "shadow",
+  state: "shadow",
+  lane: "safe",
+  createdAt: "2026-03-07T00:00:00.000Z",
+  updatedAt: "2026-03-07T00:00:00.000Z",
+  policy: {
+    maxNotionalUsd: "250.00",
+    dailyLossLimitUsd: "35.00",
+    maxSlippageBps: 50,
+    maxConcurrentRuns: 2,
+    rebalanceToleranceBps: 100,
+  },
+  capital: {
+    allocatedUsd: "1000.00",
+    reservedUsd: "125.00",
+    availableUsd: "875.00",
+  },
+  tags: ["fixture"],
+};
+
+const VALID_RUNTIME_EXECUTION_PLAN = {
+  schemaVersion: "v1",
+  planId: "plan_123",
+  deploymentId: "deployment_123",
+  runId: "run_123",
+  createdAt: "2026-03-07T00:00:00.000Z",
+  mode: "shadow",
+  lane: "safe",
+  idempotencyKey: "deployment_123:run_123",
+  simulateOnly: true,
+  dryRun: true,
+  slices: [
+    {
+      sliceId: "slice_1",
+      action: "buy",
+      inputMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      outputMint: "So11111111111111111111111111111111111111112",
+      inputAmountAtomic: "5000000",
+      minOutputAmountAtomic: "30000000",
+      notionalUsd: "5.00",
+      slippageBps: 50,
+    },
+  ],
+};
+
+describe("worker runtime internal routes", () => {
+  test("requires runtime service auth", async () => {
+    const env = createWorkerLiveEnv();
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/internal/runtime/health"),
+      env,
+      createExecutionContextStub(),
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: "auth-required",
+    });
+  });
+
+  test("fails closed when runtime service auth is not configured", async () => {
+    const env = createWorkerLiveEnv({
+      overrides: {
+        RUNTIME_INTERNAL_SERVICE_TOKEN: "",
+      },
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/internal/runtime/health", {
+        headers: {
+          authorization: "Bearer runtime-service-secret",
+        },
+      }),
+      env,
+      createExecutionContextStub(),
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: "runtime-service-auth-not-configured",
+    });
+  });
+
+  test("returns authenticated runtime bridge health", async () => {
+    const env = createWorkerLiveEnv();
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/internal/runtime/health", {
+        headers: {
+          authorization: "Bearer runtime-service-secret",
+        },
+      }),
+      env,
+      createExecutionContextStub(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      schemaVersion: "v1",
+      service: "worker-runtime-bridge",
+      authenticatedService: "runtime-rs",
+      integration: {
+        stubModeEnabled: true,
+      },
+      routes: {
+        deployments: "/api/internal/runtime/deployments",
+        executionPlans: "/api/internal/runtime/execution-plans",
+        health: "/api/internal/runtime/health",
+      },
+    });
+  });
+
+  test("accepts runtime deployment records through the private route family", async () => {
+    const env = createWorkerLiveEnv();
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/internal/runtime/deployments", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer runtime-service-secret",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(VALID_RUNTIME_DEPLOYMENT),
+      }),
+      env,
+      createExecutionContextStub(),
+    );
+
+    expect(response.status).toBe(201);
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      status: "accepted",
+      source: "stub",
+      deployment: {
+        deploymentId: "deployment_123",
+        strategyKey: "dca",
+      },
+    });
+  });
+
+  test("accepts service-authenticated runtime execution plans", async () => {
+    const env = createWorkerLiveEnv();
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/internal/runtime/execution-plans", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer runtime-service-secret",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(VALID_RUNTIME_EXECUTION_PLAN),
+      }),
+      env,
+      createExecutionContextStub(),
+    );
+
+    expect(response.status).toBe(202);
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      accepted: true,
+      source: "stub",
+      coordination: {
+        planId: "plan_123",
+        deploymentId: "deployment_123",
+        runId: "run_123",
+        sliceCount: 1,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a private `/api/internal/runtime/*` Worker route family protected by service auth, with fixture-backed deployment control, run inspection, health, PnL, positions, and execution-plan coordination stubs
- teach `runtime-rs`'s exec client about the private Worker bridge and bearer-token service auth without changing the public x402 execution contract
- seed local harness and test helpers with runtime service-auth defaults so the private bridge is verifiable in CI and under `harness:up`

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `bun run harness:up`
- `bun run harness:status`
- `curl -sS http://127.0.0.1:8980/api/internal/runtime/health -H 'authorization: Bearer runtime-service-secret'`
- `bun run harness:proof`

## Proof
- Local harness status: portal `http://localhost:3180`, worker `http://127.0.0.1:8980/api/health`, both healthy
- Local runtime bridge health:
  - `{"ok":true,"schemaVersion":"v1","service":"worker-runtime-bridge","authenticatedService":"runtime-rs","integration":{"stubModeEnabled":true,"runtimeBaseUrl":null},"routes":{"deployments":"/api/internal/runtime/deployments","runs":"/api/internal/runtime/runs/:deploymentId","positions":"/api/internal/runtime/positions","pnl":"/api/internal/runtime/pnl","executionPlans":"/api/internal/runtime/execution-plans","health":"/api/internal/runtime/health"}}`
- Browser proof summary: `/Users/guillaumebibeau-laviolette/github/serious-trader-ralph/.tmp/harness-proof/serious-trader-ralph-dd6d2404-2026-03-07T22-32-28-179Z/summary.md`
- Browser proof artifacts: `/Users/guillaumebibeau-laviolette/github/serious-trader-ralph/.tmp/harness-proof/serious-trader-ralph-dd6d2404-2026-03-07T22-32-28-179Z`

## Risk Notes
- The new internal control and inspection endpoints are intentionally fixture-backed in this phase. Real runtime-backed state and submit coordination are deferred to later runtime issues.
- The Worker remains the only public API boundary; public x402 and execution endpoints are unchanged.

Fixes #259
