### PR TITLE
Build runtime feature cache and derived market signals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "feature-cache"
+version = "0.1.0"
+dependencies = [
+ "market-adapters",
+ "serde",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +419,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "exec-client",
+ "feature-cache",
  "http-body-util",
  "market-adapters",
  "protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "crates/exec-client",
+  "crates/feature-cache",
   "crates/market-adapters",
   "crates/portfolio-ledger",
   "crates/protocol",

--- a/crates/feature-cache/Cargo.toml
+++ b/crates/feature-cache/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "feature-cache"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+market-adapters = { path = "../market-adapters" }
+serde.workspace = true
+thiserror.workspace = true
+time = { version = "=0.3.44", features = ["formatting", "parsing"] }

--- a/crates/feature-cache/src/lib.rs
+++ b/crates/feature-cache/src/lib.rs
@@ -243,11 +243,12 @@ impl FeatureCache {
 
     #[must_use]
     pub fn snapshot_at(&self, now: OffsetDateTime) -> FeatureCacheSnapshot {
+        let slot_head = self.slot_commitments.values().map(|state| state.slot).max();
         let processed_slot = self
             .slot_commitments
             .get(&SlotCommitment::Processed)
             .map(|state| state.slot)
-            .or_else(|| self.slot_commitments.values().map(|state| state.slot).max());
+            .or(slot_head);
 
         let max_slot_age_ms = self
             .slot_commitments
@@ -255,6 +256,13 @@ impl FeatureCache {
             .map(|state| age_ms(now, state.observed_at_ts))
             .max()
             .unwrap_or(0);
+        let slot_gap_observed = slot_head.map(|head| {
+            self.slot_commitments
+                .values()
+                .map(|state| head.saturating_sub(state.slot))
+                .max()
+                .unwrap_or(0)
+        });
 
         let mut stale_feature_keys = Vec::new();
         let mut max_feature_age_ms = 0_u64;
@@ -275,13 +283,12 @@ impl FeatureCache {
                 let ingest_lag_ms = age_ms(latest.received_at_ts, latest.observed_at_ts);
                 max_ingest_lag_ms = max_ingest_lag_ms.max(ingest_lag_ms);
 
-                let processed_slot_state = self.slot_commitments.get(&SlotCommitment::Processed);
-                let slot_age_ms =
-                    processed_slot_state.map(|state| age_ms(now, state.observed_at_ts));
-                let slot_gap = processed_slot
-                    .zip(processed_slot_state.map(|state| state.slot))
-                    .map(|(processed, current)| processed.saturating_sub(current))
-                    .or(Some(0));
+                let slot_age_ms = if self.slot_commitments.is_empty() {
+                    None
+                } else {
+                    Some(max_slot_age_ms)
+                };
+                let slot_gap = slot_gap_observed;
                 if let Some(gap) = slot_gap {
                     max_slot_gap_observed = max_slot_gap_observed.max(gap);
                 }

--- a/crates/feature-cache/src/lib.rs
+++ b/crates/feature-cache/src/lib.rs
@@ -1,0 +1,588 @@
+use std::collections::{BTreeMap, VecDeque};
+
+use market_adapters::{FeedReplayFixture, MarketFeedEvent, SlotCommitment, SlotFeedEvent};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use time::{format_description::well_known::Rfc3339, Duration, OffsetDateTime};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeatureCacheConfig {
+    pub feature_stale_after_ms: u64,
+    pub slot_stale_after_ms: u64,
+    pub max_slot_gap: u64,
+    pub short_window_ms: u64,
+    pub long_window_ms: u64,
+    pub volatility_window_size: usize,
+    pub max_samples_per_stream: usize,
+}
+
+impl FeatureCacheConfig {
+    #[must_use]
+    pub fn new(
+        feature_stale_after_ms: u64,
+        slot_stale_after_ms: u64,
+        max_slot_gap: u64,
+        short_window_ms: u64,
+        long_window_ms: u64,
+        volatility_window_size: usize,
+        max_samples_per_stream: usize,
+    ) -> Self {
+        Self {
+            feature_stale_after_ms,
+            slot_stale_after_ms,
+            max_slot_gap,
+            short_window_ms,
+            long_window_ms,
+            volatility_window_size,
+            max_samples_per_stream,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeatureFreshnessContracts {
+    pub feature_stale_after_ms: u64,
+    pub slot_stale_after_ms: u64,
+    pub max_slot_gap: u64,
+    pub short_window_ms: u64,
+    pub long_window_ms: u64,
+    pub volatility_window_size: usize,
+    pub max_samples_per_stream: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DerivedMarketFeatureSnapshot {
+    pub cache_key: String,
+    pub symbol: String,
+    pub source: String,
+    pub last_sequence: u64,
+    pub observed_at: String,
+    pub age_ms: u64,
+    pub stale: bool,
+    pub stale_reasons: Vec<String>,
+    pub sample_count: usize,
+    pub window_short_ms: u64,
+    pub window_long_ms: u64,
+    pub mid_price_usd: String,
+    pub bid_price_usd: Option<String>,
+    pub ask_price_usd: Option<String>,
+    pub spread_bps: Option<String>,
+    pub short_return_bps: Option<String>,
+    pub long_return_bps: Option<String>,
+    pub realized_volatility_bps: Option<String>,
+    pub processed_slot: Option<u64>,
+    pub slot_age_ms: Option<u64>,
+    pub slot_gap: Option<u64>,
+    pub last_ingest_lag_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeatureCacheSnapshot {
+    pub status: String,
+    pub freshness: FeatureFreshnessContracts,
+    pub feature_streams: Vec<DerivedMarketFeatureSnapshot>,
+    pub stale_feature_keys: Vec<String>,
+    pub max_feature_age_ms: u64,
+    pub max_slot_age_ms: u64,
+    pub max_slot_gap_observed: u64,
+    pub max_ingest_lag_ms: u64,
+    pub total_market_samples: usize,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum FeatureCacheError {
+    #[error("invalid RFC3339 timestamp: {value}")]
+    InvalidTimestamp { value: String },
+    #[error("invalid numeric value for {field}: {value}")]
+    InvalidNumber { field: &'static str, value: String },
+}
+
+#[derive(Debug, Clone)]
+struct MarketSample {
+    source: String,
+    symbol: String,
+    sequence: u64,
+    observed_at: String,
+    observed_at_ts: OffsetDateTime,
+    received_at_ts: OffsetDateTime,
+    price_usd: String,
+    price_value: f64,
+    bid_price_usd: Option<String>,
+    bid_value: Option<f64>,
+    ask_price_usd: Option<String>,
+    ask_value: Option<f64>,
+}
+
+#[derive(Debug, Clone)]
+struct SlotState {
+    slot: u64,
+    sequence: u64,
+    observed_at_ts: OffsetDateTime,
+}
+
+#[derive(Debug, Clone)]
+pub struct FeatureCache {
+    config: FeatureCacheConfig,
+    market_streams: BTreeMap<String, VecDeque<MarketSample>>,
+    slot_commitments: BTreeMap<SlotCommitment, SlotState>,
+    last_error: Option<String>,
+}
+
+impl FeatureCache {
+    #[must_use]
+    pub fn new(config: FeatureCacheConfig) -> Self {
+        Self {
+            config,
+            market_streams: BTreeMap::new(),
+            slot_commitments: BTreeMap::new(),
+            last_error: None,
+        }
+    }
+
+    pub fn mark_degraded(&mut self, reason: &str) {
+        self.last_error = Some(reason.to_string());
+    }
+
+    pub fn apply_replay_fixture(
+        &mut self,
+        fixture: &FeedReplayFixture,
+    ) -> Result<(), FeatureCacheError> {
+        for event in fixture.market_events.iter().cloned() {
+            self.ingest_market_event(event)?;
+        }
+
+        for event in fixture.slot_events.iter().cloned() {
+            self.ingest_slot_event(event)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn ingest_market_event(
+        &mut self,
+        event: MarketFeedEvent,
+    ) -> Result<bool, FeatureCacheError> {
+        let observed_at_ts = parse_timestamp(&event.observed_at)?;
+        let received_at_ts = parse_timestamp(&event.received_at)?;
+        let price_value = parse_number("priceUsd", &event.price_usd)?;
+        let bid_value = event
+            .bid_price_usd
+            .as_deref()
+            .map(|value| parse_number("bidPriceUsd", value))
+            .transpose()?;
+        let ask_value = event
+            .ask_price_usd
+            .as_deref()
+            .map(|value| parse_number("askPriceUsd", value))
+            .transpose()?;
+        let cache_key = cache_key(&event.source, &event.symbol);
+        let samples = self.market_streams.entry(cache_key).or_default();
+        let duplicate = samples
+            .back()
+            .is_some_and(|existing| event.sequence <= existing.sequence);
+        if duplicate {
+            return Ok(false);
+        }
+
+        samples.push_back(MarketSample {
+            source: event.source,
+            symbol: event.symbol,
+            sequence: event.sequence,
+            observed_at: event.observed_at,
+            observed_at_ts,
+            received_at_ts,
+            price_usd: event.price_usd,
+            price_value,
+            bid_price_usd: event.bid_price_usd,
+            bid_value,
+            ask_price_usd: event.ask_price_usd,
+            ask_value,
+        });
+
+        while samples.len() > self.config.max_samples_per_stream {
+            samples.pop_front();
+        }
+
+        self.last_error = None;
+        Ok(true)
+    }
+
+    pub fn ingest_slot_event(&mut self, event: SlotFeedEvent) -> Result<bool, FeatureCacheError> {
+        let observed_at_ts = parse_timestamp(&event.observed_at)?;
+        let duplicate = self
+            .slot_commitments
+            .get(&event.commitment)
+            .is_some_and(|existing| {
+                event.sequence <= existing.sequence || event.slot < existing.slot
+            });
+        if duplicate {
+            return Ok(false);
+        }
+
+        self.slot_commitments.insert(
+            event.commitment,
+            SlotState {
+                slot: event.slot,
+                sequence: event.sequence,
+                observed_at_ts,
+            },
+        );
+        self.last_error = None;
+        Ok(true)
+    }
+
+    #[must_use]
+    pub fn snapshot_now(&self) -> FeatureCacheSnapshot {
+        self.snapshot_at(OffsetDateTime::now_utc())
+    }
+
+    #[must_use]
+    pub fn snapshot_at(&self, now: OffsetDateTime) -> FeatureCacheSnapshot {
+        let processed_slot = self
+            .slot_commitments
+            .get(&SlotCommitment::Processed)
+            .map(|state| state.slot)
+            .or_else(|| self.slot_commitments.values().map(|state| state.slot).max());
+
+        let max_slot_age_ms = self
+            .slot_commitments
+            .values()
+            .map(|state| age_ms(now, state.observed_at_ts))
+            .max()
+            .unwrap_or(0);
+
+        let mut stale_feature_keys = Vec::new();
+        let mut max_feature_age_ms = 0_u64;
+        let mut max_slot_gap_observed = 0_u64;
+        let mut max_ingest_lag_ms = 0_u64;
+        let mut total_market_samples = 0_usize;
+
+        let feature_streams: Vec<DerivedMarketFeatureSnapshot> = self
+            .market_streams
+            .iter()
+            .map(|(key, samples)| {
+                total_market_samples += samples.len();
+                let latest = samples
+                    .back()
+                    .expect("feature cache stream to be non-empty");
+                let feature_age_ms = age_ms(now, latest.observed_at_ts);
+                max_feature_age_ms = max_feature_age_ms.max(feature_age_ms);
+                let ingest_lag_ms = age_ms(latest.received_at_ts, latest.observed_at_ts);
+                max_ingest_lag_ms = max_ingest_lag_ms.max(ingest_lag_ms);
+
+                let processed_slot_state = self.slot_commitments.get(&SlotCommitment::Processed);
+                let slot_age_ms =
+                    processed_slot_state.map(|state| age_ms(now, state.observed_at_ts));
+                let slot_gap = processed_slot
+                    .zip(processed_slot_state.map(|state| state.slot))
+                    .map(|(processed, current)| processed.saturating_sub(current))
+                    .or(Some(0));
+                if let Some(gap) = slot_gap {
+                    max_slot_gap_observed = max_slot_gap_observed.max(gap);
+                }
+
+                let mut stale_reasons = Vec::new();
+                if feature_age_ms > self.config.feature_stale_after_ms {
+                    stale_reasons.push("feature_age_exceeded".to_string());
+                }
+                if slot_age_ms.is_none() {
+                    stale_reasons.push("slot_commitment_missing".to_string());
+                }
+                if slot_age_ms.is_some_and(|age| age > self.config.slot_stale_after_ms) {
+                    stale_reasons.push("slot_age_exceeded".to_string());
+                }
+                if slot_gap.is_some_and(|gap| gap > self.config.max_slot_gap) {
+                    stale_reasons.push("slot_gap_exceeded".to_string());
+                }
+                if latest.bid_value.is_none() || latest.ask_value.is_none() {
+                    stale_reasons.push("spread_missing".to_string());
+                }
+
+                let spread_bps = latest
+                    .bid_value
+                    .zip(latest.ask_value)
+                    .and_then(|(bid, ask)| spread_bps(bid, ask));
+                let short_return_bps = trailing_return_bps(
+                    samples,
+                    latest.observed_at_ts,
+                    self.config.short_window_ms,
+                );
+                let long_return_bps =
+                    trailing_return_bps(samples, latest.observed_at_ts, self.config.long_window_ms);
+                let realized_volatility_bps =
+                    realized_volatility_bps(samples, self.config.volatility_window_size);
+
+                let stale = !stale_reasons.is_empty();
+                if stale {
+                    stale_feature_keys.push(key.clone());
+                }
+
+                DerivedMarketFeatureSnapshot {
+                    cache_key: key.clone(),
+                    symbol: latest.symbol.clone(),
+                    source: latest.source.clone(),
+                    last_sequence: latest.sequence,
+                    observed_at: latest.observed_at.clone(),
+                    age_ms: feature_age_ms,
+                    stale,
+                    stale_reasons,
+                    sample_count: samples.len(),
+                    window_short_ms: self.config.short_window_ms,
+                    window_long_ms: self.config.long_window_ms,
+                    mid_price_usd: latest.price_usd.clone(),
+                    bid_price_usd: latest.bid_price_usd.clone(),
+                    ask_price_usd: latest.ask_price_usd.clone(),
+                    spread_bps: spread_bps.map(format_metric),
+                    short_return_bps: short_return_bps.map(format_metric),
+                    long_return_bps: long_return_bps.map(format_metric),
+                    realized_volatility_bps: realized_volatility_bps.map(format_metric),
+                    processed_slot,
+                    slot_age_ms,
+                    slot_gap,
+                    last_ingest_lag_ms: ingest_lag_ms,
+                }
+            })
+            .collect();
+
+        let status = if feature_streams.is_empty() || !stale_feature_keys.is_empty() {
+            "degraded"
+        } else {
+            "healthy"
+        };
+        let status = if self.last_error.is_some() {
+            "degraded"
+        } else {
+            status
+        };
+
+        FeatureCacheSnapshot {
+            status: status.to_string(),
+            freshness: FeatureFreshnessContracts {
+                feature_stale_after_ms: self.config.feature_stale_after_ms,
+                slot_stale_after_ms: self.config.slot_stale_after_ms,
+                max_slot_gap: self.config.max_slot_gap,
+                short_window_ms: self.config.short_window_ms,
+                long_window_ms: self.config.long_window_ms,
+                volatility_window_size: self.config.volatility_window_size,
+                max_samples_per_stream: self.config.max_samples_per_stream,
+            },
+            feature_streams,
+            stale_feature_keys,
+            max_feature_age_ms,
+            max_slot_age_ms,
+            max_slot_gap_observed,
+            max_ingest_lag_ms,
+            total_market_samples,
+            last_error: self.last_error.clone(),
+        }
+    }
+}
+
+fn cache_key(source: &str, symbol: &str) -> String {
+    format!("{source}:{symbol}")
+}
+
+fn parse_timestamp(value: &str) -> Result<OffsetDateTime, FeatureCacheError> {
+    OffsetDateTime::parse(value, &Rfc3339).map_err(|_| FeatureCacheError::InvalidTimestamp {
+        value: value.to_string(),
+    })
+}
+
+fn parse_number(field: &'static str, value: &str) -> Result<f64, FeatureCacheError> {
+    value
+        .parse::<f64>()
+        .map_err(|_| FeatureCacheError::InvalidNumber {
+            field,
+            value: value.to_string(),
+        })
+}
+
+fn age_ms(now: OffsetDateTime, observed_at: OffsetDateTime) -> u64 {
+    let delta = (now - observed_at).whole_milliseconds();
+    if delta <= 0 {
+        0
+    } else {
+        delta as u64
+    }
+}
+
+fn spread_bps(bid: f64, ask: f64) -> Option<f64> {
+    let mid = (bid + ask) / 2.0;
+    if mid <= 0.0 || ask < bid {
+        None
+    } else {
+        Some(((ask - bid) / mid) * 10_000.0)
+    }
+}
+
+fn trailing_return_bps(
+    samples: &VecDeque<MarketSample>,
+    latest_ts: OffsetDateTime,
+    window_ms: u64,
+) -> Option<f64> {
+    if samples.len() < 2 {
+        return None;
+    }
+    let threshold = latest_ts - Duration::milliseconds(window_ms as i64);
+    let anchor = samples
+        .iter()
+        .find(|sample| sample.observed_at_ts >= threshold)
+        .or_else(|| samples.front())?;
+    let latest = samples.back()?;
+    if anchor.price_value <= 0.0 {
+        None
+    } else {
+        Some(((latest.price_value / anchor.price_value) - 1.0) * 10_000.0)
+    }
+}
+
+fn realized_volatility_bps(samples: &VecDeque<MarketSample>, window_size: usize) -> Option<f64> {
+    if samples.len() < 2 {
+        return None;
+    }
+
+    let returns: Vec<f64> = samples
+        .iter()
+        .zip(samples.iter().skip(1))
+        .filter_map(|(previous, current)| {
+            if previous.price_value <= 0.0 {
+                None
+            } else {
+                Some((current.price_value / previous.price_value) - 1.0)
+            }
+        })
+        .collect();
+    if returns.is_empty() {
+        return None;
+    }
+
+    let start_index = returns.len().saturating_sub(window_size);
+    let window = &returns[start_index..];
+    let mean = window.iter().sum::<f64>() / window.len() as f64;
+    let variance = window
+        .iter()
+        .map(|value| {
+            let delta = *value - mean;
+            delta * delta
+        })
+        .sum::<f64>()
+        / window.len() as f64;
+    Some(variance.sqrt() * 10_000.0)
+}
+
+fn format_metric(value: f64) -> String {
+    format!("{value:.4}")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use time::OffsetDateTime;
+
+    use super::*;
+
+    fn fixture_path() -> String {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join(
+                "../../services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json",
+            )
+            .display()
+            .to_string()
+    }
+
+    fn cache_config() -> FeatureCacheConfig {
+        FeatureCacheConfig::new(20_000, 15_000, 2, 10_000, 25_000, 4, 8)
+    }
+
+    #[test]
+    fn derives_features_deterministically_from_replay() {
+        let fixture = FeedReplayFixture::load_from_path(fixture_path()).expect("fixture to load");
+        let mut cache = FeatureCache::new(cache_config());
+        cache
+            .apply_replay_fixture(&fixture)
+            .expect("fixture replay to succeed");
+
+        let snapshot = cache.snapshot_at(
+            OffsetDateTime::parse("2026-03-07T00:00:27Z", &Rfc3339).expect("snapshot time"),
+        );
+
+        assert_eq!(snapshot.status, "healthy");
+        assert_eq!(snapshot.total_market_samples, 6);
+        assert_eq!(snapshot.max_ingest_lag_ms, 1000);
+        let stream = snapshot
+            .feature_streams
+            .first()
+            .expect("feature stream to exist");
+        assert_eq!(stream.cache_key, "fixture.jupiter:SOL/USDC");
+        assert_eq!(stream.sample_count, 6);
+        assert_eq!(stream.mid_price_usd, "142.4400");
+        assert_eq!(stream.spread_bps.as_deref(), Some("7.0205"));
+        assert_eq!(stream.short_return_bps.as_deref(), Some("9.8384"));
+        assert_eq!(stream.long_return_bps.as_deref(), Some("30.9859"));
+        assert_eq!(stream.realized_volatility_bps.as_deref(), Some("14.8619"));
+        assert_eq!(stream.last_ingest_lag_ms, 1000);
+        assert!(stream.stale_reasons.is_empty());
+    }
+
+    #[test]
+    fn enforces_feature_and_slot_freshness_windows() {
+        let fixture = FeedReplayFixture::load_from_path(fixture_path()).expect("fixture to load");
+        let mut cache = FeatureCache::new(cache_config());
+        cache
+            .apply_replay_fixture(&fixture)
+            .expect("fixture replay to succeed");
+
+        let snapshot = cache.snapshot_at(
+            OffsetDateTime::parse("2026-03-07T00:01:05Z", &Rfc3339).expect("snapshot time"),
+        );
+
+        assert_eq!(snapshot.status, "degraded");
+        assert_eq!(
+            snapshot.stale_feature_keys,
+            vec!["fixture.jupiter:SOL/USDC".to_string()]
+        );
+        let stream = snapshot
+            .feature_streams
+            .first()
+            .expect("feature stream to exist");
+        assert!(stream.stale);
+        assert!(stream
+            .stale_reasons
+            .contains(&"feature_age_exceeded".to_string()));
+        assert!(stream
+            .stale_reasons
+            .contains(&"slot_age_exceeded".to_string()));
+    }
+
+    #[test]
+    fn ignores_duplicate_sequences_and_trims_old_samples() {
+        let fixture = FeedReplayFixture::load_from_path(fixture_path()).expect("fixture to load");
+        let mut cache = FeatureCache::new(FeatureCacheConfig::new(
+            20_000, 15_000, 2, 10_000, 25_000, 4, 3,
+        ));
+        cache
+            .apply_replay_fixture(&fixture)
+            .expect("fixture replay to succeed");
+
+        let duplicate = cache
+            .ingest_market_event(fixture.market_events[0].clone())
+            .expect("duplicate event to parse");
+        assert!(!duplicate);
+
+        let snapshot = cache.snapshot_at(
+            OffsetDateTime::parse("2026-03-07T00:00:27Z", &Rfc3339).expect("snapshot time"),
+        );
+        let stream = snapshot
+            .feature_streams
+            .first()
+            .expect("feature stream to exist");
+        assert_eq!(stream.sample_count, 3);
+        assert_eq!(snapshot.total_market_samples, 3);
+    }
+}

--- a/crates/market-adapters/src/gateway.rs
+++ b/crates/market-adapters/src/gateway.rs
@@ -8,6 +8,8 @@ const DEFAULT_MARKET_SYMBOL: &str = "SOL/USDC";
 const DEFAULT_BASE_MINT: &str = "So11111111111111111111111111111111111111112";
 const DEFAULT_QUOTE_MINT: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 const DEFAULT_MARKET_PRICE_USD: &str = "142.00";
+const DEFAULT_BID_PRICE_USD: &str = "141.95";
+const DEFAULT_ASK_PRICE_USD: &str = "142.05";
 const DEFAULT_SLOT_HEAD: u64 = 310_000_000;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -148,6 +150,8 @@ pub struct MarketFeedEvent {
     pub base_mint: String,
     pub quote_mint: String,
     pub price_usd: String,
+    pub bid_price_usd: Option<String>,
+    pub ask_price_usd: Option<String>,
     pub observed_at: String,
     pub received_at: String,
     pub sequence: u64,
@@ -203,6 +207,8 @@ impl FeedReplayFixture {
                 base_mint: DEFAULT_BASE_MINT.to_string(),
                 quote_mint: DEFAULT_QUOTE_MINT.to_string(),
                 price_usd: DEFAULT_MARKET_PRICE_USD.to_string(),
+                bid_price_usd: Some(DEFAULT_BID_PRICE_USD.to_string()),
+                ask_price_usd: Some(DEFAULT_ASK_PRICE_USD.to_string()),
                 observed_at: observed_at.clone(),
                 received_at,
                 sequence: sequence_seed + 1,
@@ -710,5 +716,13 @@ mod tests {
         .expect("bootstrap fixture");
         assert_eq!(fixture.market_events.len(), 1);
         assert_eq!(fixture.slot_events.len(), 3);
+        assert_eq!(
+            fixture.market_events[0].bid_price_usd.as_deref(),
+            Some(DEFAULT_BID_PRICE_USD)
+        );
+        assert_eq!(
+            fixture.market_events[0].ask_price_usd.as_deref(),
+            Some(DEFAULT_ASK_PRICE_USD)
+        );
     }
 }

--- a/crates/runtime-ops/src/lib.rs
+++ b/crates/runtime-ops/src/lib.rs
@@ -45,6 +45,11 @@ pub struct RuntimeConfig {
     pub feed_slot_stale_after_ms: u64,
     pub feed_max_slot_gap: u64,
     pub feed_replay_fixture_path: Option<String>,
+    pub feature_stale_after_ms: u64,
+    pub feature_short_window_ms: u64,
+    pub feature_long_window_ms: u64,
+    pub feature_volatility_window_size: usize,
+    pub feature_max_samples_per_stream: usize,
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -88,6 +93,20 @@ impl RuntimeConfig {
             feed_replay_fixture_path: lookup("RUNTIME_FEED_REPLAY_FIXTURE_PATH")
                 .map(|value| value.trim().to_string())
                 .filter(|value| !value.is_empty()),
+            feature_stale_after_ms: parse_u64_env(lookup("RUNTIME_FEATURE_STALE_AFTER_MS"), 20_000),
+            feature_short_window_ms: parse_u64_env(
+                lookup("RUNTIME_FEATURE_SHORT_WINDOW_MS"),
+                10_000,
+            ),
+            feature_long_window_ms: parse_u64_env(lookup("RUNTIME_FEATURE_LONG_WINDOW_MS"), 25_000),
+            feature_volatility_window_size: parse_usize_env(
+                lookup("RUNTIME_FEATURE_VOLATILITY_WINDOW_SIZE"),
+                4,
+            ),
+            feature_max_samples_per_stream: parse_usize_env(
+                lookup("RUNTIME_FEATURE_MAX_SAMPLES_PER_STREAM"),
+                64,
+            ),
         })
     }
 
@@ -100,6 +119,11 @@ impl RuntimeConfig {
 
 fn parse_u64_env(raw: Option<String>, default_value: u64) -> u64 {
     raw.and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or(default_value)
+}
+
+fn parse_usize_env(raw: Option<String>, default_value: usize) -> usize {
+    raw.and_then(|value| value.trim().parse::<usize>().ok())
         .unwrap_or(default_value)
 }
 
@@ -141,6 +165,11 @@ mod tests {
         assert_eq!(config.feed_slot_stale_after_ms, 15_000);
         assert_eq!(config.feed_max_slot_gap, 2);
         assert_eq!(config.feed_replay_fixture_path, None);
+        assert_eq!(config.feature_stale_after_ms, 20_000);
+        assert_eq!(config.feature_short_window_ms, 10_000);
+        assert_eq!(config.feature_long_window_ms, 25_000);
+        assert_eq!(config.feature_volatility_window_size, 4);
+        assert_eq!(config.feature_max_samples_per_stream, 64);
     }
 
     #[test]
@@ -156,6 +185,11 @@ mod tests {
             "RUNTIME_FEED_SLOT_STALE_AFTER_MS" => Some("22000".to_string()),
             "RUNTIME_FEED_MAX_SLOT_GAP" => Some("4".to_string()),
             "RUNTIME_FEED_REPLAY_FIXTURE_PATH" => Some("/tmp/runtime-feed.json".to_string()),
+            "RUNTIME_FEATURE_STALE_AFTER_MS" => Some("30000".to_string()),
+            "RUNTIME_FEATURE_SHORT_WINDOW_MS" => Some("12000".to_string()),
+            "RUNTIME_FEATURE_LONG_WINDOW_MS" => Some("45000".to_string()),
+            "RUNTIME_FEATURE_VOLATILITY_WINDOW_SIZE" => Some("8".to_string()),
+            "RUNTIME_FEATURE_MAX_SAMPLES_PER_STREAM" => Some("128".to_string()),
             _ => None,
         })
         .expect("custom config to load");
@@ -176,6 +210,11 @@ mod tests {
             config.feed_replay_fixture_path.as_deref(),
             Some("/tmp/runtime-feed.json"),
         );
+        assert_eq!(config.feature_stale_after_ms, 30_000);
+        assert_eq!(config.feature_short_window_ms, 12_000);
+        assert_eq!(config.feature_long_window_ms, 45_000);
+        assert_eq!(config.feature_volatility_window_size, 8);
+        assert_eq!(config.feature_max_samples_per_stream, 128);
         assert_eq!(
             config.socket_addr().expect("socket addr to parse"),
             "0.0.0.0:9090".parse().expect("address"),

--- a/docs/reliability/autonomous-runtime-ops-runbook.md
+++ b/docs/reliability/autonomous-runtime-ops-runbook.md
@@ -35,6 +35,7 @@ Verify:
 - active region and standby region status,
 - provider connectivity,
 - feed freshness,
+- feature freshness and ingest lag,
 - reconciliation backlog,
 - runtime canary status.
 
@@ -90,6 +91,7 @@ Expected effect:
 Symptoms:
 
 - freshness budget breach,
+- feature cache marked degraded or stale,
 - risk rejects spike,
 - strategy engine stops promoting runs.
 

--- a/services/runtime-rs/Cargo.toml
+++ b/services/runtime-rs/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 axum.workspace = true
 exec-client = { path = "../../crates/exec-client" }
+feature-cache = { path = "../../crates/feature-cache" }
 market-adapters = { path = "../../crates/market-adapters" }
 protocol = { path = "../../crates/protocol" }
 runtime-ops = { path = "../../crates/runtime-ops" }

--- a/services/runtime-rs/README.md
+++ b/services/runtime-rs/README.md
@@ -43,6 +43,16 @@ bun run runtime:fly:smoke
 - `RUNTIME_FEED_REPLAY_FIXTURE_PATH`
   Optional local replay fixture. The checked-in deterministic fixture is
   `services/runtime-rs/fixtures/runtime-feed-replay.sol_usdc.v1.json`.
+- `RUNTIME_FEATURE_STALE_AFTER_MS`
+  Default: `20000`
+- `RUNTIME_FEATURE_SHORT_WINDOW_MS`
+  Default: `10000`
+- `RUNTIME_FEATURE_LONG_WINDOW_MS`
+  Default: `25000`
+- `RUNTIME_FEATURE_VOLATILITY_WINDOW_SIZE`
+  Default: `4`
+- `RUNTIME_FEATURE_MAX_SAMPLES_PER_STREAM`
+  Default: `64`
 - `RUNTIME_DATABASE_URL`
   Optional runtime-owned relational store bootstrap secret for later phases.
 
@@ -55,7 +65,8 @@ curl -fsS http://127.0.0.1:8081/metrics
 
 Expected output is a JSON document describing the service name, environment,
 protocol version, bind address, strategy support, feed freshness contracts,
-duplicate suppression counters, slot lag, and internal dependency stubs.
+duplicate suppression counters, slot lag, feature freshness windows, derived
+signal snapshots, and internal dependency stubs.
 
 ## Fly foundation
 

--- a/services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json
+++ b/services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json
@@ -1,0 +1,100 @@
+{
+  "schemaVersion": "v1",
+  "marketEvents": [
+    {
+      "source": "fixture.jupiter",
+      "symbol": "SOL/USDC",
+      "baseMint": "So11111111111111111111111111111111111111112",
+      "quoteMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "priceUsd": "142.0000",
+      "bidPriceUsd": "141.9500",
+      "askPriceUsd": "142.0500",
+      "observedAt": "2026-03-07T00:00:00Z",
+      "receivedAt": "2026-03-07T00:00:01Z",
+      "sequence": 301
+    },
+    {
+      "source": "fixture.jupiter",
+      "symbol": "SOL/USDC",
+      "baseMint": "So11111111111111111111111111111111111111112",
+      "quoteMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "priceUsd": "142.1200",
+      "bidPriceUsd": "142.0700",
+      "askPriceUsd": "142.1700",
+      "observedAt": "2026-03-07T00:00:05Z",
+      "receivedAt": "2026-03-07T00:00:06Z",
+      "sequence": 302
+    },
+    {
+      "source": "fixture.jupiter",
+      "symbol": "SOL/USDC",
+      "baseMint": "So11111111111111111111111111111111111111112",
+      "quoteMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "priceUsd": "141.9800",
+      "bidPriceUsd": "141.9300",
+      "askPriceUsd": "142.0300",
+      "observedAt": "2026-03-07T00:00:10Z",
+      "receivedAt": "2026-03-07T00:00:11Z",
+      "sequence": 303
+    },
+    {
+      "source": "fixture.jupiter",
+      "symbol": "SOL/USDC",
+      "baseMint": "So11111111111111111111111111111111111111112",
+      "quoteMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "priceUsd": "142.3000",
+      "bidPriceUsd": "142.2500",
+      "askPriceUsd": "142.3500",
+      "observedAt": "2026-03-07T00:00:15Z",
+      "receivedAt": "2026-03-07T00:00:16Z",
+      "sequence": 304
+    },
+    {
+      "source": "fixture.jupiter",
+      "symbol": "SOL/USDC",
+      "baseMint": "So11111111111111111111111111111111111111112",
+      "quoteMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "priceUsd": "142.1800",
+      "bidPriceUsd": "142.1300",
+      "askPriceUsd": "142.2300",
+      "observedAt": "2026-03-07T00:00:20Z",
+      "receivedAt": "2026-03-07T00:00:21Z",
+      "sequence": 305
+    },
+    {
+      "source": "fixture.jupiter",
+      "symbol": "SOL/USDC",
+      "baseMint": "So11111111111111111111111111111111111111112",
+      "quoteMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "priceUsd": "142.4400",
+      "bidPriceUsd": "142.3900",
+      "askPriceUsd": "142.4900",
+      "observedAt": "2026-03-07T00:00:25Z",
+      "receivedAt": "2026-03-07T00:00:26Z",
+      "sequence": 306
+    }
+  ],
+  "slotEvents": [
+    {
+      "source": "fixture.helius",
+      "commitment": "processed",
+      "slot": 310000000,
+      "observedAt": "2026-03-07T00:00:25Z",
+      "sequence": 401
+    },
+    {
+      "source": "fixture.helius",
+      "commitment": "confirmed",
+      "slot": 309999999,
+      "observedAt": "2026-03-07T00:00:24Z",
+      "sequence": 402
+    },
+    {
+      "source": "fixture.helius",
+      "commitment": "finalized",
+      "slot": 309999998,
+      "observedAt": "2026-03-07T00:00:23Z",
+      "sequence": 403
+    }
+  ]
+}

--- a/services/runtime-rs/fixtures/runtime-feed-replay.sol_usdc.v1.json
+++ b/services/runtime-rs/fixtures/runtime-feed-replay.sol_usdc.v1.json
@@ -7,6 +7,8 @@
       "baseMint": "So11111111111111111111111111111111111111112",
       "quoteMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
       "priceUsd": "142.15",
+      "bidPriceUsd": "142.10",
+      "askPriceUsd": "142.20",
       "observedAt": "2026-03-07T00:00:00Z",
       "receivedAt": "2026-03-07T00:00:00Z",
       "sequence": 101
@@ -17,6 +19,8 @@
       "baseMint": "So11111111111111111111111111111111111111112",
       "quoteMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
       "priceUsd": "142.42",
+      "bidPriceUsd": "142.37",
+      "askPriceUsd": "142.47",
       "observedAt": "2026-03-07T00:00:05Z",
       "receivedAt": "2026-03-07T00:00:05Z",
       "sequence": 102

--- a/services/runtime-rs/src/lib.rs
+++ b/services/runtime-rs/src/lib.rs
@@ -5,6 +5,7 @@ use std::{
 
 use axum::{extract::State, routing::get, Json, Router};
 use exec_client::ExecClient;
+use feature_cache::{FeatureCache, FeatureCacheConfig, FeatureCacheSnapshot};
 use market_adapters::{FeedGateway, FeedGatewayConfig, FeedGatewaySnapshot, FeedReplayFixture};
 use runtime_ops::{health_snapshot, RuntimeConfig};
 use serde::{Deserialize, Serialize};
@@ -19,17 +20,20 @@ pub struct RuntimeAppState {
     feed_bootstrap_source: String,
     feed_bootstrap_error: Option<String>,
     feed_gateway: Arc<RwLock<FeedGateway>>,
+    feature_cache: Arc<RwLock<FeatureCache>>,
 }
 
 impl RuntimeAppState {
     #[must_use]
     pub fn new(config: RuntimeConfig) -> Self {
         let mut feed_gateway = FeedGateway::new(feed_gateway_config(&config));
+        let mut feature_cache = FeatureCache::new(feature_cache_config(&config));
         let (feed_bootstrap_source, feed_bootstrap_error) =
-            bootstrap_feed_gateway(&mut feed_gateway, &config);
+            bootstrap_runtime_state(&mut feed_gateway, &mut feature_cache, &config);
         let feed_gateway = Arc::new(RwLock::new(feed_gateway));
+        let feature_cache = Arc::new(RwLock::new(feature_cache));
         if should_spawn_fixture_keepalive(&config) {
-            spawn_fixture_keepalive(feed_gateway.clone());
+            spawn_fixture_keepalive(feed_gateway.clone(), feature_cache.clone());
         }
         Self {
             config,
@@ -37,6 +41,7 @@ impl RuntimeAppState {
             feed_bootstrap_source,
             feed_bootstrap_error,
             feed_gateway,
+            feature_cache,
         }
     }
 
@@ -44,6 +49,13 @@ impl RuntimeAppState {
         self.feed_gateway
             .read()
             .expect("feed gateway read lock")
+            .snapshot_now()
+    }
+
+    fn feature_cache_snapshot(&self) -> FeatureCacheSnapshot {
+        self.feature_cache
+            .read()
+            .expect("feature cache read lock")
             .snapshot_now()
     }
 }
@@ -62,6 +74,7 @@ pub struct RuntimeHealthResponse {
     pub feed_bootstrap_source: String,
     pub feed_bootstrap_error: Option<String>,
     pub feed_gateway: FeedGatewaySnapshot,
+    pub feature_cache: FeatureCacheSnapshot,
     pub supported_strategies: Vec<String>,
 }
 
@@ -74,6 +87,7 @@ pub struct RuntimeMetricsResponse {
     pub feed_bootstrap_source: String,
     pub feed_bootstrap_error: Option<String>,
     pub feed_gateway: FeedGatewaySnapshot,
+    pub feature_cache: FeatureCacheSnapshot,
     pub supported_strategies: Vec<String>,
 }
 
@@ -87,9 +101,15 @@ pub fn app(config: RuntimeConfig) -> Router {
 fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
     let snapshot = health_snapshot(&state.config);
     let feed_gateway = state.feed_gateway_snapshot();
+    let feature_cache = state.feature_cache_snapshot();
+    let status = if feed_gateway.status == "healthy" && feature_cache.status == "healthy" {
+        snapshot.status
+    } else {
+        "degraded".to_string()
+    };
     RuntimeHealthResponse {
         service_name: snapshot.service_name,
-        status: snapshot.status,
+        status,
         environment: snapshot.environment,
         protocol_version: snapshot.protocol_version,
         bind_address: snapshot.bind_address,
@@ -99,6 +119,7 @@ fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
         feed_bootstrap_source: state.feed_bootstrap_source.clone(),
         feed_bootstrap_error: state.feed_bootstrap_error.clone(),
         feed_gateway,
+        feature_cache,
         supported_strategies: SUPPORTED_STRATEGIES
             .iter()
             .map(|strategy| strategy.as_key().to_string())
@@ -114,6 +135,7 @@ fn metrics_response(state: &RuntimeAppState) -> RuntimeMetricsResponse {
         feed_bootstrap_source: state.feed_bootstrap_source.clone(),
         feed_bootstrap_error: state.feed_bootstrap_error.clone(),
         feed_gateway: state.feed_gateway_snapshot(),
+        feature_cache: state.feature_cache_snapshot(),
         supported_strategies: SUPPORTED_STRATEGIES
             .iter()
             .map(|strategy| strategy.as_key().to_string())
@@ -140,19 +162,34 @@ fn feed_gateway_config(config: &RuntimeConfig) -> FeedGatewayConfig {
     )
 }
 
-fn bootstrap_feed_gateway(
+fn feature_cache_config(config: &RuntimeConfig) -> FeatureCacheConfig {
+    FeatureCacheConfig::new(
+        config.feature_stale_after_ms,
+        config.feed_slot_stale_after_ms,
+        config.feed_max_slot_gap,
+        config.feature_short_window_ms,
+        config.feature_long_window_ms,
+        config.feature_volatility_window_size,
+        config.feature_max_samples_per_stream,
+    )
+}
+
+fn bootstrap_runtime_state(
     feed_gateway: &mut FeedGateway,
+    feature_cache: &mut FeatureCache,
     config: &RuntimeConfig,
 ) -> (String, Option<String>) {
     if let Some(path) = config.feed_replay_fixture_path.as_deref() {
         match FeedReplayFixture::load_from_path(path)
-            .and_then(|fixture| feed_gateway.apply_replay_fixture(&fixture))
+            .map_err(BootstrapError::Feed)
+            .and_then(|fixture| apply_fixture(feed_gateway, feature_cache, &fixture))
         {
             Ok(_) => return (format!("replay:{path}"), None),
             Err(error) => {
                 let error_message = format!("replay-fixture-load-failed:{error}");
                 feed_gateway.mark_degraded(&error_message);
-                let (_, fallback_error) = seed_synthetic_bootstrap(feed_gateway);
+                feature_cache.mark_degraded(&error_message);
+                let (_, fallback_error) = seed_synthetic_bootstrap(feed_gateway, feature_cache);
                 return (
                     "synthetic-bootstrap".to_string(),
                     Some(match fallback_error {
@@ -166,17 +203,22 @@ fn bootstrap_feed_gateway(
         }
     }
 
-    seed_synthetic_bootstrap(feed_gateway)
+    seed_synthetic_bootstrap(feed_gateway, feature_cache)
 }
 
-fn seed_synthetic_bootstrap(feed_gateway: &mut FeedGateway) -> (String, Option<String>) {
+fn seed_synthetic_bootstrap(
+    feed_gateway: &mut FeedGateway,
+    feature_cache: &mut FeatureCache,
+) -> (String, Option<String>) {
     match FeedReplayFixture::bootstrap(OffsetDateTime::now_utc())
-        .and_then(|fixture| feed_gateway.apply_replay_fixture(&fixture))
+        .map_err(BootstrapError::Feed)
+        .and_then(|fixture| apply_fixture(feed_gateway, feature_cache, &fixture))
     {
         Ok(_) => ("synthetic-bootstrap".to_string(), None),
         Err(error) => {
             let error_message = format!("synthetic-bootstrap-failed:{error}");
             feed_gateway.mark_degraded(&error_message);
+            feature_cache.mark_degraded(&error_message);
             ("synthetic-bootstrap".to_string(), Some(error_message))
         }
     }
@@ -186,7 +228,10 @@ fn should_spawn_fixture_keepalive(config: &RuntimeConfig) -> bool {
     config.feed_provider == "fixture" && config.feed_replay_fixture_path.is_none()
 }
 
-fn spawn_fixture_keepalive(feed_gateway: Arc<RwLock<FeedGateway>>) {
+fn spawn_fixture_keepalive(
+    feed_gateway: Arc<RwLock<FeedGateway>>,
+    feature_cache: Arc<RwLock<FeatureCache>>,
+) {
     tokio::spawn(async move {
         let mut sequence_seed: u64 = 100;
         loop {
@@ -202,22 +247,60 @@ fn spawn_fixture_keepalive(feed_gateway: Arc<RwLock<FeedGateway>>) {
                         .write()
                         .expect("feed gateway write lock")
                         .mark_degraded(&format!("fixture-keepalive-build-failed:{error}"));
+                    feature_cache
+                        .write()
+                        .expect("feature cache write lock")
+                        .mark_degraded(&format!("fixture-keepalive-build-failed:{error}"));
                     continue;
                 }
             };
 
-            if let Err(error) = feed_gateway
-                .write()
-                .expect("feed gateway write lock")
-                .apply_replay_fixture(&fixture)
-            {
+            let apply_result = {
+                let mut feed_gateway = feed_gateway.write().expect("feed gateway write lock");
+                let mut feature_cache = feature_cache.write().expect("feature cache write lock");
+                apply_fixture(&mut feed_gateway, &mut feature_cache, &fixture)
+            };
+            if let Err(error) = apply_result {
                 feed_gateway
                     .write()
                     .expect("feed gateway write lock")
                     .mark_degraded(&format!("fixture-keepalive-apply-failed:{error}"));
+                feature_cache
+                    .write()
+                    .expect("feature cache write lock")
+                    .mark_degraded(&format!("fixture-keepalive-apply-failed:{error}"));
             }
         }
     });
+}
+
+#[derive(Debug)]
+enum BootstrapError {
+    Feed(market_adapters::FeedGatewayError),
+    Features(feature_cache::FeatureCacheError),
+}
+
+impl std::fmt::Display for BootstrapError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Feed(error) => write!(f, "{error}"),
+            Self::Features(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+fn apply_fixture(
+    feed_gateway: &mut FeedGateway,
+    feature_cache: &mut FeatureCache,
+    fixture: &FeedReplayFixture,
+) -> Result<(), BootstrapError> {
+    feed_gateway
+        .apply_replay_fixture(fixture)
+        .map_err(BootstrapError::Feed)?;
+    feature_cache
+        .apply_replay_fixture(fixture)
+        .map_err(BootstrapError::Features)?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -257,6 +340,7 @@ mod tests {
         assert_eq!(payload.market_adapter_status, "healthy");
         assert_eq!(payload.feed_bootstrap_source, "synthetic-bootstrap");
         assert!(payload.feed_bootstrap_error.is_none());
+        assert_eq!(payload.feature_cache.status, "healthy");
         assert_eq!(payload.feed_gateway.market_streams.len(), 1);
         assert_eq!(payload.feed_gateway.slot_commitments.len(), 3);
         assert_eq!(payload.feed_gateway.status, "healthy");
@@ -291,5 +375,7 @@ mod tests {
         assert_eq!(payload.feed_bootstrap_source, "synthetic-bootstrap");
         assert_eq!(payload.feed_gateway.market_events_accepted, 1);
         assert_eq!(payload.feed_gateway.slot_events_accepted, 3);
+        assert_eq!(payload.feature_cache.feature_streams.len(), 1);
+        assert_eq!(payload.feature_cache.total_market_samples, 1);
     }
 }


### PR DESCRIPTION
## Summary
- add a new `feature-cache` crate for deterministic replay-driven market feature state
- wire runtime-rs health and metrics to expose feature freshness, lag, and derived signal snapshots
- add runtime feature cache config, replay fixtures, and docs for the new internal metrics surface

## Validation
- cargo fmt --all
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- bun run lint
- bun run typecheck

## Runtime Evidence
- `cargo run -p runtime-rs` with synthetic bootstrap -> `/health` returned `status: ok`, `featureCache.status: healthy`, and `staleFeatureKeys: []`
- `RUNTIME_FEED_REPLAY_FIXTURE_PATH=services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json cargo run -p runtime-rs` -> `/metrics` and `/health` degraded as expected with `staleReasons: ["feature_age_exceeded", "slot_age_exceeded"]`, `spreadBps: "7.0205"`, `shortReturnBps: "9.8384"`, `longReturnBps: "30.9859"`, `realizedVolatilityBps: "14.8619"`, and `maxIngestLagMs: 1000`

Fixes #263
