### PR TITLE
[Phase 2] Implement runtime feed gateway and freshness contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "exec-client"
 version = "0.1.0"
 dependencies = [
@@ -238,6 +247,12 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "market-adapters"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+]
 
 [[package]]
 name = "matchers"
@@ -287,6 +302,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +337,12 @@ version = "0.1.0"
 dependencies = [
  "protocol",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -389,6 +416,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strategy-core",
+ "time",
  "tokio",
  "tower",
  "tracing",
@@ -546,6 +574,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ http-body-util = "0.1.3"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 thiserror = "2.0.17"
-tokio = { version = "1.48.0", features = ["macros", "net", "rt-multi-thread"] }
+tokio = { version = "1.48.0", features = ["macros", "net", "rt-multi-thread", "time"] }
 tower = { version = "0.5.2", features = ["util"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt"] }

--- a/crates/market-adapters/Cargo.toml
+++ b/crates/market-adapters/Cargo.toml
@@ -3,3 +3,9 @@ name = "market-adapters"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+time = { version = "0.3.44", features = ["formatting", "parsing"] }

--- a/crates/market-adapters/src/gateway.rs
+++ b/crates/market-adapters/src/gateway.rs
@@ -1,0 +1,714 @@
+use std::{collections::BTreeMap, fs, path::Path};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+const DEFAULT_MARKET_SYMBOL: &str = "SOL/USDC";
+const DEFAULT_BASE_MINT: &str = "So11111111111111111111111111111111111111112";
+const DEFAULT_QUOTE_MINT: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const DEFAULT_MARKET_PRICE_USD: &str = "142.00";
+const DEFAULT_SLOT_HEAD: u64 = 310_000_000;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AdapterStatus {
+    Healthy,
+    Degraded,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectionState {
+    Bootstrapping,
+    Connected,
+    Reconnecting,
+    Degraded,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarketAdapterHealth {
+    pub provider: String,
+    pub websocket_url: String,
+    pub rpc_url: String,
+    pub status: AdapterStatus,
+    pub connection_state: ConnectionState,
+    pub last_connected_at: Option<String>,
+    pub last_message_at: Option<String>,
+    pub reconnect_count: u64,
+    pub last_error: Option<String>,
+}
+
+impl MarketAdapterHealth {
+    #[must_use]
+    pub fn bootstrap(provider: &str, websocket_url: &str, rpc_url: &str) -> Self {
+        Self {
+            provider: provider.to_string(),
+            websocket_url: websocket_url.to_string(),
+            rpc_url: rpc_url.to_string(),
+            status: AdapterStatus::Healthy,
+            connection_state: ConnectionState::Bootstrapping,
+            last_connected_at: None,
+            last_message_at: None,
+            reconnect_count: 0,
+            last_error: None,
+        }
+    }
+
+    pub fn mark_message(&mut self, observed_at: &str) {
+        self.last_message_at = Some(observed_at.to_string());
+        if self.last_connected_at.is_none() {
+            self.last_connected_at = Some(observed_at.to_string());
+        }
+        self.status = AdapterStatus::Healthy;
+        self.connection_state = ConnectionState::Connected;
+        self.last_error = None;
+    }
+
+    pub fn mark_reconnecting(&mut self, observed_at: &str, reason: &str) {
+        self.last_message_at = Some(observed_at.to_string());
+        self.reconnect_count = self.reconnect_count.saturating_add(1);
+        self.status = AdapterStatus::Degraded;
+        self.connection_state = ConnectionState::Reconnecting;
+        self.last_error = Some(reason.to_string());
+    }
+
+    pub fn mark_degraded(&mut self, reason: &str) {
+        self.status = AdapterStatus::Degraded;
+        self.connection_state = ConnectionState::Degraded;
+        self.last_error = Some(reason.to_string());
+    }
+
+    #[must_use]
+    pub fn status_label(&self) -> &'static str {
+        match self.status {
+            AdapterStatus::Healthy => "healthy",
+            AdapterStatus::Degraded => "degraded",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeedGatewayConfig {
+    pub provider: String,
+    pub websocket_url: String,
+    pub rpc_url: String,
+    pub market_stale_after_ms: u64,
+    pub slot_stale_after_ms: u64,
+    pub max_slot_gap: u64,
+}
+
+impl FeedGatewayConfig {
+    #[must_use]
+    pub fn new(
+        provider: &str,
+        websocket_url: &str,
+        rpc_url: &str,
+        market_stale_after_ms: u64,
+        slot_stale_after_ms: u64,
+        max_slot_gap: u64,
+    ) -> Self {
+        Self {
+            provider: provider.to_string(),
+            websocket_url: websocket_url.to_string(),
+            rpc_url: rpc_url.to_string(),
+            market_stale_after_ms,
+            slot_stale_after_ms,
+            max_slot_gap,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SlotCommitment {
+    Processed,
+    Confirmed,
+    Finalized,
+}
+
+impl SlotCommitment {
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Processed => "processed",
+            Self::Confirmed => "confirmed",
+            Self::Finalized => "finalized",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarketFeedEvent {
+    pub source: String,
+    pub symbol: String,
+    pub base_mint: String,
+    pub quote_mint: String,
+    pub price_usd: String,
+    pub observed_at: String,
+    pub received_at: String,
+    pub sequence: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlotFeedEvent {
+    pub source: String,
+    pub commitment: SlotCommitment,
+    pub slot: u64,
+    pub observed_at: String,
+    pub sequence: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeedReplayFixture {
+    pub schema_version: String,
+    pub market_events: Vec<MarketFeedEvent>,
+    pub slot_events: Vec<SlotFeedEvent>,
+}
+
+impl FeedReplayFixture {
+    pub fn from_json_str(input: &str) -> Result<Self, FeedGatewayError> {
+        serde_json::from_str(input).map_err(FeedGatewayError::InvalidFixtureJson)
+    }
+
+    pub fn load_from_path(path: impl AsRef<Path>) -> Result<Self, FeedGatewayError> {
+        let raw =
+            fs::read_to_string(path.as_ref()).map_err(|source| FeedGatewayError::FixtureIo {
+                path: path.as_ref().display().to_string(),
+                source,
+            })?;
+        Self::from_json_str(&raw)
+    }
+
+    pub fn bootstrap(now: OffsetDateTime) -> Result<Self, FeedGatewayError> {
+        Self::bootstrap_with_sequence_seed(now, 0)
+    }
+
+    pub fn bootstrap_with_sequence_seed(
+        now: OffsetDateTime,
+        sequence_seed: u64,
+    ) -> Result<Self, FeedGatewayError> {
+        let observed_at = format_timestamp(now)?;
+        let received_at = format_timestamp(now)?;
+        Ok(Self {
+            schema_version: "v1".to_string(),
+            market_events: vec![MarketFeedEvent {
+                source: "fixture.jupiter".to_string(),
+                symbol: DEFAULT_MARKET_SYMBOL.to_string(),
+                base_mint: DEFAULT_BASE_MINT.to_string(),
+                quote_mint: DEFAULT_QUOTE_MINT.to_string(),
+                price_usd: DEFAULT_MARKET_PRICE_USD.to_string(),
+                observed_at: observed_at.clone(),
+                received_at,
+                sequence: sequence_seed + 1,
+            }],
+            slot_events: vec![
+                SlotFeedEvent {
+                    source: "fixture.helius".to_string(),
+                    commitment: SlotCommitment::Processed,
+                    slot: DEFAULT_SLOT_HEAD,
+                    observed_at: observed_at.clone(),
+                    sequence: sequence_seed + 11,
+                },
+                SlotFeedEvent {
+                    source: "fixture.helius".to_string(),
+                    commitment: SlotCommitment::Confirmed,
+                    slot: DEFAULT_SLOT_HEAD - 1,
+                    observed_at: observed_at.clone(),
+                    sequence: sequence_seed + 12,
+                },
+                SlotFeedEvent {
+                    source: "fixture.helius".to_string(),
+                    commitment: SlotCommitment::Finalized,
+                    slot: DEFAULT_SLOT_HEAD - 2,
+                    observed_at,
+                    sequence: sequence_seed + 13,
+                },
+            ],
+        })
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeedGatewayIngestReport {
+    pub market_events_accepted: u64,
+    pub market_events_duplicate: u64,
+    pub slot_events_accepted: u64,
+    pub slot_events_duplicate: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeedFreshnessContracts {
+    pub market_stale_after_ms: u64,
+    pub slot_stale_after_ms: u64,
+    pub max_slot_gap: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarketFeedStreamSnapshot {
+    pub stream_id: String,
+    pub symbol: String,
+    pub source: String,
+    pub last_sequence: u64,
+    pub last_price_usd: String,
+    pub observed_at: String,
+    pub age_ms: u64,
+    pub stale: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlotFeedCommitmentSnapshot {
+    pub commitment: String,
+    pub source: String,
+    pub slot: u64,
+    pub observed_at: String,
+    pub age_ms: u64,
+    pub gap_from_processed: u64,
+    pub stale: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeedGatewaySnapshot {
+    pub status: String,
+    pub adapter: MarketAdapterHealth,
+    pub freshness: FeedFreshnessContracts,
+    pub market_streams: Vec<MarketFeedStreamSnapshot>,
+    pub slot_commitments: Vec<SlotFeedCommitmentSnapshot>,
+    pub market_events_accepted: u64,
+    pub market_events_duplicate: u64,
+    pub slot_events_accepted: u64,
+    pub slot_events_duplicate: u64,
+    pub stale_market_streams: Vec<String>,
+    pub stale_slot_commitments: Vec<String>,
+    pub max_market_age_ms: u64,
+    pub max_slot_age_ms: u64,
+    pub max_slot_gap_observed: u64,
+}
+
+#[derive(Debug, Error)]
+pub enum FeedGatewayError {
+    #[error("invalid RFC3339 timestamp: {value}")]
+    InvalidTimestamp { value: String },
+    #[error("could not read feed replay fixture at {path}: {source}")]
+    FixtureIo {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("invalid feed replay fixture JSON: {0}")]
+    InvalidFixtureJson(#[source] serde_json::Error),
+}
+
+#[derive(Debug, Clone)]
+struct MarketFeedState {
+    source: String,
+    symbol: String,
+    last_sequence: u64,
+    last_price_usd: String,
+    observed_at: String,
+    observed_at_ts: OffsetDateTime,
+}
+
+#[derive(Debug, Clone)]
+struct SlotFeedState {
+    source: String,
+    slot: u64,
+    last_sequence: u64,
+    observed_at: String,
+    observed_at_ts: OffsetDateTime,
+}
+
+#[derive(Debug, Clone)]
+pub struct FeedGateway {
+    config: FeedGatewayConfig,
+    adapter: MarketAdapterHealth,
+    market_streams: BTreeMap<String, MarketFeedState>,
+    slot_commitments: BTreeMap<SlotCommitment, SlotFeedState>,
+    ingest_report: FeedGatewayIngestReport,
+}
+
+impl FeedGateway {
+    #[must_use]
+    pub fn new(config: FeedGatewayConfig) -> Self {
+        let adapter = MarketAdapterHealth::bootstrap(
+            &config.provider,
+            &config.websocket_url,
+            &config.rpc_url,
+        );
+        Self {
+            config,
+            adapter,
+            market_streams: BTreeMap::new(),
+            slot_commitments: BTreeMap::new(),
+            ingest_report: FeedGatewayIngestReport::default(),
+        }
+    }
+
+    #[must_use]
+    pub fn adapter_health(&self) -> &MarketAdapterHealth {
+        &self.adapter
+    }
+
+    pub fn mark_reconnecting(&mut self, observed_at: &str, reason: &str) {
+        self.adapter.mark_reconnecting(observed_at, reason);
+    }
+
+    pub fn mark_degraded(&mut self, reason: &str) {
+        self.adapter.mark_degraded(reason);
+    }
+
+    pub fn apply_replay_fixture(
+        &mut self,
+        fixture: &FeedReplayFixture,
+    ) -> Result<FeedGatewayIngestReport, FeedGatewayError> {
+        let mut report = FeedGatewayIngestReport::default();
+
+        for event in fixture.market_events.iter().cloned() {
+            if self.ingest_market_event(event)? {
+                report.market_events_accepted = report.market_events_accepted.saturating_add(1);
+            } else {
+                report.market_events_duplicate = report.market_events_duplicate.saturating_add(1);
+            }
+        }
+
+        for event in fixture.slot_events.iter().cloned() {
+            if self.ingest_slot_event(event)? {
+                report.slot_events_accepted = report.slot_events_accepted.saturating_add(1);
+            } else {
+                report.slot_events_duplicate = report.slot_events_duplicate.saturating_add(1);
+            }
+        }
+
+        Ok(report)
+    }
+
+    pub fn ingest_market_event(
+        &mut self,
+        event: MarketFeedEvent,
+    ) -> Result<bool, FeedGatewayError> {
+        let observed_at_ts = parse_timestamp(&event.observed_at)?;
+        let received_at_ts = parse_timestamp(&event.received_at)?;
+        let stream_id = market_stream_id(&event.source, &event.symbol);
+
+        self.adapter.mark_message(&event.received_at);
+        let duplicate = self
+            .market_streams
+            .get(&stream_id)
+            .is_some_and(|existing| event.sequence <= existing.last_sequence);
+        if duplicate {
+            self.ingest_report.market_events_duplicate =
+                self.ingest_report.market_events_duplicate.saturating_add(1);
+            if received_at_ts >= observed_at_ts {
+                self.adapter.mark_message(&event.received_at);
+            }
+            return Ok(false);
+        }
+
+        self.market_streams.insert(
+            stream_id,
+            MarketFeedState {
+                source: event.source,
+                symbol: event.symbol,
+                last_sequence: event.sequence,
+                last_price_usd: event.price_usd,
+                observed_at: event.observed_at,
+                observed_at_ts,
+            },
+        );
+        self.ingest_report.market_events_accepted =
+            self.ingest_report.market_events_accepted.saturating_add(1);
+        Ok(true)
+    }
+
+    pub fn ingest_slot_event(&mut self, event: SlotFeedEvent) -> Result<bool, FeedGatewayError> {
+        let observed_at_ts = parse_timestamp(&event.observed_at)?;
+        self.adapter.mark_message(&event.observed_at);
+        let duplicate = self
+            .slot_commitments
+            .get(&event.commitment)
+            .is_some_and(|existing| {
+                event.sequence <= existing.last_sequence || event.slot < existing.slot
+            });
+        if duplicate {
+            self.ingest_report.slot_events_duplicate =
+                self.ingest_report.slot_events_duplicate.saturating_add(1);
+            return Ok(false);
+        }
+
+        self.slot_commitments.insert(
+            event.commitment,
+            SlotFeedState {
+                source: event.source,
+                slot: event.slot,
+                last_sequence: event.sequence,
+                observed_at: event.observed_at,
+                observed_at_ts,
+            },
+        );
+        self.ingest_report.slot_events_accepted =
+            self.ingest_report.slot_events_accepted.saturating_add(1);
+        Ok(true)
+    }
+
+    #[must_use]
+    pub fn snapshot_now(&self) -> FeedGatewaySnapshot {
+        self.snapshot_at(OffsetDateTime::now_utc())
+    }
+
+    #[must_use]
+    pub fn snapshot_at(&self, now: OffsetDateTime) -> FeedGatewaySnapshot {
+        let processed_slot = self
+            .slot_commitments
+            .get(&SlotCommitment::Processed)
+            .map(|state| state.slot)
+            .or_else(|| self.slot_commitments.values().map(|state| state.slot).max())
+            .unwrap_or(0);
+
+        let mut stale_market_streams = Vec::new();
+        let mut max_market_age_ms = 0_u64;
+        let market_streams: Vec<MarketFeedStreamSnapshot> = self
+            .market_streams
+            .iter()
+            .map(|(stream_id, state)| {
+                let age_ms = age_ms(now, state.observed_at_ts);
+                let stale = age_ms > self.config.market_stale_after_ms;
+                if stale {
+                    stale_market_streams.push(stream_id.clone());
+                }
+                max_market_age_ms = max_market_age_ms.max(age_ms);
+                MarketFeedStreamSnapshot {
+                    stream_id: stream_id.clone(),
+                    symbol: state.symbol.clone(),
+                    source: state.source.clone(),
+                    last_sequence: state.last_sequence,
+                    last_price_usd: state.last_price_usd.clone(),
+                    observed_at: state.observed_at.clone(),
+                    age_ms,
+                    stale,
+                }
+            })
+            .collect();
+
+        let mut stale_slot_commitments = Vec::new();
+        let mut max_slot_age_ms = 0_u64;
+        let mut max_slot_gap_observed = 0_u64;
+        let slot_commitments: Vec<SlotFeedCommitmentSnapshot> = self
+            .slot_commitments
+            .iter()
+            .map(|(commitment, state)| {
+                let age_ms = age_ms(now, state.observed_at_ts);
+                let gap_from_processed = processed_slot.saturating_sub(state.slot);
+                let stale = age_ms > self.config.slot_stale_after_ms
+                    || gap_from_processed > self.config.max_slot_gap;
+                if stale {
+                    stale_slot_commitments.push(commitment.as_str().to_string());
+                }
+                max_slot_age_ms = max_slot_age_ms.max(age_ms);
+                max_slot_gap_observed = max_slot_gap_observed.max(gap_from_processed);
+                SlotFeedCommitmentSnapshot {
+                    commitment: commitment.as_str().to_string(),
+                    source: state.source.clone(),
+                    slot: state.slot,
+                    observed_at: state.observed_at.clone(),
+                    age_ms,
+                    gap_from_processed,
+                    stale,
+                }
+            })
+            .collect();
+
+        let status = if self.adapter.status == AdapterStatus::Degraded
+            || market_streams.is_empty()
+            || slot_commitments.is_empty()
+            || !stale_market_streams.is_empty()
+            || !stale_slot_commitments.is_empty()
+        {
+            "degraded"
+        } else {
+            "healthy"
+        };
+
+        FeedGatewaySnapshot {
+            status: status.to_string(),
+            adapter: self.adapter.clone(),
+            freshness: FeedFreshnessContracts {
+                market_stale_after_ms: self.config.market_stale_after_ms,
+                slot_stale_after_ms: self.config.slot_stale_after_ms,
+                max_slot_gap: self.config.max_slot_gap,
+            },
+            market_streams,
+            slot_commitments,
+            market_events_accepted: self.ingest_report.market_events_accepted,
+            market_events_duplicate: self.ingest_report.market_events_duplicate,
+            slot_events_accepted: self.ingest_report.slot_events_accepted,
+            slot_events_duplicate: self.ingest_report.slot_events_duplicate,
+            stale_market_streams,
+            stale_slot_commitments,
+            max_market_age_ms,
+            max_slot_age_ms,
+            max_slot_gap_observed,
+        }
+    }
+}
+
+fn market_stream_id(source: &str, symbol: &str) -> String {
+    format!("{source}:{symbol}")
+}
+
+fn parse_timestamp(value: &str) -> Result<OffsetDateTime, FeedGatewayError> {
+    OffsetDateTime::parse(value, &Rfc3339).map_err(|_| FeedGatewayError::InvalidTimestamp {
+        value: value.to_string(),
+    })
+}
+
+fn format_timestamp(value: OffsetDateTime) -> Result<String, FeedGatewayError> {
+    value
+        .format(&Rfc3339)
+        .map_err(|_| FeedGatewayError::InvalidTimestamp {
+            value: value.to_string(),
+        })
+}
+
+fn age_ms(now: OffsetDateTime, observed_at: OffsetDateTime) -> u64 {
+    let delta = (now - observed_at).whole_milliseconds();
+    if delta <= 0 {
+        0
+    } else {
+        delta as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_path() -> String {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../services/runtime-rs/fixtures/runtime-feed-replay.sol_usdc.v1.json")
+            .display()
+            .to_string()
+    }
+
+    fn gateway_config() -> FeedGatewayConfig {
+        FeedGatewayConfig::new(
+            "fixture",
+            "wss://fixture.invalid/runtime",
+            "https://fixture.invalid/runtime",
+            30_000,
+            15_000,
+            2,
+        )
+    }
+
+    #[test]
+    fn bootstraps_healthy_adapter_state() {
+        let health = MarketAdapterHealth::bootstrap(
+            "jupiter",
+            "wss://price-feed.example",
+            "https://rpc.example",
+        );
+
+        assert_eq!(health.provider, "jupiter");
+        assert_eq!(health.status_label(), "healthy");
+        assert_eq!(health.connection_state, ConnectionState::Bootstrapping);
+    }
+
+    #[test]
+    fn applies_replay_fixture_and_tracks_duplicates() {
+        let mut gateway = FeedGateway::new(gateway_config());
+        let fixture = FeedReplayFixture::load_from_path(fixture_path()).expect("fixture to load");
+
+        let first_report = gateway
+            .apply_replay_fixture(&fixture)
+            .expect("fixture replay to succeed");
+        let duplicate_report = gateway
+            .apply_replay_fixture(&fixture)
+            .expect("duplicate replay to succeed");
+
+        assert_eq!(first_report.market_events_accepted, 2);
+        assert_eq!(first_report.slot_events_accepted, 3);
+        assert_eq!(duplicate_report.market_events_duplicate, 2);
+        assert_eq!(duplicate_report.slot_events_duplicate, 3);
+        assert_eq!(
+            gateway.adapter_health().connection_state,
+            ConnectionState::Connected,
+        );
+    }
+
+    #[test]
+    fn computes_freshness_and_slot_gap_contracts() {
+        let mut gateway = FeedGateway::new(gateway_config());
+        let fixture = FeedReplayFixture::load_from_path(fixture_path()).expect("fixture to load");
+        gateway
+            .apply_replay_fixture(&fixture)
+            .expect("fixture replay to succeed");
+
+        let healthy_snapshot = gateway.snapshot_at(
+            OffsetDateTime::parse("2026-03-07T00:00:18Z", &Rfc3339).expect("snapshot time"),
+        );
+        assert_eq!(healthy_snapshot.status, "healthy");
+        assert_eq!(healthy_snapshot.max_slot_gap_observed, 2);
+        assert!(healthy_snapshot.stale_market_streams.is_empty());
+        assert!(healthy_snapshot.stale_slot_commitments.is_empty());
+
+        let stale_snapshot = gateway.snapshot_at(
+            OffsetDateTime::parse("2026-03-07T00:01:10Z", &Rfc3339).expect("stale time"),
+        );
+        assert_eq!(stale_snapshot.status, "degraded");
+        assert_eq!(
+            stale_snapshot.stale_market_streams,
+            vec!["fixture.jupiter:SOL/USDC"]
+        );
+        assert_eq!(
+            stale_snapshot.stale_slot_commitments,
+            vec!["processed", "confirmed", "finalized"],
+        );
+    }
+
+    #[test]
+    fn surfaces_reconnect_transitions() {
+        let mut gateway = FeedGateway::new(gateway_config());
+        gateway.mark_reconnecting("2026-03-07T00:00:10Z", "socket-reset");
+        assert_eq!(gateway.adapter_health().status_label(), "degraded");
+        assert_eq!(
+            gateway.adapter_health().connection_state,
+            ConnectionState::Reconnecting,
+        );
+
+        gateway
+            .ingest_slot_event(SlotFeedEvent {
+                source: "fixture.helius".to_string(),
+                commitment: SlotCommitment::Processed,
+                slot: DEFAULT_SLOT_HEAD,
+                observed_at: "2026-03-07T00:00:11Z".to_string(),
+                sequence: 10,
+            })
+            .expect("slot event to ingest");
+        assert_eq!(gateway.adapter_health().status_label(), "healthy");
+        assert_eq!(
+            gateway.adapter_health().connection_state,
+            ConnectionState::Connected,
+        );
+        assert_eq!(gateway.adapter_health().reconnect_count, 1);
+    }
+
+    #[test]
+    fn builds_bootstrap_fixture() {
+        let fixture = FeedReplayFixture::bootstrap(
+            OffsetDateTime::parse("2026-03-07T00:00:00Z", &Rfc3339).expect("bootstrap time"),
+        )
+        .expect("bootstrap fixture");
+        assert_eq!(fixture.market_events.len(), 1);
+        assert_eq!(fixture.slot_events.len(), 3);
+    }
+}

--- a/crates/market-adapters/src/lib.rs
+++ b/crates/market-adapters/src/lib.rs
@@ -1,50 +1,8 @@
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum AdapterStatus {
-    Healthy,
-    Degraded,
-}
+mod gateway;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct MarketAdapterHealth {
-    pub provider: String,
-    pub websocket_url: String,
-    pub rpc_url: String,
-    pub status: AdapterStatus,
-}
-
-impl MarketAdapterHealth {
-    #[must_use]
-    pub fn bootstrap(provider: &str, websocket_url: &str, rpc_url: &str) -> Self {
-        Self {
-            provider: provider.to_string(),
-            websocket_url: websocket_url.to_string(),
-            rpc_url: rpc_url.to_string(),
-            status: AdapterStatus::Healthy,
-        }
-    }
-
-    #[must_use]
-    pub fn status_label(&self) -> &'static str {
-        match self.status {
-            AdapterStatus::Healthy => "healthy",
-            AdapterStatus::Degraded => "degraded",
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn bootstraps_healthy_adapter_state() {
-        let health = MarketAdapterHealth::bootstrap(
-            "jupiter",
-            "wss://price-feed.example",
-            "https://rpc.example",
-        );
-
-        assert_eq!(health.provider, "jupiter");
-        assert_eq!(health.status_label(), "healthy");
-    }
-}
+pub use gateway::{
+    AdapterStatus, ConnectionState, FeedFreshnessContracts, FeedGateway, FeedGatewayConfig,
+    FeedGatewayError, FeedGatewayIngestReport, FeedGatewaySnapshot, FeedReplayFixture,
+    MarketAdapterHealth, MarketFeedEvent, MarketFeedStreamSnapshot, SlotCommitment,
+    SlotFeedCommitmentSnapshot, SlotFeedEvent,
+};

--- a/crates/runtime-ops/src/lib.rs
+++ b/crates/runtime-ops/src/lib.rs
@@ -38,6 +38,13 @@ pub struct RuntimeConfig {
     pub environment: RuntimeEnvironment,
     pub log_level: String,
     pub protocol_version: String,
+    pub feed_provider: String,
+    pub feed_websocket_url: String,
+    pub feed_http_url: String,
+    pub feed_market_stale_after_ms: u64,
+    pub feed_slot_stale_after_ms: u64,
+    pub feed_max_slot_gap: u64,
+    pub feed_replay_fixture_path: Option<String>,
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -64,6 +71,23 @@ impl RuntimeConfig {
             environment: RuntimeEnvironment::parse(lookup("RUNTIME_RS_ENV"))?,
             log_level: lookup("RUNTIME_RS_LOG").unwrap_or_else(|| "info".to_string()),
             protocol_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            feed_provider: lookup("RUNTIME_FEED_PROVIDER").unwrap_or_else(|| "fixture".to_string()),
+            feed_websocket_url: lookup("RUNTIME_FEED_WS_URL")
+                .unwrap_or_else(|| "wss://price-feed.example/runtime".to_string()),
+            feed_http_url: lookup("RUNTIME_FEED_HTTP_URL")
+                .unwrap_or_else(|| "https://rpc.example/runtime".to_string()),
+            feed_market_stale_after_ms: parse_u64_env(
+                lookup("RUNTIME_FEED_MARKET_STALE_AFTER_MS"),
+                30_000,
+            ),
+            feed_slot_stale_after_ms: parse_u64_env(
+                lookup("RUNTIME_FEED_SLOT_STALE_AFTER_MS"),
+                15_000,
+            ),
+            feed_max_slot_gap: parse_u64_env(lookup("RUNTIME_FEED_MAX_SLOT_GAP"), 2),
+            feed_replay_fixture_path: lookup("RUNTIME_FEED_REPLAY_FIXTURE_PATH")
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty()),
         })
     }
 
@@ -72,6 +96,11 @@ impl RuntimeConfig {
             .parse()
             .map_err(|_| RuntimeConfigError::InvalidBindAddress(self.bind_address.clone()))
     }
+}
+
+fn parse_u64_env(raw: Option<String>, default_value: u64) -> u64 {
+    raw.and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or(default_value)
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -107,6 +136,11 @@ mod tests {
         assert_eq!(config.bind_address, "127.0.0.1:8081");
         assert_eq!(config.environment, RuntimeEnvironment::Local);
         assert_eq!(config.protocol_version, "v1");
+        assert_eq!(config.feed_provider, "fixture");
+        assert_eq!(config.feed_market_stale_after_ms, 30_000);
+        assert_eq!(config.feed_slot_stale_after_ms, 15_000);
+        assert_eq!(config.feed_max_slot_gap, 2);
+        assert_eq!(config.feed_replay_fixture_path, None);
     }
 
     #[test]
@@ -115,6 +149,13 @@ mod tests {
             "RUNTIME_RS_BIND_ADDR" => Some("0.0.0.0:9090".to_string()),
             "RUNTIME_RS_ENV" => Some("preview".to_string()),
             "RUNTIME_RS_LOG" => Some("debug".to_string()),
+            "RUNTIME_FEED_PROVIDER" => Some("jupiter".to_string()),
+            "RUNTIME_FEED_WS_URL" => Some("wss://feeds.jupiter.example/runtime".to_string()),
+            "RUNTIME_FEED_HTTP_URL" => Some("https://rpc.jupiter.example/runtime".to_string()),
+            "RUNTIME_FEED_MARKET_STALE_AFTER_MS" => Some("45000".to_string()),
+            "RUNTIME_FEED_SLOT_STALE_AFTER_MS" => Some("22000".to_string()),
+            "RUNTIME_FEED_MAX_SLOT_GAP" => Some("4".to_string()),
+            "RUNTIME_FEED_REPLAY_FIXTURE_PATH" => Some("/tmp/runtime-feed.json".to_string()),
             _ => None,
         })
         .expect("custom config to load");
@@ -122,6 +163,19 @@ mod tests {
         assert_eq!(config.bind_address, "0.0.0.0:9090");
         assert_eq!(config.environment, RuntimeEnvironment::Preview);
         assert_eq!(config.log_level, "debug");
+        assert_eq!(config.feed_provider, "jupiter");
+        assert_eq!(
+            config.feed_websocket_url,
+            "wss://feeds.jupiter.example/runtime",
+        );
+        assert_eq!(config.feed_http_url, "https://rpc.jupiter.example/runtime");
+        assert_eq!(config.feed_market_stale_after_ms, 45_000);
+        assert_eq!(config.feed_slot_stale_after_ms, 22_000);
+        assert_eq!(config.feed_max_slot_gap, 4);
+        assert_eq!(
+            config.feed_replay_fixture_path.as_deref(),
+            Some("/tmp/runtime-feed.json"),
+        );
         assert_eq!(
             config.socket_addr().expect("socket addr to parse"),
             "0.0.0.0:9090".parse().expect("address"),

--- a/docs/reliability/autonomous-runtime-ops-runbook.md
+++ b/docs/reliability/autonomous-runtime-ops-runbook.md
@@ -52,6 +52,7 @@ Expected topology for v1:
 - active region: `ord`
 - warm standby region: `iad`
 - public health endpoint: `https://ralph-runtime-rs.fly.dev/health`
+- feed metrics endpoint: `https://ralph-runtime-rs.fly.dev/metrics`
 
 ### Pause a deployment
 

--- a/services/runtime-rs/Cargo.toml
+++ b/services/runtime-rs/Cargo.toml
@@ -16,6 +16,7 @@ strategy-core = { path = "../../crates/strategy-core" }
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+time = { version = "0.3.44", features = ["formatting", "parsing"] }
 
 [dev-dependencies]
 http-body-util.workspace = true

--- a/services/runtime-rs/README.md
+++ b/services/runtime-rs/README.md
@@ -1,8 +1,8 @@
 # runtime-rs
 
 `runtime-rs` is the minimal Rust service skeleton for the autonomous runtime
-program. In this phase it is intentionally internal-only and exposes just a
-health endpoint plus config loading.
+program. In this phase it is intentionally internal-only and exposes health and
+feed-metric endpoints plus config loading.
 
 ## Local commands
 
@@ -28,6 +28,21 @@ bun run runtime:fly:smoke
   Default: `http://127.0.0.1:8888`
 - `RUNTIME_INTERNAL_SERVICE_TOKEN`
   Shared bearer token used for private runtime-to-Worker requests.
+- `RUNTIME_FEED_PROVIDER`
+  Default: `fixture`
+- `RUNTIME_FEED_WS_URL`
+  Default: `wss://price-feed.example/runtime`
+- `RUNTIME_FEED_HTTP_URL`
+  Default: `https://rpc.example/runtime`
+- `RUNTIME_FEED_MARKET_STALE_AFTER_MS`
+  Default: `30000`
+- `RUNTIME_FEED_SLOT_STALE_AFTER_MS`
+  Default: `15000`
+- `RUNTIME_FEED_MAX_SLOT_GAP`
+  Default: `2`
+- `RUNTIME_FEED_REPLAY_FIXTURE_PATH`
+  Optional local replay fixture. The checked-in deterministic fixture is
+  `services/runtime-rs/fixtures/runtime-feed-replay.sol_usdc.v1.json`.
 - `RUNTIME_DATABASE_URL`
   Optional runtime-owned relational store bootstrap secret for later phases.
 
@@ -35,11 +50,12 @@ bun run runtime:fly:smoke
 
 ```bash
 curl -fsS http://127.0.0.1:8081/health
+curl -fsS http://127.0.0.1:8081/metrics
 ```
 
 Expected output is a JSON document describing the service name, environment,
-protocol version, bind address, strategy support, and internal dependency
-stubs.
+protocol version, bind address, strategy support, feed freshness contracts,
+duplicate suppression counters, slot lag, and internal dependency stubs.
 
 ## Fly foundation
 

--- a/services/runtime-rs/fixtures/runtime-feed-replay.sol_usdc.v1.json
+++ b/services/runtime-rs/fixtures/runtime-feed-replay.sol_usdc.v1.json
@@ -1,0 +1,48 @@
+{
+  "schemaVersion": "v1",
+  "marketEvents": [
+    {
+      "source": "fixture.jupiter",
+      "symbol": "SOL/USDC",
+      "baseMint": "So11111111111111111111111111111111111111112",
+      "quoteMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "priceUsd": "142.15",
+      "observedAt": "2026-03-07T00:00:00Z",
+      "receivedAt": "2026-03-07T00:00:00Z",
+      "sequence": 101
+    },
+    {
+      "source": "fixture.jupiter",
+      "symbol": "SOL/USDC",
+      "baseMint": "So11111111111111111111111111111111111111112",
+      "quoteMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "priceUsd": "142.42",
+      "observedAt": "2026-03-07T00:00:05Z",
+      "receivedAt": "2026-03-07T00:00:05Z",
+      "sequence": 102
+    }
+  ],
+  "slotEvents": [
+    {
+      "source": "fixture.helius",
+      "commitment": "processed",
+      "slot": 310000000,
+      "observedAt": "2026-03-07T00:00:05Z",
+      "sequence": 201
+    },
+    {
+      "source": "fixture.helius",
+      "commitment": "confirmed",
+      "slot": 309999999,
+      "observedAt": "2026-03-07T00:00:05Z",
+      "sequence": 202
+    },
+    {
+      "source": "fixture.helius",
+      "commitment": "finalized",
+      "slot": 309999998,
+      "observedAt": "2026-03-07T00:00:04Z",
+      "sequence": 203
+    }
+  ]
+}

--- a/services/runtime-rs/src/lib.rs
+++ b/services/runtime-rs/src/lib.rs
@@ -1,29 +1,50 @@
+use std::{
+    env,
+    sync::{Arc, RwLock},
+};
+
 use axum::{extract::State, routing::get, Json, Router};
 use exec_client::ExecClient;
-use market_adapters::MarketAdapterHealth;
+use market_adapters::{FeedGateway, FeedGatewayConfig, FeedGatewaySnapshot, FeedReplayFixture};
 use runtime_ops::{health_snapshot, RuntimeConfig};
 use serde::{Deserialize, Serialize};
 use strategy_core::SUPPORTED_STRATEGIES;
+use time::OffsetDateTime;
+use tokio::time::{sleep, Duration};
 
 #[derive(Debug, Clone)]
 pub struct RuntimeAppState {
     config: RuntimeConfig,
     exec_client: ExecClient,
-    market_adapter_health: MarketAdapterHealth,
+    feed_bootstrap_source: String,
+    feed_bootstrap_error: Option<String>,
+    feed_gateway: Arc<RwLock<FeedGateway>>,
 }
 
 impl RuntimeAppState {
     #[must_use]
     pub fn new(config: RuntimeConfig) -> Self {
+        let mut feed_gateway = FeedGateway::new(feed_gateway_config(&config));
+        let (feed_bootstrap_source, feed_bootstrap_error) =
+            bootstrap_feed_gateway(&mut feed_gateway, &config);
+        let feed_gateway = Arc::new(RwLock::new(feed_gateway));
+        if should_spawn_fixture_keepalive(&config) {
+            spawn_fixture_keepalive(feed_gateway.clone());
+        }
         Self {
             config,
-            exec_client: ExecClient::from_lookup(|key| std::env::var(key).ok()),
-            market_adapter_health: MarketAdapterHealth::bootstrap(
-                "bootstrap",
-                "wss://placeholder.invalid/runtime",
-                "https://placeholder.invalid/runtime",
-            ),
+            exec_client: ExecClient::from_lookup(|key| env::var(key).ok()),
+            feed_bootstrap_source,
+            feed_bootstrap_error,
+            feed_gateway,
         }
+    }
+
+    fn feed_gateway_snapshot(&self) -> FeedGatewaySnapshot {
+        self.feed_gateway
+            .read()
+            .expect("feed gateway read lock")
+            .snapshot_now()
     }
 }
 
@@ -38,17 +59,34 @@ pub struct RuntimeHealthResponse {
     pub exec_health_url: String,
     pub worker_service_auth_configured: bool,
     pub market_adapter_status: String,
+    pub feed_bootstrap_source: String,
+    pub feed_bootstrap_error: Option<String>,
+    pub feed_gateway: FeedGatewaySnapshot,
+    pub supported_strategies: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeMetricsResponse {
+    pub service_name: String,
+    pub environment: String,
+    pub protocol_version: String,
+    pub feed_bootstrap_source: String,
+    pub feed_bootstrap_error: Option<String>,
+    pub feed_gateway: FeedGatewaySnapshot,
     pub supported_strategies: Vec<String>,
 }
 
 pub fn app(config: RuntimeConfig) -> Router {
     Router::new()
         .route("/health", get(health_handler))
+        .route("/metrics", get(metrics_handler))
         .with_state(RuntimeAppState::new(config))
 }
 
 fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
     let snapshot = health_snapshot(&state.config);
+    let feed_gateway = state.feed_gateway_snapshot();
     RuntimeHealthResponse {
         service_name: snapshot.service_name,
         status: snapshot.status,
@@ -57,7 +95,25 @@ fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
         bind_address: snapshot.bind_address,
         exec_health_url: state.exec_client.health_url(),
         worker_service_auth_configured: state.exec_client.has_service_auth(),
-        market_adapter_status: state.market_adapter_health.status_label().to_string(),
+        market_adapter_status: feed_gateway.status.clone(),
+        feed_bootstrap_source: state.feed_bootstrap_source.clone(),
+        feed_bootstrap_error: state.feed_bootstrap_error.clone(),
+        feed_gateway,
+        supported_strategies: SUPPORTED_STRATEGIES
+            .iter()
+            .map(|strategy| strategy.as_key().to_string())
+            .collect(),
+    }
+}
+
+fn metrics_response(state: &RuntimeAppState) -> RuntimeMetricsResponse {
+    RuntimeMetricsResponse {
+        service_name: state.config.service_name.clone(),
+        environment: state.config.environment.as_str().to_string(),
+        protocol_version: state.config.protocol_version.clone(),
+        feed_bootstrap_source: state.feed_bootstrap_source.clone(),
+        feed_bootstrap_error: state.feed_bootstrap_error.clone(),
+        feed_gateway: state.feed_gateway_snapshot(),
         supported_strategies: SUPPORTED_STRATEGIES
             .iter()
             .map(|strategy| strategy.as_key().to_string())
@@ -67,6 +123,101 @@ fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
 
 async fn health_handler(State(state): State<RuntimeAppState>) -> Json<RuntimeHealthResponse> {
     Json(health_response(&state))
+}
+
+async fn metrics_handler(State(state): State<RuntimeAppState>) -> Json<RuntimeMetricsResponse> {
+    Json(metrics_response(&state))
+}
+
+fn feed_gateway_config(config: &RuntimeConfig) -> FeedGatewayConfig {
+    FeedGatewayConfig::new(
+        &config.feed_provider,
+        &config.feed_websocket_url,
+        &config.feed_http_url,
+        config.feed_market_stale_after_ms,
+        config.feed_slot_stale_after_ms,
+        config.feed_max_slot_gap,
+    )
+}
+
+fn bootstrap_feed_gateway(
+    feed_gateway: &mut FeedGateway,
+    config: &RuntimeConfig,
+) -> (String, Option<String>) {
+    if let Some(path) = config.feed_replay_fixture_path.as_deref() {
+        match FeedReplayFixture::load_from_path(path)
+            .and_then(|fixture| feed_gateway.apply_replay_fixture(&fixture))
+        {
+            Ok(_) => return (format!("replay:{path}"), None),
+            Err(error) => {
+                let error_message = format!("replay-fixture-load-failed:{error}");
+                feed_gateway.mark_degraded(&error_message);
+                let (_, fallback_error) = seed_synthetic_bootstrap(feed_gateway);
+                return (
+                    "synthetic-bootstrap".to_string(),
+                    Some(match fallback_error {
+                        Some(fallback_error) => {
+                            format!("{error_message}; fallback-bootstrap-failed:{fallback_error}")
+                        }
+                        None => error_message,
+                    }),
+                );
+            }
+        }
+    }
+
+    seed_synthetic_bootstrap(feed_gateway)
+}
+
+fn seed_synthetic_bootstrap(feed_gateway: &mut FeedGateway) -> (String, Option<String>) {
+    match FeedReplayFixture::bootstrap(OffsetDateTime::now_utc())
+        .and_then(|fixture| feed_gateway.apply_replay_fixture(&fixture))
+    {
+        Ok(_) => ("synthetic-bootstrap".to_string(), None),
+        Err(error) => {
+            let error_message = format!("synthetic-bootstrap-failed:{error}");
+            feed_gateway.mark_degraded(&error_message);
+            ("synthetic-bootstrap".to_string(), Some(error_message))
+        }
+    }
+}
+
+fn should_spawn_fixture_keepalive(config: &RuntimeConfig) -> bool {
+    config.feed_provider == "fixture" && config.feed_replay_fixture_path.is_none()
+}
+
+fn spawn_fixture_keepalive(feed_gateway: Arc<RwLock<FeedGateway>>) {
+    tokio::spawn(async move {
+        let mut sequence_seed: u64 = 100;
+        loop {
+            sleep(Duration::from_secs(5)).await;
+            sequence_seed = sequence_seed.saturating_add(100);
+            let fixture = match FeedReplayFixture::bootstrap_with_sequence_seed(
+                OffsetDateTime::now_utc(),
+                sequence_seed,
+            ) {
+                Ok(fixture) => fixture,
+                Err(error) => {
+                    feed_gateway
+                        .write()
+                        .expect("feed gateway write lock")
+                        .mark_degraded(&format!("fixture-keepalive-build-failed:{error}"));
+                    continue;
+                }
+            };
+
+            if let Err(error) = feed_gateway
+                .write()
+                .expect("feed gateway write lock")
+                .apply_replay_fixture(&fixture)
+            {
+                feed_gateway
+                    .write()
+                    .expect("feed gateway write lock")
+                    .mark_degraded(&format!("fixture-keepalive-apply-failed:{error}"));
+            }
+        }
+    });
 }
 
 #[cfg(test)]
@@ -103,5 +254,42 @@ mod tests {
         assert_eq!(payload.service_name, "runtime-rs");
         assert_eq!(payload.environment, "local");
         assert_eq!(payload.protocol_version, "v1");
+        assert_eq!(payload.market_adapter_status, "healthy");
+        assert_eq!(payload.feed_bootstrap_source, "synthetic-bootstrap");
+        assert!(payload.feed_bootstrap_error.is_none());
+        assert_eq!(payload.feed_gateway.market_streams.len(), 1);
+        assert_eq!(payload.feed_gateway.slot_commitments.len(), 3);
+        assert_eq!(payload.feed_gateway.status, "healthy");
+    }
+
+    #[tokio::test]
+    async fn serves_metrics_endpoint() {
+        let config = RuntimeConfig::from_lookup(|_| None).expect("config to load");
+        let response = app(config)
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(axum::body::Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("body to collect")
+            .to_bytes();
+        let payload: RuntimeMetricsResponse =
+            serde_json::from_slice(&body).expect("metrics response");
+
+        assert_eq!(payload.service_name, "runtime-rs");
+        assert_eq!(payload.environment, "local");
+        assert_eq!(payload.protocol_version, "v1");
+        assert_eq!(payload.feed_bootstrap_source, "synthetic-bootstrap");
+        assert_eq!(payload.feed_gateway.market_events_accepted, 1);
+        assert_eq!(payload.feed_gateway.slot_events_accepted, 3);
     }
 }


### PR DESCRIPTION
Fixes #262

## Summary
- add a Rust `feed_gateway` with deterministic market and slot event models, freshness contracts, reconnect state, duplicate suppression, and replay fixture loading
- extend `runtime-rs` config plus `/health` and `/metrics` so feed lag and stale-data state are visible without changing the public Worker contract
- keep the default `fixture` provider alive with a synthetic heartbeat, while replay-fixture mode intentionally surfaces stale feeds for local and CI verification

## Validation
- `cargo fmt --all`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `bun run lint`
- `bun run typecheck`

## Proof
- synthetic bootstrap smoke:
  - launched `runtime-rs` with `RUNTIME_RS_BIND_ADDR=127.0.0.1:8087` and `RUNTIME_INTERNAL_SERVICE_TOKEN=test-runtime-token`
  - after 16 seconds, `curl http://127.0.0.1:8087/health` and `curl http://127.0.0.1:8087/metrics` both showed `feedGateway.status: healthy`, `marketEventsAccepted: 5`, `slotEventsAccepted: 15`, and no stale streams or commitments
- replay-fixture smoke:
  - launched `runtime-rs` with `RUNTIME_FEED_REPLAY_FIXTURE_PATH=services/runtime-rs/fixtures/runtime-feed-replay.sol_usdc.v1.json`
  - `curl /metrics` surfaced the replayed stale market stream and stale slot commitments exactly as the freshness contracts require
- the harness browser path is unchanged by this issue; Playwright/browser-proof stays part of CI and will still run on this PR

## Risk Notes
- the runtime feed provider remains fixture-backed in this phase; real market adapters land in later issues
- top-level runtime process health remains `status: ok`; feed freshness and lag now surface via `marketAdapterStatus`, `feedGateway`, and `/metrics`
