### PR TITLE
[Phase 1] Extend harness and preview orchestration for optional runtime-rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,8 @@ jobs:
                   "- Portal: pending",
                   "- Worker: pending",
                   "- Worker name: pending",
+                  "- Runtime: pending-or-not-enabled",
+                  "- Runtime health: pending-or-not-enabled",
                   "- Preview metadata artifact: pending",
                 ]),
                 ...buildSection(

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -37,11 +37,19 @@ jobs:
           WORKER_NAME="ralph-edge-pr-${PR_NUMBER}"
           WORKER_HOST="${WORKER_NAME}.gui-bibeau.workers.dev"
           WORKER_URL="https://${WORKER_HOST}"
+          RUNTIME_URL="${RUNTIME_PREVIEW_URL:-}"
+          RUNTIME_HEALTH_URL="${RUNTIME_PREVIEW_HEALTH_URL:-}"
+
+          if [ -n "${RUNTIME_URL}" ] && [ -z "${RUNTIME_HEALTH_URL}" ]; then
+            RUNTIME_HEALTH_URL="${RUNTIME_URL%/}/health"
+          fi
 
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
           echo "worker_name=${WORKER_NAME}" >> "$GITHUB_OUTPUT"
           echo "worker_host=${WORKER_HOST}" >> "$GITHUB_OUTPUT"
           echo "worker_url=${WORKER_URL}" >> "$GITHUB_OUTPUT"
+          echo "runtime_url=${RUNTIME_URL}" >> "$GITHUB_OUTPUT"
+          echo "runtime_health_url=${RUNTIME_HEALTH_URL}" >> "$GITHUB_OUTPUT"
 
       - name: Check deployment credentials
         env:
@@ -158,15 +166,35 @@ jobs:
           fi
 
       - name: Write preview metadata
+        env:
+          PORTAL_URL: ${{ steps.portal.outputs.portal_url }}
+          PR_NUMBER: ${{ steps.preview.outputs.pr_number }}
+          RUNTIME_HEALTH_URL: ${{ steps.preview.outputs.runtime_health_url }}
+          RUNTIME_URL: ${{ steps.preview.outputs.runtime_url }}
+          WORKER_NAME: ${{ steps.preview.outputs.worker_name }}
+          WORKER_URL: ${{ steps.preview.outputs.worker_url }}
         run: |
-          cat <<'JSON' > preview-metadata.json
-          {
-            "prNumber": ${{ steps.preview.outputs.pr_number }},
-            "portalUrl": "${{ steps.portal.outputs.portal_url }}",
-            "workerName": "${{ steps.preview.outputs.worker_name }}",
-            "workerUrl": "${{ steps.preview.outputs.worker_url }}"
-          }
-          JSON
+          node <<'NODE'
+          const fs = require("node:fs");
+
+          const metadata = {
+            prNumber: Number(process.env.PR_NUMBER),
+            portalUrl: process.env.PORTAL_URL,
+            workerName: process.env.WORKER_NAME,
+            workerUrl: process.env.WORKER_URL,
+            runtimeEnabled: Boolean(
+              process.env.RUNTIME_URL || process.env.RUNTIME_HEALTH_URL,
+            ),
+            runtimeUrl: process.env.RUNTIME_URL || null,
+            runtimeHealthUrl: process.env.RUNTIME_HEALTH_URL || null,
+          };
+
+          fs.writeFileSync(
+            "preview-metadata.json",
+            JSON.stringify(metadata, null, 2),
+            "utf8",
+          );
+          NODE
 
       - name: Upload preview metadata
         uses: actions/upload-artifact@v4
@@ -178,6 +206,8 @@ jobs:
         uses: actions/github-script@v7
         env:
           PORTAL_URL: ${{ steps.portal.outputs.portal_url }}
+          RUNTIME_HEALTH_URL: ${{ steps.preview.outputs.runtime_health_url }}
+          RUNTIME_URL: ${{ steps.preview.outputs.runtime_url }}
           WORKER_NAME: ${{ steps.preview.outputs.worker_name }}
           WORKER_URL: ${{ steps.preview.outputs.worker_url }}
         with:
@@ -232,6 +262,8 @@ jobs:
                   "- Portal: pending",
                   "- Worker: pending",
                   "- Worker name: pending",
+                  "- Runtime: pending-or-not-enabled",
+                  "- Runtime health: pending-or-not-enabled",
                   "- Preview metadata artifact: pending",
                 ]),
                 ...buildSection(
@@ -313,6 +345,8 @@ jobs:
               `- Portal: ${process.env.PORTAL_URL}`,
               `- Worker: ${process.env.WORKER_URL}`,
               `- Worker name: \`${process.env.WORKER_NAME}\``,
+              `- Runtime: ${process.env.RUNTIME_URL || "not-enabled"}`,
+              `- Runtime health: ${process.env.RUNTIME_HEALTH_URL || "not-enabled"}`,
               `- Preview metadata artifact: \`pr-preview-${context.payload.pull_request.number}\``,
             ];
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ bun run runner:once
 
 - `harness:up` starts a portal and worker pair with worktree-local ports and
   worker state under `.tmp/harness/<worktree-id>/`
