### PR TITLE
[Phase 1] Use remote Fly builders in GitHub runtime workflows

### DIFF
--- a/.github/workflows/deploy-runtime-rs.yml
+++ b/.github/workflows/deploy-runtime-rs.yml
@@ -46,6 +46,7 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           FLY_APP_NAME: ralph-runtime-rs
+          FLY_DEPLOY_LOCAL_ONLY: 0
           FLY_ORG_SLUG: personal
           FLY_PRIMARY_REGION: ord
           FLY_STANDBY_REGION: iad

--- a/.github/workflows/rollback-runtime-rs.yml
+++ b/.github/workflows/rollback-runtime-rs.yml
@@ -81,6 +81,7 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           FLY_APP_NAME: ralph-runtime-rs
+          FLY_DEPLOY_LOCAL_ONLY: 0
           FLY_ORG_SLUG: personal
           FLY_PRIMARY_REGION: ord
           FLY_STANDBY_REGION: iad


### PR DESCRIPTION
## Summary
- force `FLY_DEPLOY_LOCAL_ONLY=0` in the GitHub `deploy-runtime-rs` workflow so Actions uses Fly's remote build path instead of local Docker on the runner
- mirror the same setting in `rollback-runtime-rs` so deploy and rollback use the same build mode

## Validation
- `git diff --check`
- previous live validation for the fixed deploy script remains green: `node scripts/runtime_rs/fly_smoke.mjs`

## Notes
- The preceding `main` runtime workflow was healthy at the app level but hung inside the GitHub-runner local build path. This change makes CI/CD use the same remote-build mode that completed cleanly during live validation.

Fixes #261
