### PR TITLE
[Phase 1] Add Fly deployment foundation, health checks, and rollback for runtime-rs

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -19,9 +19,33 @@ jobs:
         with:
           node-version: 20
 
+      - name: Check production deploy credentials
+        env:
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          RUNTIME_INTERNAL_SERVICE_TOKEN: ${{ secrets.RUNTIME_INTERNAL_SERVICE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          for secret_name in CLOUDFLARE_API_TOKEN ADMIN_TOKEN RUNTIME_INTERNAL_SERVICE_TOKEN; do
+            if [ -z "${!secret_name:-}" ]; then
+              echo "::error::Missing required secret ${secret_name} for production deploy."
+              exit 1
+            fi
+          done
+
       - name: Install worker deps
         working-directory: apps/worker
         run: npm install
+
+      - name: Sync runtime service auth secret to worker
+        working-directory: apps/worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          RUNTIME_INTERNAL_SERVICE_TOKEN: ${{ secrets.RUNTIME_INTERNAL_SERVICE_TOKEN }}
+        run: |
+          set -euo pipefail
+          printf '%s' "${RUNTIME_INTERNAL_SERVICE_TOKEN}" | npx wrangler secret put RUNTIME_INTERNAL_SERVICE_TOKEN --env production
 
       - name: Apply D1 migrations
         working-directory: apps/worker
@@ -38,16 +62,36 @@ jobs:
         run: |
           npx wrangler deploy --env production
 
+      - name: Smoke runtime bridge
+        env:
+          RUNTIME_INTERNAL_SERVICE_TOKEN: ${{ secrets.RUNTIME_INTERNAL_SERVICE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          response="$(
+            curl -fsS \
+              -H "authorization: Bearer ${RUNTIME_INTERNAL_SERVICE_TOKEN}" \
+              https://api.trader-ralph.com/api/internal/runtime/health
+          )"
+          RESPONSE="${response}" node <<'NODE'
+          const payload = JSON.parse(process.env.RESPONSE ?? "{}");
+
+          if (!payload?.ok) {
+            throw new Error("runtime-bridge-smoke-not-ok");
+          }
+          if (payload?.integration?.runtimeBaseUrl !== "https://ralph-runtime-rs.fly.dev") {
+            throw new Error("runtime-bridge-base-url-mismatch");
+          }
+          if (payload?.authenticatedService !== "runtime-rs") {
+            throw new Error("runtime-bridge-service-mismatch");
+          }
+          NODE
+
       - name: Trigger production execution canary
         env:
           ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         run: |
           set -euo pipefail
-
-          if [ -z "${ADMIN_TOKEN:-}" ]; then
-            echo "::error::Missing required secret ADMIN_TOKEN for production canary trigger."
-            exit 1
-          fi
 
           curl -fsS \
             -X POST \

--- a/.github/workflows/deploy-runtime-rs.yml
+++ b/.github/workflows/deploy-runtime-rs.yml
@@ -1,0 +1,71 @@
+name: Deploy runtime-rs (Fly)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/deploy-runtime-rs.yml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "fly.runtime-rs.toml"
+      - "crates/**"
+      - "scripts/runtime_rs/**"
+      - "services/runtime-rs/**"
+  workflow_dispatch:
+
+jobs:
+  deploy-runtime:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+        with:
+          version: 0.4.19
+
+      - name: Check runtime deploy credentials
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          RUNTIME_INTERNAL_SERVICE_TOKEN: ${{ secrets.RUNTIME_INTERNAL_SERVICE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          for secret_name in FLY_API_TOKEN RUNTIME_INTERNAL_SERVICE_TOKEN; do
+            if [ -z "${!secret_name:-}" ]; then
+              echo "::error::Missing required secret ${secret_name} for runtime-rs deploy."
+              exit 1
+            fi
+          done
+
+      - name: Deploy runtime-rs to Fly
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_APP_NAME: ralph-runtime-rs
+          FLY_ORG_SLUG: personal
+          FLY_PRIMARY_REGION: ord
+          FLY_STANDBY_REGION: iad
+          RUNTIME_DATABASE_URL: ${{ secrets.RUNTIME_DATABASE_URL }}
+          RUNTIME_INTERNAL_SERVICE_TOKEN: ${{ secrets.RUNTIME_INTERNAL_SERVICE_TOKEN }}
+          RUNTIME_WORKER_API_BASE: https://api.trader-ralph.com
+          RUNTIME_RS_ENV: production
+        run: |
+          set -euo pipefail
+          node scripts/runtime_rs/fly_deploy.mjs
+
+      - name: Smoke runtime-rs deployment
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_APP_NAME: ralph-runtime-rs
+          FLY_PRIMARY_REGION: ord
+          FLY_STANDBY_REGION: iad
+          RUNTIME_INTERNAL_SERVICE_TOKEN: ${{ secrets.RUNTIME_INTERNAL_SERVICE_TOKEN }}
+          RUNTIME_WORKER_API_BASE: https://api.trader-ralph.com
+          RUNTIME_RS_ENV: production
+        run: |
+          set -euo pipefail
+          node scripts/runtime_rs/fly_smoke.mjs

--- a/.github/workflows/rollback-runtime-rs.yml
+++ b/.github/workflows/rollback-runtime-rs.yml
@@ -1,0 +1,181 @@
+name: Rollback runtime-rs (Fly)
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: Why the runtime-rs rollback is being triggered
+        required: true
+        type: string
+      target_sha:
+        description: Optional commit SHA to deploy instead of previous main
+        required: false
+        type: string
+      pr_number:
+        description: Optional PR number to comment with rollback results
+        required: false
+        type: string
+      dry_run:
+        description: Resolve and report the rollback target without deploying
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  rollback-runtime:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+        with:
+          version: 0.4.19
+
+      - name: Resolve rollback target
+        id: target
+        run: |
+          set -euo pipefail
+
+          git fetch origin main --depth=2
+          PREVIOUS_MAIN_SHA="$(git rev-parse origin/main^)"
+          TARGET_SHA="${{ inputs.target_sha }}"
+
+          if [ -z "${TARGET_SHA}" ]; then
+            TARGET_SHA="${PREVIOUS_MAIN_SHA}"
+          fi
+
+          git cat-file -e "${TARGET_SHA}^{commit}"
+          echo "target_sha=${TARGET_SHA}" >> "$GITHUB_OUTPUT"
+          echo "previous_main_sha=${PREVIOUS_MAIN_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Check runtime rollback credentials
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          RUNTIME_INTERNAL_SERVICE_TOKEN: ${{ secrets.RUNTIME_INTERNAL_SERVICE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          for secret_name in FLY_API_TOKEN RUNTIME_INTERNAL_SERVICE_TOKEN; do
+            if [ -z "${!secret_name:-}" ]; then
+              echo "::error::Missing required secret ${secret_name} for runtime-rs rollback."
+              exit 1
+            fi
+          done
+
+      - name: Perform runtime-rs rollback deploy
+        id: rollback
+        continue-on-error: true
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_APP_NAME: ralph-runtime-rs
+          FLY_ORG_SLUG: personal
+          FLY_PRIMARY_REGION: ord
+          FLY_STANDBY_REGION: iad
+          RUNTIME_DATABASE_URL: ${{ secrets.RUNTIME_DATABASE_URL }}
+          RUNTIME_INTERNAL_SERVICE_TOKEN: ${{ secrets.RUNTIME_INTERNAL_SERVICE_TOKEN }}
+          RUNTIME_WORKER_API_BASE: https://api.trader-ralph.com
+          RUNTIME_RS_ENV: production
+          TARGET_SHA: ${{ steps.target.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p .tmp/runtime-rollback
+          ROLLBACK_DIR="$(pwd)/.tmp/runtime-rollback"
+          TARGET_DIR=".tmp/runtime-rollback/target"
+          rm -rf "${TARGET_DIR}"
+
+          if [ "${DRY_RUN}" = "true" ]; then
+            echo "Dry-run only; skipping runtime-rs deploy."
+            exit 0
+          fi
+
+          git worktree add --detach "${TARGET_DIR}" "${TARGET_SHA}"
+          trap 'git worktree remove --force "${TARGET_DIR}"' EXIT
+
+          cd "${TARGET_DIR}"
+          node scripts/runtime_rs/fly_deploy.mjs
+          node scripts/runtime_rs/fly_smoke.mjs > "${ROLLBACK_DIR}/smoke.json"
+
+      - name: Write runtime-rs rollback summary
+        if: always()
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          PREVIOUS_MAIN_SHA: ${{ steps.target.outputs.previous_main_sha }}
+          REASON: ${{ inputs.reason }}
+          ROLLBACK_OUTCOME: ${{ steps.rollback.outcome }}
+          TARGET_SHA: ${{ steps.target.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p .tmp/runtime-rollback
+          STATUS="failed"
+          if [ "${DRY_RUN}" = "true" ]; then
+            STATUS="dry-run"
+          elif [ "${ROLLBACK_OUTCOME}" = "success" ]; then
+            STATUS="success"
+          fi
+
+          cat <<EOF > .tmp/runtime-rollback/summary.md
+          # Runtime-rs Rollback
+          - status: ${STATUS}
+          - reason: ${REASON}
+          - target sha: \`${TARGET_SHA}\`
+          - previous main sha: \`${PREVIOUS_MAIN_SHA}\`
+          - app: \`ralph-runtime-rs\`
+          - health url: https://ralph-runtime-rs.fly.dev/health
+          EOF
+
+          if [ -f .tmp/runtime-rollback/smoke.json ]; then
+            {
+              echo
+              echo '## Smoke'
+              echo
+              cat .tmp/runtime-rollback/smoke.json
+            } >> .tmp/runtime-rollback/summary.md
+          fi
+
+          cat .tmp/runtime-rollback/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload runtime-rs rollback summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-rs-rollback-${{ github.run_id }}
+          path: .tmp/runtime-rollback
+          if-no-files-found: error
+
+      - name: Post rollback result to PR
+        if: always() && inputs.pr_number != ''
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+        with:
+          script: |
+            const fs = require("fs");
+            const body = fs.readFileSync(".tmp/runtime-rollback/summary.md", "utf8");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.PR_NUMBER),
+              body,
+            });
+
+      - name: Fail when runtime-rs rollback deploy fails
+        if: ${{ inputs.dry_run == false && steps.rollback.outcome != 'success' }}
+        run: |
+          set -euo pipefail
+          echo "::error::Runtime-rs rollback failed."
+          exit 1

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ cargo fmt --check
 cargo test --workspace
 cargo clippy --workspace --all-targets -- -D warnings
 cargo run -p runtime-rs
+bun run runtime:fly:smoke
 ```
 
 - Default health endpoint: `http://127.0.0.1:8081/health`
@@ -128,6 +129,12 @@ cargo run -p runtime-rs
   - `RUNTIME_RS_BIND_ADDR=127.0.0.1:8081`
   - `RUNTIME_RS_ENV=local|preview|production`
   - `RUNTIME_RS_LOG=info`
+- Fly foundation scripts:
+  - `bun run runtime:fly:deploy`
+  - `bun run runtime:fly:smoke`
+  - default app: `ralph-runtime-rs`
+  - default active region: `ord`
+  - default warm standby region: `iad`
 
 ### Worker only
 

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -209,6 +209,8 @@ LOOP_C_EXCLUDED_ASSETS = ""
 LOOP_C_EXCLUDED_PROTOCOLS = ""
 EXECUTION_COORDINATOR_ENABLED = "0"
 EXECUTION_AUCTION_WINDOW_MS = "250"
+RUNTIME_INTERNAL_SERVICE_NAME = "runtime-rs"
+RUNTIME_INTERNAL_BASE_URL = "https://ralph-runtime-rs.fly.dev"
 
 [[migrations]]
 tag = "v2-loop-a-coordinator"

--- a/docs/reliability/autonomous-runtime-ops-runbook.md
+++ b/docs/reliability/autonomous-runtime-ops-runbook.md
@@ -38,6 +38,21 @@ Verify:
 - reconciliation backlog,
 - runtime canary status.
 
+Fly foundation commands:
+
+```bash
+bun run runtime:fly:deploy
+bun run runtime:fly:smoke
+gh workflow run rollback-runtime-rs.yml --raw-field reason="manual rollback"
+```
+
+Expected topology for v1:
+
+- active app: `ralph-runtime-rs`
+- active region: `ord`
+- warm standby region: `iad`
+- public health endpoint: `https://ralph-runtime-rs.fly.dev/health`
+
 ### Pause a deployment
 
 Use pause when:
@@ -117,6 +132,7 @@ Response:
 - Prefer pause or kill controls before code rollback.
 - If code rollback is required, revert the offending PR and redeploy through the
   same harness flow.
+- Runtime-rs code rollback uses `.github/workflows/rollback-runtime-rs.yml`.
 - Do not shift public traffic directly to runtime-rs in any rollout covered by
   this runbook; the Worker stays the contract boundary.
 

--- a/docs/repository-verification-index.md
+++ b/docs/repository-verification-index.md
@@ -186,6 +186,23 @@ Expected behavior:
   protocol version, and bind address,
 - config loads from environment variables instead of tracked files.
 
+### 3c. Runtime-rs Fly foundation verification
+
+Fly deploy and smoke:
+
+```bash
+bun run runtime:fly:deploy
+bun run runtime:fly:smoke
+```
+
+Expected behavior:
+
+- Fly app `ralph-runtime-rs` exists in the personal Fly org,
+- one primary machine runs in `ord`,
+- one warm standby machine exists in `iad`,
+- `https://ralph-runtime-rs.fly.dev/health` returns `serviceName=runtime-rs`
+  and `environment=production`.
+
 ### 4. x402 and discovery verification
 
 Portal-side discovery:
@@ -374,6 +391,20 @@ gh workflow run rollback-production.yml \
 This redeploys the previous `main` commit unless an explicit `target_sha` is
 provided. The workflow posts a summary to the run and can also comment on a PR
 when `pr_number` is supplied.
+
+### Runtime-rs rollback automation
+
+Runtime-rs uses its own Fly rollback workflow:
+
+```bash
+gh workflow run rollback-runtime-rs.yml \
+  --raw-field reason="manual runtime-rs rollback" \
+  --raw-field pr_number="<optional-pr-number>"
+```
+
+This redeploys the previous `main` commit for `ralph-runtime-rs` unless an
+explicit `target_sha` is supplied. The workflow uploads the Fly smoke summary
+and can comment on a PR when `pr_number` is supplied.
 
 ### Production triage and verification
 

--- a/fly.runtime-rs.toml
+++ b/fly.runtime-rs.toml
@@ -1,0 +1,35 @@
+primary_region = "ord"
+
+[build]
+dockerfile = "services/runtime-rs/Dockerfile"
+
+[env]
+RUNTIME_RS_BIND_ADDR = "0.0.0.0:8080"
+RUNTIME_RS_ENV = "production"
+RUNTIME_RS_LOG = "info"
+RUNTIME_WORKER_API_BASE = "https://api.trader-ralph.com"
+
+[http_service]
+internal_port = 8080
+force_https = true
+auto_start_machines = true
+auto_stop_machines = false
+min_machines_running = 0
+processes = ["app"]
+
+  [http_service.concurrency]
+  type = "requests"
+  soft_limit = 25
+  hard_limit = 50
+
+  [[http_service.checks]]
+  grace_period = "10s"
+  interval = "15s"
+  method = "GET"
+  path = "/health"
+  timeout = "5s"
+
+[vm]
+cpu_kind = "shared"
+cpus = 1
+memory_mb = 512

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "harness:down": "bun run src/bin/harness.ts down",
     "harness:status": "bun run src/bin/harness.ts status",
     "harness:proof": "bun run src/bin/harness.ts proof",
+    "runtime:fly:deploy": "node scripts/runtime_rs/fly_deploy.mjs",
+    "runtime:fly:smoke": "node scripts/runtime_rs/fly_smoke.mjs",
     "runner:once": "bun run src/bin/runner.ts once",
     "runner:start": "bun run src/bin/runner.ts start",
     "build": "bun build src/bin/ralph.ts --outdir dist/bin --target node --format esm",

--- a/scripts/runtime_rs/fly_common.mjs
+++ b/scripts/runtime_rs/fly_common.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const FLYCTL_BIN = process.env.FLYCTL_BIN ?? "flyctl";
+
+export function resolveRepoRoot() {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+}
+
+export function readRuntimeFlyConfig(options = {}) {
+  const appName = String(process.env.FLY_APP_NAME ?? "ralph-runtime-rs").trim();
+  const orgSlug = String(process.env.FLY_ORG_SLUG ?? "personal").trim();
+  const primaryRegion = String(process.env.FLY_PRIMARY_REGION ?? "ord").trim();
+  const standbyRegion = String(process.env.FLY_STANDBY_REGION ?? "iad").trim();
+  const configPath = String(
+    process.env.FLY_CONFIG_PATH ?? "fly.runtime-rs.toml",
+  ).trim();
+  const workerApiBase = String(
+    process.env.RUNTIME_WORKER_API_BASE ?? "https://api.trader-ralph.com",
+  )
+    .trim()
+    .replace(/\/+$/g, "");
+  const environment = String(process.env.RUNTIME_RS_ENV ?? "production").trim();
+  const logLevel = String(process.env.RUNTIME_RS_LOG ?? "info").trim();
+  const localOnly =
+    String(process.env.FLY_DEPLOY_LOCAL_ONLY ?? "1").trim() !== "0";
+  const serviceToken = String(
+    process.env.RUNTIME_INTERNAL_SERVICE_TOKEN ?? "",
+  ).trim();
+  const databaseUrl = String(process.env.RUNTIME_DATABASE_URL ?? "").trim();
+  const publicUrl = `https://${appName}.fly.dev`;
+  const healthUrl = `${publicUrl}/health`;
+
+  if (!appName) {
+    throw new Error("FLY_APP_NAME is required");
+  }
+  if (!orgSlug) {
+    throw new Error("FLY_ORG_SLUG is required");
+  }
+  if (!primaryRegion) {
+    throw new Error("FLY_PRIMARY_REGION is required");
+  }
+  if (!standbyRegion) {
+    throw new Error("FLY_STANDBY_REGION is required");
+  }
+  if (options.requireServiceToken === true && !serviceToken) {
+    throw new Error("RUNTIME_INTERNAL_SERVICE_TOKEN is required");
+  }
+
+  return {
+    appName,
+    configPath,
+    databaseUrl,
+    environment,
+    healthUrl,
+    localOnly,
+    logLevel,
+    orgSlug,
+    primaryRegion,
+    publicUrl,
+    serviceToken,
+    standbyRegion,
+    workerApiBase,
+  };
+}
+
+export function runCommand(
+  command,
+  args,
+  {
+    allowFailure = false,
+    cwd = resolveRepoRoot(),
+    env = {},
+    input = undefined,
+    stdio = "pipe",
+  } = {},
+) {
+  const result = spawnSync(command, args, {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+    input,
+    stdio,
+  });
+
+  if (result.status !== 0 && !allowFailure) {
+    throw new Error(
+      [result.stdout, result.stderr]
+        .map((chunk) => String(chunk ?? "").trim())
+        .filter((chunk) => chunk.length > 0)
+        .join("\n") || `${command} ${args.join(" ")} failed`,
+    );
+  }
+
+  return result;
+}
+
+export function runFly(args, options = {}) {
+  return runCommand(FLYCTL_BIN, args, options);
+}
+
+export function runFlyJson(args, options = {}) {
+  const result = runFly([...args, "--json"], options);
+  return JSON.parse(String(result.stdout ?? "").trim());
+}
+
+export function findStandbyFor(machine) {
+  return (
+    machine?.config?.env?.FLY_STANDBY_FOR ??
+    machine?.config?.metadata?.standby_for ??
+    machine?.config?.metadata?.["fly.standby_for"] ??
+    machine?.config?.standbys?.[0] ??
+    machine?.standby_for ??
+    null
+  );
+}
+
+export function isDestroyedMachine(machine) {
+  return ["destroyed", "failed"].includes(
+    String(machine?.state ?? "").toLowerCase(),
+  );
+}

--- a/scripts/runtime_rs/fly_deploy.mjs
+++ b/scripts/runtime_rs/fly_deploy.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+
+import {
+  findStandbyFor,
+  readRuntimeFlyConfig,
+  runFly,
+  runFlyJson,
+} from "./fly_common.mjs";
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function machineSummary(machine) {
+  return {
+    id: machine?.id ?? null,
+    region: machine?.region ?? null,
+    state: machine?.state ?? null,
+    standbyFor: findStandbyFor(machine),
+  };
+}
+
+function listMachines(appName) {
+  return runFlyJson(["machine", "list", "--app", appName]);
+}
+
+function compareMachines(left, right) {
+  return (
+    Date.parse(String(right?.updated_at ?? right?.created_at ?? 0)) -
+    Date.parse(String(left?.updated_at ?? left?.created_at ?? 0))
+  );
+}
+
+function listPrimaryMachines(config, machines) {
+  return machines
+    .filter(
+      (machine) =>
+        machine?.region === config.primaryRegion &&
+        !findStandbyFor(machine) &&
+        machine?.state !== "destroyed",
+    )
+    .sort(compareMachines);
+}
+
+function selectPrimaryMachine(config, machines) {
+  const primary = listPrimaryMachines(config, machines)[0];
+  if (!primary) {
+    throw new Error(
+      `no primary machine found in ${config.primaryRegion} for ${config.appName}`,
+    );
+  }
+  return primary;
+}
+
+function pruneExtraPrimaryMachines(config, machines, keepMachineId) {
+  const extras = listPrimaryMachines(config, machines).filter(
+    (machine) => machine?.id !== keepMachineId,
+  );
+
+  for (const machine of extras) {
+    runFly(
+      ["machine", "destroy", machine.id, "--app", config.appName, "--force"],
+      { stdio: "inherit" },
+    );
+  }
+}
+
+function selectStandbyMachine(config, machines, primaryMachineId) {
+  return (
+    machines.find(
+      (machine) =>
+        machine?.region === config.standbyRegion &&
+        findStandbyFor(machine) === primaryMachineId &&
+        machine?.state !== "destroyed",
+    ) ?? null
+  );
+}
+
+function destroyMismatchedStandbys(config, machines, primaryMachineId) {
+  const mismatched = machines.filter(
+    (machine) =>
+      machine?.region === config.standbyRegion &&
+      findStandbyFor(machine) !== primaryMachineId &&
+      machine?.state !== "destroyed",
+  );
+
+  for (const machine of mismatched) {
+    runFly(
+      ["machine", "destroy", machine.id, "--app", config.appName, "--force"],
+      { stdio: "inherit" },
+    );
+  }
+}
+
+function ensureApp(config) {
+  const status = runFly(["status", "--app", config.appName], {
+    allowFailure: true,
+  });
+  if (status.status === 0) {
+    return;
+  }
+
+  runFly(["apps", "create", config.appName, "--org", config.orgSlug], {
+    stdio: "inherit",
+  });
+}
+
+function stageSecrets(config) {
+  const secrets = [`RUNTIME_INTERNAL_SERVICE_TOKEN=${config.serviceToken}`];
+  if (config.databaseUrl) {
+    secrets.push(`RUNTIME_DATABASE_URL=${config.databaseUrl}`);
+  }
+
+  runFly(["secrets", "set", "--stage", "--app", config.appName, ...secrets], {
+    stdio: "inherit",
+  });
+}
+
+function deployRuntime(config) {
+  const args = [
+    "deploy",
+    "--app",
+    config.appName,
+    "--config",
+    config.configPath,
+    "--strategy",
+    "immediate",
+    "--wait-timeout",
+    "600",
+  ];
+  if (config.localOnly) {
+    args.push("--local-only");
+  }
+  runFly(args, { stdio: "inherit" });
+}
+
+async function ensureStandby(config, primaryMachineId) {
+  let machines = listMachines(config.appName);
+  let standby = selectStandbyMachine(config, machines, primaryMachineId);
+  if (standby) {
+    return standby;
+  }
+
+  runFly(
+    [
+      "machine",
+      "clone",
+      primaryMachineId,
+      "--app",
+      config.appName,
+      "--region",
+      config.standbyRegion,
+      "--standby-for",
+      primaryMachineId,
+    ],
+    { stdio: "inherit" },
+  );
+
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    await sleep(2_000);
+    machines = listMachines(config.appName);
+    standby = selectStandbyMachine(config, machines, primaryMachineId);
+    if (standby) {
+      return standby;
+    }
+  }
+
+  throw new Error(
+    `standby machine in ${config.standbyRegion} was not created for ${config.appName}`,
+  );
+}
+
+async function main() {
+  const config = readRuntimeFlyConfig({ requireServiceToken: true });
+
+  ensureApp(config);
+  stageSecrets(config);
+  deployRuntime(config);
+
+  let machines = listMachines(config.appName);
+  const primary = selectPrimaryMachine(config, machines);
+  pruneExtraPrimaryMachines(config, machines, primary.id);
+  machines = listMachines(config.appName);
+  destroyMismatchedStandbys(config, machines, primary.id);
+  machines = listMachines(config.appName);
+  const standby = await ensureStandby(config, primary.id);
+
+  console.log(
+    JSON.stringify(
+      {
+        appName: config.appName,
+        publicUrl: config.publicUrl,
+        healthUrl: config.healthUrl,
+        primaryRegion: config.primaryRegion,
+        standbyRegion: config.standbyRegion,
+        primaryMachine: machineSummary(primary),
+        standbyMachine: machineSummary(standby),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+await main();

--- a/scripts/runtime_rs/fly_smoke.mjs
+++ b/scripts/runtime_rs/fly_smoke.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import {
+  findStandbyFor,
+  isDestroyedMachine,
+  readRuntimeFlyConfig,
+  runFlyJson,
+} from "./fly_common.mjs";
+
+async function fetchJson(url, init) {
+  const response = await fetch(url, init);
+  if (!response.ok) {
+    throw new Error(`request to ${url} failed with ${response.status}`);
+  }
+  return await response.json();
+}
+
+async function main() {
+  const config = readRuntimeFlyConfig();
+  const health = await fetchJson(config.healthUrl);
+
+  if (health?.serviceName !== "runtime-rs") {
+    throw new Error("runtime-rs health serviceName mismatch");
+  }
+  if (health?.status !== "ok") {
+    throw new Error("runtime-rs health status mismatch");
+  }
+  if (health?.environment !== config.environment) {
+    throw new Error("runtime-rs environment mismatch");
+  }
+  if (
+    health?.execHealthUrl !==
+    `${config.workerApiBase}/api/internal/runtime/health`
+  ) {
+    throw new Error("runtime-rs exec health URL mismatch");
+  }
+  if (health?.workerServiceAuthConfigured !== true) {
+    throw new Error("runtime-rs worker service auth should be configured");
+  }
+
+  const machines = runFlyJson(["machine", "list", "--app", config.appName]);
+  const primaryMachines = machines
+    .filter(
+      (machine) =>
+        machine?.region === config.primaryRegion &&
+        !findStandbyFor(machine) &&
+        !isDestroyedMachine(machine),
+    )
+    .sort(
+      (left, right) =>
+        Date.parse(String(right?.updated_at ?? right?.created_at ?? 0)) -
+        Date.parse(String(left?.updated_at ?? left?.created_at ?? 0)),
+    );
+  if (primaryMachines.length !== 1) {
+    throw new Error(
+      `expected exactly one primary machine in ${config.primaryRegion}, found ${primaryMachines.length}`,
+    );
+  }
+  const [primary] = primaryMachines;
+  const standbyMachines = machines.filter(
+    (machine) =>
+      machine?.region === config.standbyRegion &&
+      findStandbyFor(machine) === primary.id &&
+      !isDestroyedMachine(machine),
+  );
+  if (standbyMachines.length !== 1) {
+    throw new Error(
+      `expected exactly one standby machine in ${config.standbyRegion}, found ${standbyMachines.length}`,
+    );
+  }
+  const [standby] = standbyMachines;
+
+  const summary = {
+    appName: config.appName,
+    healthUrl: config.healthUrl,
+    primaryRegion: config.primaryRegion,
+    standbyRegion: config.standbyRegion,
+    primaryMachineId: primary.id,
+    standbyMachineId: standby.id,
+    runtimeHealth: health,
+  };
+
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+await main();

--- a/services/runtime-rs/Dockerfile
+++ b/services/runtime-rs/Dockerfile
@@ -1,0 +1,26 @@
+FROM rust:1.86-bookworm AS builder
+
+WORKDIR /app
+
+COPY Cargo.toml Cargo.lock ./
+COPY crates ./crates
+COPY services/runtime-rs ./services/runtime-rs
+
+RUN cargo build --release -p runtime-rs
+
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/* \
+  && useradd --create-home --uid 10001 runtime
+
+WORKDIR /app
+
+COPY --from=builder /app/target/release/runtime-rs /usr/local/bin/runtime-rs
+
+USER runtime
+
+EXPOSE 8080
+
+ENTRYPOINT ["runtime-rs"]

--- a/services/runtime-rs/README.md
+++ b/services/runtime-rs/README.md
@@ -11,6 +11,8 @@ cargo fmt --check
 cargo test --workspace
 cargo clippy --workspace --all-targets -- -D warnings
 cargo run -p runtime-rs
+bun run runtime:fly:deploy
+bun run runtime:fly:smoke
 ```
 
 ## Environment variables
@@ -26,6 +28,8 @@ cargo run -p runtime-rs
   Default: `http://127.0.0.1:8888`
 - `RUNTIME_INTERNAL_SERVICE_TOKEN`
   Shared bearer token used for private runtime-to-Worker requests.
+- `RUNTIME_DATABASE_URL`
+  Optional runtime-owned relational store bootstrap secret for later phases.
 
 ## Health check
 
@@ -36,3 +40,15 @@ curl -fsS http://127.0.0.1:8081/health
 Expected output is a JSON document describing the service name, environment,
 protocol version, bind address, strategy support, and internal dependency
 stubs.
+
+## Fly foundation
+
+- Config: `fly.runtime-rs.toml`
+- Docker image: `services/runtime-rs/Dockerfile`
+- Default app: `ralph-runtime-rs`
+- Default regions:
+  - active: `ord`
+  - warm standby: `iad`
+- GitHub workflows:
+  - `.github/workflows/deploy-runtime-rs.yml`
+  - `.github/workflows/rollback-runtime-rs.yml`


### PR DESCRIPTION
## Summary
- add the production Fly foundation for `runtime-rs`, including deploy and smoke scripts plus a dedicated `Deploy runtime-rs (Fly)` workflow
- add a `workflow_dispatch` rollback workflow for runtime-rs and document the runtime ops/runbook verification flow
- wire production worker deploys to sync runtime service auth and smoke the internal runtime bridge after Cloudflare deploy

## Validation
- `bun run lint`
- `bun run typecheck`
- `cargo test --workspace`
- `node scripts/runtime_rs/fly_smoke.mjs`
- `fly status -a ralph-runtime-rs`

## Proof
- live health URL: `https://ralph-runtime-rs.fly.dev/health`
- live smoke summary:
  - `serviceName=runtime-rs`
  - `status=ok`
  - `environment=production`
  - `execHealthUrl=https://api.trader-ralph.com/api/internal/runtime/health`
  - `workerServiceAuthConfigured=true`
- live topology:
  - primary: `91851206c49158` in `ord`
  - standby: `3287d905cdd478` in `iad`

## Notes
- I could not pre-dispatch `rollback-runtime-rs.yml` from this branch because GitHub only exposes `workflow_dispatch` for workflows that already exist on the default branch. The workflow is included here and can be dry-run validated immediately after merge.

Fixes #261
