### PR TITLE
[Phase 2] Add strategy registry and deterministic shadow trigger engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,16 +70,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cc"
+version = "1.2.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "deranged"
@@ -91,11 +135,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "exec-client"
 version = "0.1.0"
 dependencies = [
  "protocol",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "feature-cache"
@@ -106,6 +172,18 @@ dependencies = [
  "thiserror",
  "time",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -147,6 +225,34 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]
@@ -249,6 +355,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +459,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "portfolio-ledger"
 version = "0.1.0"
 dependencies = [
@@ -427,11 +550,26 @@ dependencies = [
  "serde",
  "serde_json",
  "strategy-core",
+ "strategy-registry",
  "time",
  "tokio",
  "tower",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -507,6 +645,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +663,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab"
@@ -540,6 +695,21 @@ dependencies = [
 [[package]]
 name = "strategy-core"
 version = "0.1.0"
+
+[[package]]
+name = "strategy-registry"
+version = "0.1.0"
+dependencies = [
+ "feature-cache",
+ "protocol",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2",
+ "strategy-core",
+ "thiserror",
+ "time",
+]
 
 [[package]]
 name = "syn"
@@ -734,6 +904,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,6 +920,18 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "crates/protocol",
   "crates/risk-engine",
   "crates/runtime-ops",
+  "crates/strategy-registry",
   "crates/strategy-core",
   "services/runtime-rs",
 ]

--- a/crates/runtime-ops/src/lib.rs
+++ b/crates/runtime-ops/src/lib.rs
@@ -38,6 +38,8 @@ pub struct RuntimeConfig {
     pub environment: RuntimeEnvironment,
     pub log_level: String,
     pub protocol_version: String,
+    pub internal_service_token: Option<String>,
+    pub database_url: String,
     pub feed_provider: String,
     pub feed_websocket_url: String,
     pub feed_http_url: String,
@@ -76,6 +78,13 @@ impl RuntimeConfig {
             environment: RuntimeEnvironment::parse(lookup("RUNTIME_RS_ENV"))?,
             log_level: lookup("RUNTIME_RS_LOG").unwrap_or_else(|| "info".to_string()),
             protocol_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            internal_service_token: lookup("RUNTIME_INTERNAL_SERVICE_TOKEN")
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty()),
+            database_url: lookup("RUNTIME_DATABASE_URL")
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| ".tmp/runtime-rs/strategy-registry.sqlite3".to_string()),
             feed_provider: lookup("RUNTIME_FEED_PROVIDER").unwrap_or_else(|| "fixture".to_string()),
             feed_websocket_url: lookup("RUNTIME_FEED_WS_URL")
                 .unwrap_or_else(|| "wss://price-feed.example/runtime".to_string()),
@@ -160,6 +169,11 @@ mod tests {
         assert_eq!(config.bind_address, "127.0.0.1:8081");
         assert_eq!(config.environment, RuntimeEnvironment::Local);
         assert_eq!(config.protocol_version, "v1");
+        assert_eq!(config.internal_service_token, None);
+        assert_eq!(
+            config.database_url,
+            ".tmp/runtime-rs/strategy-registry.sqlite3"
+        );
         assert_eq!(config.feed_provider, "fixture");
         assert_eq!(config.feed_market_stale_after_ms, 30_000);
         assert_eq!(config.feed_slot_stale_after_ms, 15_000);
@@ -178,6 +192,8 @@ mod tests {
             "RUNTIME_RS_BIND_ADDR" => Some("0.0.0.0:9090".to_string()),
             "RUNTIME_RS_ENV" => Some("preview".to_string()),
             "RUNTIME_RS_LOG" => Some("debug".to_string()),
+            "RUNTIME_INTERNAL_SERVICE_TOKEN" => Some("runtime-token".to_string()),
+            "RUNTIME_DATABASE_URL" => Some("/tmp/runtime-state.sqlite3".to_string()),
             "RUNTIME_FEED_PROVIDER" => Some("jupiter".to_string()),
             "RUNTIME_FEED_WS_URL" => Some("wss://feeds.jupiter.example/runtime".to_string()),
             "RUNTIME_FEED_HTTP_URL" => Some("https://rpc.jupiter.example/runtime".to_string()),
@@ -197,6 +213,11 @@ mod tests {
         assert_eq!(config.bind_address, "0.0.0.0:9090");
         assert_eq!(config.environment, RuntimeEnvironment::Preview);
         assert_eq!(config.log_level, "debug");
+        assert_eq!(
+            config.internal_service_token.as_deref(),
+            Some("runtime-token")
+        );
+        assert_eq!(config.database_url, "/tmp/runtime-state.sqlite3");
         assert_eq!(config.feed_provider, "jupiter");
         assert_eq!(
             config.feed_websocket_url,

--- a/crates/strategy-registry/Cargo.toml
+++ b/crates/strategy-registry/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "strategy-registry"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+feature-cache = { path = "../feature-cache" }
+protocol = { path = "../protocol" }
+rusqlite = { version = "0.37.0", features = ["bundled"] }
+serde.workspace = true
+serde_json.workspace = true
+sha2 = "0.10.9"
+strategy-core = { path = "../strategy-core" }
+thiserror.workspace = true
+time = { version = "=0.3.44", features = ["formatting", "parsing"] }

--- a/crates/strategy-registry/src/lib.rs
+++ b/crates/strategy-registry/src/lib.rs
@@ -1,0 +1,875 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use feature_cache::{DerivedMarketFeatureSnapshot, FeatureCacheSnapshot};
+use protocol::{
+    RuntimeDeploymentRecord, RuntimeDeploymentState, RuntimeMode, RuntimeRunRecord,
+    RuntimeRunState, RuntimeTrigger, RuntimeTriggerKind, RUNTIME_PROTOCOL_SCHEMA_VERSION,
+};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use strategy_core::SUPPORTED_STRATEGIES;
+use thiserror::Error;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StrategyRegistryConfig {
+    pub database_url: String,
+}
+
+impl StrategyRegistryConfig {
+    #[must_use]
+    pub fn new(database_url: impl Into<String>) -> Self {
+        Self {
+            database_url: database_url.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StrategyRegistry {
+    database_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StrategyRegistrySnapshot {
+    pub status: String,
+    pub deployment_count: u64,
+    pub run_count: u64,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShadowEvaluationTrigger {
+    pub kind: RuntimeTriggerKind,
+    pub source: String,
+    pub observed_at: Option<String>,
+    pub feature_snapshot_id: Option<String>,
+    pub reason: Option<String>,
+}
+
+impl Default for ShadowEvaluationTrigger {
+    fn default() -> Self {
+        Self {
+            kind: RuntimeTriggerKind::Signal,
+            source: "strategy-registry".to_string(),
+            observed_at: None,
+            feature_snapshot_id: None,
+            reason: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShadowEvaluationResult {
+    pub deployment: RuntimeDeploymentRecord,
+    pub run: RuntimeRunRecord,
+    pub created: bool,
+    pub feature_snapshot: DerivedMarketFeatureSnapshot,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeploymentWriteResult {
+    pub deployment: RuntimeDeploymentRecord,
+    pub created: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum StrategyRegistryError {
+    #[error("storage io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("storage error: {0}")]
+    Storage(#[from] rusqlite::Error),
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("deployment {deployment_id} not found")]
+    DeploymentNotFound { deployment_id: String },
+    #[error("unsupported strategy key: {0}")]
+    UnsupportedStrategy(String),
+    #[error("immutable deployment field changed for {deployment_id}: {field}")]
+    ImmutableFieldChanged {
+        deployment_id: String,
+        field: &'static str,
+    },
+    #[error("invalid deployment transition for {deployment_id}: {from_state:?} -> {to_state:?}")]
+    InvalidStateTransition {
+        deployment_id: String,
+        from_state: RuntimeDeploymentState,
+        to_state: RuntimeDeploymentState,
+    },
+    #[error("deployment {deployment_id} must be in shadow state to evaluate, found {state:?}")]
+    DeploymentNotShadow {
+        deployment_id: String,
+        state: RuntimeDeploymentState,
+    },
+    #[error("feature stream missing for pair {symbol}")]
+    FeatureStreamMissing { symbol: String },
+    #[error("feature stream stale for pair {symbol}: {reasons}")]
+    FeatureStreamStale { symbol: String, reasons: String },
+    #[error("invalid observedAt timestamp: {0}")]
+    InvalidObservedAt(String),
+}
+
+impl StrategyRegistry {
+    pub fn new(config: StrategyRegistryConfig) -> Result<Self, StrategyRegistryError> {
+        let database_path = normalize_database_path(&config.database_url);
+        if database_path != Path::new(":memory:") {
+            if let Some(parent) = database_path
+                .parent()
+                .filter(|path| !path.as_os_str().is_empty())
+            {
+                fs::create_dir_all(parent)?;
+            }
+        }
+        let registry = Self { database_path };
+        let connection = registry.open_connection()?;
+        initialize_schema(&connection)?;
+        Ok(registry)
+    }
+
+    pub fn upsert_deployment(
+        &self,
+        deployment: &RuntimeDeploymentRecord,
+    ) -> Result<DeploymentWriteResult, StrategyRegistryError> {
+        ensure_supported_strategy(&deployment.strategy_key)?;
+
+        let mut connection = self.open_connection()?;
+        let transaction = connection.transaction()?;
+        let existing = load_deployment(&transaction, &deployment.deployment_id)?;
+
+        if let Some(existing_deployment) = existing.as_ref() {
+            ensure_immutable_deployment_fields(existing_deployment, deployment)?;
+            if existing_deployment.state != deployment.state
+                && !existing_deployment
+                    .state
+                    .can_transition_to(&deployment.state)
+            {
+                return Err(StrategyRegistryError::InvalidStateTransition {
+                    deployment_id: deployment.deployment_id.clone(),
+                    from_state: existing_deployment.state.clone(),
+                    to_state: deployment.state.clone(),
+                });
+            }
+        }
+
+        persist_deployment(&transaction, deployment)?;
+        transaction.commit()?;
+
+        Ok(DeploymentWriteResult {
+            deployment: deployment.clone(),
+            created: existing.is_none(),
+        })
+    }
+
+    pub fn get_deployment(
+        &self,
+        deployment_id: &str,
+    ) -> Result<Option<RuntimeDeploymentRecord>, StrategyRegistryError> {
+        let connection = self.open_connection()?;
+        load_deployment(&connection, deployment_id)
+    }
+
+    pub fn transition_deployment(
+        &self,
+        deployment_id: &str,
+        next_state: RuntimeDeploymentState,
+    ) -> Result<RuntimeDeploymentRecord, StrategyRegistryError> {
+        let mut connection = self.open_connection()?;
+        let transaction = connection.transaction()?;
+        let mut deployment = load_deployment(&transaction, deployment_id)?.ok_or_else(|| {
+            StrategyRegistryError::DeploymentNotFound {
+                deployment_id: deployment_id.to_string(),
+            }
+        })?;
+
+        if deployment.state != next_state && !deployment.state.can_transition_to(&next_state) {
+            return Err(StrategyRegistryError::InvalidStateTransition {
+                deployment_id: deployment_id.to_string(),
+                from_state: deployment.state.clone(),
+                to_state: next_state,
+            });
+        }
+
+        let now = now_rfc3339();
+        deployment.state = next_state.clone();
+        deployment.updated_at = now.clone();
+        if next_state == RuntimeDeploymentState::Paused {
+            deployment.paused_at = Some(now.clone());
+        }
+        if next_state == RuntimeDeploymentState::Killed {
+            deployment.killed_at = Some(now.clone());
+        }
+        if matches!(
+            next_state,
+            RuntimeDeploymentState::Paper | RuntimeDeploymentState::Live
+        ) {
+            deployment.promoted_at = Some(now);
+        }
+
+        persist_deployment(&transaction, &deployment)?;
+        transaction.commit()?;
+
+        Ok(deployment)
+    }
+
+    pub fn list_runs(
+        &self,
+        deployment_id: &str,
+    ) -> Result<Vec<RuntimeRunRecord>, StrategyRegistryError> {
+        let connection = self.open_connection()?;
+        let mut statement = connection.prepare(
+            "SELECT record_json
+             FROM runs
+             WHERE deployment_id = ?1
+             ORDER BY planned_at DESC, updated_at DESC, run_id DESC",
+        )?;
+
+        let rows = statement.query_map(params![deployment_id], |row| row.get::<_, String>(0))?;
+        let mut runs = Vec::new();
+        for row in rows {
+            runs.push(deserialize_json(&row?)?);
+        }
+
+        Ok(runs)
+    }
+
+    pub fn evaluate_shadow_trigger(
+        &self,
+        deployment_id: &str,
+        feature_cache_snapshot: &FeatureCacheSnapshot,
+        trigger: Option<ShadowEvaluationTrigger>,
+    ) -> Result<ShadowEvaluationResult, StrategyRegistryError> {
+        let mut connection = self.open_connection()?;
+        let transaction = connection.transaction()?;
+        let deployment = load_deployment(&transaction, deployment_id)?.ok_or_else(|| {
+            StrategyRegistryError::DeploymentNotFound {
+                deployment_id: deployment_id.to_string(),
+            }
+        })?;
+
+        if deployment.state != RuntimeDeploymentState::Shadow {
+            return Err(StrategyRegistryError::DeploymentNotShadow {
+                deployment_id: deployment_id.to_string(),
+                state: deployment.state,
+            });
+        }
+
+        let feature_snapshot =
+            select_feature_snapshot(feature_cache_snapshot, &deployment.pair.symbol)?;
+        if feature_snapshot.stale {
+            return Err(StrategyRegistryError::FeatureStreamStale {
+                symbol: deployment.pair.symbol.clone(),
+                reasons: feature_snapshot.stale_reasons.join(","),
+            });
+        }
+
+        let trigger = build_runtime_trigger(trigger, &feature_snapshot)?;
+        let run_key = build_run_key(deployment_id, &trigger);
+        if let Some(existing_run) = load_run_by_key(&transaction, &run_key)? {
+            transaction.commit()?;
+            return Ok(ShadowEvaluationResult {
+                deployment,
+                run: existing_run,
+                created: false,
+                feature_snapshot,
+            });
+        }
+
+        let run = RuntimeRunRecord {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            run_id: build_run_id(&run_key),
+            deployment_id: deployment_id.to_string(),
+            run_key: run_key.clone(),
+            trigger,
+            state: RuntimeRunState::Planned,
+            planned_at: feature_snapshot.observed_at.clone(),
+            updated_at: now_rfc3339(),
+            risk_verdict_id: None,
+            execution_plan_id: None,
+            submit_request_id: None,
+            receipt_id: None,
+            failure_code: None,
+            failure_message: None,
+        };
+
+        persist_run(&transaction, &run)?;
+        transaction.commit()?;
+
+        Ok(ShadowEvaluationResult {
+            deployment,
+            run,
+            created: true,
+            feature_snapshot,
+        })
+    }
+
+    #[must_use]
+    pub fn snapshot_now(&self) -> StrategyRegistrySnapshot {
+        match self.snapshot_counts() {
+            Ok((deployment_count, run_count)) => StrategyRegistrySnapshot {
+                status: "healthy".to_string(),
+                deployment_count,
+                run_count,
+                last_error: None,
+            },
+            Err(error) => StrategyRegistrySnapshot {
+                status: "degraded".to_string(),
+                deployment_count: 0,
+                run_count: 0,
+                last_error: Some(error.to_string()),
+            },
+        }
+    }
+
+    fn snapshot_counts(&self) -> Result<(u64, u64), StrategyRegistryError> {
+        let connection = self.open_connection()?;
+        let deployment_count =
+            connection.query_row("SELECT COUNT(*) FROM deployments", [], |row| {
+                row.get::<_, u64>(0)
+            })?;
+        let run_count =
+            connection.query_row("SELECT COUNT(*) FROM runs", [], |row| row.get::<_, u64>(0))?;
+        Ok((deployment_count, run_count))
+    }
+
+    fn open_connection(&self) -> Result<Connection, StrategyRegistryError> {
+        let connection = Connection::open(&self.database_path)?;
+        connection.busy_timeout(std::time::Duration::from_secs(5))?;
+        connection.pragma_update(None, "foreign_keys", "ON")?;
+        Ok(connection)
+    }
+}
+
+fn normalize_database_path(database_url: &str) -> PathBuf {
+    let trimmed = database_url.trim();
+    if trimmed.is_empty() {
+        return PathBuf::from(".tmp/runtime-rs/strategy-registry.sqlite3");
+    }
+    if let Some(stripped) = trimmed.strip_prefix("sqlite://") {
+        return PathBuf::from(stripped);
+    }
+    if let Some(stripped) = trimmed.strip_prefix("file:") {
+        return PathBuf::from(stripped);
+    }
+    PathBuf::from(trimmed)
+}
+
+fn initialize_schema(connection: &Connection) -> Result<(), rusqlite::Error> {
+    connection.execute_batch(
+        "CREATE TABLE IF NOT EXISTS deployments (
+            deployment_id TEXT PRIMARY KEY,
+            strategy_key TEXT NOT NULL,
+            sleeve_id TEXT NOT NULL,
+            owner_user_id TEXT NOT NULL,
+            mode TEXT NOT NULL,
+            state TEXT NOT NULL,
+            pair_symbol TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            record_json TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS runs (
+            run_id TEXT PRIMARY KEY,
+            deployment_id TEXT NOT NULL,
+            run_key TEXT NOT NULL UNIQUE,
+            planned_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            record_json TEXT NOT NULL,
+            FOREIGN KEY (deployment_id) REFERENCES deployments(deployment_id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_runs_deployment_planned_at
+            ON runs (deployment_id, planned_at DESC, updated_at DESC);",
+    )
+}
+
+fn ensure_supported_strategy(strategy_key: &str) -> Result<(), StrategyRegistryError> {
+    if SUPPORTED_STRATEGIES
+        .iter()
+        .any(|strategy| strategy.as_key() == strategy_key)
+    {
+        return Ok(());
+    }
+    Err(StrategyRegistryError::UnsupportedStrategy(
+        strategy_key.to_string(),
+    ))
+}
+
+fn ensure_immutable_deployment_fields(
+    existing: &RuntimeDeploymentRecord,
+    incoming: &RuntimeDeploymentRecord,
+) -> Result<(), StrategyRegistryError> {
+    if existing.strategy_key != incoming.strategy_key {
+        return Err(StrategyRegistryError::ImmutableFieldChanged {
+            deployment_id: incoming.deployment_id.clone(),
+            field: "strategyKey",
+        });
+    }
+    if existing.sleeve_id != incoming.sleeve_id {
+        return Err(StrategyRegistryError::ImmutableFieldChanged {
+            deployment_id: incoming.deployment_id.clone(),
+            field: "sleeveId",
+        });
+    }
+    if existing.owner_user_id != incoming.owner_user_id {
+        return Err(StrategyRegistryError::ImmutableFieldChanged {
+            deployment_id: incoming.deployment_id.clone(),
+            field: "ownerUserId",
+        });
+    }
+    if existing.pair != incoming.pair {
+        return Err(StrategyRegistryError::ImmutableFieldChanged {
+            deployment_id: incoming.deployment_id.clone(),
+            field: "pair",
+        });
+    }
+    if existing.mode != incoming.mode {
+        return Err(StrategyRegistryError::ImmutableFieldChanged {
+            deployment_id: incoming.deployment_id.clone(),
+            field: "mode",
+        });
+    }
+    Ok(())
+}
+
+fn persist_deployment(
+    connection: &Connection,
+    deployment: &RuntimeDeploymentRecord,
+) -> Result<(), StrategyRegistryError> {
+    connection.execute(
+        "INSERT INTO deployments (
+            deployment_id,
+            strategy_key,
+            sleeve_id,
+            owner_user_id,
+            mode,
+            state,
+            pair_symbol,
+            updated_at,
+            record_json
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+        ON CONFLICT(deployment_id) DO UPDATE SET
+            strategy_key = excluded.strategy_key,
+            sleeve_id = excluded.sleeve_id,
+            owner_user_id = excluded.owner_user_id,
+            mode = excluded.mode,
+            state = excluded.state,
+            pair_symbol = excluded.pair_symbol,
+            updated_at = excluded.updated_at,
+            record_json = excluded.record_json",
+        params![
+            &deployment.deployment_id,
+            &deployment.strategy_key,
+            &deployment.sleeve_id,
+            &deployment.owner_user_id,
+            state_mode_key(&deployment.mode),
+            state_key(&deployment.state),
+            &deployment.pair.symbol,
+            &deployment.updated_at,
+            serialize_json(deployment)?,
+        ],
+    )?;
+    Ok(())
+}
+
+fn load_deployment(
+    connection: &Connection,
+    deployment_id: &str,
+) -> Result<Option<RuntimeDeploymentRecord>, StrategyRegistryError> {
+    let raw = connection
+        .query_row(
+            "SELECT record_json FROM deployments WHERE deployment_id = ?1",
+            params![deployment_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    Ok(raw.map(|value| deserialize_json(&value)).transpose()?)
+}
+
+fn persist_run(
+    connection: &Connection,
+    run: &RuntimeRunRecord,
+) -> Result<(), StrategyRegistryError> {
+    connection.execute(
+        "INSERT INTO runs (
+            run_id,
+            deployment_id,
+            run_key,
+            planned_at,
+            updated_at,
+            record_json
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            &run.run_id,
+            &run.deployment_id,
+            &run.run_key,
+            &run.planned_at,
+            &run.updated_at,
+            serialize_json(run)?,
+        ],
+    )?;
+    Ok(())
+}
+
+fn load_run_by_key(
+    connection: &Connection,
+    run_key: &str,
+) -> Result<Option<RuntimeRunRecord>, StrategyRegistryError> {
+    let raw = connection
+        .query_row(
+            "SELECT record_json FROM runs WHERE run_key = ?1",
+            params![run_key],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    Ok(raw.map(|value| deserialize_json(&value)).transpose()?)
+}
+
+fn select_feature_snapshot(
+    feature_cache_snapshot: &FeatureCacheSnapshot,
+    symbol: &str,
+) -> Result<DerivedMarketFeatureSnapshot, StrategyRegistryError> {
+    feature_cache_snapshot
+        .feature_streams
+        .iter()
+        .filter(|snapshot| snapshot.symbol == symbol)
+        .max_by_key(|snapshot| snapshot.last_sequence)
+        .cloned()
+        .ok_or_else(|| StrategyRegistryError::FeatureStreamMissing {
+            symbol: symbol.to_string(),
+        })
+}
+
+fn build_runtime_trigger(
+    trigger: Option<ShadowEvaluationTrigger>,
+    feature_snapshot: &DerivedMarketFeatureSnapshot,
+) -> Result<RuntimeTrigger, StrategyRegistryError> {
+    let trigger = trigger.unwrap_or_default();
+    let observed_at = trigger
+        .observed_at
+        .unwrap_or_else(|| feature_snapshot.observed_at.clone());
+    OffsetDateTime::parse(&observed_at, &Rfc3339)
+        .map_err(|_| StrategyRegistryError::InvalidObservedAt(observed_at.clone()))?;
+
+    Ok(RuntimeTrigger {
+        kind: trigger.kind,
+        source: if trigger.source.trim().is_empty() {
+            "strategy-registry".to_string()
+        } else {
+            trigger.source
+        },
+        observed_at,
+        feature_snapshot_id: Some(
+            trigger
+                .feature_snapshot_id
+                .unwrap_or_else(|| feature_snapshot_identity(feature_snapshot)),
+        ),
+        reason: Some(
+            trigger
+                .reason
+                .unwrap_or_else(|| "shadow-feature-evaluation".to_string()),
+        ),
+    })
+}
+
+fn build_run_key(deployment_id: &str, trigger: &RuntimeTrigger) -> String {
+    let identity = trigger
+        .feature_snapshot_id
+        .as_deref()
+        .unwrap_or(trigger.observed_at.as_str());
+    format!(
+        "{deployment_id}:{identity}:{}",
+        trigger_kind_key(&trigger.kind)
+    )
+}
+
+fn build_run_id(run_key: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(run_key.as_bytes());
+    let digest = hasher.finalize();
+    let hex = hex_encode(&digest[..12]);
+    format!("run_{hex}")
+}
+
+fn feature_snapshot_identity(feature_snapshot: &DerivedMarketFeatureSnapshot) -> String {
+    format!(
+        "{}:{}:{}",
+        feature_snapshot.cache_key, feature_snapshot.last_sequence, feature_snapshot.observed_at
+    )
+}
+
+fn state_key(state: &RuntimeDeploymentState) -> &'static str {
+    match state {
+        RuntimeDeploymentState::Draft => "draft",
+        RuntimeDeploymentState::Shadow => "shadow",
+        RuntimeDeploymentState::Paper => "paper",
+        RuntimeDeploymentState::Live => "live",
+        RuntimeDeploymentState::Paused => "paused",
+        RuntimeDeploymentState::Killed => "killed",
+        RuntimeDeploymentState::Archived => "archived",
+    }
+}
+
+fn state_mode_key(mode: &RuntimeMode) -> &'static str {
+    match mode {
+        RuntimeMode::Shadow => "shadow",
+        RuntimeMode::Paper => "paper",
+        RuntimeMode::Live => "live",
+    }
+}
+
+fn trigger_kind_key(kind: &RuntimeTriggerKind) -> &'static str {
+    match kind {
+        RuntimeTriggerKind::Cron => "cron",
+        RuntimeTriggerKind::Signal => "signal",
+        RuntimeTriggerKind::Rebalance => "rebalance",
+        RuntimeTriggerKind::Operator => "operator",
+        RuntimeTriggerKind::Canary => "canary",
+    }
+}
+
+fn serialize_json<T: Serialize>(value: &T) -> Result<String, serde_json::Error> {
+    serde_json::to_string(value)
+}
+
+fn deserialize_json<T: DeserializeOwned>(raw: &str) -> Result<T, serde_json::Error> {
+    serde_json::from_str(raw)
+}
+
+fn hex_encode(input: &[u8]) -> String {
+    let mut output = String::with_capacity(input.len() * 2);
+    for byte in input {
+        use std::fmt::Write as _;
+        let _ = write!(&mut output, "{byte:02x}");
+    }
+    output
+}
+
+fn now_rfc3339() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .expect("current time to format")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+    use protocol::{RuntimeCapital, RuntimeLane, RuntimePair, RuntimePolicy};
+
+    fn temp_database_url(test_name: &str) -> String {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        std::env::temp_dir()
+            .join(format!("strategy-registry-{test_name}-{unique}.sqlite3"))
+            .display()
+            .to_string()
+    }
+
+    fn registry(test_name: &str) -> StrategyRegistry {
+        StrategyRegistry::new(StrategyRegistryConfig::new(temp_database_url(test_name)))
+            .expect("registry to initialize")
+    }
+
+    fn deployment(
+        deployment_id: &str,
+        mode: RuntimeMode,
+        state: RuntimeDeploymentState,
+    ) -> RuntimeDeploymentRecord {
+        RuntimeDeploymentRecord {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            deployment_id: deployment_id.to_string(),
+            strategy_key: "dca".to_string(),
+            sleeve_id: "sleeve_alpha".to_string(),
+            owner_user_id: "user_123".to_string(),
+            pair: RuntimePair {
+                symbol: "SOL/USDC".to_string(),
+                base_mint: "So11111111111111111111111111111111111111112".to_string(),
+                quote_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+            },
+            mode,
+            state,
+            lane: RuntimeLane::Safe,
+            created_at: "2026-03-07T00:00:00.000Z".to_string(),
+            updated_at: "2026-03-07T00:00:00.000Z".to_string(),
+            promoted_at: None,
+            paused_at: None,
+            killed_at: None,
+            policy: RuntimePolicy {
+                max_notional_usd: "250.00".to_string(),
+                daily_loss_limit_usd: "35.00".to_string(),
+                max_slippage_bps: 50,
+                max_concurrent_runs: 2,
+                rebalance_tolerance_bps: 100,
+            },
+            capital: RuntimeCapital {
+                allocated_usd: "1000.00".to_string(),
+                reserved_usd: "125.00".to_string(),
+                available_usd: "875.00".to_string(),
+            },
+            tags: vec!["test".to_string()],
+        }
+    }
+
+    fn feature_cache_snapshot(stale: bool) -> FeatureCacheSnapshot {
+        FeatureCacheSnapshot {
+            status: if stale {
+                "degraded".to_string()
+            } else {
+                "healthy".to_string()
+            },
+            freshness: feature_cache::FeatureFreshnessContracts {
+                feature_stale_after_ms: 20_000,
+                slot_stale_after_ms: 15_000,
+                max_slot_gap: 2,
+                short_window_ms: 10_000,
+                long_window_ms: 25_000,
+                volatility_window_size: 4,
+                max_samples_per_stream: 64,
+            },
+            feature_streams: vec![DerivedMarketFeatureSnapshot {
+                cache_key: "fixture:SOL/USDC".to_string(),
+                symbol: "SOL/USDC".to_string(),
+                source: "fixture".to_string(),
+                last_sequence: 42,
+                observed_at: "2026-03-07T00:00:05.000Z".to_string(),
+                age_ms: 100,
+                stale,
+                stale_reasons: if stale {
+                    vec!["feature_age_exceeded".to_string()]
+                } else {
+                    Vec::new()
+                },
+                sample_count: 4,
+                window_short_ms: 10_000,
+                window_long_ms: 25_000,
+                mid_price_usd: "142.00".to_string(),
+                bid_price_usd: Some("141.95".to_string()),
+                ask_price_usd: Some("142.05".to_string()),
+                spread_bps: Some("7.04".to_string()),
+                short_return_bps: Some("12.00".to_string()),
+                long_return_bps: Some("18.00".to_string()),
+                realized_volatility_bps: Some("9.00".to_string()),
+                processed_slot: Some(321),
+                slot_age_ms: Some(20),
+                slot_gap: Some(0),
+                last_ingest_lag_ms: 10,
+            }],
+            stale_feature_keys: if stale {
+                vec!["fixture:SOL/USDC".to_string()]
+            } else {
+                Vec::new()
+            },
+            max_feature_age_ms: 100,
+            max_slot_age_ms: 20,
+            max_slot_gap_observed: 0,
+            max_ingest_lag_ms: 10,
+            total_market_samples: 4,
+            last_error: None,
+        }
+    }
+
+    #[test]
+    fn stores_and_fetches_deployments() {
+        let registry = registry("store-deployment");
+        let deployment = deployment(
+            "deployment_store",
+            RuntimeMode::Shadow,
+            RuntimeDeploymentState::Draft,
+        );
+
+        let result = registry
+            .upsert_deployment(&deployment)
+            .expect("deployment to store");
+
+        assert!(result.created);
+        assert_eq!(
+            registry
+                .get_deployment("deployment_store")
+                .expect("deployment lookup")
+                .expect("deployment to exist"),
+            deployment
+        );
+    }
+
+    #[test]
+    fn enforces_state_transitions() {
+        let registry = registry("transition");
+        let deployment = deployment(
+            "deployment_transition",
+            RuntimeMode::Shadow,
+            RuntimeDeploymentState::Killed,
+        );
+        registry
+            .upsert_deployment(&deployment)
+            .expect("deployment to store");
+
+        let error = registry
+            .transition_deployment("deployment_transition", RuntimeDeploymentState::Live)
+            .expect_err("transition should fail");
+
+        assert!(matches!(
+            error,
+            StrategyRegistryError::InvalidStateTransition { .. }
+        ));
+    }
+
+    #[test]
+    fn creates_deterministic_shadow_runs_and_prevents_duplicates() {
+        let registry = registry("duplicates");
+        registry
+            .upsert_deployment(&deployment(
+                "deployment_shadow",
+                RuntimeMode::Shadow,
+                RuntimeDeploymentState::Shadow,
+            ))
+            .expect("deployment to store");
+
+        let first = registry
+            .evaluate_shadow_trigger("deployment_shadow", &feature_cache_snapshot(false), None)
+            .expect("first evaluation");
+        let second = registry
+            .evaluate_shadow_trigger("deployment_shadow", &feature_cache_snapshot(false), None)
+            .expect("second evaluation");
+
+        assert!(first.created);
+        assert!(!second.created);
+        assert_eq!(first.run.run_key, second.run.run_key);
+        assert_eq!(first.run.run_id, second.run.run_id);
+        assert_eq!(
+            registry
+                .list_runs("deployment_shadow")
+                .expect("runs to load")
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn rejects_stale_feature_streams() {
+        let registry = registry("stale");
+        registry
+            .upsert_deployment(&deployment(
+                "deployment_stale",
+                RuntimeMode::Shadow,
+                RuntimeDeploymentState::Shadow,
+            ))
+            .expect("deployment to store");
+
+        let error = registry
+            .evaluate_shadow_trigger("deployment_stale", &feature_cache_snapshot(true), None)
+            .expect_err("stale feature stream should fail");
+
+        assert!(matches!(
+            error,
+            StrategyRegistryError::FeatureStreamStale { .. }
+        ));
+    }
+}

--- a/docs/reliability/autonomous-runtime-ops-runbook.md
+++ b/docs/reliability/autonomous-runtime-ops-runbook.md
@@ -36,6 +36,7 @@ Verify:
 - provider connectivity,
 - feed freshness,
 - feature freshness and ingest lag,
+- strategy registry health and deployment/run counts,
 - reconciliation backlog,
 - runtime canary status.
 
@@ -55,6 +56,16 @@ Expected topology for v1:
 - public health endpoint: `https://ralph-runtime-rs.fly.dev/health`
 - feed metrics endpoint: `https://ralph-runtime-rs.fly.dev/metrics`
 
+Internal inspection examples:
+
+```bash
+curl -fsS https://ralph-runtime-rs.fly.dev/api/internal/runtime/health \
+  -H "authorization: Bearer ${RUNTIME_INTERNAL_SERVICE_TOKEN}"
+
+curl -fsS https://ralph-runtime-rs.fly.dev/api/internal/runtime/runs/<deployment-id> \
+  -H "authorization: Bearer ${RUNTIME_INTERNAL_SERVICE_TOKEN}"
+```
+
 ### Pause a deployment
 
 Use pause when:
@@ -65,7 +76,7 @@ Use pause when:
 
 Expected effect:
 
-- new execution plans stop,
+- new shadow evaluations stop,
 - reconciliation continues,
 - existing state remains inspectable.
 
@@ -99,7 +110,9 @@ Response:
 
 1. Pause affected deployments.
 2. Confirm provider and socket health.
-3. Keep the runtime canary disabled until freshness is restored.
+3. Confirm `feature-stream-stale` or `feature-stream-missing` appears on the
+   affected shadow evaluations.
+4. Keep the runtime canary disabled until freshness is restored.
 
 ### Reconciliation incident
 

--- a/services/runtime-rs/Cargo.toml
+++ b/services/runtime-rs/Cargo.toml
@@ -14,6 +14,7 @@ runtime-ops = { path = "../../crates/runtime-ops" }
 serde.workspace = true
 serde_json.workspace = true
 strategy-core = { path = "../../crates/strategy-core" }
+strategy-registry = { path = "../../crates/strategy-registry" }
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/services/runtime-rs/README.md
+++ b/services/runtime-rs/README.md
@@ -1,8 +1,12 @@
 # runtime-rs
 
-`runtime-rs` is the minimal Rust service skeleton for the autonomous runtime
-program. In this phase it is intentionally internal-only and exposes health and
-feed-metric endpoints plus config loading.
+`runtime-rs` is the internal Rust hot path for the autonomous runtime program.
+In this phase it remains shadow-only and exposes:
+
+- public health and metrics endpoints,
+- authenticated internal deployment and run-inspection routes,
+- a runtime-owned SQLite strategy registry,
+- deterministic shadow trigger evaluation backed by the feature cache.
 
 ## Local commands
 
@@ -54,7 +58,8 @@ bun run runtime:fly:smoke
 - `RUNTIME_FEATURE_MAX_SAMPLES_PER_STREAM`
   Default: `64`
 - `RUNTIME_DATABASE_URL`
-  Optional runtime-owned relational store bootstrap secret for later phases.
+  SQLite database path or `sqlite://` URL for the runtime-owned registry.
+  Default: `.tmp/runtime-rs/strategy-registry.sqlite3`
 
 ## Health check
 
@@ -65,8 +70,45 @@ curl -fsS http://127.0.0.1:8081/metrics
 
 Expected output is a JSON document describing the service name, environment,
 protocol version, bind address, strategy support, feed freshness contracts,
-duplicate suppression counters, slot lag, feature freshness windows, derived
-signal snapshots, and internal dependency stubs.
+slot lag, feature freshness windows, derived signal snapshots, and strategy
+registry status.
+
+## Internal routes
+
+All internal routes require:
+
+```bash
+export RUNTIME_INTERNAL_SERVICE_TOKEN=...
+```
+
+Route surface:
+
+- `GET /api/internal/runtime/health`
+- `POST /api/internal/runtime/deployments`
+- `GET /api/internal/runtime/deployments/:deploymentId`
+- `POST /api/internal/runtime/deployments/:deploymentId/pause`
+- `POST /api/internal/runtime/deployments/:deploymentId/resume`
+- `POST /api/internal/runtime/deployments/:deploymentId/kill`
+- `POST /api/internal/runtime/deployments/:deploymentId/evaluate`
+- `GET /api/internal/runtime/runs/:deploymentId`
+
+Example shadow evaluation flow:
+
+```bash
+curl -fsS http://127.0.0.1:8081/api/internal/runtime/deployments \
+  -H "authorization: Bearer ${RUNTIME_INTERNAL_SERVICE_TOKEN}" \
+  -H "content-type: application/json" \
+  --data @docs/runtime-contracts/fixtures/runtime.deployment.valid.v1.json
+
+curl -fsS http://127.0.0.1:8081/api/internal/runtime/deployments/dep_runtime_sol_usdc_shadow/evaluate \
+  -X POST \
+  -H "authorization: Bearer ${RUNTIME_INTERNAL_SERVICE_TOKEN}" \
+  -H "content-type: application/json" \
+  --data '{}'
+
+curl -fsS http://127.0.0.1:8081/api/internal/runtime/runs/dep_runtime_sol_usdc_shadow \
+  -H "authorization: Bearer ${RUNTIME_INTERNAL_SERVICE_TOKEN}"
+```
 
 ## Fly foundation
 

--- a/services/runtime-rs/src/lib.rs
+++ b/services/runtime-rs/src/lib.rs
@@ -3,15 +3,32 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use axum::{extract::State, routing::get, Json, Router};
+use axum::{
+    body::Bytes,
+    extract::{Path, State},
+    http::{HeaderMap, StatusCode},
+    routing::{get, post},
+    Json, Router,
+};
 use exec_client::ExecClient;
 use feature_cache::{FeatureCache, FeatureCacheConfig, FeatureCacheSnapshot};
 use market_adapters::{FeedGateway, FeedGatewayConfig, FeedGatewaySnapshot, FeedReplayFixture};
+use protocol::{RuntimeDeploymentRecord, RuntimeDeploymentState, RuntimeRunRecord};
 use runtime_ops::{health_snapshot, RuntimeConfig};
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::{json, Value};
 use strategy_core::SUPPORTED_STRATEGIES;
+use strategy_registry::{
+    ShadowEvaluationResult, ShadowEvaluationTrigger, StrategyRegistry, StrategyRegistryConfig,
+    StrategyRegistryError, StrategyRegistrySnapshot,
+};
 use time::OffsetDateTime;
 use tokio::time::{sleep, Duration};
+
+const INTERNAL_RUNTIME_PREFIX: &str = "/api/internal/runtime";
+
+type JsonPayload = (StatusCode, Json<Value>);
+type HandlerResult = Result<JsonPayload, JsonPayload>;
 
 #[derive(Debug, Clone)]
 pub struct RuntimeAppState {
@@ -21,6 +38,7 @@ pub struct RuntimeAppState {
     feed_bootstrap_error: Option<String>,
     feed_gateway: Arc<RwLock<FeedGateway>>,
     feature_cache: Arc<RwLock<FeatureCache>>,
+    strategy_registry: StrategyRegistry,
 }
 
 impl RuntimeAppState {
@@ -35,6 +53,9 @@ impl RuntimeAppState {
         if should_spawn_fixture_keepalive(&config) {
             spawn_fixture_keepalive(feed_gateway.clone(), feature_cache.clone());
         }
+        let strategy_registry =
+            StrategyRegistry::new(StrategyRegistryConfig::new(config.database_url.clone()))
+                .expect("strategy registry to initialize");
         Self {
             config,
             exec_client: ExecClient::from_lookup(|key| env::var(key).ok()),
@@ -42,6 +63,7 @@ impl RuntimeAppState {
             feed_bootstrap_error,
             feed_gateway,
             feature_cache,
+            strategy_registry,
         }
     }
 
@@ -58,6 +80,10 @@ impl RuntimeAppState {
             .expect("feature cache read lock")
             .snapshot_now()
     }
+
+    fn strategy_registry_snapshot(&self) -> StrategyRegistrySnapshot {
+        self.strategy_registry.snapshot_now()
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -70,11 +96,13 @@ pub struct RuntimeHealthResponse {
     pub bind_address: String,
     pub exec_health_url: String,
     pub worker_service_auth_configured: bool,
+    pub internal_service_auth_configured: bool,
     pub market_adapter_status: String,
     pub feed_bootstrap_source: String,
     pub feed_bootstrap_error: Option<String>,
     pub feed_gateway: FeedGatewaySnapshot,
     pub feature_cache: FeatureCacheSnapshot,
+    pub strategy_registry: StrategyRegistrySnapshot,
     pub supported_strategies: Vec<String>,
 }
 
@@ -88,13 +116,52 @@ pub struct RuntimeMetricsResponse {
     pub feed_bootstrap_error: Option<String>,
     pub feed_gateway: FeedGatewaySnapshot,
     pub feature_cache: FeatureCacheSnapshot,
+    pub strategy_registry: StrategyRegistrySnapshot,
     pub supported_strategies: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct RuntimeShadowEvaluationRequest {
+    pub trigger: Option<ShadowEvaluationTrigger>,
 }
 
 pub fn app(config: RuntimeConfig) -> Router {
     Router::new()
         .route("/health", get(health_handler))
         .route("/metrics", get(metrics_handler))
+        .route(
+            &format!("{INTERNAL_RUNTIME_PREFIX}/health"),
+            get(internal_health_handler),
+        )
+        .route(
+            &format!("{INTERNAL_RUNTIME_PREFIX}/deployments"),
+            post(create_deployment_handler),
+        )
+        .route(
+            &format!("{INTERNAL_RUNTIME_PREFIX}/deployments/{{deployment_id}}"),
+            get(get_deployment_handler),
+        )
+        .route(
+            &format!("{INTERNAL_RUNTIME_PREFIX}/deployments/{{deployment_id}}/pause"),
+            post(pause_deployment_handler),
+        )
+        .route(
+            &format!("{INTERNAL_RUNTIME_PREFIX}/deployments/{{deployment_id}}/resume"),
+            post(resume_deployment_handler),
+        )
+        .route(
+            &format!("{INTERNAL_RUNTIME_PREFIX}/deployments/{{deployment_id}}/kill"),
+            post(kill_deployment_handler),
+        )
+        .route(
+            &format!("{INTERNAL_RUNTIME_PREFIX}/deployments/{{deployment_id}}/evaluate"),
+            post(evaluate_deployment_handler),
+        )
+        .route(
+            &format!("{INTERNAL_RUNTIME_PREFIX}/runs/{{deployment_id}}"),
+            get(list_runs_handler),
+        )
         .with_state(RuntimeAppState::new(config))
 }
 
@@ -102,7 +169,11 @@ fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
     let snapshot = health_snapshot(&state.config);
     let feed_gateway = state.feed_gateway_snapshot();
     let feature_cache = state.feature_cache_snapshot();
-    let status = if feed_gateway.status == "healthy" && feature_cache.status == "healthy" {
+    let strategy_registry = state.strategy_registry_snapshot();
+    let status = if feed_gateway.status == "healthy"
+        && feature_cache.status == "healthy"
+        && strategy_registry.status == "healthy"
+    {
         snapshot.status
     } else {
         "degraded".to_string()
@@ -115,11 +186,13 @@ fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
         bind_address: snapshot.bind_address,
         exec_health_url: state.exec_client.health_url(),
         worker_service_auth_configured: state.exec_client.has_service_auth(),
+        internal_service_auth_configured: state.config.internal_service_token.is_some(),
         market_adapter_status: feed_gateway.status.clone(),
         feed_bootstrap_source: state.feed_bootstrap_source.clone(),
         feed_bootstrap_error: state.feed_bootstrap_error.clone(),
         feed_gateway,
         feature_cache,
+        strategy_registry,
         supported_strategies: SUPPORTED_STRATEGIES
             .iter()
             .map(|strategy| strategy.as_key().to_string())
@@ -136,6 +209,7 @@ fn metrics_response(state: &RuntimeAppState) -> RuntimeMetricsResponse {
         feed_bootstrap_error: state.feed_bootstrap_error.clone(),
         feed_gateway: state.feed_gateway_snapshot(),
         feature_cache: state.feature_cache_snapshot(),
+        strategy_registry: state.strategy_registry_snapshot(),
         supported_strategies: SUPPORTED_STRATEGIES
             .iter()
             .map(|strategy| strategy.as_key().to_string())
@@ -149,6 +223,375 @@ async fn health_handler(State(state): State<RuntimeAppState>) -> Json<RuntimeHea
 
 async fn metrics_handler(State(state): State<RuntimeAppState>) -> Json<RuntimeMetricsResponse> {
     Json(metrics_response(&state))
+}
+
+async fn internal_health_handler(
+    headers: HeaderMap,
+    State(state): State<RuntimeAppState>,
+) -> HandlerResult {
+    authorize_internal_request(&headers, &state)?;
+    Ok(OkJson::with_status(
+        StatusCode::OK,
+        json!({
+            "ok": true,
+            "source": "runtime-rs",
+            "health": health_response(&state),
+        }),
+    ))
+}
+
+async fn create_deployment_handler(
+    headers: HeaderMap,
+    State(state): State<RuntimeAppState>,
+    body: Bytes,
+) -> HandlerResult {
+    authorize_internal_request(&headers, &state)?;
+    let deployment: RuntimeDeploymentRecord = parse_json_body(&body, "invalid-runtime-deployment")?;
+    let result = state
+        .strategy_registry
+        .upsert_deployment(&deployment)
+        .map_err(map_registry_error)?;
+    Ok(OkJson::with_status(
+        if result.created {
+            StatusCode::CREATED
+        } else {
+            StatusCode::OK
+        },
+        json!({
+            "ok": true,
+            "source": "runtime-rs",
+            "created": result.created,
+            "deployment": result.deployment,
+        }),
+    ))
+}
+
+async fn get_deployment_handler(
+    headers: HeaderMap,
+    Path(deployment_id): Path<String>,
+    State(state): State<RuntimeAppState>,
+) -> HandlerResult {
+    authorize_internal_request(&headers, &state)?;
+    let deployment = state
+        .strategy_registry
+        .get_deployment(&deployment_id)
+        .map_err(map_registry_error)?
+        .ok_or_else(|| {
+            error_json(
+                StatusCode::NOT_FOUND,
+                "deployment-not-found",
+                json!({ "deploymentId": deployment_id }),
+            )
+        })?;
+    Ok(OkJson::with_status(
+        StatusCode::OK,
+        json!({
+            "ok": true,
+            "source": "runtime-rs",
+            "deployment": deployment,
+        }),
+    ))
+}
+
+async fn pause_deployment_handler(
+    headers: HeaderMap,
+    Path(deployment_id): Path<String>,
+    State(state): State<RuntimeAppState>,
+) -> HandlerResult {
+    transition_deployment_handler(
+        headers,
+        deployment_id,
+        state,
+        RuntimeDeploymentState::Paused,
+    )
+    .await
+}
+
+async fn resume_deployment_handler(
+    headers: HeaderMap,
+    Path(deployment_id): Path<String>,
+    State(state): State<RuntimeAppState>,
+) -> HandlerResult {
+    authorize_internal_request(&headers, &state)?;
+    let deployment = state
+        .strategy_registry
+        .get_deployment(&deployment_id)
+        .map_err(map_registry_error)?
+        .ok_or_else(|| {
+            error_json(
+                StatusCode::NOT_FOUND,
+                "deployment-not-found",
+                json!({ "deploymentId": deployment_id }),
+            )
+        })?;
+    let next_state = match deployment.mode {
+        protocol::RuntimeMode::Shadow => RuntimeDeploymentState::Shadow,
+        protocol::RuntimeMode::Paper => RuntimeDeploymentState::Paper,
+        protocol::RuntimeMode::Live => RuntimeDeploymentState::Live,
+    };
+    transition_deployment(deployment_id, state, next_state)
+}
+
+async fn kill_deployment_handler(
+    headers: HeaderMap,
+    Path(deployment_id): Path<String>,
+    State(state): State<RuntimeAppState>,
+) -> HandlerResult {
+    transition_deployment_handler(
+        headers,
+        deployment_id,
+        state,
+        RuntimeDeploymentState::Killed,
+    )
+    .await
+}
+
+async fn transition_deployment_handler(
+    headers: HeaderMap,
+    deployment_id: String,
+    state: RuntimeAppState,
+    next_state: RuntimeDeploymentState,
+) -> HandlerResult {
+    authorize_internal_request(&headers, &state)?;
+    transition_deployment(deployment_id, state, next_state)
+}
+
+fn transition_deployment(
+    deployment_id: String,
+    state: RuntimeAppState,
+    next_state: RuntimeDeploymentState,
+) -> HandlerResult {
+    let deployment = state
+        .strategy_registry
+        .transition_deployment(&deployment_id, next_state)
+        .map_err(map_registry_error)?;
+    Ok(OkJson::with_status(
+        StatusCode::OK,
+        json!({
+            "ok": true,
+            "source": "runtime-rs",
+            "deployment": deployment,
+        }),
+    ))
+}
+
+async fn evaluate_deployment_handler(
+    headers: HeaderMap,
+    Path(deployment_id): Path<String>,
+    State(state): State<RuntimeAppState>,
+    body: Bytes,
+) -> HandlerResult {
+    authorize_internal_request(&headers, &state)?;
+    let request = if body.is_empty() {
+        RuntimeShadowEvaluationRequest::default()
+    } else {
+        parse_json_body::<RuntimeShadowEvaluationRequest>(&body, "invalid-runtime-evaluation")?
+    };
+    let result = state
+        .strategy_registry
+        .evaluate_shadow_trigger(
+            &deployment_id,
+            &state.feature_cache_snapshot(),
+            request.trigger,
+        )
+        .map_err(map_registry_error)?;
+    Ok(shadow_evaluation_json(result))
+}
+
+async fn list_runs_handler(
+    headers: HeaderMap,
+    Path(deployment_id): Path<String>,
+    State(state): State<RuntimeAppState>,
+) -> HandlerResult {
+    authorize_internal_request(&headers, &state)?;
+    let runs: Vec<RuntimeRunRecord> = state
+        .strategy_registry
+        .list_runs(&deployment_id)
+        .map_err(map_registry_error)?;
+    Ok(OkJson::with_status(
+        StatusCode::OK,
+        json!({
+            "ok": true,
+            "source": "runtime-rs",
+            "deploymentId": deployment_id,
+            "runs": runs,
+        }),
+    ))
+}
+
+fn shadow_evaluation_json(result: ShadowEvaluationResult) -> JsonPayload {
+    OkJson::with_status(
+        if result.created {
+            StatusCode::CREATED
+        } else {
+            StatusCode::OK
+        },
+        json!({
+            "ok": true,
+            "source": "runtime-rs",
+            "created": result.created,
+            "deployment": result.deployment,
+            "run": result.run,
+            "featureSnapshot": result.feature_snapshot,
+        }),
+    )
+}
+
+fn parse_json_body<T: DeserializeOwned>(body: &[u8], error_code: &str) -> Result<T, JsonPayload> {
+    serde_json::from_slice(body).map_err(|error| {
+        error_json(
+            StatusCode::BAD_REQUEST,
+            error_code,
+            json!({ "reason": error.to_string() }),
+        )
+    })
+}
+
+fn authorize_internal_request(
+    headers: &HeaderMap,
+    state: &RuntimeAppState,
+) -> Result<(), JsonPayload> {
+    let configured_token = state
+        .config
+        .internal_service_token
+        .as_deref()
+        .unwrap_or("")
+        .trim();
+    if configured_token.is_empty() {
+        return Err(error_json(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "runtime-service-auth-not-configured",
+            json!({}),
+        ));
+    }
+
+    let provided_token = headers
+        .get("authorization")
+        .and_then(|value| value.to_str().ok())
+        .and_then(parse_bearer_token);
+
+    if provided_token.as_deref() != Some(configured_token) {
+        return Err(error_json(
+            StatusCode::UNAUTHORIZED,
+            "auth-required",
+            json!({}),
+        ));
+    }
+
+    Ok(())
+}
+
+fn parse_bearer_token(value: &str) -> Option<String> {
+    let raw = value.trim();
+    if raw.len() < 7 {
+        return None;
+    }
+    let (scheme, token) = raw.split_at(7);
+    if !scheme.eq_ignore_ascii_case("bearer ") {
+        return None;
+    }
+    let token = token.trim();
+    if token.is_empty() {
+        None
+    } else {
+        Some(token.to_string())
+    }
+}
+
+fn map_registry_error(error: StrategyRegistryError) -> JsonPayload {
+    match error {
+        StrategyRegistryError::DeploymentNotFound { deployment_id } => error_json(
+            StatusCode::NOT_FOUND,
+            "deployment-not-found",
+            json!({ "deploymentId": deployment_id }),
+        ),
+        StrategyRegistryError::UnsupportedStrategy(strategy_key) => error_json(
+            StatusCode::BAD_REQUEST,
+            "unsupported-strategy",
+            json!({ "strategyKey": strategy_key }),
+        ),
+        StrategyRegistryError::ImmutableFieldChanged {
+            deployment_id,
+            field,
+        } => error_json(
+            StatusCode::CONFLICT,
+            "deployment-conflict",
+            json!({ "deploymentId": deployment_id, "field": field }),
+        ),
+        StrategyRegistryError::InvalidStateTransition {
+            deployment_id,
+            from_state,
+            to_state,
+        } => error_json(
+            StatusCode::CONFLICT,
+            "invalid-state-transition",
+            json!({
+                "deploymentId": deployment_id,
+                "fromState": from_state,
+                "toState": to_state,
+            }),
+        ),
+        StrategyRegistryError::DeploymentNotShadow {
+            deployment_id,
+            state,
+        } => error_json(
+            StatusCode::CONFLICT,
+            "deployment-not-shadow",
+            json!({
+                "deploymentId": deployment_id,
+                "state": state,
+            }),
+        ),
+        StrategyRegistryError::FeatureStreamMissing { symbol } => error_json(
+            StatusCode::CONFLICT,
+            "feature-stream-missing",
+            json!({ "symbol": symbol }),
+        ),
+        StrategyRegistryError::FeatureStreamStale { symbol, reasons } => error_json(
+            StatusCode::CONFLICT,
+            "feature-stream-stale",
+            json!({ "symbol": symbol, "reasons": reasons }),
+        ),
+        StrategyRegistryError::InvalidObservedAt(value) => error_json(
+            StatusCode::BAD_REQUEST,
+            "invalid-trigger",
+            json!({ "observedAt": value }),
+        ),
+        StrategyRegistryError::Io(error) => error_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "runtime-registry-error",
+            json!({ "reason": error.to_string() }),
+        ),
+        StrategyRegistryError::Storage(error) => error_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "runtime-registry-error",
+            json!({ "reason": error.to_string() }),
+        ),
+        StrategyRegistryError::Serialization(error) => error_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "runtime-registry-error",
+            json!({ "reason": error.to_string() }),
+        ),
+    }
+}
+
+fn error_json(status: StatusCode, error: &str, details: Value) -> JsonPayload {
+    (
+        status,
+        Json(json!({
+            "ok": false,
+            "error": error,
+            "details": details,
+        })),
+    )
+}
+
+struct OkJson;
+
+impl OkJson {
+    fn with_status(status: StatusCode, payload: Value) -> JsonPayload {
+        (status, Json(payload))
+    }
 }
 
 fn feed_gateway_config(config: &RuntimeConfig) -> FeedGatewayConfig {
@@ -305,34 +748,62 @@ fn apply_fixture(
 
 #[cfg(test)]
 mod tests {
-    use axum::http::{Request, StatusCode};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
     use http_body_util::BodyExt;
     use tower::ServiceExt;
 
     use super::*;
 
-    #[tokio::test]
-    async fn serves_health_endpoint() {
-        let config = RuntimeConfig::from_lookup(|_| None).expect("config to load");
-        let response = app(config)
-            .oneshot(
-                Request::builder()
-                    .uri("/health")
-                    .body(axum::body::Body::empty())
-                    .expect("request"),
-            )
-            .await
-            .expect("response");
+    fn temp_database_url(test_name: &str) -> String {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        std::env::temp_dir()
+            .join(format!("runtime-rs-{test_name}-{unique}.sqlite3"))
+            .display()
+            .to_string()
+    }
 
-        assert_eq!(response.status(), StatusCode::OK);
+    fn test_config() -> RuntimeConfig {
+        RuntimeConfig::from_lookup(|key| match key {
+            "RUNTIME_INTERNAL_SERVICE_TOKEN" => Some("runtime-service-secret".to_string()),
+            "RUNTIME_DATABASE_URL" => Some(temp_database_url("config")),
+            _ => None,
+        })
+        .expect("config to load")
+    }
+
+    async fn read_json(response: axum::response::Response) -> Value {
         let body = response
             .into_body()
             .collect()
             .await
             .expect("body to collect")
             .to_bytes();
+        serde_json::from_slice(&body).expect("json payload")
+    }
+
+    #[tokio::test]
+    async fn serves_health_endpoint() {
+        let response = app(test_config())
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
         let payload: RuntimeHealthResponse =
-            serde_json::from_slice(&body).expect("health response");
+            serde_json::from_value(read_json(response).await).expect("health response");
 
         assert_eq!(payload.service_name, "runtime-rs");
         assert_eq!(payload.environment, "local");
@@ -344,30 +815,26 @@ mod tests {
         assert_eq!(payload.feed_gateway.market_streams.len(), 1);
         assert_eq!(payload.feed_gateway.slot_commitments.len(), 3);
         assert_eq!(payload.feed_gateway.status, "healthy");
+        assert_eq!(payload.strategy_registry.status, "healthy");
+        assert_eq!(payload.strategy_registry.deployment_count, 0);
+        assert!(payload.internal_service_auth_configured);
     }
 
     #[tokio::test]
     async fn serves_metrics_endpoint() {
-        let config = RuntimeConfig::from_lookup(|_| None).expect("config to load");
-        let response = app(config)
+        let response = app(test_config())
             .oneshot(
                 Request::builder()
                     .uri("/metrics")
-                    .body(axum::body::Body::empty())
+                    .body(Body::empty())
                     .expect("request"),
             )
             .await
             .expect("response");
 
         assert_eq!(response.status(), StatusCode::OK);
-        let body = response
-            .into_body()
-            .collect()
-            .await
-            .expect("body to collect")
-            .to_bytes();
         let payload: RuntimeMetricsResponse =
-            serde_json::from_slice(&body).expect("metrics response");
+            serde_json::from_value(read_json(response).await).expect("metrics response");
 
         assert_eq!(payload.service_name, "runtime-rs");
         assert_eq!(payload.environment, "local");
@@ -377,5 +844,133 @@ mod tests {
         assert_eq!(payload.feed_gateway.slot_events_accepted, 3);
         assert_eq!(payload.feature_cache.feature_streams.len(), 1);
         assert_eq!(payload.feature_cache.total_market_samples, 1);
+        assert_eq!(payload.strategy_registry.status, "healthy");
+    }
+
+    #[tokio::test]
+    async fn internal_routes_require_service_auth() {
+        let response = app(test_config())
+            .oneshot(
+                Request::builder()
+                    .uri("/api/internal/runtime/health")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            read_json(response).await,
+            json!({
+                "ok": false,
+                "error": "auth-required",
+                "details": {},
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn stores_and_evaluates_shadow_deployments() {
+        let router = app(test_config());
+        let deployment = json!({
+            "schemaVersion": "v1",
+            "deploymentId": "deployment_123",
+            "strategyKey": "dca",
+            "sleeveId": "sleeve_alpha",
+            "ownerUserId": "user_123",
+            "pair": {
+                "symbol": "SOL/USDC",
+                "baseMint": "So11111111111111111111111111111111111111112",
+                "quoteMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+            },
+            "mode": "shadow",
+            "state": "shadow",
+            "lane": "safe",
+            "createdAt": "2026-03-07T00:00:00.000Z",
+            "updatedAt": "2026-03-07T00:00:00.000Z",
+            "policy": {
+                "maxNotionalUsd": "250.00",
+                "dailyLossLimitUsd": "35.00",
+                "maxSlippageBps": 50,
+                "maxConcurrentRuns": 2,
+                "rebalanceToleranceBps": 100
+            },
+            "capital": {
+                "allocatedUsd": "1000.00",
+                "reservedUsd": "125.00",
+                "availableUsd": "875.00"
+            },
+            "tags": ["fixture"]
+        });
+
+        let create_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/deployments")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(deployment.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(create_response.status(), StatusCode::CREATED);
+
+        let evaluate_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/deployments/deployment_123/evaluate")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(evaluate_response.status(), StatusCode::CREATED);
+        let evaluation_payload = read_json(evaluate_response).await;
+        assert_eq!(evaluation_payload["ok"], json!(true));
+        assert_eq!(evaluation_payload["created"], json!(true));
+        assert_eq!(evaluation_payload["run"]["state"], json!("planned"));
+
+        let duplicate_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/deployments/deployment_123/evaluate")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(duplicate_response.status(), StatusCode::OK);
+        let duplicate_payload = read_json(duplicate_response).await;
+        assert_eq!(duplicate_payload["created"], json!(false));
+        assert_eq!(
+            duplicate_payload["run"]["runKey"],
+            evaluation_payload["run"]["runKey"]
+        );
+
+        let runs_response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/api/internal/runtime/runs/deployment_123")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(runs_response.status(), StatusCode::OK);
+        let runs_payload = read_json(runs_response).await;
+        assert_eq!(runs_payload["runs"].as_array().expect("array").len(), 1);
     }
 }


### PR DESCRIPTION
## Summary
- add a runtime-owned `strategy-registry` crate backed by SQLite for deployment and run state
- expose authenticated runtime-rs internal routes for deployment lifecycle, shadow evaluation, and run inspection
- surface registry health in runtime-rs health/metrics and document the new operator flow

Fixes #264

## Validation
- `cargo fmt --all`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `bun run lint`
- `bun run typecheck`

## Runtime Smoke
- booted `runtime-rs` locally with `RUNTIME_INTERNAL_SERVICE_TOKEN` and a temp SQLite DB
- `GET /health` returned `status=ok` and `strategyRegistry.status=healthy`
- `GET /api/internal/runtime/health` succeeded with bearer auth
- `POST /api/internal/runtime/deployments` accepted `runtime.deployment.valid.v1.json`
- `POST /api/internal/runtime/deployments/dep_runtime_sol_usdc_shadow/evaluate` created a deterministic planned shadow run
- `GET /api/internal/runtime/runs/dep_runtime_sol_usdc_shadow` returned the single planned run

## Risk Notes
- storage is SQLite-backed and shadow-only for now; later phases still need ledger, planner, and reconciliation wiring before paper/live promotion
- Worker internal routes remain unchanged in this PR; runtime-rs now owns the real deployment/run state seam behind the existing harness model
