### PR TITLE
Pin time crate for Fly builder compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "once_cell"
@@ -578,30 +578,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde_core",
+ "serde",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",

--- a/crates/market-adapters/Cargo.toml
+++ b/crates/market-adapters/Cargo.toml
@@ -8,4 +8,4 @@ license.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-time = { version = "0.3.44", features = ["formatting", "parsing"] }
+time = { version = "=0.3.44", features = ["formatting", "parsing"] }

--- a/services/runtime-rs/Cargo.toml
+++ b/services/runtime-rs/Cargo.toml
@@ -16,7 +16,7 @@ strategy-core = { path = "../../crates/strategy-core" }
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-time = { version = "0.3.44", features = ["formatting", "parsing"] }
+time = { version = "=0.3.44", features = ["formatting", "parsing"] }
 
 [dev-dependencies]
 http-body-util.workspace = true


### PR DESCRIPTION
## Summary
- pin the Rust `time` dependency in runtime crates to `=0.3.44`
- regenerate `Cargo.lock` so Fly's current builder toolchain stays within MSRV
- unblock the `main` deployment regression introduced while closing #262

## Validation
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- bun run lint
- bun run typecheck

Fixes #262