+- set `HARNESS_RUNTIME_RS=1` before `harness:up` to start the optional
+  `runtime-rs` sidecar and include its health in `harness:status`
 - fresh worktrees bootstrap workspace dependencies automatically before the
   local stack starts
 - `harness:status` prints the current local URLs, health, log directory, and

--- a/src/harness/manager.ts
+++ b/src/harness/manager.ts
@@ -12,12 +12,17 @@ import net from "node:net";
 import { basename, join, resolve } from "node:path";
 
 const PORTAL_PORT_BASE = 3000;
+const RUNTIME_PORT_BASE = 8080;
 const WORKER_PORT_BASE = 8800;
 const PORT_SCAN_WINDOW = 400;
 const STARTUP_TIMEOUT_MS = 90_000;
 const POLL_INTERVAL_MS = 1_000;
 const DEFAULT_RUNTIME_INTERNAL_SERVICE_TOKEN = "runtime-service-secret";
 const DEFAULT_RUNTIME_INTERNAL_SERVICE_NAME = "runtime-rs";
+const DEFAULT_RUNTIME_RS_LOG_LEVEL = "info";
+
+type HarnessServiceHealth = "healthy" | "unhealthy" | "stopped";
+type HarnessRuntimeHealth = HarnessServiceHealth | "disabled";
 
 export type HarnessState = {
   version: 1;
@@ -28,11 +33,15 @@ export type HarnessState = {
   workerPort: number;
   portalPid: number;
   workerPid: number;
+  runtimeEnabled?: boolean;
+  runtimePort?: number;
+  runtimePid?: number;
   startedAt: string;
   paths: {
     harnessDir: string;
     logsDir: string;
     portalLog: string;
+    runtimeLog: string;
     workerLog: string;
     workerStateDir: string;
     stateFile: string;
@@ -46,13 +55,17 @@ export type HarnessStatus = {
   branch: string;
   root: string;
   portalUrl: string;
+  runtimeUrl: string;
   workerUrl: string;
-  portalHealth: "healthy" | "unhealthy" | "stopped";
-  workerHealth: "healthy" | "unhealthy" | "stopped";
+  portalHealth: HarnessServiceHealth;
+  runtimeHealth: HarnessRuntimeHealth;
+  workerHealth: HarnessServiceHealth;
   portalPid: number | null;
+  runtimePid: number | null;
   workerPid: number | null;
   stateFile: string;
   logsDir: string;
+  runtimeEnabled: boolean;
 };
 
 export function resolveWorktreeId(root: string): string {
@@ -73,6 +86,7 @@ export function resolveHarnessPaths(root: string): HarnessPaths {
     harnessDir,
     logsDir,
     portalLog: join(logsDir, "portal.log"),
+    runtimeLog: join(logsDir, "runtime-rs.log"),
     workerLog: join(logsDir, "worker.log"),
     workerStateDir: join(harnessDir, "worker-state"),
     stateFile: join(harnessDir, "state.json"),
@@ -81,12 +95,14 @@ export function resolveHarnessPaths(root: string): HarnessPaths {
 
 export function resolvePreferredPorts(root: string): {
   portalPort: number;
+  runtimePort: number;
   workerPort: number;
 } {
   const digest = createHash("sha256").update(resolve(root)).digest("hex");
   const offset = Number.parseInt(digest.slice(0, 8), 16) % PORT_SCAN_WINDOW;
   return {
     portalPort: PORTAL_PORT_BASE + offset,
+    runtimePort: RUNTIME_PORT_BASE + offset,
     workerPort: WORKER_PORT_BASE + offset,
   };
 }
@@ -186,6 +202,30 @@ function ensureHarnessDirs(paths: HarnessPaths): void {
   mkdirSync(paths.workerStateDir, { recursive: true });
 }
 
+function parseBooleanEnv(
+  value: string | null | undefined,
+): boolean | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+  if (["0", "false", "no", "off"].includes(normalized)) {
+    return false;
+  }
+  return undefined;
+}
+
+function isRuntimeHarnessEnabled(): boolean {
+  return (
+    parseBooleanEnv(process.env.HARNESS_RUNTIME_RS_ENABLED) ??
+    parseBooleanEnv(process.env.HARNESS_RUNTIME_RS) ??
+    false
+  );
+}
+
 function hasWorkspaceDependencies(root: string): boolean {
   return (
     existsSync(join(root, "node_modules")) &&
@@ -280,30 +320,56 @@ export async function getHarnessStatus(
       branch,
       root,
       portalUrl: "not-running",
+      runtimeUrl: "not-enabled",
       workerUrl: "not-running",
       portalHealth: "stopped",
+      runtimeHealth: "disabled",
       workerHealth: "stopped",
       portalPid: null,
+      runtimePid: null,
       workerPid: null,
       stateFile: paths.stateFile,
       logsDir: paths.logsDir,
+      runtimeEnabled: false,
     };
   }
 
   const portalRunning = isPidRunning(state.portalPid);
+  const runtimeEnabled = Boolean(state.runtimeEnabled);
+  const runtimeRunning =
+    runtimeEnabled &&
+    state.runtimePid != null &&
+    isPidRunning(state.runtimePid);
   const workerRunning = isPidRunning(state.workerPid);
   const portalUrl = `http://localhost:${state.portalPort}`;
+  const runtimeUrl =
+    runtimeEnabled && state.runtimePort != null
+      ? `http://127.0.0.1:${state.runtimePort}/health`
+      : "not-enabled";
   const workerUrl = `http://127.0.0.1:${state.workerPort}`;
 
-  let portalHealth: HarnessStatus["portalHealth"] = portalRunning
+  let portalHealth: HarnessServiceHealth = portalRunning
     ? "unhealthy"
     : "stopped";
-  let workerHealth: HarnessStatus["workerHealth"] = workerRunning
+  let runtimeHealth: HarnessRuntimeHealth = runtimeEnabled
+    ? runtimeRunning
+      ? "unhealthy"
+      : "stopped"
+    : "disabled";
+  let workerHealth: HarnessServiceHealth = workerRunning
     ? "unhealthy"
     : "stopped";
 
   if (portalRunning && (await waitForHttp(`${portalUrl}/login`, 2_000))) {
     portalHealth = "healthy";
+  }
+  if (
+    runtimeEnabled &&
+    runtimeRunning &&
+    runtimeUrl !== "not-enabled" &&
+    (await waitForHttp(runtimeUrl, 2_000))
+  ) {
+    runtimeHealth = "healthy";
   }
   if (workerRunning && (await waitForHttp(`${workerUrl}/api/health`, 2_000))) {
     workerHealth = "healthy";
@@ -314,28 +380,40 @@ export async function getHarnessStatus(
     branch,
     root,
     portalUrl,
+    runtimeUrl,
     workerUrl: `${workerUrl}/api/health`,
     portalHealth,
+    runtimeHealth,
     workerHealth,
     portalPid: portalRunning ? state.portalPid : null,
+    runtimePid: runtimeRunning ? (state.runtimePid ?? null) : null,
     workerPid: workerRunning ? state.workerPid : null,
     stateFile: state.paths.stateFile,
     logsDir: state.paths.logsDir,
+    runtimeEnabled,
   };
 }
 
 export async function startHarness(root = resolveRepoRoot()): Promise<void> {
   const existing = loadHarnessState(root);
+  const runtimeEnabled = isRuntimeHarnessEnabled();
   if (
     existing &&
     isPidRunning(existing.portalPid) &&
-    isPidRunning(existing.workerPid)
+    isPidRunning(existing.workerPid) &&
+    Boolean(existing.runtimeEnabled) === runtimeEnabled &&
+    (!runtimeEnabled ||
+      (existing.runtimePid != null && isPidRunning(existing.runtimePid)))
   ) {
     await printHarnessStatus(root);
     return;
   }
 
   if (existing) {
+    killPid(existing.portalPid);
+    killPid(existing.runtimePid);
+    killPid(existing.workerPid);
+    await sleep(1_000);
     removeHarnessState(root);
   }
 
@@ -345,6 +423,9 @@ export async function startHarness(root = resolveRepoRoot()): Promise<void> {
 
   const preferred = resolvePreferredPorts(root);
   const portalPort = await findAvailablePort(preferred.portalPort);
+  const runtimePort = runtimeEnabled
+    ? await findAvailablePort(preferred.runtimePort)
+    : undefined;
   const workerPort = await findAvailablePort(preferred.workerPort);
 
   const workerDir = join(root, "apps", "worker");
@@ -360,79 +441,118 @@ export async function startHarness(root = resolveRepoRoot()): Promise<void> {
   ensureWorkspaceDependencies(root);
   runWorkerMigration(workerDir, paths.workerStateDir);
 
-  const workerPid = startProcess({
-    cwd: workerDir,
-    command: "bunx",
-    args: [
-      "wrangler",
-      "dev",
-      "--local",
-      "--persist-to",
-      paths.workerStateDir,
-      "--test-scheduled",
-      "--port",
-      String(workerPort),
-      "--var",
-      `RUNTIME_INTERNAL_SERVICE_TOKEN:${runtimeInternalServiceToken}`,
-      "--var",
-      `RUNTIME_INTERNAL_SERVICE_NAME:${runtimeInternalServiceName}`,
-      "--var",
-      `RUNTIME_INTERNAL_STUB_MODE:${runtimeInternalStubMode}`,
-    ],
-    logFile: paths.workerLog,
-  });
+  let workerPid: number | undefined;
+  let portalPid: number | undefined;
+  let runtimePid: number | undefined;
 
-  const workerHealthy = await waitForHttp(
-    `http://127.0.0.1:${workerPort}/api/health`,
-    STARTUP_TIMEOUT_MS,
-  );
-  if (!workerHealthy) {
-    killPid(workerPid);
-    removeHarnessState(root);
-    throw new Error(`worker failed to become healthy on port ${workerPort}`);
-  }
+  try {
+    workerPid = startProcess({
+      cwd: workerDir,
+      command: "bunx",
+      args: [
+        "wrangler",
+        "dev",
+        "--local",
+        "--persist-to",
+        paths.workerStateDir,
+        "--test-scheduled",
+        "--port",
+        String(workerPort),
+        "--var",
+        `RUNTIME_INTERNAL_SERVICE_TOKEN:${runtimeInternalServiceToken}`,
+        "--var",
+        `RUNTIME_INTERNAL_SERVICE_NAME:${runtimeInternalServiceName}`,
+        "--var",
+        `RUNTIME_INTERNAL_STUB_MODE:${runtimeInternalStubMode}`,
+      ],
+      logFile: paths.workerLog,
+    });
 
-  const portalPid = startProcess({
-    cwd: portalDir,
-    command: "bunx",
-    args: [
-      "next",
-      "dev",
-      "--hostname",
-      "localhost",
-      "--port",
-      String(portalPort),
-    ],
-    env: {
-      NEXT_PUBLIC_EDGE_API_BASE: `http://127.0.0.1:${workerPort}`,
-      NEXT_PUBLIC_SITE_URL: `http://localhost:${portalPort}`,
-    },
-    logFile: paths.portalLog,
-  });
+    const workerHealthy = await waitForHttp(
+      `http://127.0.0.1:${workerPort}/api/health`,
+      STARTUP_TIMEOUT_MS,
+    );
+    if (!workerHealthy) {
+      throw new Error(`worker failed to become healthy on port ${workerPort}`);
+    }
 
-  const portalHealthy = await waitForHttp(
-    `http://localhost:${portalPort}/login`,
-    STARTUP_TIMEOUT_MS,
-  );
-  if (!portalHealthy) {
+    if (runtimeEnabled) {
+      if (runtimePort == null) {
+        throw new Error("runtime-rs port resolution failed");
+      }
+      runtimePid = startProcess({
+        cwd: root,
+        command: "cargo",
+        args: ["run", "-p", "runtime-rs"],
+        env: {
+          RUNTIME_RS_BIND_ADDR: `127.0.0.1:${runtimePort}`,
+          RUNTIME_RS_ENV: "local",
+          RUNTIME_RS_LOG: DEFAULT_RUNTIME_RS_LOG_LEVEL,
+          RUNTIME_WORKER_API_BASE: `http://127.0.0.1:${workerPort}`,
+          RUNTIME_INTERNAL_SERVICE_TOKEN: runtimeInternalServiceToken,
+        },
+        logFile: paths.runtimeLog,
+      });
+
+      const runtimeHealthy = await waitForHttp(
+        `http://127.0.0.1:${runtimePort}/health`,
+        STARTUP_TIMEOUT_MS,
+      );
+      if (!runtimeHealthy) {
+        throw new Error(
+          `runtime-rs failed to become healthy on port ${runtimePort}`,
+        );
+      }
+    }
+
+    portalPid = startProcess({
+      cwd: portalDir,
+      command: "bunx",
+      args: [
+        "next",
+        "dev",
+        "--hostname",
+        "localhost",
+        "--port",
+        String(portalPort),
+      ],
+      env: {
+        NEXT_PUBLIC_EDGE_API_BASE: `http://127.0.0.1:${workerPort}`,
+        NEXT_PUBLIC_SITE_URL: `http://localhost:${portalPort}`,
+      },
+      logFile: paths.portalLog,
+    });
+
+    const portalHealthy = await waitForHttp(
+      `http://localhost:${portalPort}/login`,
+      STARTUP_TIMEOUT_MS,
+    );
+    if (!portalHealthy) {
+      throw new Error(`portal failed to become healthy on port ${portalPort}`);
+    }
+
+    saveHarnessState({
+      version: 1,
+      root,
+      branch,
+      worktreeId: resolveWorktreeId(root),
+      portalPort,
+      workerPort,
+      portalPid,
+      workerPid,
+      runtimeEnabled,
+      runtimePort,
+      runtimePid,
+      startedAt: new Date().toISOString(),
+      paths,
+    });
+  } catch (error) {
     killPid(portalPid);
+    killPid(runtimePid);
     killPid(workerPid);
     removeHarnessState(root);
-    throw new Error(`portal failed to become healthy on port ${portalPort}`);
+    throw error;
   }
-
-  saveHarnessState({
-    version: 1,
-    root,
-    branch,
-    worktreeId: resolveWorktreeId(root),
-    portalPort,
-    workerPort,
-    portalPid,
-    workerPid,
-    startedAt: new Date().toISOString(),
-    paths,
-  });
 
   await printHarnessStatus(root);
 }
@@ -441,6 +561,7 @@ export async function stopHarness(root = resolveRepoRoot()): Promise<void> {
   const state = loadHarnessState(root);
   if (state) {
     killPid(state.portalPid);
+    killPid(state.runtimePid);
     killPid(state.workerPid);
     await sleep(1_000);
   }

--- a/src/harness/proof.ts
+++ b/src/harness/proof.ts
@@ -9,6 +9,7 @@ import {
 import { join, resolve } from "node:path";
 import {
   getHarnessStatus,
+  type HarnessStatus,
   resolveWorktreeId,
   startHarness,
   stopHarness,
@@ -32,6 +33,16 @@ type HarnessProofSummary = {
   status: "passed" | "failed";
   baseUrl: string;
   startedLocalHarness: boolean;
+  harnessStatus: Pick<
+    HarnessStatus,
+    | "portalUrl"
+    | "portalHealth"
+    | "runtimeEnabled"
+    | "runtimeUrl"
+    | "runtimeHealth"
+    | "workerUrl"
+    | "workerHealth"
+  > | null;
   artifactsDir: string;
   screenshotDir: string;
   screenshots: string[];
@@ -105,6 +116,7 @@ export async function runHarnessProof(
 
   try {
     let baseUrl = options.baseUrl ? normalizeUrl(options.baseUrl) : "";
+    let harnessStatus: HarnessProofSummary["harnessStatus"] = null;
     if (!baseUrl) {
       const initialStatus = await getHarnessStatus(normalizedRoot);
       if (initialStatus.portalHealth !== "healthy") {
@@ -119,6 +131,15 @@ export async function runHarnessProof(
         throw new Error("local harness portal is not healthy");
       }
       baseUrl = normalizeUrl(status.portalUrl);
+      harnessStatus = {
+        portalUrl: status.portalUrl,
+        portalHealth: status.portalHealth,
+        runtimeEnabled: status.runtimeEnabled,
+        runtimeUrl: status.runtimeUrl,
+        runtimeHealth: status.runtimeHealth,
+        workerUrl: status.workerUrl,
+        workerHealth: status.workerHealth,
+      };
     }
 
     const artifactsDir =
@@ -171,6 +192,7 @@ export async function runHarnessProof(
       status: result.status === 0 ? "passed" : "failed",
       baseUrl,
       startedLocalHarness,
+      harnessStatus,
       artifactsDir,
       screenshotDir,
       screenshots,
@@ -188,6 +210,13 @@ export async function runHarnessProof(
         `- Status: ${summary.status}`,
         `- Base URL: ${summary.baseUrl}`,
         `- Started local harness: ${summary.startedLocalHarness ? "yes" : "no"}`,
+        ...(summary.harnessStatus
+          ? [
+              `- Local portal: ${summary.harnessStatus.portalUrl} (${summary.harnessStatus.portalHealth})`,
+              `- Local worker: ${summary.harnessStatus.workerUrl} (${summary.harnessStatus.workerHealth})`,
+              `- Local runtime: ${summary.harnessStatus.runtimeUrl} (${summary.harnessStatus.runtimeHealth})`,
+            ]
+          : []),
         `- Expected tests: ${summary.stats.expected}`,
         `- Unexpected tests: ${summary.stats.unexpected}`,
         `- Skipped tests: ${summary.stats.skipped}`,

--- a/src/runner/comments.ts
+++ b/src/runner/comments.ts
@@ -47,6 +47,8 @@ export function buildRunnerSuccessComment(input: {
     "- Portal: pending",
     "- Worker: pending",
     "- Worker name: pending",
+    "- Runtime: pending-or-not-enabled",
+    "- Runtime health: pending-or-not-enabled",
     "- Preview metadata artifact: pending",
   ];
   const checkLines = REQUIRED_CHECKS.map((check) => `- ${check}: pending`);

--- a/tests/unit/harness_manager.test.ts
+++ b/tests/unit/harness_manager.test.ts
@@ -22,6 +22,7 @@ test("resolveHarnessPaths scopes state to the current worktree", () => {
   expect(paths.workerStateDir).toContain(paths.harnessDir);
   expect(paths.stateFile).toContain(paths.harnessDir);
   expect(paths.logsDir).toContain(paths.harnessDir);
+  expect(paths.runtimeLog).toContain(paths.logsDir);
   expect(paths.workerStateDir.endsWith("/worker-state")).toBeTrue();
 });
 
@@ -31,6 +32,8 @@ test("resolvePreferredPorts is deterministic and lane-separated", () => {
 
   expect(first.portalPort).toBeGreaterThanOrEqual(3000);
   expect(first.portalPort).toBeLessThan(3400);
+  expect(first.runtimePort).toBeGreaterThanOrEqual(8080);
+  expect(first.runtimePort).toBeLessThan(8480);
   expect(first.workerPort).toBeGreaterThanOrEqual(8800);
   expect(first.workerPort).toBeLessThan(9200);
   expect(first).not.toEqual(second);

--- a/tests/unit/runner_service.test.ts
+++ b/tests/unit/runner_service.test.ts
@@ -107,6 +107,8 @@ test("runner comments include the key handoff details", () => {
   expect(success).toContain("Harness Proof Bundle");
   expect(success).toContain("<!-- harness-proof-bundle -->");
   expect(success).toContain("<!-- pr-preview -->");
+  expect(success).toContain("- Runtime: pending-or-not-enabled");
+  expect(success).toContain("- Runtime health: pending-or-not-enabled");
   expect(success).toContain("- browser-proof: pending");
   expect(success).not.toContain("/tmp/runner");
   expect(failure).toContain("Harness Runner Failure");


### PR DESCRIPTION
Fixes #260

## Summary
- add opt-in `runtime-rs` orchestration to `harness:up`/`harness:status`/`harness:down` behind `HARNESS_RUNTIME_RS=1` while keeping the default portal + worker flow unchanged
- include runtime health in local harness proof summaries and keep runner/CI proof-bundle preview sections runtime-aware
- extend PR preview metadata so future runtime preview endpoints can be attached without changing the proof-bundle contract again

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit`
- `bun run harness:up`
- `bun run harness:status`
- `bun run harness:proof`
- `bun run harness:down`
- `HARNESS_RUNTIME_RS=1 bun run harness:up`
- `HARNESS_RUNTIME_RS=1 bun run harness:status`
- `curl -fsS http://127.0.0.1:8260/health`
- `HARNESS_RUNTIME_RS=1 bun run harness:proof`
- `HARNESS_RUNTIME_RS=1 bun run harness:down`

## Local Verification
- default harness URLs: `http://localhost:3180`, `http://127.0.0.1:8980/api/health`
- runtime-enabled harness URL: `http://127.0.0.1:8260/health`
- runtime health returned `status=ok`, `environment=local`, and `workerServiceAuthConfigured=true`

## Risk Notes
- preview runtime deployment is still out of scope here; this PR only keeps the preview metadata/comment contract ready for when a runtime preview URL exists
- the Worker remains the only public API boundary; runtime-rs stays internal-only in this issue