### PR TITLE
[Phase 1] Stabilize runtime-rs standby convergence on Fly

### DIFF
--- a/scripts/runtime_rs/fly_deploy.mjs
+++ b/scripts/runtime_rs/fly_deploy.mjs
@@ -94,6 +94,35 @@ function destroyMismatchedStandbys(config, machines, primaryMachineId) {
   }
 }
 
+async function replaceStandbyRegionMachines(config, primaryMachineId) {
+  const deadline = Date.now() + 120_000;
+
+  while (Date.now() < deadline) {
+    const standbyRegionMachines = listMachines(config.appName).filter(
+      (machine) =>
+        machine?.region === config.standbyRegion &&
+        machine?.state !== "destroyed",
+    );
+
+    if (standbyRegionMachines.length === 0) {
+      return ensureStandby(config, primaryMachineId);
+    }
+
+    for (const machine of standbyRegionMachines) {
+      runFly(
+        ["machine", "destroy", machine.id, "--app", config.appName, "--force"],
+        { stdio: "inherit" },
+      );
+    }
+
+    await sleep(2_000);
+  }
+
+  throw new Error(
+    `standby region ${config.standbyRegion} did not converge for ${config.appName}`,
+  );
+}
+
 function ensureApp(config) {
   const status = runFly(["status", "--app", config.appName], {
     allowFailure: true,
@@ -185,8 +214,7 @@ async function main() {
   pruneExtraPrimaryMachines(config, machines, primary.id);
   machines = listMachines(config.appName);
   destroyMismatchedStandbys(config, machines, primary.id);
-  machines = listMachines(config.appName);
-  const standby = await ensureStandby(config, primary.id);
+  const standby = await replaceStandbyRegionMachines(config, primary.id);
 
   console.log(
     JSON.stringify(


### PR DESCRIPTION
## Summary
- replace any non-primary runtime-rs machines in the standby region before cloning the standby back from the current primary
- stop trusting a standby-region machine that `fly deploy` has converted into a regular machine during update
- keep the runtime smoke contract unchanged while making the deploy script converge to the topology the smoke expects

## Validation
- `bun run lint`
- `node scripts/runtime_rs/fly_smoke.mjs`
- `RUNTIME_INTERNAL_SERVICE_TOKEN=... FLY_DEPLOY_LOCAL_ONLY=0 node scripts/runtime_rs/fly_deploy.mjs`

## Proof
- live smoke after the patched deploy script:
  - primary: `91851206c49158` in `ord`
  - standby: `d8d356db799058` in `iad`
  - `workerServiceAuthConfigured=true`
- current health URL: `https://ralph-runtime-rs.fly.dev/health`

## Notes
- Outside this PR, I rotated the GitHub `production` secrets so `RUNTIME_INTERNAL_SERVICE_TOKEN` is non-empty and `FLY_API_TOKEN` is org-scoped for the Fly deploy workflow.
- This PR is the repo-side fix for the remaining `#261` failure mode on `main`.

Fixes #261
