### PR TITLE
Add deterministic portfolio ledger reservations (#265)

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -141,29 +141,41 @@ jobs:
             retry 12 5 curl -fsS -o /dev/null "${WORKER_URL}${path}"
           done
 
-          curl -fsS "${PORTAL_URL}/endpoints.json" | grep -q "${WORKER_HOST}"
-          curl -fsS "${PORTAL_URL}/agent-registry/metadata.json" | grep -q "${WORKER_HOST}"
-          curl -fsS "${WORKER_URL}/agent-registry/metadata.json" | grep -q "${WORKER_HOST}"
+          assert_preview_host_wiring() {
+            curl -fsS "${PORTAL_URL}/endpoints.json" | grep -q "${WORKER_HOST}"
+            curl -fsS "${PORTAL_URL}/agent-registry/metadata.json" | grep -q "${WORKER_HOST}"
+            curl -fsS "${WORKER_URL}/agent-registry/metadata.json" | grep -q "${WORKER_HOST}"
+          }
 
-          tmp="$(mktemp -d)"
-          trap 'rm -rf "$tmp"' EXIT
+          retry 12 5 assert_preview_host_wiring
 
-          curl -fsSL "${PORTAL_URL}/login" > "${tmp}/login.html"
-          grep -oE '/_next/static/[^" ]+\.js' "${tmp}/login.html" | sort -u > "${tmp}/scripts.txt"
+          assert_preview_bundle() {
+            local tmp
+            tmp="$(mktemp -d)"
 
-          if [ ! -s "${tmp}/scripts.txt" ]; then
-            echo "No Next.js JS bundle references found on ${PORTAL_URL}/login" >&2
-            exit 1
-          fi
+            curl -fsSL "${PORTAL_URL}/login" > "${tmp}/login.html"
+            grep -oE '/_next/static/[^" ]+\.js' "${tmp}/login.html" | sort -u > "${tmp}/scripts.txt"
 
-          while read -r script_path; do
-            curl -fsSL "${PORTAL_URL}${script_path}" >> "${tmp}/bundle.js"
-          done < "${tmp}/scripts.txt"
+            if [ ! -s "${tmp}/scripts.txt" ]; then
+              echo "No Next.js JS bundle references found on ${PORTAL_URL}/login" >&2
+              rm -rf "${tmp}"
+              return 1
+            fi
 
-          if ! grep -q "${WORKER_HOST}" "${tmp}/bundle.js"; then
-            echo "Expected preview worker host ${WORKER_HOST} not found in login bundle" >&2
-            exit 1
-          fi
+            while read -r script_path; do
+              curl -fsSL "${PORTAL_URL}${script_path}" >> "${tmp}/bundle.js"
+            done < "${tmp}/scripts.txt"
+
+            if ! grep -q "${WORKER_HOST}" "${tmp}/bundle.js"; then
+              echo "Expected preview worker host ${WORKER_HOST} not found in login bundle" >&2
+              rm -rf "${tmp}"
+              return 1
+            fi
+
+            rm -rf "${tmp}"
+          }
+
+          retry 12 5 assert_preview_bundle
 
       - name: Write preview metadata
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,10 @@ name = "portfolio-ledger"
 version = "0.1.0"
 dependencies = [
  "protocol",
+ "rusqlite",
+ "serde",
+ "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -545,6 +549,7 @@ dependencies = [
  "feature-cache",
  "http-body-util",
  "market-adapters",
+ "portfolio-ledger",
  "protocol",
  "runtime-ops",
  "serde",

--- a/crates/portfolio-ledger/Cargo.toml
+++ b/crates/portfolio-ledger/Cargo.toml
@@ -6,3 +6,7 @@ license.workspace = true
 
 [dependencies]
 protocol = { path = "../protocol" }
+rusqlite = { version = "0.37.0", features = ["bundled"] }
+serde.workspace = true
+thiserror.workspace = true
+time = { version = "=0.3.44", features = ["formatting", "parsing"] }

--- a/crates/portfolio-ledger/src/lib.rs
+++ b/crates/portfolio-ledger/src/lib.rs
@@ -697,7 +697,6 @@ fn parse_usd_cents(field: &'static str, value: &str) -> Result<i64, PortfolioLed
         || !fraction_raw
             .chars()
             .all(|character| character.is_ascii_digit())
-        || fraction_raw.len() > 2
     {
         return Err(PortfolioLedgerError::InvalidUsdAmount {
             field,
@@ -711,16 +710,19 @@ fn parse_usd_cents(field: &'static str, value: &str) -> Result<i64, PortfolioLed
             field,
             value: trimmed.to_string(),
         })?;
-    let fraction = match fraction_raw.len() {
-        0 => Ok(0),
-        1 => fraction_raw.parse::<i64>().map(|value| value * 10),
-        2 => fraction_raw.parse::<i64>(),
-        _ => unreachable!("fraction length checked above"),
+    let fraction_bytes = fraction_raw.as_bytes();
+    let tenths = fraction_bytes
+        .first()
+        .map(|digit| i64::from(digit - b'0'))
+        .unwrap_or(0);
+    let hundredths = fraction_bytes
+        .get(1)
+        .map(|digit| i64::from(digit - b'0'))
+        .unwrap_or(0);
+    let mut fraction = tenths * 10 + hundredths;
+    if fraction_bytes.get(2).is_some_and(|digit| *digit >= b'5') {
+        fraction += 1;
     }
-    .map_err(|_| PortfolioLedgerError::InvalidUsdAmount {
-        field,
-        value: trimmed.to_string(),
-    })?;
 
     let cents = whole
         .checked_mul(100)
@@ -972,5 +974,23 @@ mod tests {
             Some("140.00")
         );
         assert_eq!(snapshot.totals.unrealized_pnl_usd, "2.00");
+    }
+
+    #[test]
+    fn accepts_subcent_precision_and_rounds_to_cents() {
+        let ledger = ledger("subcent");
+
+        let result = ledger
+            .sync_deployment(&deployment(
+                "deployment_1",
+                "sleeve_alpha",
+                "100.005",
+                "5.125",
+            ))
+            .expect("deployment to sync");
+
+        assert_eq!(result.snapshot.totals.equity_usd, "100.01");
+        assert_eq!(result.snapshot.totals.reserved_usd, "5.13");
+        assert_eq!(result.snapshot.totals.available_usd, "94.88");
     }
 }

--- a/crates/portfolio-ledger/src/lib.rs
+++ b/crates/portfolio-ledger/src/lib.rs
@@ -1,59 +1,976 @@
-use protocol::RuntimeLedgerSnapshot;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use protocol::{
+    RuntimeDeploymentRecord, RuntimeDeploymentState, RuntimeLedgerBalance, RuntimeLedgerPosition,
+    RuntimeLedgerSnapshot, RuntimeLedgerTotals, RuntimePositionSide,
+    RUNTIME_PROTOCOL_SCHEMA_VERSION,
+};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PortfolioLedgerConfig {
+    pub database_url: String,
+}
+
+impl PortfolioLedgerConfig {
+    #[must_use]
+    pub fn new(database_url: impl Into<String>) -> Self {
+        Self {
+            database_url: database_url.into(),
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct PortfolioLedger {
-    snapshot: RuntimeLedgerSnapshot,
+    database_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PortfolioLedgerSnapshot {
+    pub status: String,
+    pub sleeve_count: u64,
+    pub deployment_count: u64,
+    pub total_reserved_usd: String,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LedgerSyncResult {
+    pub snapshot: RuntimeLedgerSnapshot,
+    pub created: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum PortfolioLedgerError {
+    #[error("storage io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("storage error: {0}")]
+    Storage(#[from] rusqlite::Error),
+    #[error("deployment {deployment_id} not found in ledger")]
+    DeploymentNotFound { deployment_id: String },
+    #[error("sleeve {sleeve_id} is oversubscribed: requested {requested_usd} > available {available_usd}")]
+    SleeveOversubscribed {
+        sleeve_id: String,
+        requested_usd: String,
+        available_usd: String,
+    },
+    #[error("invalid usd amount for {field}: {value}")]
+    InvalidUsdAmount { field: &'static str, value: String },
+    #[error("correction for sleeve {sleeve_id} would break allocation invariants")]
+    InvalidCorrection { sleeve_id: String },
 }
 
 impl PortfolioLedger {
-    #[must_use]
-    pub fn new(snapshot: RuntimeLedgerSnapshot) -> Self {
-        Self { snapshot }
+    pub fn new(config: PortfolioLedgerConfig) -> Result<Self, PortfolioLedgerError> {
+        let requested_path = normalize_database_path(&config.database_url);
+        match Self::initialize_at_path(requested_path.clone()) {
+            Ok(ledger) => Ok(ledger),
+            Err(error) if should_fallback_to_tmp(&requested_path, &error) => {
+                Self::initialize_at_path(fallback_database_path())
+            }
+            Err(error) => Err(error),
+        }
     }
 
     #[must_use]
-    pub fn available_usd(&self) -> &str {
-        &self.snapshot.totals.available_usd
+    pub fn database_path(&self) -> &Path {
+        &self.database_path
+    }
+
+    pub fn sync_deployment(
+        &self,
+        deployment: &RuntimeDeploymentRecord,
+    ) -> Result<LedgerSyncResult, PortfolioLedgerError> {
+        let mut connection = self.open_connection()?;
+        let transaction = connection.transaction()?;
+
+        let allocated_cents =
+            parse_usd_cents("capital.allocatedUsd", &deployment.capital.allocated_usd)?;
+        let reserved_cents = effective_reserved_cents(deployment)?;
+        let existing = load_deployment_state(&transaction, &deployment.deployment_id)?;
+        let sleeve = load_sleeve_state(&transaction, &deployment.sleeve_id)?;
+        let quote_symbol = quote_symbol(&deployment.pair.symbol);
+
+        let sleeve_equity_cents = sleeve
+            .as_ref()
+            .map(|state| state.equity_cents)
+            .unwrap_or(allocated_cents);
+
+        let other_allocated_cents = sum_deployment_cents(
+            &transaction,
+            &deployment.sleeve_id,
+            "allocated_cents",
+            Some(&deployment.deployment_id),
+        )?;
+        let other_reserved_cents = sum_deployment_cents(
+            &transaction,
+            &deployment.sleeve_id,
+            "reserved_cents",
+            Some(&deployment.deployment_id),
+        )?;
+
+        ensure_within_sleeve_capacity(
+            &deployment.sleeve_id,
+            sleeve_equity_cents,
+            other_allocated_cents + allocated_cents,
+        )?;
+        ensure_within_sleeve_capacity(
+            &deployment.sleeve_id,
+            sleeve_equity_cents,
+            other_reserved_cents + reserved_cents,
+        )?;
+
+        upsert_sleeve_state(
+            &transaction,
+            &deployment.sleeve_id,
+            sleeve_equity_cents,
+            other_reserved_cents + reserved_cents,
+            &deployment.pair.quote_mint,
+            &quote_symbol,
+        )?;
+
+        let available_cents = allocated_cents.saturating_sub(reserved_cents);
+        upsert_deployment_state(
+            &transaction,
+            deployment,
+            allocated_cents,
+            reserved_cents,
+            available_cents,
+        )?;
+
+        let snapshot = build_snapshot(&transaction, &deployment.deployment_id)?;
+        transaction.commit()?;
+
+        Ok(LedgerSyncResult {
+            snapshot,
+            created: existing.is_none(),
+        })
+    }
+
+    pub fn apply_sleeve_correction(
+        &self,
+        sleeve_id: &str,
+        corrected_equity_usd: &str,
+    ) -> Result<(), PortfolioLedgerError> {
+        let corrected_equity_cents = parse_usd_cents("correctedEquityUsd", corrected_equity_usd)?;
+        let mut connection = self.open_connection()?;
+        let transaction = connection.transaction()?;
+        let sleeve = load_sleeve_state(&transaction, sleeve_id)?.ok_or_else(|| {
+            PortfolioLedgerError::InvalidCorrection {
+                sleeve_id: sleeve_id.to_string(),
+            }
+        })?;
+
+        let allocated_cents =
+            sum_deployment_cents(&transaction, sleeve_id, "allocated_cents", None)?;
+        let reserved_cents = sum_deployment_cents(&transaction, sleeve_id, "reserved_cents", None)?;
+        if corrected_equity_cents < allocated_cents || corrected_equity_cents < reserved_cents {
+            return Err(PortfolioLedgerError::InvalidCorrection {
+                sleeve_id: sleeve_id.to_string(),
+            });
+        }
+
+        upsert_sleeve_state(
+            &transaction,
+            sleeve_id,
+            corrected_equity_cents,
+            sleeve.reserved_cents,
+            &sleeve.quote_mint,
+            &sleeve.quote_symbol,
+        )?;
+        transaction.commit()?;
+        Ok(())
+    }
+
+    pub fn upsert_position(
+        &self,
+        deployment_id: &str,
+        position: &RuntimeLedgerPosition,
+    ) -> Result<(), PortfolioLedgerError> {
+        let mut connection = self.open_connection()?;
+        let transaction = connection.transaction()?;
+        transaction.execute(
+            "INSERT INTO ledger_positions (
+                deployment_id,
+                instrument_id,
+                side,
+                quantity_atomic,
+                entry_price_usd,
+                mark_price_usd,
+                unrealized_pnl_usd
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+            ON CONFLICT(deployment_id, instrument_id) DO UPDATE SET
+                side = excluded.side,
+                quantity_atomic = excluded.quantity_atomic,
+                entry_price_usd = excluded.entry_price_usd,
+                mark_price_usd = excluded.mark_price_usd,
+                unrealized_pnl_usd = excluded.unrealized_pnl_usd",
+            params![
+                deployment_id,
+                &position.instrument_id,
+                side_key(&position.side),
+                &position.quantity_atomic,
+                &position.entry_price_usd,
+                &position.mark_price_usd,
+                &position.unrealized_pnl_usd,
+            ],
+        )?;
+        transaction.commit()?;
+        Ok(())
+    }
+
+    pub fn snapshot_for_deployment(
+        &self,
+        deployment_id: &str,
+    ) -> Result<RuntimeLedgerSnapshot, PortfolioLedgerError> {
+        let connection = self.open_connection()?;
+        build_snapshot(&connection, deployment_id)
+    }
+
+    pub fn pnl_for_deployment(
+        &self,
+        deployment_id: &str,
+    ) -> Result<RuntimeLedgerTotals, PortfolioLedgerError> {
+        Ok(self.snapshot_for_deployment(deployment_id)?.totals)
     }
 
     #[must_use]
-    pub fn reserved_usd(&self) -> &str {
-        &self.snapshot.totals.reserved_usd
+    pub fn snapshot_now(&self) -> PortfolioLedgerSnapshot {
+        match self.counts_and_reserved() {
+            Ok((sleeve_count, deployment_count, total_reserved_cents)) => PortfolioLedgerSnapshot {
+                status: "healthy".to_string(),
+                sleeve_count,
+                deployment_count,
+                total_reserved_usd: format_usd_cents(total_reserved_cents),
+                last_error: None,
+            },
+            Err(error) => PortfolioLedgerSnapshot {
+                status: "degraded".to_string(),
+                sleeve_count: 0,
+                deployment_count: 0,
+                total_reserved_usd: "0.00".to_string(),
+                last_error: Some(error.to_string()),
+            },
+        }
     }
 
-    #[must_use]
-    pub fn balance_count(&self) -> usize {
-        self.snapshot.balances.len()
+    fn counts_and_reserved(&self) -> Result<(u64, u64, i64), PortfolioLedgerError> {
+        let connection = self.open_connection()?;
+        let sleeve_count =
+            connection.query_row("SELECT COUNT(*) FROM ledger_sleeves", [], |row| {
+                row.get::<_, u64>(0)
+            })?;
+        let deployment_count =
+            connection.query_row("SELECT COUNT(*) FROM ledger_deployments", [], |row| {
+                row.get::<_, u64>(0)
+            })?;
+        let total_reserved = connection.query_row(
+            "SELECT COALESCE(SUM(reserved_cents), 0) FROM ledger_deployments",
+            [],
+            |row| row.get::<_, i64>(0),
+        )?;
+        Ok((sleeve_count, deployment_count, total_reserved))
     }
+
+    fn open_connection(&self) -> Result<Connection, PortfolioLedgerError> {
+        let connection = Connection::open(&self.database_path)?;
+        connection.busy_timeout(std::time::Duration::from_secs(5))?;
+        connection.pragma_update(None, "foreign_keys", "ON")?;
+        Ok(connection)
+    }
+
+    fn initialize_at_path(database_path: PathBuf) -> Result<Self, PortfolioLedgerError> {
+        if database_path != Path::new(":memory:") {
+            if let Some(parent) = database_path
+                .parent()
+                .filter(|path| !path.as_os_str().is_empty())
+            {
+                fs::create_dir_all(parent)?;
+            }
+        }
+        let ledger = Self { database_path };
+        let connection = ledger.open_connection()?;
+        initialize_schema(&connection)?;
+        Ok(ledger)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SleeveState {
+    sleeve_id: String,
+    equity_cents: i64,
+    reserved_cents: i64,
+    quote_mint: String,
+    quote_symbol: String,
+}
+
+#[derive(Debug, Clone)]
+struct DeploymentLedgerState {
+    deployment_id: String,
+    sleeve_id: String,
+    allocated_cents: i64,
+    reserved_cents: i64,
+    available_cents: i64,
+    realized_pnl_cents: i64,
+    quote_mint: String,
+    quote_symbol: String,
+}
+
+fn initialize_schema(connection: &Connection) -> Result<(), rusqlite::Error> {
+    connection.execute_batch(
+        "CREATE TABLE IF NOT EXISTS ledger_sleeves (
+            sleeve_id TEXT PRIMARY KEY,
+            equity_cents INTEGER NOT NULL,
+            reserved_cents INTEGER NOT NULL,
+            quote_mint TEXT NOT NULL,
+            quote_symbol TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS ledger_deployments (
+            deployment_id TEXT PRIMARY KEY,
+            sleeve_id TEXT NOT NULL,
+            strategy_key TEXT NOT NULL,
+            state TEXT NOT NULL,
+            allocated_cents INTEGER NOT NULL,
+            reserved_cents INTEGER NOT NULL,
+            available_cents INTEGER NOT NULL,
+            realized_pnl_cents INTEGER NOT NULL,
+            quote_mint TEXT NOT NULL,
+            quote_symbol TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            FOREIGN KEY (sleeve_id) REFERENCES ledger_sleeves(sleeve_id) ON DELETE CASCADE
+        );
+        CREATE TABLE IF NOT EXISTS ledger_positions (
+            deployment_id TEXT NOT NULL,
+            instrument_id TEXT NOT NULL,
+            side TEXT NOT NULL,
+            quantity_atomic TEXT NOT NULL,
+            entry_price_usd TEXT,
+            mark_price_usd TEXT,
+            unrealized_pnl_usd TEXT,
+            PRIMARY KEY (deployment_id, instrument_id),
+            FOREIGN KEY (deployment_id) REFERENCES ledger_deployments(deployment_id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_ledger_deployments_sleeve
+            ON ledger_deployments (sleeve_id);",
+    )
+}
+
+fn normalize_database_path(database_url: &str) -> PathBuf {
+    let trimmed = database_url.trim();
+    if trimmed.is_empty() {
+        return PathBuf::from(".tmp/runtime-rs/portfolio-ledger.sqlite3");
+    }
+    if let Some(stripped) = trimmed.strip_prefix("sqlite://") {
+        return PathBuf::from(stripped);
+    }
+    if let Some(stripped) = trimmed.strip_prefix("file:") {
+        return PathBuf::from(stripped);
+    }
+    PathBuf::from(trimmed)
+}
+
+fn fallback_database_path() -> PathBuf {
+    std::env::temp_dir()
+        .join("runtime-rs")
+        .join("portfolio-ledger.sqlite3")
+}
+
+fn should_fallback_to_tmp(database_path: &Path, error: &PortfolioLedgerError) -> bool {
+    if database_path == Path::new(":memory:") || database_path == fallback_database_path() {
+        return false;
+    }
+
+    match error {
+        PortfolioLedgerError::Io(inner) => inner.kind() == std::io::ErrorKind::PermissionDenied,
+        PortfolioLedgerError::Storage(inner) => {
+            matches!(
+                inner,
+                rusqlite::Error::SqliteFailure(code, _)
+                    if code.code == rusqlite::ErrorCode::CannotOpen
+            )
+        }
+        PortfolioLedgerError::DeploymentNotFound { .. }
+        | PortfolioLedgerError::SleeveOversubscribed { .. }
+        | PortfolioLedgerError::InvalidUsdAmount { .. }
+        | PortfolioLedgerError::InvalidCorrection { .. } => false,
+    }
+}
+
+fn effective_reserved_cents(
+    deployment: &RuntimeDeploymentRecord,
+) -> Result<i64, PortfolioLedgerError> {
+    let reserved_cents = parse_usd_cents("capital.reservedUsd", &deployment.capital.reserved_usd)?;
+    Ok(
+        if matches!(
+            deployment.state,
+            RuntimeDeploymentState::Killed | RuntimeDeploymentState::Archived
+        ) {
+            0
+        } else {
+            reserved_cents
+        },
+    )
+}
+
+fn ensure_within_sleeve_capacity(
+    sleeve_id: &str,
+    sleeve_equity_cents: i64,
+    requested_cents: i64,
+) -> Result<(), PortfolioLedgerError> {
+    if requested_cents <= sleeve_equity_cents {
+        return Ok(());
+    }
+    Err(PortfolioLedgerError::SleeveOversubscribed {
+        sleeve_id: sleeve_id.to_string(),
+        requested_usd: format_usd_cents(requested_cents),
+        available_usd: format_usd_cents(sleeve_equity_cents),
+    })
+}
+
+fn upsert_sleeve_state(
+    connection: &Connection,
+    sleeve_id: &str,
+    equity_cents: i64,
+    reserved_cents: i64,
+    quote_mint: &str,
+    quote_symbol: &str,
+) -> Result<(), rusqlite::Error> {
+    connection.execute(
+        "INSERT INTO ledger_sleeves (
+            sleeve_id,
+            equity_cents,
+            reserved_cents,
+            quote_mint,
+            quote_symbol,
+            updated_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+        ON CONFLICT(sleeve_id) DO UPDATE SET
+            equity_cents = excluded.equity_cents,
+            reserved_cents = excluded.reserved_cents,
+            quote_mint = excluded.quote_mint,
+            quote_symbol = excluded.quote_symbol,
+            updated_at = excluded.updated_at",
+        params![
+            sleeve_id,
+            equity_cents,
+            reserved_cents,
+            quote_mint,
+            quote_symbol,
+            now_rfc3339(),
+        ],
+    )?;
+    Ok(())
+}
+
+fn upsert_deployment_state(
+    connection: &Connection,
+    deployment: &RuntimeDeploymentRecord,
+    allocated_cents: i64,
+    reserved_cents: i64,
+    available_cents: i64,
+) -> Result<(), rusqlite::Error> {
+    connection.execute(
+        "INSERT INTO ledger_deployments (
+            deployment_id,
+            sleeve_id,
+            strategy_key,
+            state,
+            allocated_cents,
+            reserved_cents,
+            available_cents,
+            realized_pnl_cents,
+            quote_mint,
+            quote_symbol,
+            updated_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0, ?8, ?9, ?10)
+        ON CONFLICT(deployment_id) DO UPDATE SET
+            sleeve_id = excluded.sleeve_id,
+            strategy_key = excluded.strategy_key,
+            state = excluded.state,
+            allocated_cents = excluded.allocated_cents,
+            reserved_cents = excluded.reserved_cents,
+            available_cents = excluded.available_cents,
+            quote_mint = excluded.quote_mint,
+            quote_symbol = excluded.quote_symbol,
+            updated_at = excluded.updated_at",
+        params![
+            &deployment.deployment_id,
+            &deployment.sleeve_id,
+            &deployment.strategy_key,
+            state_key(&deployment.state),
+            allocated_cents,
+            reserved_cents,
+            available_cents,
+            &deployment.pair.quote_mint,
+            quote_symbol(&deployment.pair.symbol),
+            now_rfc3339(),
+        ],
+    )?;
+    Ok(())
+}
+
+fn load_sleeve_state(
+    connection: &Connection,
+    sleeve_id: &str,
+) -> Result<Option<SleeveState>, PortfolioLedgerError> {
+    connection
+        .query_row(
+            "SELECT sleeve_id, equity_cents, reserved_cents, quote_mint, quote_symbol
+             FROM ledger_sleeves
+             WHERE sleeve_id = ?1",
+            params![sleeve_id],
+            |row| {
+                Ok(SleeveState {
+                    sleeve_id: row.get(0)?,
+                    equity_cents: row.get(1)?,
+                    reserved_cents: row.get(2)?,
+                    quote_mint: row.get(3)?,
+                    quote_symbol: row.get(4)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(PortfolioLedgerError::from)
+}
+
+fn load_deployment_state(
+    connection: &Connection,
+    deployment_id: &str,
+) -> Result<Option<DeploymentLedgerState>, PortfolioLedgerError> {
+    connection
+        .query_row(
+            "SELECT deployment_id, sleeve_id, allocated_cents, reserved_cents, available_cents,
+                    realized_pnl_cents, quote_mint, quote_symbol
+             FROM ledger_deployments
+             WHERE deployment_id = ?1",
+            params![deployment_id],
+            |row| {
+                Ok(DeploymentLedgerState {
+                    deployment_id: row.get(0)?,
+                    sleeve_id: row.get(1)?,
+                    allocated_cents: row.get(2)?,
+                    reserved_cents: row.get(3)?,
+                    available_cents: row.get(4)?,
+                    realized_pnl_cents: row.get(5)?,
+                    quote_mint: row.get(6)?,
+                    quote_symbol: row.get(7)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(PortfolioLedgerError::from)
+}
+
+fn sum_deployment_cents(
+    connection: &Connection,
+    sleeve_id: &str,
+    column: &str,
+    exclude_deployment_id: Option<&str>,
+) -> Result<i64, PortfolioLedgerError> {
+    let sql = if exclude_deployment_id.is_some() {
+        format!(
+            "SELECT COALESCE(SUM({column}), 0) FROM ledger_deployments WHERE sleeve_id = ?1 AND deployment_id != ?2"
+        )
+    } else {
+        format!("SELECT COALESCE(SUM({column}), 0) FROM ledger_deployments WHERE sleeve_id = ?1")
+    };
+
+    let total = match exclude_deployment_id {
+        Some(deployment_id) => {
+            connection.query_row(&sql, params![sleeve_id, deployment_id], |row| {
+                row.get::<_, i64>(0)
+            })?
+        }
+        None => connection.query_row(&sql, params![sleeve_id], |row| row.get::<_, i64>(0))?,
+    };
+    Ok(total)
+}
+
+fn build_snapshot(
+    connection: &Connection,
+    deployment_id: &str,
+) -> Result<RuntimeLedgerSnapshot, PortfolioLedgerError> {
+    let deployment_state = load_deployment_state(connection, deployment_id)?.ok_or_else(|| {
+        PortfolioLedgerError::DeploymentNotFound {
+            deployment_id: deployment_id.to_string(),
+        }
+    })?;
+    let sleeve = load_sleeve_state(connection, &deployment_state.sleeve_id)?.ok_or_else(|| {
+        PortfolioLedgerError::DeploymentNotFound {
+            deployment_id: deployment_id.to_string(),
+        }
+    })?;
+    let positions = load_positions(connection, deployment_id)?;
+    let unrealized_pnl_cents = positions
+        .iter()
+        .filter_map(|position| position.unrealized_pnl_usd.as_deref())
+        .map(|value| parse_usd_cents("positions.unrealizedPnlUsd", value))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .sum::<i64>();
+
+    Ok(RuntimeLedgerSnapshot {
+        schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+        snapshot_id: format!("ledger_{deployment_id}_{}", timestamp_compact()),
+        deployment_id: deployment_state.deployment_id,
+        sleeve_id: sleeve.sleeve_id,
+        as_of: now_rfc3339(),
+        balances: vec![RuntimeLedgerBalance {
+            mint: deployment_state.quote_mint,
+            symbol: deployment_state.quote_symbol,
+            decimals: 6,
+            free_atomic: format_atomic_from_cents(deployment_state.available_cents),
+            reserved_atomic: format_atomic_from_cents(deployment_state.reserved_cents),
+            price_usd: Some("1.00".to_string()),
+        }],
+        positions,
+        totals: RuntimeLedgerTotals {
+            equity_usd: format_usd_cents(deployment_state.allocated_cents),
+            reserved_usd: format_usd_cents(deployment_state.reserved_cents),
+            available_usd: format_usd_cents(deployment_state.available_cents),
+            realized_pnl_usd: format_usd_cents(deployment_state.realized_pnl_cents),
+            unrealized_pnl_usd: format_usd_cents(unrealized_pnl_cents),
+        },
+    })
+}
+
+fn load_positions(
+    connection: &Connection,
+    deployment_id: &str,
+) -> Result<Vec<RuntimeLedgerPosition>, PortfolioLedgerError> {
+    let mut statement = connection.prepare(
+        "SELECT instrument_id, side, quantity_atomic, entry_price_usd, mark_price_usd, unrealized_pnl_usd
+         FROM ledger_positions
+         WHERE deployment_id = ?1
+         ORDER BY instrument_id ASC",
+    )?;
+
+    let rows = statement.query_map(params![deployment_id], |row| {
+        Ok(RuntimeLedgerPosition {
+            instrument_id: row.get(0)?,
+            side: parse_side(&row.get::<_, String>(1)?),
+            quantity_atomic: row.get(2)?,
+            entry_price_usd: row.get(3)?,
+            mark_price_usd: row.get(4)?,
+            unrealized_pnl_usd: row.get(5)?,
+        })
+    })?;
+
+    let mut positions = Vec::new();
+    for row in rows {
+        positions.push(row?);
+    }
+    Ok(positions)
+}
+
+fn parse_usd_cents(field: &'static str, value: &str) -> Result<i64, PortfolioLedgerError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(PortfolioLedgerError::InvalidUsdAmount {
+            field,
+            value: trimmed.to_string(),
+        });
+    }
+
+    let (sign, digits) = if let Some(rest) = trimmed.strip_prefix('-') {
+        (-1_i64, rest)
+    } else if let Some(rest) = trimmed.strip_prefix('+') {
+        (1_i64, rest)
+    } else {
+        (1_i64, trimmed)
+    };
+
+    let (whole_raw, fraction_raw) = digits.split_once('.').unwrap_or((digits, ""));
+    if whole_raw.is_empty()
+        || !whole_raw
+            .chars()
+            .all(|character| character.is_ascii_digit())
+        || !fraction_raw
+            .chars()
+            .all(|character| character.is_ascii_digit())
+        || fraction_raw.len() > 2
+    {
+        return Err(PortfolioLedgerError::InvalidUsdAmount {
+            field,
+            value: trimmed.to_string(),
+        });
+    }
+
+    let whole = whole_raw
+        .parse::<i64>()
+        .map_err(|_| PortfolioLedgerError::InvalidUsdAmount {
+            field,
+            value: trimmed.to_string(),
+        })?;
+    let fraction = match fraction_raw.len() {
+        0 => Ok(0),
+        1 => fraction_raw.parse::<i64>().map(|value| value * 10),
+        2 => fraction_raw.parse::<i64>(),
+        _ => unreachable!("fraction length checked above"),
+    }
+    .map_err(|_| PortfolioLedgerError::InvalidUsdAmount {
+        field,
+        value: trimmed.to_string(),
+    })?;
+
+    let cents = whole
+        .checked_mul(100)
+        .and_then(|value| value.checked_add(fraction))
+        .ok_or_else(|| PortfolioLedgerError::InvalidUsdAmount {
+            field,
+            value: trimmed.to_string(),
+        })?;
+
+    Ok(sign * cents)
+}
+
+fn format_usd_cents(value: i64) -> String {
+    let sign = if value < 0 { "-" } else { "" };
+    let absolute = value.abs();
+    format!("{sign}{}.{:02}", absolute / 100, absolute % 100)
+}
+
+fn format_atomic_from_cents(value: i64) -> String {
+    (value * 10_000).to_string()
+}
+
+fn quote_symbol(pair_symbol: &str) -> String {
+    pair_symbol.split('/').nth(1).unwrap_or("USDC").to_string()
+}
+
+fn state_key(state: &RuntimeDeploymentState) -> &'static str {
+    match state {
+        RuntimeDeploymentState::Draft => "draft",
+        RuntimeDeploymentState::Shadow => "shadow",
+        RuntimeDeploymentState::Paper => "paper",
+        RuntimeDeploymentState::Live => "live",
+        RuntimeDeploymentState::Paused => "paused",
+        RuntimeDeploymentState::Killed => "killed",
+        RuntimeDeploymentState::Archived => "archived",
+    }
+}
+
+fn side_key(side: &RuntimePositionSide) -> &'static str {
+    match side {
+        RuntimePositionSide::Long => "long",
+        RuntimePositionSide::Short => "short",
+        RuntimePositionSide::Flat => "flat",
+    }
+}
+
+fn parse_side(value: &str) -> RuntimePositionSide {
+    match value {
+        "long" => RuntimePositionSide::Long,
+        "short" => RuntimePositionSide::Short,
+        _ => RuntimePositionSide::Flat,
+    }
+}
+
+fn now_rfc3339() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .expect("current time to format")
+}
+
+fn timestamp_compact() -> String {
+    OffsetDateTime::now_utc().unix_timestamp_nanos().to_string()
 }
 
 #[cfg(test)]
 mod tests {
-    use protocol::RuntimeLedgerTotals;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use protocol::{RuntimeCapital, RuntimeLane, RuntimePair, RuntimePolicy};
 
     use super::*;
 
-    #[test]
-    fn exposes_snapshot_totals() {
-        let ledger = PortfolioLedger::new(RuntimeLedgerSnapshot {
-            schema_version: "v1".to_string(),
-            snapshot_id: "ledger_1".to_string(),
-            deployment_id: "dep_1".to_string(),
-            sleeve_id: "sleeve_1".to_string(),
-            as_of: "2026-03-07T19:05:00Z".to_string(),
-            balances: vec![],
-            positions: vec![],
-            totals: RuntimeLedgerTotals {
-                equity_usd: "100".to_string(),
-                reserved_usd: "5".to_string(),
-                available_usd: "95".to_string(),
-                realized_pnl_usd: "0".to_string(),
-                unrealized_pnl_usd: "0".to_string(),
-            },
-        });
+    fn temp_database_url(test_name: &str) -> String {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        std::env::temp_dir()
+            .join(format!("portfolio-ledger-{test_name}-{unique}.sqlite3"))
+            .display()
+            .to_string()
+    }
 
-        assert_eq!(ledger.available_usd(), "95");
-        assert_eq!(ledger.reserved_usd(), "5");
-        assert_eq!(ledger.balance_count(), 0);
+    fn ledger(test_name: &str) -> PortfolioLedger {
+        PortfolioLedger::new(PortfolioLedgerConfig::new(temp_database_url(test_name)))
+            .expect("ledger to initialize")
+    }
+
+    fn deployment(
+        deployment_id: &str,
+        sleeve_id: &str,
+        allocated_usd: &str,
+        reserved_usd: &str,
+    ) -> RuntimeDeploymentRecord {
+        RuntimeDeploymentRecord {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            deployment_id: deployment_id.to_string(),
+            strategy_key: "dca".to_string(),
+            sleeve_id: sleeve_id.to_string(),
+            owner_user_id: "user_123".to_string(),
+            pair: RuntimePair {
+                symbol: "SOL/USDC".to_string(),
+                base_mint: "So11111111111111111111111111111111111111112".to_string(),
+                quote_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+            },
+            mode: protocol::RuntimeMode::Shadow,
+            state: RuntimeDeploymentState::Shadow,
+            lane: RuntimeLane::Safe,
+            created_at: "2026-03-07T00:00:00.000Z".to_string(),
+            updated_at: "2026-03-07T00:00:00.000Z".to_string(),
+            promoted_at: None,
+            paused_at: None,
+            killed_at: None,
+            policy: RuntimePolicy {
+                max_notional_usd: "250.00".to_string(),
+                daily_loss_limit_usd: "35.00".to_string(),
+                max_slippage_bps: 50,
+                max_concurrent_runs: 2,
+                rebalance_tolerance_bps: 100,
+            },
+            capital: RuntimeCapital {
+                allocated_usd: allocated_usd.to_string(),
+                reserved_usd: reserved_usd.to_string(),
+                available_usd: format_usd_cents(
+                    parse_usd_cents("available", allocated_usd).expect("allocated")
+                        - parse_usd_cents("reserved", reserved_usd).expect("reserved"),
+                ),
+            },
+            tags: vec!["test".to_string()],
+        }
+    }
+
+    #[test]
+    fn builds_ledger_snapshots_from_deployments() {
+        let ledger = ledger("snapshot");
+
+        let result = ledger
+            .sync_deployment(&deployment(
+                "deployment_1",
+                "sleeve_alpha",
+                "100.00",
+                "5.00",
+            ))
+            .expect("deployment to sync");
+
+        assert!(result.created);
+        assert_eq!(result.snapshot.totals.equity_usd, "100.00");
+        assert_eq!(result.snapshot.totals.reserved_usd, "5.00");
+        assert_eq!(result.snapshot.totals.available_usd, "95.00");
+        assert_eq!(result.snapshot.balances.len(), 1);
+    }
+
+    #[test]
+    fn prevents_conflicting_reservations_across_deployments() {
+        let ledger = ledger("conflict");
+        ledger
+            .sync_deployment(&deployment(
+                "deployment_1",
+                "sleeve_alpha",
+                "100.00",
+                "60.00",
+            ))
+            .expect("first deployment to sync");
+
+        let error = ledger
+            .sync_deployment(&deployment(
+                "deployment_2",
+                "sleeve_alpha",
+                "50.00",
+                "50.00",
+            ))
+            .expect_err("second deployment should oversubscribe the sleeve");
+
+        assert!(matches!(
+            error,
+            PortfolioLedgerError::SleeveOversubscribed { .. }
+        ));
+    }
+
+    #[test]
+    fn supports_deterministic_recovery_via_sleeve_correction() {
+        let ledger = ledger("recovery");
+        ledger
+            .sync_deployment(&deployment(
+                "deployment_1",
+                "sleeve_alpha",
+                "100.00",
+                "60.00",
+            ))
+            .expect("first deployment to sync");
+        assert!(matches!(
+            ledger.sync_deployment(&deployment(
+                "deployment_2",
+                "sleeve_alpha",
+                "50.00",
+                "20.00"
+            )),
+            Err(PortfolioLedgerError::SleeveOversubscribed { .. })
+        ));
+
+        ledger
+            .apply_sleeve_correction("sleeve_alpha", "200.00")
+            .expect("correction to apply");
+
+        let result = ledger
+            .sync_deployment(&deployment(
+                "deployment_2",
+                "sleeve_alpha",
+                "50.00",
+                "20.00",
+            ))
+            .expect("second deployment to sync after correction");
+
+        assert_eq!(result.snapshot.totals.available_usd, "30.00");
+    }
+
+    #[test]
+    fn includes_positions_and_cost_basis_in_snapshots() {
+        let ledger = ledger("positions");
+        ledger
+            .sync_deployment(&deployment(
+                "deployment_1",
+                "sleeve_alpha",
+                "100.00",
+                "5.00",
+            ))
+            .expect("deployment to sync");
+        ledger
+            .upsert_position(
+                "deployment_1",
+                &RuntimeLedgerPosition {
+                    instrument_id: "SOL/USDC".to_string(),
+                    side: RuntimePositionSide::Long,
+                    quantity_atomic: "100000000".to_string(),
+                    entry_price_usd: Some("140.00".to_string()),
+                    mark_price_usd: Some("142.00".to_string()),
+                    unrealized_pnl_usd: Some("2.00".to_string()),
+                },
+            )
+            .expect("position to store");
+
+        let snapshot = ledger
+            .snapshot_for_deployment("deployment_1")
+            .expect("snapshot to load");
+
+        assert_eq!(snapshot.positions.len(), 1);
+        assert_eq!(
+            snapshot.positions[0].entry_price_usd.as_deref(),
+            Some("140.00")
+        );
+        assert_eq!(snapshot.totals.unrealized_pnl_usd, "2.00");
     }
 }

--- a/crates/portfolio-ledger/src/lib.rs
+++ b/crates/portfolio-ledger/src/lib.rs
@@ -92,8 +92,10 @@ impl PortfolioLedger {
         let mut connection = self.open_connection()?;
         let transaction = connection.transaction()?;
 
-        let allocated_cents =
-            parse_usd_cents("capital.allocatedUsd", &deployment.capital.allocated_usd)?;
+        let allocated_cents = parse_non_negative_usd_cents(
+            "capital.allocatedUsd",
+            &deployment.capital.allocated_usd,
+        )?;
         let reserved_cents = effective_reserved_cents(deployment)?;
         let existing = load_deployment_state(&transaction, &deployment.deployment_id)?;
         let sleeve = load_sleeve_state(&transaction, &deployment.sleeve_id)?;
@@ -160,7 +162,8 @@ impl PortfolioLedger {
         sleeve_id: &str,
         corrected_equity_usd: &str,
     ) -> Result<(), PortfolioLedgerError> {
-        let corrected_equity_cents = parse_usd_cents("correctedEquityUsd", corrected_equity_usd)?;
+        let corrected_equity_cents =
+            parse_non_negative_usd_cents("correctedEquityUsd", corrected_equity_usd)?;
         let mut connection = self.open_connection()?;
         let transaction = connection.transaction()?;
         let sleeve = load_sleeve_state(&transaction, sleeve_id)?.ok_or_else(|| {
@@ -408,7 +411,8 @@ fn should_fallback_to_tmp(database_path: &Path, error: &PortfolioLedgerError) ->
 fn effective_reserved_cents(
     deployment: &RuntimeDeploymentRecord,
 ) -> Result<i64, PortfolioLedgerError> {
-    let reserved_cents = parse_usd_cents("capital.reservedUsd", &deployment.capital.reserved_usd)?;
+    let reserved_cents =
+        parse_non_negative_usd_cents("capital.reservedUsd", &deployment.capital.reserved_usd)?;
     Ok(
         if matches!(
             deployment.state,
@@ -735,6 +739,20 @@ fn parse_usd_cents(field: &'static str, value: &str) -> Result<i64, PortfolioLed
     Ok(sign * cents)
 }
 
+fn parse_non_negative_usd_cents(
+    field: &'static str,
+    value: &str,
+) -> Result<i64, PortfolioLedgerError> {
+    let cents = parse_usd_cents(field, value)?;
+    if cents < 0 {
+        return Err(PortfolioLedgerError::InvalidUsdAmount {
+            field,
+            value: value.trim().to_string(),
+        });
+    }
+    Ok(cents)
+}
+
 fn format_usd_cents(value: i64) -> String {
     let sign = if value < 0 { "-" } else { "" };
     let absolute = value.abs();
@@ -992,5 +1010,27 @@ mod tests {
         assert_eq!(result.snapshot.totals.equity_usd, "100.01");
         assert_eq!(result.snapshot.totals.reserved_usd, "5.13");
         assert_eq!(result.snapshot.totals.available_usd, "94.88");
+    }
+
+    #[test]
+    fn rejects_negative_capital_amounts() {
+        let ledger = ledger("negative-capital");
+
+        let error = ledger
+            .sync_deployment(&deployment(
+                "deployment_1",
+                "sleeve_alpha",
+                "-100.00",
+                "5.00",
+            ))
+            .expect_err("negative capital should fail");
+
+        assert!(matches!(
+            error,
+            PortfolioLedgerError::InvalidUsdAmount {
+                field: "capital.allocatedUsd",
+                ..
+            }
+        ));
     }
 }

--- a/crates/strategy-registry/src/lib.rs
+++ b/crates/strategy-registry/src/lib.rs
@@ -218,6 +218,15 @@ impl StrategyRegistry {
         Ok(deployment)
     }
 
+    pub fn delete_deployment(&self, deployment_id: &str) -> Result<bool, StrategyRegistryError> {
+        let connection = self.open_connection()?;
+        let deleted = connection.execute(
+            "DELETE FROM deployments WHERE deployment_id = ?1",
+            params![deployment_id],
+        )?;
+        Ok(deleted > 0)
+    }
+
     pub fn list_runs(
         &self,
         deployment_id: &str,
@@ -952,5 +961,34 @@ mod tests {
             error,
             StrategyRegistryError::FeatureStreamStale { .. }
         ));
+    }
+
+    #[test]
+    fn deletes_deployments_and_associated_runs() {
+        let registry = registry("delete");
+        registry
+            .upsert_deployment(&deployment(
+                "deployment_delete",
+                RuntimeMode::Shadow,
+                RuntimeDeploymentState::Shadow,
+            ))
+            .expect("deployment to store");
+        registry
+            .evaluate_shadow_trigger("deployment_delete", &feature_cache_snapshot(false), None)
+            .expect("run to store");
+
+        let deleted = registry
+            .delete_deployment("deployment_delete")
+            .expect("deployment to delete");
+
+        assert!(deleted);
+        assert!(registry
+            .get_deployment("deployment_delete")
+            .expect("lookup to succeed")
+            .is_none());
+        assert!(registry
+            .list_runs("deployment_delete")
+            .expect("runs lookup to succeed")
+            .is_empty());
     }
 }

--- a/services/runtime-rs/Cargo.toml
+++ b/services/runtime-rs/Cargo.toml
@@ -9,6 +9,7 @@ axum.workspace = true
 exec-client = { path = "../../crates/exec-client" }
 feature-cache = { path = "../../crates/feature-cache" }
 market-adapters = { path = "../../crates/market-adapters" }
+portfolio-ledger = { path = "../../crates/portfolio-ledger" }
 protocol = { path = "../../crates/protocol" }
 runtime-ops = { path = "../../crates/runtime-ops" }
 serde.workspace = true

--- a/services/runtime-rs/src/lib.rs
+++ b/services/runtime-rs/src/lib.rs
@@ -5,7 +5,7 @@ use std::{
 
 use axum::{
     body::Bytes,
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::{HeaderMap, StatusCode},
     routing::{get, post},
     Json, Router,
@@ -13,6 +13,9 @@ use axum::{
 use exec_client::ExecClient;
 use feature_cache::{FeatureCache, FeatureCacheConfig, FeatureCacheSnapshot};
 use market_adapters::{FeedGateway, FeedGatewayConfig, FeedGatewaySnapshot, FeedReplayFixture};
+use portfolio_ledger::{
+    PortfolioLedger, PortfolioLedgerConfig, PortfolioLedgerError, PortfolioLedgerSnapshot,
+};
 use protocol::{RuntimeDeploymentRecord, RuntimeDeploymentState, RuntimeRunRecord};
 use runtime_ops::{health_snapshot, RuntimeConfig};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -39,6 +42,7 @@ pub struct RuntimeAppState {
     feed_gateway: Arc<RwLock<FeedGateway>>,
     feature_cache: Arc<RwLock<FeatureCache>>,
     strategy_registry: StrategyRegistry,
+    portfolio_ledger: PortfolioLedger,
 }
 
 impl RuntimeAppState {
@@ -56,6 +60,9 @@ impl RuntimeAppState {
         let strategy_registry =
             StrategyRegistry::new(StrategyRegistryConfig::new(config.database_url.clone()))
                 .expect("strategy registry to initialize");
+        let portfolio_ledger =
+            PortfolioLedger::new(PortfolioLedgerConfig::new(config.database_url.clone()))
+                .expect("portfolio ledger to initialize");
         Self {
             config,
             exec_client: ExecClient::from_lookup(|key| env::var(key).ok()),
@@ -64,6 +71,7 @@ impl RuntimeAppState {
             feed_gateway,
             feature_cache,
             strategy_registry,
+            portfolio_ledger,
         }
     }
 
@@ -84,6 +92,10 @@ impl RuntimeAppState {
     fn strategy_registry_snapshot(&self) -> StrategyRegistrySnapshot {
         self.strategy_registry.snapshot_now()
     }
+
+    fn portfolio_ledger_snapshot(&self) -> PortfolioLedgerSnapshot {
+        self.portfolio_ledger.snapshot_now()
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -103,6 +115,7 @@ pub struct RuntimeHealthResponse {
     pub feed_gateway: FeedGatewaySnapshot,
     pub feature_cache: FeatureCacheSnapshot,
     pub strategy_registry: StrategyRegistrySnapshot,
+    pub portfolio_ledger: PortfolioLedgerSnapshot,
     pub supported_strategies: Vec<String>,
 }
 
@@ -117,6 +130,7 @@ pub struct RuntimeMetricsResponse {
     pub feed_gateway: FeedGatewaySnapshot,
     pub feature_cache: FeatureCacheSnapshot,
     pub strategy_registry: StrategyRegistrySnapshot,
+    pub portfolio_ledger: PortfolioLedgerSnapshot,
     pub supported_strategies: Vec<String>,
 }
 
@@ -124,6 +138,12 @@ pub struct RuntimeMetricsResponse {
 #[serde(rename_all = "camelCase")]
 struct RuntimeShadowEvaluationRequest {
     pub trigger: Option<ShadowEvaluationTrigger>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct RuntimeDeploymentQuery {
+    pub deployment_id: Option<String>,
 }
 
 pub fn app(config: RuntimeConfig) -> Router {
@@ -162,6 +182,11 @@ pub fn app(config: RuntimeConfig) -> Router {
             &format!("{INTERNAL_RUNTIME_PREFIX}/runs/{{deployment_id}}"),
             get(list_runs_handler),
         )
+        .route(
+            &format!("{INTERNAL_RUNTIME_PREFIX}/positions"),
+            get(positions_handler),
+        )
+        .route(&format!("{INTERNAL_RUNTIME_PREFIX}/pnl"), get(pnl_handler))
         .with_state(RuntimeAppState::new(config))
 }
 
@@ -170,9 +195,11 @@ fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
     let feed_gateway = state.feed_gateway_snapshot();
     let feature_cache = state.feature_cache_snapshot();
     let strategy_registry = state.strategy_registry_snapshot();
+    let portfolio_ledger = state.portfolio_ledger_snapshot();
     let status = if feed_gateway.status == "healthy"
         && feature_cache.status == "healthy"
         && strategy_registry.status == "healthy"
+        && portfolio_ledger.status == "healthy"
     {
         snapshot.status
     } else {
@@ -193,6 +220,7 @@ fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
         feed_gateway,
         feature_cache,
         strategy_registry,
+        portfolio_ledger,
         supported_strategies: SUPPORTED_STRATEGIES
             .iter()
             .map(|strategy| strategy.as_key().to_string())
@@ -210,6 +238,7 @@ fn metrics_response(state: &RuntimeAppState) -> RuntimeMetricsResponse {
         feed_gateway: state.feed_gateway_snapshot(),
         feature_cache: state.feature_cache_snapshot(),
         strategy_registry: state.strategy_registry_snapshot(),
+        portfolio_ledger: state.portfolio_ledger_snapshot(),
         supported_strategies: SUPPORTED_STRATEGIES
             .iter()
             .map(|strategy| strategy.as_key().to_string())
@@ -247,10 +276,15 @@ async fn create_deployment_handler(
 ) -> HandlerResult {
     authorize_internal_request(&headers, &state)?;
     let deployment: RuntimeDeploymentRecord = parse_json_body(&body, "invalid-runtime-deployment")?;
+    let previous = state
+        .strategy_registry
+        .get_deployment(&deployment.deployment_id)
+        .map_err(map_registry_error)?;
     let result = state
         .strategy_registry
         .upsert_deployment(&deployment)
         .map_err(map_registry_error)?;
+    let ledger = sync_ledger_with_rollback(&state, previous, &result.deployment)?;
     Ok(OkJson::with_status(
         if result.created {
             StatusCode::CREATED
@@ -262,6 +296,7 @@ async fn create_deployment_handler(
             "source": "runtime-rs",
             "created": result.created,
             "deployment": result.deployment,
+            "ledger": ledger.snapshot,
         }),
     ))
 }
@@ -329,7 +364,7 @@ async fn resume_deployment_handler(
         protocol::RuntimeMode::Paper => RuntimeDeploymentState::Paper,
         protocol::RuntimeMode::Live => RuntimeDeploymentState::Live,
     };
-    transition_deployment(deployment_id, state, next_state)
+    transition_deployment(&deployment_id, &state, next_state)
 }
 
 async fn kill_deployment_handler(
@@ -353,24 +388,30 @@ async fn transition_deployment_handler(
     next_state: RuntimeDeploymentState,
 ) -> HandlerResult {
     authorize_internal_request(&headers, &state)?;
-    transition_deployment(deployment_id, state, next_state)
+    transition_deployment(&deployment_id, &state, next_state)
 }
 
 fn transition_deployment(
-    deployment_id: String,
-    state: RuntimeAppState,
+    deployment_id: &str,
+    state: &RuntimeAppState,
     next_state: RuntimeDeploymentState,
 ) -> HandlerResult {
+    let previous = state
+        .strategy_registry
+        .get_deployment(deployment_id)
+        .map_err(map_registry_error)?;
     let deployment = state
         .strategy_registry
-        .transition_deployment(&deployment_id, next_state)
+        .transition_deployment(deployment_id, next_state)
         .map_err(map_registry_error)?;
+    let ledger = sync_ledger_with_rollback(state, previous, &deployment)?;
     Ok(OkJson::with_status(
         StatusCode::OK,
         json!({
             "ok": true,
             "source": "runtime-rs",
             "deployment": deployment,
+            "ledger": ledger.snapshot,
         }),
     ))
 }
@@ -419,6 +460,51 @@ async fn list_runs_handler(
     ))
 }
 
+async fn positions_handler(
+    headers: HeaderMap,
+    Query(query): Query<RuntimeDeploymentQuery>,
+    State(state): State<RuntimeAppState>,
+) -> HandlerResult {
+    authorize_internal_request(&headers, &state)?;
+    let deployment_id = require_deployment_id(query)?;
+    let snapshot = state
+        .portfolio_ledger
+        .snapshot_for_deployment(&deployment_id)
+        .map_err(map_ledger_error)?;
+    Ok(OkJson::with_status(
+        StatusCode::OK,
+        json!({
+            "ok": true,
+            "source": "runtime-rs",
+            "deploymentId": deployment_id,
+            "snapshot": snapshot,
+        }),
+    ))
+}
+
+async fn pnl_handler(
+    headers: HeaderMap,
+    Query(query): Query<RuntimeDeploymentQuery>,
+    State(state): State<RuntimeAppState>,
+) -> HandlerResult {
+    authorize_internal_request(&headers, &state)?;
+    let deployment_id = require_deployment_id(query)?;
+    let snapshot = state
+        .portfolio_ledger
+        .snapshot_for_deployment(&deployment_id)
+        .map_err(map_ledger_error)?;
+    Ok(OkJson::with_status(
+        StatusCode::OK,
+        json!({
+            "ok": true,
+            "source": "runtime-rs",
+            "deploymentId": deployment_id,
+            "asOf": snapshot.as_of,
+            "totals": snapshot.totals,
+        }),
+    ))
+}
+
 fn shadow_evaluation_json(result: ShadowEvaluationResult) -> JsonPayload {
     OkJson::with_status(
         if result.created {
@@ -445,6 +531,55 @@ fn parse_json_body<T: DeserializeOwned>(body: &[u8], error_code: &str) -> Result
             json!({ "reason": error.to_string() }),
         )
     })
+}
+
+fn require_deployment_id(query: RuntimeDeploymentQuery) -> Result<String, JsonPayload> {
+    query
+        .deployment_id
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| error_json(StatusCode::BAD_REQUEST, "deployment-id-required", json!({})))
+}
+
+fn sync_ledger_with_rollback(
+    state: &RuntimeAppState,
+    previous: Option<RuntimeDeploymentRecord>,
+    deployment: &RuntimeDeploymentRecord,
+) -> Result<portfolio_ledger::LedgerSyncResult, JsonPayload> {
+    match state.portfolio_ledger.sync_deployment(deployment) {
+        Ok(result) => Ok(result),
+        Err(error) => {
+            rollback_registry_change(
+                &state.strategy_registry,
+                previous,
+                &deployment.deployment_id,
+            )
+            .map_err(|rollback_error| {
+                error_json(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "runtime-ledger-rollback-failed",
+                    json!({
+                        "deploymentId": deployment.deployment_id,
+                        "reason": error.to_string(),
+                        "rollbackReason": rollback_error.to_string(),
+                    }),
+                )
+            })?;
+            Err(map_ledger_error(error))
+        }
+    }
+}
+
+fn rollback_registry_change(
+    strategy_registry: &StrategyRegistry,
+    previous: Option<RuntimeDeploymentRecord>,
+    deployment_id: &str,
+) -> Result<(), StrategyRegistryError> {
+    if let Some(previous) = previous {
+        strategy_registry.upsert_deployment(&previous)?;
+    } else {
+        let _ = strategy_registry.delete_deployment(deployment_id)?;
+    }
+    Ok(())
 }
 
 fn authorize_internal_request(
@@ -570,6 +705,49 @@ fn map_registry_error(error: StrategyRegistryError) -> JsonPayload {
         StrategyRegistryError::Serialization(error) => error_json(
             StatusCode::INTERNAL_SERVER_ERROR,
             "runtime-registry-error",
+            json!({ "reason": error.to_string() }),
+        ),
+    }
+}
+
+fn map_ledger_error(error: PortfolioLedgerError) -> JsonPayload {
+    match error {
+        PortfolioLedgerError::DeploymentNotFound { deployment_id } => error_json(
+            StatusCode::NOT_FOUND,
+            "deployment-not-found",
+            json!({ "deploymentId": deployment_id }),
+        ),
+        PortfolioLedgerError::SleeveOversubscribed {
+            sleeve_id,
+            requested_usd,
+            available_usd,
+        } => error_json(
+            StatusCode::CONFLICT,
+            "sleeve-oversubscribed",
+            json!({
+                "sleeveId": sleeve_id,
+                "requestedUsd": requested_usd,
+                "availableUsd": available_usd,
+            }),
+        ),
+        PortfolioLedgerError::InvalidUsdAmount { field, value } => error_json(
+            StatusCode::BAD_REQUEST,
+            "invalid-ledger-amount",
+            json!({ "field": field, "value": value }),
+        ),
+        PortfolioLedgerError::InvalidCorrection { sleeve_id } => error_json(
+            StatusCode::CONFLICT,
+            "invalid-ledger-correction",
+            json!({ "sleeveId": sleeve_id }),
+        ),
+        PortfolioLedgerError::Io(error) => error_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "runtime-ledger-error",
+            json!({ "reason": error.to_string() }),
+        ),
+        PortfolioLedgerError::Storage(error) => error_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "runtime-ledger-error",
             json!({ "reason": error.to_string() }),
         ),
     }
@@ -779,6 +957,44 @@ mod tests {
         .expect("config to load")
     }
 
+    fn runtime_deployment(
+        deployment_id: &str,
+        sleeve_id: &str,
+        allocated_usd: &str,
+        reserved_usd: &str,
+    ) -> Value {
+        json!({
+            "schemaVersion": "v1",
+            "deploymentId": deployment_id,
+            "strategyKey": "dca",
+            "sleeveId": sleeve_id,
+            "ownerUserId": "user_123",
+            "pair": {
+                "symbol": "SOL/USDC",
+                "baseMint": "So11111111111111111111111111111111111111112",
+                "quoteMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+            },
+            "mode": "shadow",
+            "state": "shadow",
+            "lane": "safe",
+            "createdAt": "2026-03-07T00:00:00.000Z",
+            "updatedAt": "2026-03-07T00:00:00.000Z",
+            "policy": {
+                "maxNotionalUsd": "250.00",
+                "dailyLossLimitUsd": "35.00",
+                "maxSlippageBps": 50,
+                "maxConcurrentRuns": 2,
+                "rebalanceToleranceBps": 100
+            },
+            "capital": {
+                "allocatedUsd": allocated_usd,
+                "reservedUsd": reserved_usd,
+                "availableUsd": "0.00"
+            },
+            "tags": ["fixture"]
+        })
+    }
+
     async fn read_json(response: axum::response::Response) -> Value {
         let body = response
             .into_body()
@@ -817,6 +1033,8 @@ mod tests {
         assert_eq!(payload.feed_gateway.status, "healthy");
         assert_eq!(payload.strategy_registry.status, "healthy");
         assert_eq!(payload.strategy_registry.deployment_count, 0);
+        assert_eq!(payload.portfolio_ledger.status, "healthy");
+        assert_eq!(payload.portfolio_ledger.deployment_count, 0);
         assert!(payload.internal_service_auth_configured);
     }
 
@@ -845,6 +1063,7 @@ mod tests {
         assert_eq!(payload.feature_cache.feature_streams.len(), 1);
         assert_eq!(payload.feature_cache.total_market_samples, 1);
         assert_eq!(payload.strategy_registry.status, "healthy");
+        assert_eq!(payload.portfolio_ledger.status, "healthy");
     }
 
     #[tokio::test]
@@ -873,36 +1092,7 @@ mod tests {
     #[tokio::test]
     async fn stores_and_evaluates_shadow_deployments() {
         let router = app(test_config());
-        let deployment = json!({
-            "schemaVersion": "v1",
-            "deploymentId": "deployment_123",
-            "strategyKey": "dca",
-            "sleeveId": "sleeve_alpha",
-            "ownerUserId": "user_123",
-            "pair": {
-                "symbol": "SOL/USDC",
-                "baseMint": "So11111111111111111111111111111111111111112",
-                "quoteMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
-            },
-            "mode": "shadow",
-            "state": "shadow",
-            "lane": "safe",
-            "createdAt": "2026-03-07T00:00:00.000Z",
-            "updatedAt": "2026-03-07T00:00:00.000Z",
-            "policy": {
-                "maxNotionalUsd": "250.00",
-                "dailyLossLimitUsd": "35.00",
-                "maxSlippageBps": 50,
-                "maxConcurrentRuns": 2,
-                "rebalanceToleranceBps": 100
-            },
-            "capital": {
-                "allocatedUsd": "1000.00",
-                "reservedUsd": "125.00",
-                "availableUsd": "875.00"
-            },
-            "tags": ["fixture"]
-        });
+        let deployment = runtime_deployment("deployment_123", "sleeve_alpha", "1000.00", "125.00");
 
         let create_response = router
             .clone()
@@ -918,6 +1108,11 @@ mod tests {
             .await
             .expect("response");
         assert_eq!(create_response.status(), StatusCode::CREATED);
+        let create_payload = read_json(create_response).await;
+        assert_eq!(
+            create_payload["ledger"]["totals"]["reservedUsd"],
+            json!("125.00")
+        );
 
         let evaluate_response = router
             .clone()
@@ -972,5 +1167,100 @@ mod tests {
         assert_eq!(runs_response.status(), StatusCode::OK);
         let runs_payload = read_json(runs_response).await;
         assert_eq!(runs_payload["runs"].as_array().expect("array").len(), 1);
+    }
+
+    #[tokio::test]
+    async fn serves_real_ledger_snapshots_and_rolls_back_conflicts() {
+        let router = app(test_config());
+
+        let create_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/deployments")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        runtime_deployment("deployment_alpha", "sleeve_alpha", "100.00", "60.00")
+                            .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(create_response.status(), StatusCode::CREATED);
+
+        let positions_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/internal/runtime/positions?deploymentId=deployment_alpha")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(positions_response.status(), StatusCode::OK);
+        let positions_payload = read_json(positions_response).await;
+        assert_eq!(
+            positions_payload["snapshot"]["totals"]["reservedUsd"],
+            json!("60.00")
+        );
+        assert_eq!(
+            positions_payload["snapshot"]["totals"]["availableUsd"],
+            json!("40.00")
+        );
+
+        let pnl_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/internal/runtime/pnl?deploymentId=deployment_alpha")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(pnl_response.status(), StatusCode::OK);
+        let pnl_payload = read_json(pnl_response).await;
+        assert_eq!(pnl_payload["totals"]["equityUsd"], json!("100.00"));
+        assert_eq!(pnl_payload["totals"]["reservedUsd"], json!("60.00"));
+
+        let conflict_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/deployments")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        runtime_deployment("deployment_beta", "sleeve_alpha", "50.00", "50.00")
+                            .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(conflict_response.status(), StatusCode::CONFLICT);
+        assert_eq!(
+            read_json(conflict_response).await["error"],
+            json!("sleeve-oversubscribed")
+        );
+
+        let missing_response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/api/internal/runtime/deployments/deployment_beta")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(missing_response.status(), StatusCode::NOT_FOUND);
     }
 }


### PR DESCRIPTION
## Summary
- implement a SQLite-backed portfolio ledger crate with deterministic USD accounting, sleeve reservations, correction hooks, and position snapshots
- integrate the ledger into runtime-rs health, deployment writes, and new internal positions/pnl routes with rollback-safe registry coordination
- add Rust coverage for reservation conflicts, real ledger read models, and deployment rollback when a sleeve is oversubscribed

## Validation
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- bun run lint
- bun run typecheck

Closes #265