### PR TITLE
Add execution planner and runtime coordination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +89,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -105,6 +117,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cpufeatures"
@@ -145,10 +163,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "exec-client"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "protocol",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "execution-planner"
+version = "0.1.0"
+dependencies = [
+ "feature-cache",
+ "protocol",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -238,6 +286,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +394,24 @@ dependencies = [
  "pin-utils",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -327,13 +420,139 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -341,6 +560,16 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -366,10 +595,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "market-adapters"
@@ -416,7 +657,7 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -425,7 +666,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -476,10 +717,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -499,12 +758,102 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -523,6 +872,58 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "risk-engine"
@@ -553,6 +954,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "exec-client",
+ "execution-planner",
  "feature-cache",
  "http-body-util",
  "market-adapters",
@@ -584,6 +986,53 @@ dependencies = [
  "libsqlite3-sys",
  "smallvec",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -702,8 +1151,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strategy-core"
@@ -725,6 +1180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +1201,20 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "thiserror"
@@ -802,17 +1277,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -824,6 +1325,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -840,6 +1351,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -917,6 +1446,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,6 +1462,30 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "valuable"
@@ -947,10 +1506,116 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "windows-link"
@@ -960,11 +1625,273 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+  "crates/execution-planner",
   "crates/exec-client",
   "crates/feature-cache",
   "crates/market-adapters",

--- a/crates/exec-client/Cargo.toml
+++ b/crates/exec-client/Cargo.toml
@@ -6,3 +6,10 @@ license.workspace = true
 
 [dependencies]
 protocol = { path = "../protocol" }
+reqwest = { version = "0.12.24", default-features = false, features = ["json", "rustls-tls"] }
+serde.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+axum.workspace = true
+tokio.workspace = true

--- a/crates/exec-client/src/lib.rs
+++ b/crates/exec-client/src/lib.rs
@@ -1,9 +1,55 @@
-use protocol::RuntimeExecutionPlan;
+use protocol::{RuntimeExecutionPlan, RuntimeLane, RuntimeMode};
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
 
 pub const RUNTIME_INTERNAL_AUTH_HEADER: &str = "authorization";
 const DEFAULT_RUNTIME_WORKER_API_BASE: &str = "http://127.0.0.1:8888";
 const DEFAULT_RUNTIME_EXECUTION_PLAN_PATH: &str = "/api/internal/runtime/execution-plans";
 const DEFAULT_RUNTIME_HEALTH_PATH: &str = "/api/internal/runtime/health";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecPlanCoordination {
+    pub plan_id: String,
+    pub deployment_id: String,
+    pub run_id: String,
+    pub mode: RuntimeMode,
+    pub lane: RuntimeLane,
+    pub slice_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecSubmitResponse {
+    pub ok: bool,
+    pub accepted: bool,
+    pub source: String,
+    pub coordination: ExecPlanCoordination,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExecClientError {
+    pub code: ExecClientErrorCode,
+    pub status: u16,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ExecClientErrorCode {
+    PaymentRequired,
+    AuthRequired,
+    InvalidRequest,
+    InvalidTransaction,
+    PolicyDenied,
+    UnsupportedLane,
+    InsufficientBalance,
+    VenueTimeout,
+    SubmissionFailed,
+    ExpiredBlockhash,
+    NotFound,
+    NotReady,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExecClientConfig {
@@ -105,10 +151,91 @@ impl ExecClient {
     pub fn submit_reference(&self, plan: &RuntimeExecutionPlan) -> String {
         format!("{}#{}", self.submit_url(), plan.plan_id)
     }
+
+    pub async fn submit_plan(
+        &self,
+        plan: &RuntimeExecutionPlan,
+    ) -> Result<ExecSubmitResponse, ExecClientError> {
+        let client = reqwest::Client::new();
+        let mut request = client
+            .post(self.submit_url())
+            .header("content-type", "application/json")
+            .json(plan);
+        if let Some(value) = self.auth_header_value() {
+            request = request.header(RUNTIME_INTERNAL_AUTH_HEADER, value);
+        }
+
+        let response = request.send().await.map_err(|error| ExecClientError {
+            code: ExecClientErrorCode::SubmissionFailed,
+            status: 502,
+            message: error.to_string(),
+        })?;
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+
+        if !status.is_success() {
+            return Err(map_error_response(status, &body));
+        }
+
+        serde_json::from_str::<ExecSubmitResponse>(&body).map_err(|error| ExecClientError {
+            code: ExecClientErrorCode::SubmissionFailed,
+            status: 502,
+            message: error.to_string(),
+        })
+    }
+}
+
+fn map_error_response(status: StatusCode, body: &str) -> ExecClientError {
+    let lower = body.trim().to_lowercase();
+    let code = if status == StatusCode::PAYMENT_REQUIRED || lower.contains("payment-required") {
+        ExecClientErrorCode::PaymentRequired
+    } else if status == StatusCode::UNAUTHORIZED || lower.contains("auth-required") {
+        ExecClientErrorCode::AuthRequired
+    } else if lower.contains("invalid-request") || lower.contains("invalid-runtime-execution-plan")
+    {
+        ExecClientErrorCode::InvalidRequest
+    } else if lower.contains("invalid-transaction") {
+        ExecClientErrorCode::InvalidTransaction
+    } else if lower.contains("policy-denied") {
+        ExecClientErrorCode::PolicyDenied
+    } else if lower.contains("unsupported-lane") {
+        ExecClientErrorCode::UnsupportedLane
+    } else if lower.contains("insufficient-balance") {
+        ExecClientErrorCode::InsufficientBalance
+    } else if lower.contains("timeout") {
+        ExecClientErrorCode::VenueTimeout
+    } else if lower.contains("expired-blockhash") {
+        ExecClientErrorCode::ExpiredBlockhash
+    } else if status == StatusCode::NOT_FOUND || lower.contains("not-found") {
+        ExecClientErrorCode::NotFound
+    } else if status == StatusCode::SERVICE_UNAVAILABLE
+        || lower.contains("runtime-integration-not-configured")
+        || lower.contains("not-ready")
+    {
+        ExecClientErrorCode::NotReady
+    } else {
+        ExecClientErrorCode::SubmissionFailed
+    };
+    ExecClientError {
+        code,
+        status: status.as_u16(),
+        message: if body.trim().is_empty() {
+            format!(
+                "runtime execution coordination failed with status {}",
+                status.as_u16()
+            )
+        } else {
+            body.trim().to_string()
+        },
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use axum::{routing::post, Json, Router};
+    use serde_json::json;
+    use tokio::net::TcpListener;
+
     use protocol::{RuntimeLane, RuntimeMode};
 
     use super::*;
@@ -163,5 +290,123 @@ mod tests {
             Some("Bearer runtime-secret"),
         );
         assert!(client.has_service_auth());
+    }
+
+    #[tokio::test]
+    async fn submits_execution_plans_with_service_auth() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("listener");
+        let address = listener.local_addr().expect("address");
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                Router::new().route(
+                    "/api/internal/runtime/execution-plans",
+                    post(
+                        |headers: reqwest::header::HeaderMap,
+                         Json(plan): Json<RuntimeExecutionPlan>| async move {
+                            assert_eq!(
+                                headers
+                                    .get("authorization")
+                                    .and_then(|value| value.to_str().ok()),
+                                Some("Bearer runtime-secret"),
+                            );
+                            Json(json!({
+                                "ok": true,
+                                "accepted": true,
+                                "source": "stub",
+                                "coordination": {
+                                    "planId": plan.plan_id,
+                                    "deploymentId": plan.deployment_id,
+                                    "runId": plan.run_id,
+                                    "mode": plan.mode,
+                                    "lane": plan.lane,
+                                    "sliceCount": plan.slices.len(),
+                                }
+                            }))
+                        },
+                    ),
+                ),
+            )
+            .await
+            .expect("server");
+        });
+
+        let client = ExecClient::from_lookup(|key| match key {
+            "RUNTIME_WORKER_API_BASE" => Some(format!("http://{address}")),
+            "RUNTIME_INTERNAL_SERVICE_TOKEN" => Some("runtime-secret".to_string()),
+            _ => None,
+        });
+        let plan = RuntimeExecutionPlan {
+            schema_version: "v1".to_string(),
+            plan_id: "plan_1".to_string(),
+            deployment_id: "dep_1".to_string(),
+            run_id: "run_1".to_string(),
+            created_at: "2026-03-07T19:00:00Z".to_string(),
+            mode: RuntimeMode::Paper,
+            lane: RuntimeLane::Protected,
+            idempotency_key: "dep_1:run_1".to_string(),
+            simulate_only: false,
+            dry_run: true,
+            slices: vec![],
+        };
+
+        let response = client.submit_plan(&plan).await.expect("submit to succeed");
+        assert!(response.accepted);
+        assert_eq!(response.coordination.plan_id, "plan_1");
+        assert_eq!(response.coordination.lane, RuntimeLane::Protected);
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn maps_internal_route_errors_to_canonical_codes() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("listener");
+        let address = listener.local_addr().expect("address");
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                Router::new().route(
+                    "/api/internal/runtime/execution-plans",
+                    post(|| async move {
+                        (
+                            StatusCode::SERVICE_UNAVAILABLE,
+                            Json(json!({
+                                "ok": false,
+                                "error": "runtime-integration-not-configured"
+                            })),
+                        )
+                    }),
+                ),
+            )
+            .await
+            .expect("server");
+        });
+
+        let client = ExecClient::from_lookup(|key| match key {
+            "RUNTIME_WORKER_API_BASE" => Some(format!("http://{address}")),
+            _ => None,
+        });
+        let plan = RuntimeExecutionPlan {
+            schema_version: "v1".to_string(),
+            plan_id: "plan_2".to_string(),
+            deployment_id: "dep_2".to_string(),
+            run_id: "run_2".to_string(),
+            created_at: "2026-03-07T19:00:00Z".to_string(),
+            mode: RuntimeMode::Shadow,
+            lane: RuntimeLane::Safe,
+            idempotency_key: "dep_2:run_2".to_string(),
+            simulate_only: true,
+            dry_run: true,
+            slices: vec![],
+        };
+
+        let error = client
+            .submit_plan(&plan)
+            .await
+            .expect_err("submit should fail");
+        assert_eq!(error.code, ExecClientErrorCode::NotReady);
+        assert_eq!(error.status, 503);
+
+        server.abort();
     }
 }

--- a/crates/execution-planner/Cargo.toml
+++ b/crates/execution-planner/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "execution-planner"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+feature-cache = { path = "../feature-cache" }
+protocol = { path = "../protocol" }
+rusqlite = { version = "0.37.0", features = ["bundled"] }
+serde.workspace = true
+serde_json.workspace = true
+sha2 = "0.10.9"
+thiserror.workspace = true
+time = { version = "=0.3.44", features = ["formatting", "parsing"] }

--- a/crates/execution-planner/src/lib.rs
+++ b/crates/execution-planner/src/lib.rs
@@ -1,0 +1,937 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use feature_cache::DerivedMarketFeatureSnapshot;
+use protocol::{
+    RuntimeDeploymentRecord, RuntimeExecutionAction, RuntimeExecutionPlan, RuntimeExecutionSlice,
+    RuntimeLane, RuntimeLedgerBalance, RuntimeLedgerSnapshot, RuntimeMode, RuntimeRiskDecision,
+    RuntimeRiskVerdict, RuntimeRunRecord, RUNTIME_PROTOCOL_SCHEMA_VERSION,
+};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use time::OffsetDateTime;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionPlannerConfig {
+    pub database_url: String,
+}
+
+impl ExecutionPlannerConfig {
+    #[must_use]
+    pub fn new(database_url: impl Into<String>) -> Self {
+        Self {
+            database_url: database_url.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ExecutionPlanner {
+    database_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecutionPlannerSnapshot {
+    pub status: String,
+    pub plan_count: u64,
+    pub latest_plan_at: Option<String>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionPlannerInput {
+    pub deployment: RuntimeDeploymentRecord,
+    pub run: RuntimeRunRecord,
+    pub feature_snapshot: DerivedMarketFeatureSnapshot,
+    pub ledger_snapshot: RuntimeLedgerSnapshot,
+    pub risk_verdict: RuntimeRiskVerdict,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionPlanningResult {
+    pub plan: RuntimeExecutionPlan,
+    pub created: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum ExecutionPlannerError {
+    #[error("storage io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("storage error: {0}")]
+    Storage(#[from] rusqlite::Error),
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("invalid usd amount for {field}: {value}")]
+    InvalidUsdAmount { field: &'static str, value: String },
+    #[error("invalid numeric value for {field}: {value}")]
+    InvalidNumericValue { field: &'static str, value: String },
+    #[error("risk verdict {verdict_id} is not allow")]
+    RiskNotAllowed { verdict_id: String },
+    #[error("execution plan {plan_id} not found")]
+    PlanNotFound { plan_id: String },
+}
+
+impl ExecutionPlanner {
+    pub fn new(config: ExecutionPlannerConfig) -> Result<Self, ExecutionPlannerError> {
+        let requested_path = normalize_database_path(&config.database_url);
+        match Self::initialize_at_path(requested_path.clone()) {
+            Ok(planner) => Ok(planner),
+            Err(error) if should_fallback_to_tmp(&requested_path, &error) => {
+                Self::initialize_at_path(fallback_database_path())
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    pub fn plan_and_store(
+        &self,
+        input: &ExecutionPlannerInput,
+    ) -> Result<ExecutionPlanningResult, ExecutionPlannerError> {
+        let mut connection = self.open_connection()?;
+        let transaction = connection.transaction()?;
+
+        if let Some(existing) = load_plan_by_run_id(&transaction, &input.run.run_id)? {
+            transaction.commit()?;
+            return Ok(ExecutionPlanningResult {
+                plan: existing,
+                created: false,
+            });
+        }
+
+        let plan = build_plan(input)?;
+        persist_plan(&transaction, &plan)?;
+        transaction.commit()?;
+
+        Ok(ExecutionPlanningResult {
+            plan,
+            created: true,
+        })
+    }
+
+    pub fn get_plan(
+        &self,
+        plan_id: &str,
+    ) -> Result<Option<RuntimeExecutionPlan>, ExecutionPlannerError> {
+        let connection = self.open_connection()?;
+        load_plan(&connection, plan_id)
+    }
+
+    pub fn list_plans(
+        &self,
+        deployment_id: &str,
+    ) -> Result<Vec<RuntimeExecutionPlan>, ExecutionPlannerError> {
+        let connection = self.open_connection()?;
+        let mut statement = connection.prepare(
+            "SELECT record_json
+             FROM execution_plans
+             WHERE deployment_id = ?1
+             ORDER BY created_at DESC, plan_id DESC",
+        )?;
+        let rows = statement.query_map(params![deployment_id], |row| row.get::<_, String>(0))?;
+        let mut plans = Vec::new();
+        for row in rows {
+            plans.push(deserialize_json(&row?)?);
+        }
+        Ok(plans)
+    }
+
+    #[must_use]
+    pub fn snapshot_now(&self) -> ExecutionPlannerSnapshot {
+        match self.snapshot_counts() {
+            Ok((plan_count, latest_plan_at)) => ExecutionPlannerSnapshot {
+                status: "healthy".to_string(),
+                plan_count,
+                latest_plan_at,
+                last_error: None,
+            },
+            Err(error) => ExecutionPlannerSnapshot {
+                status: "degraded".to_string(),
+                plan_count: 0,
+                latest_plan_at: None,
+                last_error: Some(error.to_string()),
+            },
+        }
+    }
+
+    fn snapshot_counts(&self) -> Result<(u64, Option<String>), ExecutionPlannerError> {
+        let connection = self.open_connection()?;
+        let plan_count =
+            connection.query_row("SELECT COUNT(*) FROM execution_plans", [], |row| {
+                row.get::<_, u64>(0)
+            })?;
+        let latest_plan_at = connection
+            .query_row(
+                "SELECT created_at
+                 FROM execution_plans
+                 ORDER BY created_at DESC, plan_id DESC
+                 LIMIT 1",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        Ok((plan_count, latest_plan_at))
+    }
+
+    fn open_connection(&self) -> Result<Connection, ExecutionPlannerError> {
+        let connection = Connection::open(&self.database_path)?;
+        connection.busy_timeout(std::time::Duration::from_secs(5))?;
+        connection.pragma_update(None, "foreign_keys", "ON")?;
+        Ok(connection)
+    }
+
+    fn initialize_at_path(database_path: PathBuf) -> Result<Self, ExecutionPlannerError> {
+        if database_path != Path::new(":memory:") {
+            if let Some(parent) = database_path
+                .parent()
+                .filter(|path| !path.as_os_str().is_empty())
+            {
+                fs::create_dir_all(parent)?;
+            }
+        }
+        let planner = Self { database_path };
+        let connection = planner.open_connection()?;
+        initialize_schema(&connection)?;
+        Ok(planner)
+    }
+}
+
+fn initialize_schema(connection: &Connection) -> Result<(), rusqlite::Error> {
+    connection.execute_batch(
+        "CREATE TABLE IF NOT EXISTS execution_plans (
+            plan_id TEXT PRIMARY KEY,
+            deployment_id TEXT NOT NULL,
+            run_id TEXT NOT NULL UNIQUE,
+            lane TEXT NOT NULL,
+            mode TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            record_json TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_execution_plans_deployment_created
+            ON execution_plans (deployment_id, created_at DESC);",
+    )
+}
+
+fn normalize_database_path(database_url: &str) -> PathBuf {
+    let trimmed = database_url.trim();
+    if trimmed.is_empty() {
+        return PathBuf::from(".tmp/runtime-rs/execution-planner.sqlite3");
+    }
+    if let Some(stripped) = trimmed.strip_prefix("sqlite://") {
+        return PathBuf::from(stripped);
+    }
+    if let Some(stripped) = trimmed.strip_prefix("file:") {
+        return PathBuf::from(stripped);
+    }
+    PathBuf::from(trimmed)
+}
+
+fn fallback_database_path() -> PathBuf {
+    std::env::temp_dir()
+        .join("runtime-rs")
+        .join("execution-planner.sqlite3")
+}
+
+fn should_fallback_to_tmp(database_path: &Path, error: &ExecutionPlannerError) -> bool {
+    if database_path == Path::new(":memory:") || database_path == fallback_database_path() {
+        return false;
+    }
+
+    match error {
+        ExecutionPlannerError::Io(inner) => inner.kind() == std::io::ErrorKind::PermissionDenied,
+        ExecutionPlannerError::Storage(inner) => {
+            matches!(
+                inner,
+                rusqlite::Error::SqliteFailure(code, _)
+                    if code.code == rusqlite::ErrorCode::CannotOpen
+            )
+        }
+        ExecutionPlannerError::Serialization(_)
+        | ExecutionPlannerError::InvalidUsdAmount { .. }
+        | ExecutionPlannerError::InvalidNumericValue { .. }
+        | ExecutionPlannerError::RiskNotAllowed { .. }
+        | ExecutionPlannerError::PlanNotFound { .. } => false,
+    }
+}
+
+fn build_plan(
+    input: &ExecutionPlannerInput,
+) -> Result<RuntimeExecutionPlan, ExecutionPlannerError> {
+    if input.risk_verdict.verdict != RuntimeRiskDecision::Allow {
+        return Err(ExecutionPlannerError::RiskNotAllowed {
+            verdict_id: input.risk_verdict.verdict_id.clone(),
+        });
+    }
+
+    let lane = selected_lane(&input.deployment);
+    let (simulate_only, dry_run) = execution_flags(&input.deployment.mode);
+    let notional_cents = desired_notional_cents(&input.deployment)?;
+    let mid_price = parse_decimal(
+        "featureSnapshot.midPriceUsd",
+        &input.feature_snapshot.mid_price_usd,
+    )?;
+    let quote_decimals = balance_decimals(
+        &input.ledger_snapshot.balances,
+        &input.deployment.pair.quote_mint,
+        6,
+    );
+    let base_decimals = balance_decimals(
+        &input.ledger_snapshot.balances,
+        &input.deployment.pair.base_mint,
+        9,
+    );
+    let action = plan_action(input)?;
+    let slippage_bps = input.deployment.policy.max_slippage_bps;
+    let notional_usd = format_usd_cents(notional_cents);
+    let input_amount_atomic = match action {
+        RuntimeExecutionAction::Buy | RuntimeExecutionAction::Rebalance => {
+            atomic_from_usd_cents(notional_cents, quote_decimals)
+        }
+        RuntimeExecutionAction::Sell => {
+            let quantity = ((notional_cents as f64) / 100.0) / mid_price;
+            atomic_from_token_amount(quantity, base_decimals)
+        }
+    };
+    let min_output_amount_atomic = Some(match action {
+        RuntimeExecutionAction::Buy | RuntimeExecutionAction::Rebalance => {
+            let quantity = (((notional_cents as f64) / 100.0) / mid_price)
+                * (1.0 - (f64::from(slippage_bps) / 10_000.0));
+            atomic_from_token_amount(quantity, base_decimals)
+        }
+        RuntimeExecutionAction::Sell => {
+            let output_usd =
+                ((notional_cents as f64) / 100.0) * (1.0 - (f64::from(slippage_bps) / 10_000.0));
+            atomic_from_token_amount(output_usd, quote_decimals)
+        }
+    });
+    let (input_mint, output_mint) = match action {
+        RuntimeExecutionAction::Buy | RuntimeExecutionAction::Rebalance => (
+            input.deployment.pair.quote_mint.clone(),
+            input.deployment.pair.base_mint.clone(),
+        ),
+        RuntimeExecutionAction::Sell => (
+            input.deployment.pair.base_mint.clone(),
+            input.deployment.pair.quote_mint.clone(),
+        ),
+    };
+    let idempotency_key = format!("{}:{}", input.deployment.deployment_id, input.run.run_id);
+
+    Ok(RuntimeExecutionPlan {
+        schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+        plan_id: build_plan_id(&idempotency_key),
+        deployment_id: input.deployment.deployment_id.clone(),
+        run_id: input.run.run_id.clone(),
+        created_at: now_rfc3339(),
+        mode: input.deployment.mode.clone(),
+        lane,
+        idempotency_key,
+        simulate_only,
+        dry_run,
+        slices: vec![RuntimeExecutionSlice {
+            slice_id: "slice_1".to_string(),
+            action,
+            input_mint,
+            output_mint,
+            input_amount_atomic,
+            min_output_amount_atomic,
+            notional_usd,
+            slippage_bps,
+        }],
+    })
+}
+
+fn plan_action(
+    input: &ExecutionPlannerInput,
+) -> Result<RuntimeExecutionAction, ExecutionPlannerError> {
+    let signal = input
+        .feature_snapshot
+        .short_return_bps
+        .as_deref()
+        .map(|value| parse_signed_decimal("featureSnapshot.shortReturnBps", value))
+        .transpose()?
+        .unwrap_or(0.0);
+    Ok(match input.deployment.strategy_key.as_str() {
+        "threshold_rebalance" => RuntimeExecutionAction::Rebalance,
+        "trend_following" => {
+            if signal >= 0.0 {
+                RuntimeExecutionAction::Buy
+            } else {
+                RuntimeExecutionAction::Sell
+            }
+        }
+        "mean_reversion" => {
+            if signal >= 0.0 {
+                RuntimeExecutionAction::Sell
+            } else {
+                RuntimeExecutionAction::Buy
+            }
+        }
+        _ => RuntimeExecutionAction::Buy,
+    })
+}
+
+fn selected_lane(deployment: &RuntimeDeploymentRecord) -> RuntimeLane {
+    if deployment.mode == RuntimeMode::Shadow {
+        RuntimeLane::Safe
+    } else {
+        deployment.lane.clone()
+    }
+}
+
+fn execution_flags(mode: &RuntimeMode) -> (bool, bool) {
+    match mode {
+        RuntimeMode::Shadow => (true, true),
+        RuntimeMode::Paper => (false, true),
+        RuntimeMode::Live => (false, false),
+    }
+}
+
+fn desired_notional_cents(
+    deployment: &RuntimeDeploymentRecord,
+) -> Result<i64, ExecutionPlannerError> {
+    let reserved_cents =
+        parse_non_negative_usd_cents("capital.reservedUsd", &deployment.capital.reserved_usd)?;
+    let max_notional_cents =
+        parse_non_negative_usd_cents("policy.maxNotionalUsd", &deployment.policy.max_notional_usd)?;
+    Ok(reserved_cents.min(max_notional_cents))
+}
+
+fn balance_decimals(balances: &[RuntimeLedgerBalance], mint: &str, fallback: u8) -> u8 {
+    balances
+        .iter()
+        .find(|balance| balance.mint == mint)
+        .map(|balance| balance.decimals)
+        .unwrap_or(fallback)
+}
+
+fn atomic_from_usd_cents(cents: i64, decimals: u8) -> String {
+    let multiplier = 10_i128.pow(u32::from(decimals.saturating_sub(2)));
+    (i128::from(cents) * multiplier).to_string()
+}
+
+fn atomic_from_token_amount(amount: f64, decimals: u8) -> String {
+    let scale = 10_f64.powi(i32::from(decimals));
+    amount.max(0.0).mul_add(scale, 0.0).floor().to_string()
+}
+
+fn parse_decimal(field: &'static str, value: &str) -> Result<f64, ExecutionPlannerError> {
+    value
+        .trim()
+        .parse::<f64>()
+        .ok()
+        .filter(|parsed| parsed.is_finite() && *parsed >= 0.0)
+        .ok_or_else(|| ExecutionPlannerError::InvalidNumericValue {
+            field,
+            value: value.to_string(),
+        })
+}
+
+fn parse_signed_decimal(field: &'static str, value: &str) -> Result<f64, ExecutionPlannerError> {
+    value
+        .trim()
+        .parse::<f64>()
+        .ok()
+        .filter(|parsed| parsed.is_finite())
+        .ok_or_else(|| ExecutionPlannerError::InvalidNumericValue {
+            field,
+            value: value.to_string(),
+        })
+}
+
+fn load_plan(
+    connection: &Connection,
+    plan_id: &str,
+) -> Result<Option<RuntimeExecutionPlan>, ExecutionPlannerError> {
+    let raw = connection
+        .query_row(
+            "SELECT record_json FROM execution_plans WHERE plan_id = ?1",
+            params![plan_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    Ok(raw.map(|value| deserialize_json(&value)).transpose()?)
+}
+
+fn load_plan_by_run_id(
+    connection: &Connection,
+    run_id: &str,
+) -> Result<Option<RuntimeExecutionPlan>, ExecutionPlannerError> {
+    let raw = connection
+        .query_row(
+            "SELECT record_json FROM execution_plans WHERE run_id = ?1",
+            params![run_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    Ok(raw.map(|value| deserialize_json(&value)).transpose()?)
+}
+
+fn persist_plan(
+    connection: &Connection,
+    plan: &RuntimeExecutionPlan,
+) -> Result<(), ExecutionPlannerError> {
+    connection.execute(
+        "INSERT INTO execution_plans (
+            plan_id,
+            deployment_id,
+            run_id,
+            lane,
+            mode,
+            created_at,
+            record_json
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            &plan.plan_id,
+            &plan.deployment_id,
+            &plan.run_id,
+            lane_key(&plan.lane),
+            mode_key(&plan.mode),
+            &plan.created_at,
+            serialize_json(plan)?,
+        ],
+    )?;
+    Ok(())
+}
+
+fn lane_key(lane: &RuntimeLane) -> &'static str {
+    match lane {
+        RuntimeLane::Safe => "safe",
+        RuntimeLane::Protected => "protected",
+        RuntimeLane::Fast => "fast",
+    }
+}
+
+fn mode_key(mode: &RuntimeMode) -> &'static str {
+    match mode {
+        RuntimeMode::Shadow => "shadow",
+        RuntimeMode::Paper => "paper",
+        RuntimeMode::Live => "live",
+    }
+}
+
+fn build_plan_id(idempotency_key: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(idempotency_key.as_bytes());
+    let digest = hasher.finalize();
+    format!("plan_{}", hex_encode(&digest[..12]))
+}
+
+fn parse_usd_cents(field: &'static str, value: &str) -> Result<i64, ExecutionPlannerError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(ExecutionPlannerError::InvalidUsdAmount {
+            field,
+            value: trimmed.to_string(),
+        });
+    }
+
+    let (sign, digits) = if let Some(rest) = trimmed.strip_prefix('-') {
+        (-1_i64, rest)
+    } else if let Some(rest) = trimmed.strip_prefix('+') {
+        (1_i64, rest)
+    } else {
+        (1_i64, trimmed)
+    };
+
+    let (whole_raw, fraction_raw) = digits.split_once('.').unwrap_or((digits, ""));
+    if whole_raw.is_empty()
+        || !whole_raw
+            .chars()
+            .all(|character| character.is_ascii_digit())
+        || !fraction_raw
+            .chars()
+            .all(|character| character.is_ascii_digit())
+    {
+        return Err(ExecutionPlannerError::InvalidUsdAmount {
+            field,
+            value: trimmed.to_string(),
+        });
+    }
+
+    let whole = whole_raw
+        .parse::<i64>()
+        .map_err(|_| ExecutionPlannerError::InvalidUsdAmount {
+            field,
+            value: trimmed.to_string(),
+        })?;
+    let fraction_bytes = fraction_raw.as_bytes();
+    let tenths = fraction_bytes
+        .first()
+        .map(|digit| i64::from(digit - b'0'))
+        .unwrap_or(0);
+    let hundredths = fraction_bytes
+        .get(1)
+        .map(|digit| i64::from(digit - b'0'))
+        .unwrap_or(0);
+    let mut fraction = tenths * 10 + hundredths;
+    if fraction_bytes.get(2).is_some_and(|digit| *digit >= b'5') {
+        fraction += 1;
+    }
+    let cents = whole
+        .checked_mul(100)
+        .and_then(|value| value.checked_add(fraction))
+        .ok_or_else(|| ExecutionPlannerError::InvalidUsdAmount {
+            field,
+            value: trimmed.to_string(),
+        })?;
+
+    Ok(sign * cents)
+}
+
+fn parse_non_negative_usd_cents(
+    field: &'static str,
+    value: &str,
+) -> Result<i64, ExecutionPlannerError> {
+    let cents = parse_usd_cents(field, value)?;
+    if cents < 0 {
+        return Err(ExecutionPlannerError::InvalidUsdAmount {
+            field,
+            value: value.trim().to_string(),
+        });
+    }
+    Ok(cents)
+}
+
+fn format_usd_cents(value: i64) -> String {
+    let sign = if value < 0 { "-" } else { "" };
+    let absolute = value.abs();
+    format!("{sign}{}.{:02}", absolute / 100, absolute % 100)
+}
+
+fn serialize_json<T: Serialize>(value: &T) -> Result<String, serde_json::Error> {
+    serde_json::to_string(value)
+}
+
+fn deserialize_json<T: for<'de> Deserialize<'de>>(raw: &str) -> Result<T, serde_json::Error> {
+    serde_json::from_str(raw)
+}
+
+fn hex_encode(input: &[u8]) -> String {
+    let mut output = String::with_capacity(input.len() * 2);
+    for byte in input {
+        use std::fmt::Write as _;
+        let _ = write!(&mut output, "{byte:02x}");
+    }
+    output
+}
+
+fn now_rfc3339() -> String {
+    OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .expect("current time to format")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use protocol::{
+        RuntimeCapital, RuntimeDeploymentState, RuntimeLedgerTotals, RuntimePair, RuntimePolicy,
+        RuntimeRiskLimits, RuntimeRiskObserved, RuntimeRiskReason, RuntimeRiskSeverity,
+        RuntimeRunState, RuntimeTrigger, RuntimeTriggerKind,
+    };
+
+    use super::*;
+
+    fn temp_database_url(test_name: &str) -> String {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        std::env::temp_dir()
+            .join(format!("execution-planner-{test_name}-{unique}.sqlite3"))
+            .display()
+            .to_string()
+    }
+
+    fn planner(test_name: &str) -> ExecutionPlanner {
+        ExecutionPlanner::new(ExecutionPlannerConfig::new(temp_database_url(test_name)))
+            .expect("planner to initialize")
+    }
+
+    fn deployment(
+        strategy_key: &str,
+        mode: RuntimeMode,
+        lane: RuntimeLane,
+    ) -> RuntimeDeploymentRecord {
+        RuntimeDeploymentRecord {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            deployment_id: "dep_1".to_string(),
+            strategy_key: strategy_key.to_string(),
+            sleeve_id: "sleeve_1".to_string(),
+            owner_user_id: "user_1".to_string(),
+            pair: RuntimePair {
+                symbol: "SOL/USDC".to_string(),
+                base_mint: "So11111111111111111111111111111111111111112".to_string(),
+                quote_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+            },
+            mode,
+            state: RuntimeDeploymentState::Shadow,
+            lane,
+            created_at: "2026-03-07T18:00:00Z".to_string(),
+            updated_at: "2026-03-07T18:00:00Z".to_string(),
+            promoted_at: None,
+            paused_at: None,
+            killed_at: None,
+            policy: RuntimePolicy {
+                max_notional_usd: "25".to_string(),
+                daily_loss_limit_usd: "35".to_string(),
+                max_slippage_bps: 50,
+                max_concurrent_runs: 2,
+                rebalance_tolerance_bps: 100,
+            },
+            capital: RuntimeCapital {
+                allocated_usd: "100".to_string(),
+                reserved_usd: "5".to_string(),
+                available_usd: "95".to_string(),
+            },
+            tags: vec!["fixture".to_string()],
+        }
+    }
+
+    fn run(run_id: &str) -> RuntimeRunRecord {
+        RuntimeRunRecord {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            run_id: run_id.to_string(),
+            deployment_id: "dep_1".to_string(),
+            run_key: format!("dep_1:{run_id}"),
+            trigger: RuntimeTrigger {
+                kind: RuntimeTriggerKind::Signal,
+                source: "test".to_string(),
+                observed_at: "2026-03-07T18:05:00Z".to_string(),
+                feature_snapshot_id: Some("snapshot_1".to_string()),
+                reason: Some("test".to_string()),
+            },
+            state: RuntimeRunState::Planned,
+            planned_at: "2026-03-07T18:05:00Z".to_string(),
+            updated_at: "2026-03-07T18:05:00Z".to_string(),
+            risk_verdict_id: Some("risk_1".to_string()),
+            execution_plan_id: None,
+            submit_request_id: None,
+            receipt_id: None,
+            failure_code: None,
+            failure_message: None,
+        }
+    }
+
+    fn feature_snapshot(short_return_bps: &str) -> DerivedMarketFeatureSnapshot {
+        DerivedMarketFeatureSnapshot {
+            cache_key: "fixture:SOL/USDC".to_string(),
+            symbol: "SOL/USDC".to_string(),
+            source: "fixture".to_string(),
+            last_sequence: 1,
+            observed_at: "2026-03-07T18:05:00Z".to_string(),
+            age_ms: 100,
+            stale: false,
+            stale_reasons: Vec::new(),
+            sample_count: 8,
+            window_short_ms: 10_000,
+            window_long_ms: 25_000,
+            mid_price_usd: "150.00".to_string(),
+            bid_price_usd: Some("149.95".to_string()),
+            ask_price_usd: Some("150.05".to_string()),
+            spread_bps: Some("15.0".to_string()),
+            short_return_bps: Some(short_return_bps.to_string()),
+            long_return_bps: Some("20.0".to_string()),
+            realized_volatility_bps: Some("18.0".to_string()),
+            processed_slot: Some(123),
+            slot_age_ms: Some(100),
+            slot_gap: Some(0),
+            last_ingest_lag_ms: 10,
+        }
+    }
+
+    fn ledger_snapshot() -> RuntimeLedgerSnapshot {
+        RuntimeLedgerSnapshot {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            snapshot_id: "ledger_1".to_string(),
+            deployment_id: "dep_1".to_string(),
+            sleeve_id: "sleeve_1".to_string(),
+            as_of: "2026-03-07T18:05:00Z".to_string(),
+            balances: vec![
+                RuntimeLedgerBalance {
+                    mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+                    symbol: "USDC".to_string(),
+                    decimals: 6,
+                    free_atomic: "95000000".to_string(),
+                    reserved_atomic: "5000000".to_string(),
+                    price_usd: Some("1.00".to_string()),
+                },
+                RuntimeLedgerBalance {
+                    mint: "So11111111111111111111111111111111111111112".to_string(),
+                    symbol: "SOL".to_string(),
+                    decimals: 9,
+                    free_atomic: "100000000".to_string(),
+                    reserved_atomic: "0".to_string(),
+                    price_usd: Some("150.00".to_string()),
+                },
+            ],
+            positions: Vec::new(),
+            totals: RuntimeLedgerTotals {
+                equity_usd: "100".to_string(),
+                reserved_usd: "5".to_string(),
+                available_usd: "95".to_string(),
+                realized_pnl_usd: "0".to_string(),
+                unrealized_pnl_usd: "0".to_string(),
+            },
+        }
+    }
+
+    fn allow_verdict() -> RuntimeRiskVerdict {
+        RuntimeRiskVerdict {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            verdict_id: "risk_1".to_string(),
+            deployment_id: "dep_1".to_string(),
+            run_id: "run_1".to_string(),
+            decided_at: "2026-03-07T18:05:01Z".to_string(),
+            verdict: RuntimeRiskDecision::Allow,
+            reasons: vec![RuntimeRiskReason {
+                code: "within_limits".to_string(),
+                message: "within limits".to_string(),
+                severity: RuntimeRiskSeverity::Info,
+            }],
+            observed: RuntimeRiskObserved {
+                requested_notional_usd: "5".to_string(),
+                reserved_usd: "5".to_string(),
+                concentration_bps: 500,
+                feature_age_ms: 100,
+            },
+            limits: RuntimeRiskLimits {
+                max_notional_usd: "25".to_string(),
+                max_reserved_usd: "50".to_string(),
+                max_concentration_bps: 3500,
+                stale_after_ms: 5000,
+            },
+        }
+    }
+
+    fn input(
+        run_id: &str,
+        strategy_key: &str,
+        mode: RuntimeMode,
+        lane: RuntimeLane,
+        short_return_bps: &str,
+    ) -> ExecutionPlannerInput {
+        let mut verdict = allow_verdict();
+        verdict.run_id = run_id.to_string();
+        ExecutionPlannerInput {
+            deployment: deployment(strategy_key, mode, lane),
+            run: run(run_id),
+            feature_snapshot: feature_snapshot(short_return_bps),
+            ledger_snapshot: ledger_snapshot(),
+            risk_verdict: verdict,
+        }
+    }
+
+    #[test]
+    fn builds_shadow_dca_plans_deterministically() {
+        let planner = planner("shadow-dca");
+        let result = planner
+            .plan_and_store(&input(
+                "run_1",
+                "dca",
+                RuntimeMode::Shadow,
+                RuntimeLane::Fast,
+                "10.0",
+            ))
+            .expect("plan to store");
+
+        assert!(result.created);
+        assert_eq!(result.plan.lane, RuntimeLane::Safe);
+        assert!(result.plan.simulate_only);
+        assert!(result.plan.dry_run);
+        assert_eq!(result.plan.slices[0].action, RuntimeExecutionAction::Buy);
+        assert_eq!(result.plan.slices[0].input_amount_atomic, "5000000");
+    }
+
+    #[test]
+    fn preserves_lane_for_paper_mode() {
+        let planner = planner("paper-lane");
+        let result = planner
+            .plan_and_store(&input(
+                "run_2",
+                "dca",
+                RuntimeMode::Paper,
+                RuntimeLane::Protected,
+                "10.0",
+            ))
+            .expect("plan to store");
+
+        assert_eq!(result.plan.lane, RuntimeLane::Protected);
+        assert!(!result.plan.simulate_only);
+        assert!(result.plan.dry_run);
+    }
+
+    #[test]
+    fn trend_following_can_plan_sells() {
+        let planner = planner("sell");
+        let result = planner
+            .plan_and_store(&input(
+                "run_3",
+                "trend_following",
+                RuntimeMode::Paper,
+                RuntimeLane::Fast,
+                "-15.0",
+            ))
+            .expect("plan to store");
+
+        assert_eq!(result.plan.slices[0].action, RuntimeExecutionAction::Sell);
+        assert_eq!(
+            result.plan.slices[0].input_mint,
+            "So11111111111111111111111111111111111111112"
+        );
+    }
+
+    #[test]
+    fn is_idempotent_for_existing_run_ids() {
+        let planner = planner("idempotent");
+        let first = planner
+            .plan_and_store(&input(
+                "run_4",
+                "dca",
+                RuntimeMode::Shadow,
+                RuntimeLane::Safe,
+                "10.0",
+            ))
+            .expect("first plan");
+        let second = planner
+            .plan_and_store(&input(
+                "run_4",
+                "dca",
+                RuntimeMode::Shadow,
+                RuntimeLane::Safe,
+                "10.0",
+            ))
+            .expect("second plan");
+
+        assert!(first.created);
+        assert!(!second.created);
+        assert_eq!(first.plan.plan_id, second.plan.plan_id);
+    }
+
+    #[test]
+    fn rejects_non_allow_risk_verdicts() {
+        let planner = planner("deny");
+        let mut input = input(
+            "run_5",
+            "dca",
+            RuntimeMode::Shadow,
+            RuntimeLane::Safe,
+            "10.0",
+        );
+        input.risk_verdict.verdict = RuntimeRiskDecision::Reject;
+
+        let error = planner
+            .plan_and_store(&input)
+            .expect_err("rejected verdict should fail");
+
+        assert!(matches!(
+            error,
+            ExecutionPlannerError::RiskNotAllowed { .. }
+        ));
+    }
+}

--- a/crates/runtime-ops/src/lib.rs
+++ b/crates/runtime-ops/src/lib.rs
@@ -39,6 +39,9 @@ pub struct RuntimeConfig {
     pub log_level: String,
     pub protocol_version: String,
     pub internal_service_token: Option<String>,
+    pub worker_api_base: String,
+    pub worker_execution_plan_path: String,
+    pub worker_health_path: String,
     pub database_url: String,
     pub feed_provider: String,
     pub feed_websocket_url: String,
@@ -81,6 +84,14 @@ impl RuntimeConfig {
             internal_service_token: lookup("RUNTIME_INTERNAL_SERVICE_TOKEN")
                 .map(|value| value.trim().to_string())
                 .filter(|value| !value.is_empty()),
+            worker_api_base: lookup("RUNTIME_WORKER_API_BASE")
+                .unwrap_or_else(|| "http://127.0.0.1:8888".to_string())
+                .trim_end_matches('/')
+                .to_string(),
+            worker_execution_plan_path: lookup("RUNTIME_WORKER_EXECUTION_PLAN_PATH")
+                .unwrap_or_else(|| "/api/internal/runtime/execution-plans".to_string()),
+            worker_health_path: lookup("RUNTIME_WORKER_HEALTH_PATH")
+                .unwrap_or_else(|| "/api/internal/runtime/health".to_string()),
             database_url: lookup("RUNTIME_DATABASE_URL")
                 .map(|value| value.trim().to_string())
                 .filter(|value| !value.is_empty())
@@ -170,6 +181,12 @@ mod tests {
         assert_eq!(config.environment, RuntimeEnvironment::Local);
         assert_eq!(config.protocol_version, "v1");
         assert_eq!(config.internal_service_token, None);
+        assert_eq!(config.worker_api_base, "http://127.0.0.1:8888");
+        assert_eq!(
+            config.worker_execution_plan_path,
+            "/api/internal/runtime/execution-plans"
+        );
+        assert_eq!(config.worker_health_path, "/api/internal/runtime/health");
         assert_eq!(
             config.database_url,
             ".tmp/runtime-rs/strategy-registry.sqlite3"
@@ -193,6 +210,11 @@ mod tests {
             "RUNTIME_RS_ENV" => Some("preview".to_string()),
             "RUNTIME_RS_LOG" => Some("debug".to_string()),
             "RUNTIME_INTERNAL_SERVICE_TOKEN" => Some("runtime-token".to_string()),
+            "RUNTIME_WORKER_API_BASE" => Some("https://worker.preview.internal".to_string()),
+            "RUNTIME_WORKER_EXECUTION_PLAN_PATH" => {
+                Some("/api/internal/runtime/execution-plans".to_string())
+            }
+            "RUNTIME_WORKER_HEALTH_PATH" => Some("/api/internal/runtime/health".to_string()),
             "RUNTIME_DATABASE_URL" => Some("/tmp/runtime-state.sqlite3".to_string()),
             "RUNTIME_FEED_PROVIDER" => Some("jupiter".to_string()),
             "RUNTIME_FEED_WS_URL" => Some("wss://feeds.jupiter.example/runtime".to_string()),
@@ -217,6 +239,12 @@ mod tests {
             config.internal_service_token.as_deref(),
             Some("runtime-token")
         );
+        assert_eq!(config.worker_api_base, "https://worker.preview.internal");
+        assert_eq!(
+            config.worker_execution_plan_path,
+            "/api/internal/runtime/execution-plans"
+        );
+        assert_eq!(config.worker_health_path, "/api/internal/runtime/health");
         assert_eq!(config.database_url, "/tmp/runtime-state.sqlite3");
         assert_eq!(config.feed_provider, "jupiter");
         assert_eq!(

--- a/crates/strategy-registry/src/lib.rs
+++ b/crates/strategy-registry/src/lib.rs
@@ -313,6 +313,48 @@ impl StrategyRegistry {
         Ok(run)
     }
 
+    pub fn apply_execution_plan(
+        &self,
+        run_id: &str,
+        plan_id: &str,
+        submit_request_id: Option<&str>,
+        complete_immediately: bool,
+    ) -> Result<RuntimeRunRecord, StrategyRegistryError> {
+        let mut connection = self.open_connection()?;
+        let transaction = connection.transaction()?;
+        let mut run =
+            load_run(&transaction, run_id)?.ok_or_else(|| StrategyRegistryError::RunNotFound {
+                run_id: run_id.to_string(),
+            })?;
+
+        if run.execution_plan_id.as_deref() == Some(plan_id)
+            && execution_state_matches(run.state.clone(), complete_immediately)
+        {
+            transaction.commit()?;
+            return Ok(run);
+        }
+
+        run.execution_plan_id = Some(plan_id.to_string());
+        if let Some(submit_request_id) = submit_request_id {
+            run.submit_request_id = Some(submit_request_id.to_string());
+        }
+        transition_run_state(
+            &mut run,
+            if complete_immediately {
+                RuntimeRunState::Completed
+            } else {
+                RuntimeRunState::Submitted
+            },
+        )?;
+        run.updated_at = now_rfc3339();
+        run.failure_code = None;
+        run.failure_message = None;
+
+        update_run(&transaction, &run)?;
+        transaction.commit()?;
+        Ok(run)
+    }
+
     pub fn evaluate_shadow_trigger(
         &self,
         deployment_id: &str,
@@ -705,9 +747,19 @@ fn run_state_matches_verdict(state: &RuntimeRunState, verdict: &RuntimeRiskDecis
     matches!(
         (state, verdict),
         (RuntimeRunState::Planned, RuntimeRiskDecision::Allow)
+            | (RuntimeRunState::Submitted, RuntimeRiskDecision::Allow)
+            | (RuntimeRunState::Completed, RuntimeRiskDecision::Allow)
             | (RuntimeRunState::Rejected, RuntimeRiskDecision::Reject)
             | (RuntimeRunState::Killed, RuntimeRiskDecision::Pause)
     )
+}
+
+fn execution_state_matches(state: RuntimeRunState, complete_immediately: bool) -> bool {
+    if complete_immediately {
+        state == RuntimeRunState::Completed
+    } else {
+        state == RuntimeRunState::Submitted
+    }
 }
 
 fn select_feature_snapshot(
@@ -1171,6 +1223,52 @@ mod tests {
 
         assert_eq!(rejected.state, RuntimeRunState::Rejected);
         assert_eq!(rejected.failure_code.as_deref(), Some("cooldown_active"));
+    }
+
+    #[test]
+    fn applies_execution_plans_to_allowed_runs() {
+        let registry = registry("execution-plan");
+        registry
+            .upsert_deployment(&deployment(
+                "deployment_shadow",
+                RuntimeMode::Shadow,
+                RuntimeDeploymentState::Shadow,
+            ))
+            .expect("deployment to store");
+
+        let evaluation = registry
+            .evaluate_shadow_trigger("deployment_shadow", &feature_cache_snapshot(false), None)
+            .expect("run to create");
+        let planned = registry
+            .apply_risk_verdict(&RuntimeRiskVerdict {
+                schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+                verdict_id: "risk_allow".to_string(),
+                deployment_id: "deployment_shadow".to_string(),
+                run_id: evaluation.run.run_id.clone(),
+                decided_at: "2026-03-07T00:00:06.000Z".to_string(),
+                verdict: RuntimeRiskDecision::Allow,
+                reasons: Vec::new(),
+                observed: protocol::RuntimeRiskObserved {
+                    requested_notional_usd: "5.00".to_string(),
+                    reserved_usd: "5.00".to_string(),
+                    concentration_bps: 500,
+                    feature_age_ms: 100,
+                },
+                limits: protocol::RuntimeRiskLimits {
+                    max_notional_usd: "25.00".to_string(),
+                    max_reserved_usd: "50.00".to_string(),
+                    max_concentration_bps: 3500,
+                    stale_after_ms: 20_000,
+                },
+            })
+            .expect("allow verdict to apply");
+
+        let completed = registry
+            .apply_execution_plan(&planned.run_id, "plan_123", None, true)
+            .expect("plan to apply");
+
+        assert_eq!(completed.state, RuntimeRunState::Completed);
+        assert_eq!(completed.execution_plan_id.as_deref(), Some("plan_123"));
     }
 
     #[test]

--- a/services/runtime-rs/Cargo.toml
+++ b/services/runtime-rs/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 axum.workspace = true
+execution-planner = { path = "../../crates/execution-planner" }
 exec-client = { path = "../../crates/exec-client" }
 feature-cache = { path = "../../crates/feature-cache" }
 market-adapters = { path = "../../crates/market-adapters" }

--- a/services/runtime-rs/src/lib.rs
+++ b/services/runtime-rs/src/lib.rs
@@ -1,7 +1,4 @@
-use std::{
-    env,
-    sync::{Arc, RwLock},
-};
+use std::sync::{Arc, RwLock};
 
 use axum::{
     body::Bytes,
@@ -10,7 +7,11 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use exec_client::ExecClient;
+use exec_client::{ExecClient, ExecClientConfig, ExecClientError, ExecSubmitResponse};
+use execution_planner::{
+    ExecutionPlanner, ExecutionPlannerConfig, ExecutionPlannerError, ExecutionPlannerInput,
+    ExecutionPlannerSnapshot,
+};
 use feature_cache::{FeatureCache, FeatureCacheConfig, FeatureCacheSnapshot};
 use market_adapters::{FeedGateway, FeedGatewayConfig, FeedGatewaySnapshot, FeedReplayFixture};
 use portfolio_ledger::{
@@ -49,6 +50,7 @@ pub struct RuntimeAppState {
     strategy_registry: StrategyRegistry,
     portfolio_ledger: PortfolioLedger,
     risk_engine: RiskEngine,
+    execution_planner: ExecutionPlanner,
 }
 
 impl RuntimeAppState {
@@ -74,9 +76,18 @@ impl RuntimeAppState {
             config.feature_stale_after_ms,
         ))
         .expect("risk engine to initialize");
+        let execution_planner =
+            ExecutionPlanner::new(ExecutionPlannerConfig::new(config.database_url.clone()))
+                .expect("execution planner to initialize");
+        let exec_client = ExecClient::new(ExecClientConfig {
+            api_base: config.worker_api_base.clone(),
+            submit_path: config.worker_execution_plan_path.clone(),
+            health_path: config.worker_health_path.clone(),
+            service_auth_token: config.internal_service_token.clone(),
+        });
         Self {
             config,
-            exec_client: ExecClient::from_lookup(|key| env::var(key).ok()),
+            exec_client,
             feed_bootstrap_source,
             feed_bootstrap_error,
             feed_gateway,
@@ -84,6 +95,7 @@ impl RuntimeAppState {
             strategy_registry,
             portfolio_ledger,
             risk_engine,
+            execution_planner,
         }
     }
 
@@ -112,6 +124,10 @@ impl RuntimeAppState {
     fn risk_engine_snapshot(&self) -> RiskEngineSnapshot {
         self.risk_engine.snapshot_now()
     }
+
+    fn execution_planner_snapshot(&self) -> ExecutionPlannerSnapshot {
+        self.execution_planner.snapshot_now()
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -133,6 +149,7 @@ pub struct RuntimeHealthResponse {
     pub strategy_registry: StrategyRegistrySnapshot,
     pub portfolio_ledger: PortfolioLedgerSnapshot,
     pub risk_engine: RiskEngineSnapshot,
+    pub execution_planner: ExecutionPlannerSnapshot,
     pub supported_strategies: Vec<String>,
 }
 
@@ -149,6 +166,7 @@ pub struct RuntimeMetricsResponse {
     pub strategy_registry: StrategyRegistrySnapshot,
     pub portfolio_ledger: PortfolioLedgerSnapshot,
     pub risk_engine: RiskEngineSnapshot,
+    pub execution_planner: ExecutionPlannerSnapshot,
     pub supported_strategies: Vec<String>,
 }
 
@@ -201,6 +219,10 @@ pub fn app(config: RuntimeConfig) -> Router {
             get(list_runs_handler),
         )
         .route(
+            &format!("{INTERNAL_RUNTIME_PREFIX}/execution-plans"),
+            get(execution_plans_handler),
+        )
+        .route(
             &format!("{INTERNAL_RUNTIME_PREFIX}/risk"),
             get(risk_handler),
         )
@@ -219,11 +241,13 @@ fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
     let strategy_registry = state.strategy_registry_snapshot();
     let portfolio_ledger = state.portfolio_ledger_snapshot();
     let risk_engine = state.risk_engine_snapshot();
+    let execution_planner = state.execution_planner_snapshot();
     let status = if feed_gateway.status == "healthy"
         && feature_cache.status == "healthy"
         && strategy_registry.status == "healthy"
         && portfolio_ledger.status == "healthy"
         && risk_engine.status == "healthy"
+        && execution_planner.status == "healthy"
     {
         snapshot.status
     } else {
@@ -246,6 +270,7 @@ fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
         strategy_registry,
         portfolio_ledger,
         risk_engine,
+        execution_planner,
         supported_strategies: SUPPORTED_STRATEGIES
             .iter()
             .map(|strategy| strategy.as_key().to_string())
@@ -265,6 +290,7 @@ fn metrics_response(state: &RuntimeAppState) -> RuntimeMetricsResponse {
         strategy_registry: state.strategy_registry_snapshot(),
         portfolio_ledger: state.portfolio_ledger_snapshot(),
         risk_engine: state.risk_engine_snapshot(),
+        execution_planner: state.execution_planner_snapshot(),
         supported_strategies: SUPPORTED_STRATEGIES
             .iter()
             .map(|strategy| strategy.as_key().to_string())
@@ -479,6 +505,63 @@ async fn evaluate_deployment_handler(
         .strategy_registry
         .apply_risk_verdict(&assessment.verdict)
         .map_err(map_registry_error)?;
+    let mut execution_plan = None;
+    let mut coordination = None;
+    let mut coordinated_run = run.clone();
+    let ledger_snapshot = state
+        .portfolio_ledger
+        .snapshot_for_deployment(&deployment_id)
+        .map_err(map_ledger_error)?;
+
+    if assessment.verdict.verdict == protocol::RuntimeRiskDecision::Allow {
+        if let Some(plan_id) = coordinated_run.execution_plan_id.as_deref() {
+            execution_plan = Some(
+                state
+                    .execution_planner
+                    .get_plan(plan_id)
+                    .map_err(map_execution_planner_error)?
+                    .ok_or_else(|| {
+                        error_json(
+                            StatusCode::NOT_FOUND,
+                            "execution-plan-not-found",
+                            json!({ "planId": plan_id }),
+                        )
+                    })?,
+            );
+        } else {
+            let planning = state
+                .execution_planner
+                .plan_and_store(&ExecutionPlannerInput {
+                    deployment: result.deployment.clone(),
+                    run: coordinated_run.clone(),
+                    feature_snapshot: result.feature_snapshot.clone(),
+                    ledger_snapshot: ledger_snapshot.clone(),
+                    risk_verdict: assessment.verdict.clone(),
+                })
+                .map_err(map_execution_planner_error)?;
+            let plan = planning.plan;
+            let submit = state
+                .exec_client
+                .submit_plan(&plan)
+                .await
+                .map_err(map_exec_client_error)?;
+            coordinated_run = state
+                .strategy_registry
+                .apply_execution_plan(
+                    &coordinated_run.run_id,
+                    &plan.plan_id,
+                    if plan.dry_run {
+                        None
+                    } else {
+                        Some(plan.idempotency_key.as_str())
+                    },
+                    plan.dry_run,
+                )
+                .map_err(map_registry_error)?;
+            execution_plan = Some(plan);
+            coordination = Some(submit);
+        }
+    }
     let (deployment, ledger_snapshot) = if should_pause_runtime(&assessment.verdict) {
         let previous = Some(result.deployment.clone());
         let deployment = state
@@ -496,14 +579,16 @@ async fn evaluate_deployment_handler(
                 .map_err(map_ledger_error)?,
         )
     };
-    Ok(shadow_evaluation_json(
-        result.created,
+    Ok(shadow_evaluation_json(ShadowEvaluationResponse {
+        created: result.created,
         deployment,
-        run,
-        assessment.verdict,
-        result.feature_snapshot,
+        run: coordinated_run,
+        risk_verdict: assessment.verdict,
+        feature_snapshot: result.feature_snapshot,
         ledger_snapshot,
-    ))
+        execution_plan,
+        coordination,
+    }))
 }
 
 async fn list_runs_handler(
@@ -545,6 +630,28 @@ async fn risk_handler(
             "source": "runtime-rs",
             "deploymentId": deployment_id,
             "verdicts": verdicts,
+        }),
+    ))
+}
+
+async fn execution_plans_handler(
+    headers: HeaderMap,
+    Query(query): Query<RuntimeDeploymentQuery>,
+    State(state): State<RuntimeAppState>,
+) -> HandlerResult {
+    authorize_internal_request(&headers, &state)?;
+    let deployment_id = require_deployment_id(query)?;
+    let plans = state
+        .execution_planner
+        .list_plans(&deployment_id)
+        .map_err(map_execution_planner_error)?;
+    Ok(OkJson::with_status(
+        StatusCode::OK,
+        json!({
+            "ok": true,
+            "source": "runtime-rs",
+            "deploymentId": deployment_id,
+            "plans": plans,
         }),
     ))
 }
@@ -594,16 +701,20 @@ async fn pnl_handler(
     ))
 }
 
-fn shadow_evaluation_json(
+struct ShadowEvaluationResponse {
     created: bool,
     deployment: RuntimeDeploymentRecord,
     run: RuntimeRunRecord,
     risk_verdict: protocol::RuntimeRiskVerdict,
     feature_snapshot: feature_cache::DerivedMarketFeatureSnapshot,
     ledger_snapshot: protocol::RuntimeLedgerSnapshot,
-) -> JsonPayload {
+    execution_plan: Option<protocol::RuntimeExecutionPlan>,
+    coordination: Option<ExecSubmitResponse>,
+}
+
+fn shadow_evaluation_json(payload: ShadowEvaluationResponse) -> JsonPayload {
     OkJson::with_status(
-        if created {
+        if payload.created {
             StatusCode::CREATED
         } else {
             StatusCode::OK
@@ -611,12 +722,14 @@ fn shadow_evaluation_json(
         json!({
             "ok": true,
             "source": "runtime-rs",
-            "created": created,
-            "deployment": deployment,
-            "run": run,
-            "riskVerdict": risk_verdict,
-            "featureSnapshot": feature_snapshot,
-            "ledger": ledger_snapshot,
+            "created": payload.created,
+            "deployment": payload.deployment,
+            "run": payload.run,
+            "riskVerdict": payload.risk_verdict,
+            "featureSnapshot": payload.feature_snapshot,
+            "ledger": payload.ledger_snapshot,
+            "executionPlan": payload.execution_plan,
+            "coordination": payload.coordination,
         }),
     )
 }
@@ -856,6 +969,57 @@ fn map_risk_error(error: RiskEngineError) -> JsonPayload {
     }
 }
 
+fn map_execution_planner_error(error: ExecutionPlannerError) -> JsonPayload {
+    match error {
+        ExecutionPlannerError::InvalidUsdAmount { field, value } => error_json(
+            StatusCode::BAD_REQUEST,
+            "invalid-execution-plan-amount",
+            json!({ "field": field, "value": value }),
+        ),
+        ExecutionPlannerError::InvalidNumericValue { field, value } => error_json(
+            StatusCode::BAD_REQUEST,
+            "invalid-execution-plan-number",
+            json!({ "field": field, "value": value }),
+        ),
+        ExecutionPlannerError::RiskNotAllowed { verdict_id } => error_json(
+            StatusCode::CONFLICT,
+            "risk-not-allowed",
+            json!({ "verdictId": verdict_id }),
+        ),
+        ExecutionPlannerError::PlanNotFound { plan_id } => error_json(
+            StatusCode::NOT_FOUND,
+            "execution-plan-not-found",
+            json!({ "planId": plan_id }),
+        ),
+        ExecutionPlannerError::Io(error) => error_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "runtime-execution-plan-error",
+            json!({ "reason": error.to_string() }),
+        ),
+        ExecutionPlannerError::Storage(error) => error_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "runtime-execution-plan-error",
+            json!({ "reason": error.to_string() }),
+        ),
+        ExecutionPlannerError::Serialization(error) => error_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "runtime-execution-plan-error",
+            json!({ "reason": error.to_string() }),
+        ),
+    }
+}
+
+fn map_exec_client_error(error: ExecClientError) -> JsonPayload {
+    error_json(
+        StatusCode::from_u16(error.status).unwrap_or(StatusCode::BAD_GATEWAY),
+        "runtime-exec-coordination-error",
+        json!({
+            "code": error.code,
+            "message": error.message,
+        }),
+    )
+}
+
 fn deployment_has_kill_switch(deployment: &RuntimeDeploymentRecord) -> bool {
     deployment
         .tags
@@ -1079,35 +1243,109 @@ fn apply_fixture(
 
 #[cfg(test)]
 mod tests {
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::{
+        sync::atomic::{AtomicU64, Ordering},
+        time::{SystemTime, UNIX_EPOCH},
+    };
 
     use axum::{
         body::Body,
-        http::{Request, StatusCode},
+        extract::State,
+        http::{HeaderMap, Request, StatusCode},
+        routing::{get, post},
+        Json, Router,
     };
     use http_body_util::BodyExt;
+    use tokio::net::TcpListener;
     use tower::ServiceExt;
 
     use super::*;
+
+    static NEXT_TEST_ID: AtomicU64 = AtomicU64::new(0);
 
     fn temp_database_url(test_name: &str) -> String {
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
             .as_nanos();
+        let sequence = NEXT_TEST_ID.fetch_add(1, Ordering::Relaxed);
         std::env::temp_dir()
-            .join(format!("runtime-rs-{test_name}-{unique}.sqlite3"))
+            .join(format!(
+                "runtime-rs-{test_name}-{unique}-{sequence}.sqlite3"
+            ))
             .display()
             .to_string()
     }
 
+    #[derive(Clone)]
+    struct ExecStubState {
+        expected_auth: String,
+    }
+
     fn test_config() -> RuntimeConfig {
+        test_config_with_worker_api_base(None)
+    }
+
+    fn test_config_with_worker_api_base(worker_api_base: Option<&str>) -> RuntimeConfig {
         RuntimeConfig::from_lookup(|key| match key {
             "RUNTIME_INTERNAL_SERVICE_TOKEN" => Some("runtime-service-secret".to_string()),
+            "RUNTIME_WORKER_API_BASE" => worker_api_base.map(str::to_string),
             "RUNTIME_DATABASE_URL" => Some(temp_database_url("config")),
             _ => None,
         })
         .expect("config to load")
+    }
+
+    async fn spawn_exec_coordination_stub() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener to bind");
+        let address = listener.local_addr().expect("local addr");
+        let app = Router::new()
+            .route(
+                "/api/internal/runtime/health",
+                get(|| async { Json(json!({ "ok": true, "source": "test-stub" })) }),
+            )
+            .route(
+                "/api/internal/runtime/execution-plans",
+                post(
+                    |State(state): State<ExecStubState>,
+                     headers: HeaderMap,
+                     Json(plan): Json<protocol::RuntimeExecutionPlan>| async move {
+                        assert_eq!(
+                            headers
+                                .get("authorization")
+                                .and_then(|value| value.to_str().ok()),
+                            Some(state.expected_auth.as_str())
+                        );
+                        (
+                            StatusCode::ACCEPTED,
+                            Json(json!({
+                                "ok": true,
+                                "accepted": true,
+                                "source": "test-stub",
+                                "coordination": {
+                                    "planId": plan.plan_id,
+                                    "deploymentId": plan.deployment_id,
+                                    "runId": plan.run_id,
+                                    "mode": plan.mode,
+                                    "lane": plan.lane,
+                                    "sliceCount": plan.slices.len(),
+                                }
+                            })),
+                        )
+                    },
+                ),
+            )
+            .with_state(ExecStubState {
+                expected_auth: "Bearer runtime-service-secret".to_string(),
+            });
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("exec stub to serve");
+        });
+        format!("http://{address}")
     }
 
     fn runtime_deployment(
@@ -1190,6 +1428,8 @@ mod tests {
         assert_eq!(payload.portfolio_ledger.deployment_count, 0);
         assert_eq!(payload.risk_engine.status, "healthy");
         assert_eq!(payload.risk_engine.verdict_count, 0);
+        assert_eq!(payload.execution_planner.status, "healthy");
+        assert_eq!(payload.execution_planner.plan_count, 0);
         assert!(payload.internal_service_auth_configured);
     }
 
@@ -1220,6 +1460,7 @@ mod tests {
         assert_eq!(payload.strategy_registry.status, "healthy");
         assert_eq!(payload.portfolio_ledger.status, "healthy");
         assert_eq!(payload.risk_engine.status, "healthy");
+        assert_eq!(payload.execution_planner.status, "healthy");
     }
 
     #[tokio::test]
@@ -1247,7 +1488,8 @@ mod tests {
 
     #[tokio::test]
     async fn stores_and_evaluates_shadow_deployments() {
-        let router = app(test_config());
+        let worker_api_base = spawn_exec_coordination_stub().await;
+        let router = app(test_config_with_worker_api_base(Some(&worker_api_base)));
         let deployment = runtime_deployment("deployment_123", "sleeve_alpha", "1000.00", "125.00");
 
         let create_response = router
@@ -1287,7 +1529,7 @@ mod tests {
         let evaluation_payload = read_json(evaluate_response).await;
         assert_eq!(evaluation_payload["ok"], json!(true));
         assert_eq!(evaluation_payload["created"], json!(true));
-        assert_eq!(evaluation_payload["run"]["state"], json!("planned"));
+        assert_eq!(evaluation_payload["run"]["state"], json!("completed"));
         assert_eq!(evaluation_payload["riskVerdict"]["verdict"], json!("allow"));
         assert_eq!(
             evaluation_payload["run"]["riskVerdictId"],
@@ -1297,6 +1539,16 @@ mod tests {
             evaluation_payload["ledger"]["totals"]["reservedUsd"],
             json!("125.00")
         );
+        assert_eq!(evaluation_payload["executionPlan"]["lane"], json!("safe"));
+        assert_eq!(
+            evaluation_payload["executionPlan"]["runId"],
+            evaluation_payload["run"]["runId"]
+        );
+        assert_eq!(
+            evaluation_payload["executionPlan"]["deploymentId"],
+            json!("deployment_123")
+        );
+        assert_eq!(evaluation_payload["coordination"]["accepted"], json!(true));
 
         let duplicate_response = router
             .clone()
@@ -1335,6 +1587,7 @@ mod tests {
         assert_eq!(runs_payload["runs"].as_array().expect("array").len(), 1);
 
         let risk_response = router
+            .clone()
             .oneshot(
                 Request::builder()
                     .uri("/api/internal/runtime/risk?deploymentId=deployment_123")
@@ -1347,6 +1600,20 @@ mod tests {
         assert_eq!(risk_response.status(), StatusCode::OK);
         let risk_payload = read_json(risk_response).await;
         assert_eq!(risk_payload["verdicts"].as_array().expect("array").len(), 1);
+
+        let plans_response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/api/internal/runtime/execution-plans?deploymentId=deployment_123")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(plans_response.status(), StatusCode::OK);
+        let plans_payload = read_json(plans_response).await;
+        assert_eq!(plans_payload["plans"].as_array().expect("array").len(), 1);
     }
 
     #[tokio::test]
@@ -1394,6 +1661,7 @@ mod tests {
             evaluation_payload["run"]["failureCode"],
             json!("requested_notional_exceeded")
         );
+        assert_eq!(evaluation_payload["executionPlan"], json!(null));
     }
 
     #[tokio::test]
@@ -1436,6 +1704,7 @@ mod tests {
         assert_eq!(evaluation_payload["run"]["state"], json!("killed"));
         assert_eq!(evaluation_payload["riskVerdict"]["verdict"], json!("pause"));
         assert_eq!(evaluation_payload["deployment"]["state"], json!("paused"));
+        assert_eq!(evaluation_payload["executionPlan"], json!(null));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add a persisted `execution-planner` crate for deterministic execution slice generation and auditable plan storage
- expand `exec-client` and `runtime-rs` so runtime evaluations coordinate execution plans through the Worker internal route
- move Worker coordination config into `RuntimeConfig` and harden runtime tests with hermetic local exec stubs

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `bun run lint`
- `bun run typecheck`
- `bun test tests/unit/worker_runtime_internal_routes.test.ts`

Fixes #267
