### PR TITLE
Add runtime reconciliation and drift correction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,6 +857,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "reconciler"
+version = "0.1.0"
+dependencies = [
+ "protocol",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,6 +973,7 @@ dependencies = [
  "market-adapters",
  "portfolio-ledger",
  "protocol",
+ "reconciler",
  "risk-engine",
  "runtime-ops",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "crates/market-adapters",
   "crates/portfolio-ledger",
   "crates/protocol",
+  "crates/reconciler",
   "crates/risk-engine",
   "crates/runtime-ops",
   "crates/strategy-registry",

--- a/apps/worker/src/runtime_internal.ts
+++ b/apps/worker/src/runtime_internal.ts
@@ -411,6 +411,7 @@ export async function handleRuntimeInternalRoute(
         ok: true,
         accepted: true,
         source: "stub",
+        submitRequestId: `submit_${plan.planId}`,
         coordination: {
           planId: plan.planId,
           deploymentId: plan.deploymentId,

--- a/crates/exec-client/src/lib.rs
+++ b/crates/exec-client/src/lib.rs
@@ -24,6 +24,7 @@ pub struct ExecSubmitResponse {
     pub ok: bool,
     pub accepted: bool,
     pub source: String,
+    pub submit_request_id: String,
     pub coordination: ExecPlanCoordination,
 }
 
@@ -302,7 +303,7 @@ mod tests {
                 Router::new().route(
                     "/api/internal/runtime/execution-plans",
                     post(
-                        |headers: reqwest::header::HeaderMap,
+                        |headers: axum::http::HeaderMap,
                          Json(plan): Json<RuntimeExecutionPlan>| async move {
                             assert_eq!(
                                 headers
@@ -314,6 +315,7 @@ mod tests {
                                 "ok": true,
                                 "accepted": true,
                                 "source": "stub",
+                                "submitRequestId": "submit_runtime_1",
                                 "coordination": {
                                     "planId": plan.plan_id,
                                     "deploymentId": plan.deployment_id,
@@ -352,6 +354,7 @@ mod tests {
 
         let response = client.submit_plan(&plan).await.expect("submit to succeed");
         assert!(response.accepted);
+        assert_eq!(response.submit_request_id, "submit_runtime_1");
         assert_eq!(response.coordination.plan_id, "plan_1");
         assert_eq!(response.coordination.lane, RuntimeLane::Protected);
 

--- a/crates/portfolio-ledger/src/lib.rs
+++ b/crates/portfolio-ledger/src/lib.rs
@@ -193,6 +193,95 @@ impl PortfolioLedger {
         Ok(())
     }
 
+    pub fn apply_observed_snapshot(
+        &self,
+        deployment_id: &str,
+        snapshot: &RuntimeLedgerSnapshot,
+    ) -> Result<RuntimeLedgerSnapshot, PortfolioLedgerError> {
+        let observed_equity_cents =
+            parse_non_negative_usd_cents("snapshot.totals.equityUsd", &snapshot.totals.equity_usd)?;
+        let observed_reserved_cents = parse_non_negative_usd_cents(
+            "snapshot.totals.reservedUsd",
+            &snapshot.totals.reserved_usd,
+        )?;
+        let observed_available_cents = parse_non_negative_usd_cents(
+            "snapshot.totals.availableUsd",
+            &snapshot.totals.available_usd,
+        )?;
+        let observed_realized_pnl_cents = parse_usd_cents(
+            "snapshot.totals.realizedPnlUsd",
+            &snapshot.totals.realized_pnl_usd,
+        )?;
+        if observed_reserved_cents + observed_available_cents != observed_equity_cents {
+            return Err(PortfolioLedgerError::InvalidCorrection {
+                sleeve_id: snapshot.sleeve_id.clone(),
+            });
+        }
+
+        let mut connection = self.open_connection()?;
+        let transaction = connection.transaction()?;
+        let deployment = load_deployment_state(&transaction, deployment_id)?.ok_or_else(|| {
+            PortfolioLedgerError::DeploymentNotFound {
+                deployment_id: deployment_id.to_string(),
+            }
+        })?;
+        let sleeve = load_sleeve_state(&transaction, &deployment.sleeve_id)?.ok_or_else(|| {
+            PortfolioLedgerError::DeploymentNotFound {
+                deployment_id: deployment_id.to_string(),
+            }
+        })?;
+
+        let other_allocated_cents = sum_deployment_cents(
+            &transaction,
+            &deployment.sleeve_id,
+            "allocated_cents",
+            Some(deployment_id),
+        )?;
+        let other_reserved_cents = sum_deployment_cents(
+            &transaction,
+            &deployment.sleeve_id,
+            "reserved_cents",
+            Some(deployment_id),
+        )?;
+        let corrected_sleeve_equity_cents = sleeve
+            .equity_cents
+            .saturating_sub(deployment.allocated_cents)
+            .saturating_add(observed_equity_cents);
+
+        ensure_within_sleeve_capacity(
+            &deployment.sleeve_id,
+            corrected_sleeve_equity_cents,
+            other_allocated_cents + observed_equity_cents,
+        )?;
+        ensure_within_sleeve_capacity(
+            &deployment.sleeve_id,
+            corrected_sleeve_equity_cents,
+            other_reserved_cents + observed_reserved_cents,
+        )?;
+
+        upsert_sleeve_state(
+            &transaction,
+            &deployment.sleeve_id,
+            corrected_sleeve_equity_cents,
+            other_reserved_cents + observed_reserved_cents,
+            &deployment.quote_mint,
+            &deployment.quote_symbol,
+        )?;
+        upsert_deployment_ledger_state(
+            &transaction,
+            &deployment,
+            observed_equity_cents,
+            observed_reserved_cents,
+            observed_available_cents,
+            observed_realized_pnl_cents,
+        )?;
+        replace_positions(&transaction, deployment_id, &snapshot.positions)?;
+
+        let corrected_snapshot = build_snapshot(&transaction, deployment_id)?;
+        transaction.commit()?;
+        Ok(corrected_snapshot)
+    }
+
     pub fn upsert_position(
         &self,
         deployment_id: &str,
@@ -319,12 +408,27 @@ struct SleeveState {
 struct DeploymentLedgerState {
     deployment_id: String,
     sleeve_id: String,
+    strategy_key: String,
+    state: String,
     allocated_cents: i64,
     reserved_cents: i64,
     available_cents: i64,
     realized_pnl_cents: i64,
     quote_mint: String,
     quote_symbol: String,
+}
+
+struct DeploymentLedgerStateUpsert<'a> {
+    deployment_id: &'a str,
+    sleeve_id: &'a str,
+    strategy_key: &'a str,
+    state: &'a str,
+    allocated_cents: i64,
+    reserved_cents: i64,
+    available_cents: i64,
+    realized_pnl_cents: i64,
+    quote_mint: &'a str,
+    quote_symbol: &'a str,
 }
 
 fn initialize_schema(connection: &Connection) -> Result<(), rusqlite::Error> {
@@ -482,6 +586,53 @@ fn upsert_deployment_state(
     reserved_cents: i64,
     available_cents: i64,
 ) -> Result<(), rusqlite::Error> {
+    let quote_symbol = quote_symbol(&deployment.pair.symbol);
+    upsert_deployment_ledger_state_record(
+        connection,
+        &DeploymentLedgerStateUpsert {
+            deployment_id: &deployment.deployment_id,
+            sleeve_id: &deployment.sleeve_id,
+            strategy_key: &deployment.strategy_key,
+            state: state_key(&deployment.state),
+            allocated_cents,
+            reserved_cents,
+            available_cents,
+            realized_pnl_cents: 0,
+            quote_mint: &deployment.pair.quote_mint,
+            quote_symbol: &quote_symbol,
+        },
+    )
+}
+
+fn upsert_deployment_ledger_state(
+    connection: &Connection,
+    deployment: &DeploymentLedgerState,
+    allocated_cents: i64,
+    reserved_cents: i64,
+    available_cents: i64,
+    realized_pnl_cents: i64,
+) -> Result<(), rusqlite::Error> {
+    upsert_deployment_ledger_state_record(
+        connection,
+        &DeploymentLedgerStateUpsert {
+            deployment_id: &deployment.deployment_id,
+            sleeve_id: &deployment.sleeve_id,
+            strategy_key: &deployment.strategy_key,
+            state: &deployment.state,
+            allocated_cents,
+            reserved_cents,
+            available_cents,
+            realized_pnl_cents,
+            quote_mint: &deployment.quote_mint,
+            quote_symbol: &deployment.quote_symbol,
+        },
+    )
+}
+
+fn upsert_deployment_ledger_state_record(
+    connection: &Connection,
+    record: &DeploymentLedgerStateUpsert<'_>,
+) -> Result<(), rusqlite::Error> {
     connection.execute(
         "INSERT INTO ledger_deployments (
             deployment_id,
@@ -495,7 +646,7 @@ fn upsert_deployment_state(
             quote_mint,
             quote_symbol,
             updated_at
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0, ?8, ?9, ?10)
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
         ON CONFLICT(deployment_id) DO UPDATE SET
             sleeve_id = excluded.sleeve_id,
             strategy_key = excluded.strategy_key,
@@ -503,22 +654,58 @@ fn upsert_deployment_state(
             allocated_cents = excluded.allocated_cents,
             reserved_cents = excluded.reserved_cents,
             available_cents = excluded.available_cents,
+            realized_pnl_cents = excluded.realized_pnl_cents,
             quote_mint = excluded.quote_mint,
             quote_symbol = excluded.quote_symbol,
             updated_at = excluded.updated_at",
         params![
-            &deployment.deployment_id,
-            &deployment.sleeve_id,
-            &deployment.strategy_key,
-            state_key(&deployment.state),
-            allocated_cents,
-            reserved_cents,
-            available_cents,
-            &deployment.pair.quote_mint,
-            quote_symbol(&deployment.pair.symbol),
+            record.deployment_id,
+            record.sleeve_id,
+            record.strategy_key,
+            record.state,
+            record.allocated_cents,
+            record.reserved_cents,
+            record.available_cents,
+            record.realized_pnl_cents,
+            record.quote_mint,
+            record.quote_symbol,
             now_rfc3339(),
         ],
     )?;
+    Ok(())
+}
+
+fn replace_positions(
+    connection: &Connection,
+    deployment_id: &str,
+    positions: &[RuntimeLedgerPosition],
+) -> Result<(), rusqlite::Error> {
+    connection.execute(
+        "DELETE FROM ledger_positions WHERE deployment_id = ?1",
+        params![deployment_id],
+    )?;
+    for position in positions {
+        connection.execute(
+            "INSERT INTO ledger_positions (
+                deployment_id,
+                instrument_id,
+                side,
+                quantity_atomic,
+                entry_price_usd,
+                mark_price_usd,
+                unrealized_pnl_usd
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                deployment_id,
+                &position.instrument_id,
+                side_key(&position.side),
+                &position.quantity_atomic,
+                &position.entry_price_usd,
+                &position.mark_price_usd,
+                &position.unrealized_pnl_usd,
+            ],
+        )?;
+    }
     Ok(())
 }
 
@@ -552,7 +739,7 @@ fn load_deployment_state(
 ) -> Result<Option<DeploymentLedgerState>, PortfolioLedgerError> {
     connection
         .query_row(
-            "SELECT deployment_id, sleeve_id, allocated_cents, reserved_cents, available_cents,
+            "SELECT deployment_id, sleeve_id, strategy_key, state, allocated_cents, reserved_cents, available_cents,
                     realized_pnl_cents, quote_mint, quote_symbol
              FROM ledger_deployments
              WHERE deployment_id = ?1",
@@ -561,12 +748,14 @@ fn load_deployment_state(
                 Ok(DeploymentLedgerState {
                     deployment_id: row.get(0)?,
                     sleeve_id: row.get(1)?,
-                    allocated_cents: row.get(2)?,
-                    reserved_cents: row.get(3)?,
-                    available_cents: row.get(4)?,
-                    realized_pnl_cents: row.get(5)?,
-                    quote_mint: row.get(6)?,
-                    quote_symbol: row.get(7)?,
+                    strategy_key: row.get(2)?,
+                    state: row.get(3)?,
+                    allocated_cents: row.get(4)?,
+                    reserved_cents: row.get(5)?,
+                    available_cents: row.get(6)?,
+                    realized_pnl_cents: row.get(7)?,
+                    quote_mint: row.get(8)?,
+                    quote_symbol: row.get(9)?,
                 })
             },
         )
@@ -992,6 +1181,65 @@ mod tests {
             Some("140.00")
         );
         assert_eq!(snapshot.totals.unrealized_pnl_usd, "2.00");
+    }
+
+    #[test]
+    fn applies_observed_snapshots_as_auditable_corrections() {
+        let ledger = ledger("observed-correction");
+        ledger
+            .sync_deployment(&deployment(
+                "deployment_1",
+                "sleeve_alpha",
+                "100.00",
+                "5.00",
+            ))
+            .expect("deployment to sync");
+
+        let corrected = ledger
+            .apply_observed_snapshot(
+                "deployment_1",
+                &RuntimeLedgerSnapshot {
+                    schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+                    snapshot_id: "wallet_1".to_string(),
+                    deployment_id: "deployment_1".to_string(),
+                    sleeve_id: "sleeve_alpha".to_string(),
+                    as_of: "2026-03-08T15:10:00Z".to_string(),
+                    balances: vec![RuntimeLedgerBalance {
+                        mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+                        symbol: "USDC".to_string(),
+                        decimals: 6,
+                        free_atomic: "103000000".to_string(),
+                        reserved_atomic: "7000000".to_string(),
+                        price_usd: Some("1.00".to_string()),
+                    }],
+                    positions: vec![RuntimeLedgerPosition {
+                        instrument_id: "SOL/USDC".to_string(),
+                        side: RuntimePositionSide::Long,
+                        quantity_atomic: "150000000".to_string(),
+                        entry_price_usd: Some("141.00".to_string()),
+                        mark_price_usd: Some("143.00".to_string()),
+                        unrealized_pnl_usd: Some("3.00".to_string()),
+                    }],
+                    totals: RuntimeLedgerTotals {
+                        equity_usd: "110.00".to_string(),
+                        reserved_usd: "7.00".to_string(),
+                        available_usd: "103.00".to_string(),
+                        realized_pnl_usd: "1.50".to_string(),
+                        unrealized_pnl_usd: "3.00".to_string(),
+                    },
+                },
+            )
+            .expect("observed snapshot to apply");
+
+        assert_eq!(corrected.totals.equity_usd, "110.00");
+        assert_eq!(corrected.totals.reserved_usd, "7.00");
+        assert_eq!(corrected.totals.available_usd, "103.00");
+        assert_eq!(corrected.totals.realized_pnl_usd, "1.50");
+        assert_eq!(corrected.positions.len(), 1);
+        assert_eq!(
+            corrected.positions[0].entry_price_usd.as_deref(),
+            Some("141.00")
+        );
     }
 
     #[test]

--- a/crates/reconciler/Cargo.toml
+++ b/crates/reconciler/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "reconciler"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+protocol = { path = "../protocol" }
+rusqlite = { version = "0.37.0", features = ["bundled"] }
+serde.workspace = true
+serde_json.workspace = true
+sha2 = "0.10.9"
+thiserror.workspace = true
+time = { version = "=0.3.44", features = ["formatting", "parsing"] }

--- a/crates/reconciler/src/lib.rs
+++ b/crates/reconciler/src/lib.rs
@@ -1,0 +1,1199 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::{Path, PathBuf},
+};
+
+use protocol::{
+    RuntimeExecutionPlan, RuntimeLedgerBalance, RuntimeLedgerPosition, RuntimeLedgerSnapshot,
+    RuntimeMode, RuntimeReconciliationResult, RuntimeReconciliationStatus, RuntimeWalletDelta,
+    RUNTIME_PROTOCOL_SCHEMA_VERSION,
+};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use time::OffsetDateTime;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReconcilerConfig {
+    pub database_url: String,
+}
+
+impl ReconcilerConfig {
+    #[must_use]
+    pub fn new(database_url: impl Into<String>) -> Self {
+        Self {
+            database_url: database_url.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Reconciler {
+    database_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReconciliationThresholds {
+    pub warn_total_delta_usd: String,
+    pub fail_total_delta_usd: String,
+    pub auto_correct_max_total_delta_usd: String,
+    pub warn_position_delta_usd: String,
+    pub fail_position_delta_usd: String,
+}
+
+impl Default for ReconciliationThresholds {
+    fn default() -> Self {
+        Self {
+            warn_total_delta_usd: "1.00".to_string(),
+            fail_total_delta_usd: "10.00".to_string(),
+            auto_correct_max_total_delta_usd: "2.50".to_string(),
+            warn_position_delta_usd: "2.00".to_string(),
+            fail_position_delta_usd: "15.00".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReconcilerSnapshot {
+    pub status: String,
+    pub submit_attempt_count: u64,
+    pub receipt_count: u64,
+    pub wallet_observation_count: u64,
+    pub reconciliation_count: u64,
+    pub drift_alert_count: u64,
+    pub latest_completed_at: Option<String>,
+    pub thresholds: ReconciliationThresholds,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeSubmitAttemptRecord {
+    pub attempt_id: String,
+    pub deployment_id: String,
+    pub run_id: String,
+    pub plan_id: String,
+    pub submit_request_id: String,
+    pub recorded_at: String,
+    pub mode: RuntimeMode,
+    pub source: String,
+    pub accepted: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeReceiptObservation {
+    pub receipt_id: String,
+    pub deployment_id: String,
+    pub run_id: String,
+    pub submit_request_id: String,
+    pub observed_at: String,
+    pub source: String,
+    pub status: String,
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeWalletObservationRecord {
+    pub observation_id: String,
+    pub deployment_id: String,
+    pub run_id: String,
+    pub observed_at: String,
+    pub source: String,
+    pub snapshot: RuntimeLedgerSnapshot,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReconciliationInput {
+    pub deployment_id: String,
+    pub run_id: String,
+    pub plan: RuntimeExecutionPlan,
+    pub receipt: RuntimeReceiptObservation,
+    pub expected_ledger: RuntimeLedgerSnapshot,
+    pub observed_ledger: RuntimeLedgerSnapshot,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReconciliationOutcome {
+    pub result: RuntimeReconciliationResult,
+    pub should_apply_correction: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReconciliationBundle {
+    pub submit_attempts: Vec<RuntimeSubmitAttemptRecord>,
+    pub receipts: Vec<RuntimeReceiptObservation>,
+    pub wallet_observations: Vec<RuntimeWalletObservationRecord>,
+    pub results: Vec<RuntimeReconciliationResult>,
+    pub thresholds: ReconciliationThresholds,
+}
+
+#[derive(Debug, Error)]
+pub enum ReconcilerError {
+    #[error("storage io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("storage error: {0}")]
+    Storage(#[from] rusqlite::Error),
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("invalid numeric value for {field}: {value}")]
+    InvalidNumericValue { field: &'static str, value: String },
+    #[error("reconciliation result {run_id} not found")]
+    ResultNotFound { run_id: String },
+}
+
+impl Reconciler {
+    pub fn new(config: ReconcilerConfig) -> Result<Self, ReconcilerError> {
+        let requested_path = normalize_database_path(&config.database_url);
+        match Self::initialize_at_path(requested_path.clone()) {
+            Ok(reconciler) => Ok(reconciler),
+            Err(error) if should_fallback_to_tmp(&requested_path, &error) => {
+                Self::initialize_at_path(fallback_database_path())
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    pub fn record_submit_attempt(
+        &self,
+        plan: &RuntimeExecutionPlan,
+        submit_request_id: &str,
+        accepted: bool,
+        source: &str,
+    ) -> Result<RuntimeSubmitAttemptRecord, ReconcilerError> {
+        let mut connection = self.open_connection()?;
+        let transaction = connection.transaction()?;
+        if let Some(existing) = load_submit_attempt_by_run_id(&transaction, &plan.run_id)? {
+            transaction.commit()?;
+            return Ok(existing);
+        }
+
+        let record = RuntimeSubmitAttemptRecord {
+            attempt_id: build_prefixed_id(
+                "attempt",
+                &format!("{}:{submit_request_id}", plan.run_id),
+            ),
+            deployment_id: plan.deployment_id.clone(),
+            run_id: plan.run_id.clone(),
+            plan_id: plan.plan_id.clone(),
+            submit_request_id: submit_request_id.to_string(),
+            recorded_at: now_rfc3339(),
+            mode: plan.mode.clone(),
+            source: source.to_string(),
+            accepted,
+        };
+        transaction.execute(
+            "INSERT INTO runtime_submit_attempts (
+                attempt_id,
+                deployment_id,
+                run_id,
+                plan_id,
+                submit_request_id,
+                recorded_at,
+                mode,
+                source,
+                accepted,
+                record_json
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            params![
+                &record.attempt_id,
+                &record.deployment_id,
+                &record.run_id,
+                &record.plan_id,
+                &record.submit_request_id,
+                &record.recorded_at,
+                mode_key(&record.mode),
+                &record.source,
+                record.accepted,
+                serialize_json(&record)?,
+            ],
+        )?;
+        transaction.commit()?;
+        Ok(record)
+    }
+
+    pub fn record_synthetic_receipt(
+        &self,
+        plan: &RuntimeExecutionPlan,
+        submit_request_id: &str,
+        source: &str,
+        status: &str,
+        notes: &[&str],
+    ) -> Result<RuntimeReceiptObservation, ReconcilerError> {
+        let mut connection = self.open_connection()?;
+        let transaction = connection.transaction()?;
+        if let Some(existing) = load_receipt_by_run_id(&transaction, &plan.run_id)? {
+            transaction.commit()?;
+            return Ok(existing);
+        }
+
+        let record = RuntimeReceiptObservation {
+            receipt_id: build_prefixed_id("receipt", submit_request_id),
+            deployment_id: plan.deployment_id.clone(),
+            run_id: plan.run_id.clone(),
+            submit_request_id: submit_request_id.to_string(),
+            observed_at: now_rfc3339(),
+            source: source.to_string(),
+            status: status.to_string(),
+            notes: notes.iter().map(|note| (*note).to_string()).collect(),
+        };
+        transaction.execute(
+            "INSERT INTO runtime_receipts (
+                receipt_id,
+                deployment_id,
+                run_id,
+                submit_request_id,
+                observed_at,
+                source,
+                status,
+                record_json
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                &record.receipt_id,
+                &record.deployment_id,
+                &record.run_id,
+                &record.submit_request_id,
+                &record.observed_at,
+                &record.source,
+                &record.status,
+                serialize_json(&record)?,
+            ],
+        )?;
+        transaction.commit()?;
+        Ok(record)
+    }
+
+    pub fn record_wallet_observation(
+        &self,
+        deployment_id: &str,
+        run_id: &str,
+        source: &str,
+        snapshot: &RuntimeLedgerSnapshot,
+    ) -> Result<RuntimeWalletObservationRecord, ReconcilerError> {
+        let mut connection = self.open_connection()?;
+        let transaction = connection.transaction()?;
+        if let Some(existing) = load_wallet_observation_by_run_id(&transaction, run_id)? {
+            transaction.commit()?;
+            return Ok(existing);
+        }
+
+        let record = RuntimeWalletObservationRecord {
+            observation_id: build_prefixed_id("wallet", run_id),
+            deployment_id: deployment_id.to_string(),
+            run_id: run_id.to_string(),
+            observed_at: now_rfc3339(),
+            source: source.to_string(),
+            snapshot: snapshot.clone(),
+        };
+        transaction.execute(
+            "INSERT INTO runtime_wallet_observations (
+                observation_id,
+                deployment_id,
+                run_id,
+                observed_at,
+                source,
+                snapshot_json,
+                record_json
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                &record.observation_id,
+                &record.deployment_id,
+                &record.run_id,
+                &record.observed_at,
+                &record.source,
+                serialize_json(snapshot)?,
+                serialize_json(&record)?,
+            ],
+        )?;
+        transaction.commit()?;
+        Ok(record)
+    }
+
+    pub fn reconcile_and_store(
+        &self,
+        input: &ReconciliationInput,
+    ) -> Result<ReconciliationOutcome, ReconcilerError> {
+        let mut connection = self.open_connection()?;
+        let transaction = connection.transaction()?;
+        if let Some(existing) = load_result_by_run_id(&transaction, &input.run_id)? {
+            transaction.commit()?;
+            return Ok(ReconciliationOutcome {
+                result: existing,
+                should_apply_correction: false,
+            });
+        }
+
+        let wallet_deltas = wallet_deltas(&input.expected_ledger, &input.observed_ledger)?;
+        let total_wallet_delta_cents = wallet_deltas
+            .iter()
+            .map(wallet_delta_usd_cents)
+            .sum::<Result<i64, _>>()?;
+        let position_delta_cents = position_delta_usd_cents(
+            &input.expected_ledger.positions,
+            &input.observed_ledger.positions,
+        )?;
+        let thresholds = ReconciliationThresholds::default();
+        let warn_total_cents = parse_usd_cents(
+            "thresholds.warnTotalDeltaUsd",
+            &thresholds.warn_total_delta_usd,
+        )?;
+        let fail_total_cents = parse_usd_cents(
+            "thresholds.failTotalDeltaUsd",
+            &thresholds.fail_total_delta_usd,
+        )?;
+        let auto_correct_cents = parse_usd_cents(
+            "thresholds.autoCorrectMaxTotalDeltaUsd",
+            &thresholds.auto_correct_max_total_delta_usd,
+        )?;
+        let warn_position_cents = parse_usd_cents(
+            "thresholds.warnPositionDeltaUsd",
+            &thresholds.warn_position_delta_usd,
+        )?;
+        let fail_position_cents = parse_usd_cents(
+            "thresholds.failPositionDeltaUsd",
+            &thresholds.fail_position_delta_usd,
+        )?;
+
+        let status = if total_wallet_delta_cents >= fail_total_cents
+            || position_delta_cents >= fail_position_cents
+        {
+            RuntimeReconciliationStatus::Failed
+        } else if total_wallet_delta_cents > warn_total_cents
+            || position_delta_cents > warn_position_cents
+        {
+            RuntimeReconciliationStatus::NeedsManualReview
+        } else {
+            RuntimeReconciliationStatus::Passed
+        };
+        let should_apply_correction = total_wallet_delta_cents > 0
+            && total_wallet_delta_cents <= auto_correct_cents
+            && status == RuntimeReconciliationStatus::Passed;
+        let notes = build_notes(
+            &status,
+            total_wallet_delta_cents,
+            position_delta_cents,
+            should_apply_correction,
+        );
+        let result = RuntimeReconciliationResult {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            reconciliation_id: build_prefixed_id(
+                "recon",
+                &format!("{}:{}", input.run_id, input.receipt.receipt_id),
+            ),
+            deployment_id: input.deployment_id.clone(),
+            run_id: input.run_id.clone(),
+            receipt_id: input.receipt.receipt_id.clone(),
+            completed_at: now_rfc3339(),
+            status,
+            wallet_deltas,
+            position_delta_usd: format_usd_cents(position_delta_cents),
+            notes,
+            correction_applied: should_apply_correction,
+        };
+        transaction.execute(
+            "INSERT INTO runtime_reconciliation_results (
+                reconciliation_id,
+                deployment_id,
+                run_id,
+                receipt_id,
+                completed_at,
+                status,
+                correction_applied,
+                record_json
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                &result.reconciliation_id,
+                &result.deployment_id,
+                &result.run_id,
+                &result.receipt_id,
+                &result.completed_at,
+                reconciliation_status_key(&result.status),
+                result.correction_applied,
+                serialize_json(&result)?,
+            ],
+        )?;
+        transaction.commit()?;
+        Ok(ReconciliationOutcome {
+            result,
+            should_apply_correction,
+        })
+    }
+
+    pub fn get_result_by_run_id(
+        &self,
+        run_id: &str,
+    ) -> Result<Option<RuntimeReconciliationResult>, ReconcilerError> {
+        let connection = self.open_connection()?;
+        load_result_by_run_id(&connection, run_id)
+    }
+
+    pub fn get_submit_attempt_by_run_id(
+        &self,
+        run_id: &str,
+    ) -> Result<Option<RuntimeSubmitAttemptRecord>, ReconcilerError> {
+        let connection = self.open_connection()?;
+        load_submit_attempt_by_run_id(&connection, run_id)
+    }
+
+    pub fn get_receipt_by_run_id(
+        &self,
+        run_id: &str,
+    ) -> Result<Option<RuntimeReceiptObservation>, ReconcilerError> {
+        let connection = self.open_connection()?;
+        load_receipt_by_run_id(&connection, run_id)
+    }
+
+    pub fn get_wallet_observation_by_run_id(
+        &self,
+        run_id: &str,
+    ) -> Result<Option<RuntimeWalletObservationRecord>, ReconcilerError> {
+        let connection = self.open_connection()?;
+        load_wallet_observation_by_run_id(&connection, run_id)
+    }
+
+    pub fn bundle_for_deployment(
+        &self,
+        deployment_id: &str,
+    ) -> Result<ReconciliationBundle, ReconcilerError> {
+        let connection = self.open_connection()?;
+        Ok(ReconciliationBundle {
+            submit_attempts: list_records(
+                &connection,
+                "SELECT record_json FROM runtime_submit_attempts WHERE deployment_id = ?1 ORDER BY recorded_at DESC, attempt_id DESC",
+                deployment_id,
+            )?,
+            receipts: list_records(
+                &connection,
+                "SELECT record_json FROM runtime_receipts WHERE deployment_id = ?1 ORDER BY observed_at DESC, receipt_id DESC",
+                deployment_id,
+            )?,
+            wallet_observations: list_records(
+                &connection,
+                "SELECT record_json FROM runtime_wallet_observations WHERE deployment_id = ?1 ORDER BY observed_at DESC, observation_id DESC",
+                deployment_id,
+            )?,
+            results: list_records(
+                &connection,
+                "SELECT record_json FROM runtime_reconciliation_results WHERE deployment_id = ?1 ORDER BY completed_at DESC, reconciliation_id DESC",
+                deployment_id,
+            )?,
+            thresholds: ReconciliationThresholds::default(),
+        })
+    }
+
+    #[must_use]
+    pub fn snapshot_now(&self) -> ReconcilerSnapshot {
+        match self.snapshot_counts() {
+            Ok(snapshot) => snapshot,
+            Err(error) => ReconcilerSnapshot {
+                status: "degraded".to_string(),
+                submit_attempt_count: 0,
+                receipt_count: 0,
+                wallet_observation_count: 0,
+                reconciliation_count: 0,
+                drift_alert_count: 0,
+                latest_completed_at: None,
+                thresholds: ReconciliationThresholds::default(),
+                last_error: Some(error.to_string()),
+            },
+        }
+    }
+
+    fn snapshot_counts(&self) -> Result<ReconcilerSnapshot, ReconcilerError> {
+        let connection = self.open_connection()?;
+        let submit_attempt_count =
+            connection.query_row("SELECT COUNT(*) FROM runtime_submit_attempts", [], |row| {
+                row.get::<_, u64>(0)
+            })?;
+        let receipt_count =
+            connection.query_row("SELECT COUNT(*) FROM runtime_receipts", [], |row| {
+                row.get::<_, u64>(0)
+            })?;
+        let wallet_observation_count = connection.query_row(
+            "SELECT COUNT(*) FROM runtime_wallet_observations",
+            [],
+            |row| row.get::<_, u64>(0),
+        )?;
+        let reconciliation_count = connection.query_row(
+            "SELECT COUNT(*) FROM runtime_reconciliation_results",
+            [],
+            |row| row.get::<_, u64>(0),
+        )?;
+        let drift_alert_count = connection.query_row(
+            "SELECT COUNT(*) FROM runtime_reconciliation_results WHERE status != 'passed'",
+            [],
+            |row| row.get::<_, u64>(0),
+        )?;
+        let latest_completed_at = connection
+            .query_row(
+                "SELECT completed_at FROM runtime_reconciliation_results ORDER BY completed_at DESC, reconciliation_id DESC LIMIT 1",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+
+        Ok(ReconcilerSnapshot {
+            status: "healthy".to_string(),
+            submit_attempt_count,
+            receipt_count,
+            wallet_observation_count,
+            reconciliation_count,
+            drift_alert_count,
+            latest_completed_at,
+            thresholds: ReconciliationThresholds::default(),
+            last_error: None,
+        })
+    }
+
+    fn open_connection(&self) -> Result<Connection, ReconcilerError> {
+        let connection = Connection::open(&self.database_path)?;
+        connection.busy_timeout(std::time::Duration::from_secs(5))?;
+        connection.pragma_update(None, "foreign_keys", "ON")?;
+        Ok(connection)
+    }
+
+    fn initialize_at_path(database_path: PathBuf) -> Result<Self, ReconcilerError> {
+        if database_path != Path::new(":memory:") {
+            if let Some(parent) = database_path
+                .parent()
+                .filter(|path| !path.as_os_str().is_empty())
+            {
+                fs::create_dir_all(parent)?;
+            }
+        }
+        let reconciler = Self { database_path };
+        let connection = reconciler.open_connection()?;
+        initialize_schema(&connection)?;
+        Ok(reconciler)
+    }
+}
+
+fn initialize_schema(connection: &Connection) -> Result<(), rusqlite::Error> {
+    connection.execute_batch(
+        "CREATE TABLE IF NOT EXISTS runtime_submit_attempts (
+            attempt_id TEXT PRIMARY KEY,
+            deployment_id TEXT NOT NULL,
+            run_id TEXT NOT NULL UNIQUE,
+            plan_id TEXT NOT NULL,
+            submit_request_id TEXT NOT NULL,
+            recorded_at TEXT NOT NULL,
+            mode TEXT NOT NULL,
+            source TEXT NOT NULL,
+            accepted INTEGER NOT NULL,
+            record_json TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_runtime_submit_attempts_deployment
+            ON runtime_submit_attempts (deployment_id, recorded_at DESC);
+
+        CREATE TABLE IF NOT EXISTS runtime_receipts (
+            receipt_id TEXT PRIMARY KEY,
+            deployment_id TEXT NOT NULL,
+            run_id TEXT NOT NULL UNIQUE,
+            submit_request_id TEXT NOT NULL,
+            observed_at TEXT NOT NULL,
+            source TEXT NOT NULL,
+            status TEXT NOT NULL,
+            record_json TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_runtime_receipts_deployment
+            ON runtime_receipts (deployment_id, observed_at DESC);
+
+        CREATE TABLE IF NOT EXISTS runtime_wallet_observations (
+            observation_id TEXT PRIMARY KEY,
+            deployment_id TEXT NOT NULL,
+            run_id TEXT NOT NULL UNIQUE,
+            observed_at TEXT NOT NULL,
+            source TEXT NOT NULL,
+            snapshot_json TEXT NOT NULL,
+            record_json TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_runtime_wallet_observations_deployment
+            ON runtime_wallet_observations (deployment_id, observed_at DESC);
+
+        CREATE TABLE IF NOT EXISTS runtime_reconciliation_results (
+            reconciliation_id TEXT PRIMARY KEY,
+            deployment_id TEXT NOT NULL,
+            run_id TEXT NOT NULL UNIQUE,
+            receipt_id TEXT NOT NULL,
+            completed_at TEXT NOT NULL,
+            status TEXT NOT NULL,
+            correction_applied INTEGER NOT NULL,
+            record_json TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_runtime_reconciliation_results_deployment
+            ON runtime_reconciliation_results (deployment_id, completed_at DESC);",
+    )
+}
+
+fn normalize_database_path(database_url: &str) -> PathBuf {
+    let trimmed = database_url.trim();
+    if trimmed.is_empty() {
+        return PathBuf::from(".tmp/runtime-rs/reconciler.sqlite3");
+    }
+    if let Some(stripped) = trimmed.strip_prefix("sqlite://") {
+        return PathBuf::from(stripped);
+    }
+    if let Some(stripped) = trimmed.strip_prefix("file:") {
+        return PathBuf::from(stripped);
+    }
+    PathBuf::from(trimmed)
+}
+
+fn fallback_database_path() -> PathBuf {
+    std::env::temp_dir()
+        .join("runtime-rs")
+        .join("reconciler.sqlite3")
+}
+
+fn should_fallback_to_tmp(database_path: &Path, error: &ReconcilerError) -> bool {
+    if database_path == Path::new(":memory:") || database_path == fallback_database_path() {
+        return false;
+    }
+    match error {
+        ReconcilerError::Io(inner) => inner.kind() == std::io::ErrorKind::PermissionDenied,
+        ReconcilerError::Storage(inner) => {
+            matches!(
+                inner,
+                rusqlite::Error::SqliteFailure(code, _)
+                    if code.code == rusqlite::ErrorCode::CannotOpen
+            )
+        }
+        ReconcilerError::Serialization(_)
+        | ReconcilerError::InvalidNumericValue { .. }
+        | ReconcilerError::ResultNotFound { .. } => false,
+    }
+}
+
+fn wallet_deltas(
+    expected: &RuntimeLedgerSnapshot,
+    observed: &RuntimeLedgerSnapshot,
+) -> Result<Vec<RuntimeWalletDelta>, ReconcilerError> {
+    let mut expected_by_mint = BTreeMap::new();
+    let mut observed_by_mint = BTreeMap::new();
+    for balance in &expected.balances {
+        expected_by_mint.insert(balance.mint.clone(), balance);
+    }
+    for balance in &observed.balances {
+        observed_by_mint.insert(balance.mint.clone(), balance);
+    }
+
+    let mut all_mints = BTreeSet::new();
+    all_mints.extend(expected_by_mint.keys().cloned());
+    all_mints.extend(observed_by_mint.keys().cloned());
+
+    let mut deltas = Vec::new();
+    for mint in all_mints {
+        let expected_balance = expected_by_mint.get(&mint).copied();
+        let observed_balance = observed_by_mint.get(&mint).copied();
+        let expected_atomic = total_atomic(expected_balance)?;
+        let actual_atomic = total_atomic(observed_balance)?;
+        deltas.push(RuntimeWalletDelta {
+            mint,
+            expected_atomic: expected_atomic.to_string(),
+            actual_atomic: actual_atomic.to_string(),
+            delta_atomic: (actual_atomic - expected_atomic).to_string(),
+        });
+    }
+    Ok(deltas)
+}
+
+fn total_atomic(balance: Option<&RuntimeLedgerBalance>) -> Result<i128, ReconcilerError> {
+    let Some(balance) = balance else {
+        return Ok(0);
+    };
+    let free = parse_atomic_i128("balances.freeAtomic", &balance.free_atomic)?;
+    let reserved = parse_atomic_i128("balances.reservedAtomic", &balance.reserved_atomic)?;
+    Ok(free + reserved)
+}
+
+fn wallet_delta_usd_cents(delta: &RuntimeWalletDelta) -> Result<i64, ReconcilerError> {
+    let absolute_atomic = parse_atomic_i128("walletDeltas.deltaAtomic", &delta.delta_atomic)?.abs();
+    if delta.mint == "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" {
+        return Ok((absolute_atomic / 10_000_i128) as i64);
+    }
+    Ok(0)
+}
+
+fn position_delta_usd_cents(
+    expected: &[RuntimeLedgerPosition],
+    observed: &[RuntimeLedgerPosition],
+) -> Result<i64, ReconcilerError> {
+    let mut expected_by_instrument = BTreeMap::new();
+    let mut observed_by_instrument = BTreeMap::new();
+    for position in expected {
+        expected_by_instrument.insert(position.instrument_id.clone(), position);
+    }
+    for position in observed {
+        observed_by_instrument.insert(position.instrument_id.clone(), position);
+    }
+    let mut instruments = BTreeSet::new();
+    instruments.extend(expected_by_instrument.keys().cloned());
+    instruments.extend(observed_by_instrument.keys().cloned());
+
+    let mut total = 0_i64;
+    for instrument in instruments {
+        let expected_cents = expected_by_instrument
+            .get(&instrument)
+            .and_then(|position| position.unrealized_pnl_usd.as_deref())
+            .map(|value| parse_usd_cents("positions.unrealizedPnlUsd", value))
+            .transpose()?
+            .unwrap_or(0);
+        let observed_cents = observed_by_instrument
+            .get(&instrument)
+            .and_then(|position| position.unrealized_pnl_usd.as_deref())
+            .map(|value| parse_usd_cents("positions.unrealizedPnlUsd", value))
+            .transpose()?
+            .unwrap_or(0);
+        total += (observed_cents - expected_cents).abs();
+    }
+    Ok(total)
+}
+
+fn build_notes(
+    status: &RuntimeReconciliationStatus,
+    total_wallet_delta_cents: i64,
+    position_delta_cents: i64,
+    should_apply_correction: bool,
+) -> Vec<String> {
+    let mut notes = vec![format!(
+        "wallet delta {} and position delta {} evaluated",
+        format_usd_cents(total_wallet_delta_cents),
+        format_usd_cents(position_delta_cents),
+    )];
+    if should_apply_correction {
+        notes.push("wallet state drift is within auto-correction threshold".to_string());
+    }
+    match status {
+        RuntimeReconciliationStatus::Passed => notes
+            .push("receipt and wallet state reconciled without manual intervention".to_string()),
+        RuntimeReconciliationStatus::NeedsManualReview => {
+            notes.push("drift exceeded warning threshold and requires manual review".to_string())
+        }
+        RuntimeReconciliationStatus::Failed => {
+            notes.push("drift exceeded failure threshold and reconciliation failed".to_string())
+        }
+    }
+    notes
+}
+
+fn load_submit_attempt_by_run_id(
+    connection: &Connection,
+    run_id: &str,
+) -> Result<Option<RuntimeSubmitAttemptRecord>, ReconcilerError> {
+    load_optional_record(
+        connection,
+        "SELECT record_json FROM runtime_submit_attempts WHERE run_id = ?1",
+        run_id,
+    )
+}
+
+fn load_receipt_by_run_id(
+    connection: &Connection,
+    run_id: &str,
+) -> Result<Option<RuntimeReceiptObservation>, ReconcilerError> {
+    load_optional_record(
+        connection,
+        "SELECT record_json FROM runtime_receipts WHERE run_id = ?1",
+        run_id,
+    )
+}
+
+fn load_wallet_observation_by_run_id(
+    connection: &Connection,
+    run_id: &str,
+) -> Result<Option<RuntimeWalletObservationRecord>, ReconcilerError> {
+    load_optional_record(
+        connection,
+        "SELECT record_json FROM runtime_wallet_observations WHERE run_id = ?1",
+        run_id,
+    )
+}
+
+fn load_result_by_run_id(
+    connection: &Connection,
+    run_id: &str,
+) -> Result<Option<RuntimeReconciliationResult>, ReconcilerError> {
+    load_optional_record(
+        connection,
+        "SELECT record_json FROM runtime_reconciliation_results WHERE run_id = ?1",
+        run_id,
+    )
+}
+
+fn load_optional_record<T: for<'de> Deserialize<'de>>(
+    connection: &Connection,
+    sql: &str,
+    key: &str,
+) -> Result<Option<T>, ReconcilerError> {
+    let raw = connection
+        .query_row(sql, params![key], |row| row.get::<_, String>(0))
+        .optional()?;
+    Ok(raw.map(|value| deserialize_json(&value)).transpose()?)
+}
+
+fn list_records<T: for<'de> Deserialize<'de>>(
+    connection: &Connection,
+    sql: &str,
+    deployment_id: &str,
+) -> Result<Vec<T>, ReconcilerError> {
+    let mut statement = connection.prepare(sql)?;
+    let rows = statement.query_map(params![deployment_id], |row| row.get::<_, String>(0))?;
+    let mut values = Vec::new();
+    for row in rows {
+        values.push(deserialize_json(&row?)?);
+    }
+    Ok(values)
+}
+
+fn parse_atomic_i128(field: &'static str, value: &str) -> Result<i128, ReconcilerError> {
+    value
+        .trim()
+        .parse::<i128>()
+        .map_err(|_| ReconcilerError::InvalidNumericValue {
+            field,
+            value: value.to_string(),
+        })
+}
+
+fn parse_usd_cents(field: &'static str, value: &str) -> Result<i64, ReconcilerError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(ReconcilerError::InvalidNumericValue {
+            field,
+            value: trimmed.to_string(),
+        });
+    }
+
+    let (sign, digits) = if let Some(rest) = trimmed.strip_prefix('-') {
+        (-1_i64, rest)
+    } else if let Some(rest) = trimmed.strip_prefix('+') {
+        (1_i64, rest)
+    } else {
+        (1_i64, trimmed)
+    };
+    let (whole_raw, fraction_raw) = digits.split_once('.').unwrap_or((digits, ""));
+    if whole_raw.is_empty()
+        || !whole_raw
+            .chars()
+            .all(|character| character.is_ascii_digit())
+        || !fraction_raw
+            .chars()
+            .all(|character| character.is_ascii_digit())
+    {
+        return Err(ReconcilerError::InvalidNumericValue {
+            field,
+            value: trimmed.to_string(),
+        });
+    }
+    let whole = whole_raw
+        .parse::<i64>()
+        .map_err(|_| ReconcilerError::InvalidNumericValue {
+            field,
+            value: trimmed.to_string(),
+        })?;
+    let fraction_bytes = fraction_raw.as_bytes();
+    let tenths = fraction_bytes
+        .first()
+        .map(|digit| i64::from(digit - b'0'))
+        .unwrap_or(0);
+    let hundredths = fraction_bytes
+        .get(1)
+        .map(|digit| i64::from(digit - b'0'))
+        .unwrap_or(0);
+    let mut fraction = tenths * 10 + hundredths;
+    if fraction_bytes.get(2).is_some_and(|digit| *digit >= b'5') {
+        fraction += 1;
+    }
+    let cents = whole
+        .checked_mul(100)
+        .and_then(|value| value.checked_add(fraction))
+        .ok_or_else(|| ReconcilerError::InvalidNumericValue {
+            field,
+            value: trimmed.to_string(),
+        })?;
+    Ok(sign * cents)
+}
+
+fn format_usd_cents(value: i64) -> String {
+    let sign = if value < 0 { "-" } else { "" };
+    let absolute = value.abs();
+    format!("{sign}{}.{:02}", absolute / 100, absolute % 100)
+}
+
+fn serialize_json<T: Serialize>(value: &T) -> Result<String, serde_json::Error> {
+    serde_json::to_string(value)
+}
+
+fn deserialize_json<T: for<'de> Deserialize<'de>>(raw: &str) -> Result<T, serde_json::Error> {
+    serde_json::from_str(raw)
+}
+
+fn build_prefixed_id(prefix: &str, value: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_bytes());
+    let digest = hasher.finalize();
+    format!("{prefix}_{}", hex_encode(&digest[..12]))
+}
+
+fn mode_key(mode: &RuntimeMode) -> &'static str {
+    match mode {
+        RuntimeMode::Shadow => "shadow",
+        RuntimeMode::Paper => "paper",
+        RuntimeMode::Live => "live",
+    }
+}
+
+fn reconciliation_status_key(status: &RuntimeReconciliationStatus) -> &'static str {
+    match status {
+        RuntimeReconciliationStatus::Passed => "passed",
+        RuntimeReconciliationStatus::NeedsManualReview => "needs_manual_review",
+        RuntimeReconciliationStatus::Failed => "failed",
+    }
+}
+
+fn hex_encode(input: &[u8]) -> String {
+    let mut output = String::with_capacity(input.len() * 2);
+    for byte in input {
+        use std::fmt::Write as _;
+        let _ = write!(&mut output, "{byte:02x}");
+    }
+    output
+}
+
+fn now_rfc3339() -> String {
+    OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .expect("current time to format")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::atomic::{AtomicU64, Ordering},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use protocol::{
+        RuntimeExecutionAction, RuntimeExecutionSlice, RuntimeLane, RuntimeLedgerTotals,
+        RuntimeMode, RuntimePositionSide,
+    };
+
+    use super::*;
+
+    static NEXT_TEST_ID: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_database_url(test_name: &str) -> String {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let sequence = NEXT_TEST_ID.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir()
+            .join(format!(
+                "reconciler-{test_name}-{unique}-{sequence}.sqlite3"
+            ))
+            .display()
+            .to_string()
+    }
+
+    fn reconciler(test_name: &str) -> Reconciler {
+        Reconciler::new(ReconcilerConfig::new(temp_database_url(test_name)))
+            .expect("reconciler to initialize")
+    }
+
+    fn plan(run_id: &str, mode: RuntimeMode) -> RuntimeExecutionPlan {
+        RuntimeExecutionPlan {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            plan_id: format!("plan_{run_id}"),
+            deployment_id: "dep_1".to_string(),
+            run_id: run_id.to_string(),
+            created_at: "2026-03-08T15:00:00Z".to_string(),
+            mode: mode.clone(),
+            lane: RuntimeLane::Safe,
+            idempotency_key: format!("dep_1:{run_id}"),
+            simulate_only: mode == RuntimeMode::Shadow,
+            dry_run: mode != RuntimeMode::Live,
+            slices: vec![RuntimeExecutionSlice {
+                slice_id: "slice_1".to_string(),
+                action: RuntimeExecutionAction::Buy,
+                input_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+                output_mint: "So11111111111111111111111111111111111111112".to_string(),
+                input_amount_atomic: "5000000".to_string(),
+                min_output_amount_atomic: Some("35000000".to_string()),
+                notional_usd: "5.00".to_string(),
+                slippage_bps: 50,
+            }],
+        }
+    }
+
+    fn ledger_snapshot(
+        deployment_id: &str,
+        available_usd: &str,
+        reserved_usd: &str,
+        equity_usd: &str,
+        unrealized_pnl_usd: &str,
+    ) -> RuntimeLedgerSnapshot {
+        RuntimeLedgerSnapshot {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            snapshot_id: format!("ledger_{deployment_id}"),
+            deployment_id: deployment_id.to_string(),
+            sleeve_id: "sleeve_1".to_string(),
+            as_of: "2026-03-08T15:00:01Z".to_string(),
+            balances: vec![RuntimeLedgerBalance {
+                mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+                symbol: "USDC".to_string(),
+                decimals: 6,
+                free_atomic: format!(
+                    "{}",
+                    parse_usd_cents("available", available_usd).expect("cents") * 10_000
+                ),
+                reserved_atomic: format!(
+                    "{}",
+                    parse_usd_cents("reserved", reserved_usd).expect("cents") * 10_000
+                ),
+                price_usd: Some("1.00".to_string()),
+            }],
+            positions: vec![RuntimeLedgerPosition {
+                instrument_id: "SOL".to_string(),
+                side: RuntimePositionSide::Long,
+                quantity_atomic: "1000000000".to_string(),
+                entry_price_usd: Some("140.00".to_string()),
+                mark_price_usd: Some("142.00".to_string()),
+                unrealized_pnl_usd: Some(unrealized_pnl_usd.to_string()),
+            }],
+            totals: RuntimeLedgerTotals {
+                equity_usd: equity_usd.to_string(),
+                reserved_usd: reserved_usd.to_string(),
+                available_usd: available_usd.to_string(),
+                realized_pnl_usd: "0.00".to_string(),
+                unrealized_pnl_usd: unrealized_pnl_usd.to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn records_attempts_receipts_and_wallet_observations_idempotently() {
+        let reconciler = reconciler("records");
+        let plan = plan("run_1", RuntimeMode::Shadow);
+
+        let first_attempt = reconciler
+            .record_submit_attempt(&plan, "submit_1", true, "runtime-rs")
+            .expect("attempt");
+        let second_attempt = reconciler
+            .record_submit_attempt(&plan, "submit_2", true, "runtime-rs")
+            .expect("attempt");
+        assert_eq!(first_attempt.attempt_id, second_attempt.attempt_id);
+        assert_eq!(second_attempt.submit_request_id, "submit_1");
+
+        let first_receipt = reconciler
+            .record_synthetic_receipt(&plan, "submit_1", "runtime-rs", "accepted", &["dry run"])
+            .expect("receipt");
+        let second_receipt = reconciler
+            .record_synthetic_receipt(&plan, "submit_1", "runtime-rs", "accepted", &["dry run"])
+            .expect("receipt");
+        assert_eq!(first_receipt.receipt_id, second_receipt.receipt_id);
+
+        let wallet = ledger_snapshot("dep_1", "95.00", "5.00", "100.00", "2.00");
+        let first_observation = reconciler
+            .record_wallet_observation("dep_1", "run_1", "runtime-rs", &wallet)
+            .expect("wallet observation");
+        let second_observation = reconciler
+            .record_wallet_observation("dep_1", "run_1", "runtime-rs", &wallet)
+            .expect("wallet observation");
+        assert_eq!(
+            first_observation.observation_id,
+            second_observation.observation_id
+        );
+
+        let bundle = reconciler
+            .bundle_for_deployment("dep_1")
+            .expect("bundle to load");
+        assert_eq!(bundle.submit_attempts.len(), 1);
+        assert_eq!(bundle.receipts.len(), 1);
+        assert_eq!(bundle.wallet_observations.len(), 1);
+    }
+
+    #[test]
+    fn passes_zero_drift_reconciliation() {
+        let reconciler = reconciler("passes");
+        let plan = plan("run_2", RuntimeMode::Shadow);
+        let receipt = reconciler
+            .record_synthetic_receipt(&plan, "submit_2", "runtime-rs", "accepted", &["dry run"])
+            .expect("receipt");
+        let expected = ledger_snapshot("dep_1", "95.00", "5.00", "100.00", "2.00");
+        let observed = expected.clone();
+
+        let outcome = reconciler
+            .reconcile_and_store(&ReconciliationInput {
+                deployment_id: "dep_1".to_string(),
+                run_id: "run_2".to_string(),
+                plan,
+                receipt,
+                expected_ledger: expected,
+                observed_ledger: observed,
+            })
+            .expect("reconciliation");
+
+        assert_eq!(outcome.result.status, RuntimeReconciliationStatus::Passed);
+        assert!(!outcome.should_apply_correction);
+        assert_eq!(outcome.result.position_delta_usd, "0.00");
+        assert_eq!(outcome.result.wallet_deltas.len(), 1);
+    }
+
+    #[test]
+    fn auto_corrects_small_wallet_drift() {
+        let reconciler = reconciler("autocorrect");
+        let plan = plan("run_3", RuntimeMode::Paper);
+        let receipt = reconciler
+            .record_synthetic_receipt(&plan, "submit_3", "runtime-rs", "accepted", &["paper"])
+            .expect("receipt");
+        let expected = ledger_snapshot("dep_1", "95.00", "5.00", "100.00", "2.00");
+        let observed = ledger_snapshot("dep_1", "94.50", "5.00", "99.50", "2.00");
+
+        let outcome = reconciler
+            .reconcile_and_store(&ReconciliationInput {
+                deployment_id: "dep_1".to_string(),
+                run_id: "run_3".to_string(),
+                plan,
+                receipt,
+                expected_ledger: expected,
+                observed_ledger: observed,
+            })
+            .expect("reconciliation");
+
+        assert_eq!(outcome.result.status, RuntimeReconciliationStatus::Passed);
+        assert!(outcome.should_apply_correction);
+        assert!(outcome.result.correction_applied);
+    }
+
+    #[test]
+    fn flags_large_drift_for_manual_intervention() {
+        let reconciler = reconciler("large-drift");
+        let plan = plan("run_4", RuntimeMode::Paper);
+        let receipt = reconciler
+            .record_synthetic_receipt(&plan, "submit_4", "runtime-rs", "accepted", &["paper"])
+            .expect("receipt");
+        let expected = ledger_snapshot("dep_1", "95.00", "5.00", "100.00", "2.00");
+        let observed = ledger_snapshot("dep_1", "80.00", "5.00", "85.00", "9.00");
+
+        let outcome = reconciler
+            .reconcile_and_store(&ReconciliationInput {
+                deployment_id: "dep_1".to_string(),
+                run_id: "run_4".to_string(),
+                plan,
+                receipt,
+                expected_ledger: expected,
+                observed_ledger: observed,
+            })
+            .expect("reconciliation");
+
+        assert_eq!(outcome.result.status, RuntimeReconciliationStatus::Failed);
+        assert!(!outcome.should_apply_correction);
+        assert!(!outcome.result.correction_applied);
+    }
+}

--- a/crates/strategy-registry/src/lib.rs
+++ b/crates/strategy-registry/src/lib.rs
@@ -317,8 +317,7 @@ impl StrategyRegistry {
         &self,
         run_id: &str,
         plan_id: &str,
-        submit_request_id: Option<&str>,
-        complete_immediately: bool,
+        submit_request_id: &str,
     ) -> Result<RuntimeRunRecord, StrategyRegistryError> {
         let mut connection = self.open_connection()?;
         let transaction = connection.transaction()?;
@@ -327,28 +326,104 @@ impl StrategyRegistry {
                 run_id: run_id.to_string(),
             })?;
 
-        if run.execution_plan_id.as_deref() == Some(plan_id)
-            && execution_state_matches(run.state.clone(), complete_immediately)
+        if run.execution_plan_id.as_deref() == Some(plan_id) && execution_state_matches(&run.state)
         {
             transaction.commit()?;
             return Ok(run);
         }
 
         run.execution_plan_id = Some(plan_id.to_string());
-        if let Some(submit_request_id) = submit_request_id {
-            run.submit_request_id = Some(submit_request_id.to_string());
-        }
-        transition_run_state(
-            &mut run,
-            if complete_immediately {
-                RuntimeRunState::Completed
-            } else {
-                RuntimeRunState::Submitted
-            },
-        )?;
+        run.submit_request_id = Some(submit_request_id.to_string());
+        transition_run_state(&mut run, RuntimeRunState::Submitted)?;
         run.updated_at = now_rfc3339();
         run.failure_code = None;
         run.failure_message = None;
+
+        update_run(&transaction, &run)?;
+        transaction.commit()?;
+        Ok(run)
+    }
+
+    pub fn apply_receipt(
+        &self,
+        run_id: &str,
+        receipt_id: &str,
+    ) -> Result<RuntimeRunRecord, StrategyRegistryError> {
+        let mut connection = self.open_connection()?;
+        let transaction = connection.transaction()?;
+        let mut run =
+            load_run(&transaction, run_id)?.ok_or_else(|| StrategyRegistryError::RunNotFound {
+                run_id: run_id.to_string(),
+            })?;
+
+        if run.receipt_id.as_deref() == Some(receipt_id) && receipt_state_matches(&run.state) {
+            transaction.commit()?;
+            return Ok(run);
+        }
+
+        run.receipt_id = Some(receipt_id.to_string());
+        transition_run_state(&mut run, RuntimeRunState::ReceiptPending)?;
+        run.updated_at = now_rfc3339();
+        run.failure_code = None;
+        run.failure_message = None;
+
+        update_run(&transaction, &run)?;
+        transaction.commit()?;
+        Ok(run)
+    }
+
+    pub fn apply_reconciliation_result(
+        &self,
+        run_id: &str,
+        status: protocol::RuntimeReconciliationStatus,
+        failure_code: Option<&str>,
+        failure_message: Option<&str>,
+    ) -> Result<RuntimeRunRecord, StrategyRegistryError> {
+        let mut connection = self.open_connection()?;
+        let transaction = connection.transaction()?;
+        let mut run =
+            load_run(&transaction, run_id)?.ok_or_else(|| StrategyRegistryError::RunNotFound {
+                run_id: run_id.to_string(),
+            })?;
+
+        if reconciliation_state_matches(&run.state, &status) {
+            transaction.commit()?;
+            return Ok(run);
+        }
+
+        match status {
+            protocol::RuntimeReconciliationStatus::Passed => {
+                transition_run_state(&mut run, RuntimeRunState::Reconciled)?;
+                transition_run_state(&mut run, RuntimeRunState::Completed)?;
+                run.failure_code = None;
+                run.failure_message = None;
+            }
+            protocol::RuntimeReconciliationStatus::NeedsManualReview => {
+                transition_run_state(&mut run, RuntimeRunState::Reconciled)?;
+                transition_run_state(&mut run, RuntimeRunState::NeedsManualReview)?;
+                run.failure_code = Some(
+                    failure_code
+                        .unwrap_or("reconciliation-needs-manual-review")
+                        .to_string(),
+                );
+                run.failure_message = Some(
+                    failure_message
+                        .unwrap_or("reconciliation requires manual review")
+                        .to_string(),
+                );
+            }
+            protocol::RuntimeReconciliationStatus::Failed => {
+                transition_run_state(&mut run, RuntimeRunState::Failed)?;
+                run.failure_code =
+                    Some(failure_code.unwrap_or("reconciliation-failed").to_string());
+                run.failure_message = Some(
+                    failure_message
+                        .unwrap_or("reconciliation failed")
+                        .to_string(),
+                );
+            }
+        }
+        run.updated_at = now_rfc3339();
 
         update_run(&transaction, &run)?;
         transaction.commit()?;
@@ -748,18 +823,53 @@ fn run_state_matches_verdict(state: &RuntimeRunState, verdict: &RuntimeRiskDecis
         (state, verdict),
         (RuntimeRunState::Planned, RuntimeRiskDecision::Allow)
             | (RuntimeRunState::Submitted, RuntimeRiskDecision::Allow)
+            | (RuntimeRunState::ReceiptPending, RuntimeRiskDecision::Allow)
+            | (
+                RuntimeRunState::NeedsManualReview,
+                RuntimeRiskDecision::Allow
+            )
             | (RuntimeRunState::Completed, RuntimeRiskDecision::Allow)
             | (RuntimeRunState::Rejected, RuntimeRiskDecision::Reject)
             | (RuntimeRunState::Killed, RuntimeRiskDecision::Pause)
     )
 }
 
-fn execution_state_matches(state: RuntimeRunState, complete_immediately: bool) -> bool {
-    if complete_immediately {
-        state == RuntimeRunState::Completed
-    } else {
-        state == RuntimeRunState::Submitted
-    }
+fn execution_state_matches(state: &RuntimeRunState) -> bool {
+    matches!(
+        state,
+        RuntimeRunState::Submitted
+            | RuntimeRunState::ReceiptPending
+            | RuntimeRunState::Completed
+            | RuntimeRunState::NeedsManualReview
+    )
+}
+
+fn receipt_state_matches(state: &RuntimeRunState) -> bool {
+    matches!(
+        state,
+        RuntimeRunState::ReceiptPending
+            | RuntimeRunState::Completed
+            | RuntimeRunState::NeedsManualReview
+    )
+}
+
+fn reconciliation_state_matches(
+    state: &RuntimeRunState,
+    status: &protocol::RuntimeReconciliationStatus,
+) -> bool {
+    matches!(
+        (state, status),
+        (
+            RuntimeRunState::Completed,
+            protocol::RuntimeReconciliationStatus::Passed
+        ) | (
+            RuntimeRunState::NeedsManualReview,
+            protocol::RuntimeReconciliationStatus::NeedsManualReview,
+        ) | (
+            RuntimeRunState::Failed,
+            protocol::RuntimeReconciliationStatus::Failed
+        )
+    )
 }
 
 fn select_feature_snapshot(
@@ -1263,10 +1373,25 @@ mod tests {
             })
             .expect("allow verdict to apply");
 
-        let completed = registry
-            .apply_execution_plan(&planned.run_id, "plan_123", None, true)
+        let submitted = registry
+            .apply_execution_plan(&planned.run_id, "plan_123", "submit_123")
             .expect("plan to apply");
+        let receipt_pending = registry
+            .apply_receipt(&planned.run_id, "receipt_123")
+            .expect("receipt to apply");
+        let completed = registry
+            .apply_reconciliation_result(
+                &planned.run_id,
+                protocol::RuntimeReconciliationStatus::Passed,
+                None,
+                None,
+            )
+            .expect("reconciliation to apply");
 
+        assert_eq!(submitted.state, RuntimeRunState::Submitted);
+        assert_eq!(submitted.submit_request_id.as_deref(), Some("submit_123"));
+        assert_eq!(receipt_pending.state, RuntimeRunState::ReceiptPending);
+        assert_eq!(receipt_pending.receipt_id.as_deref(), Some("receipt_123"));
         assert_eq!(completed.state, RuntimeRunState::Completed);
         assert_eq!(completed.execution_plan_id.as_deref(), Some("plan_123"));
     }

--- a/services/runtime-rs/Cargo.toml
+++ b/services/runtime-rs/Cargo.toml
@@ -12,6 +12,7 @@ feature-cache = { path = "../../crates/feature-cache" }
 market-adapters = { path = "../../crates/market-adapters" }
 portfolio-ledger = { path = "../../crates/portfolio-ledger" }
 protocol = { path = "../../crates/protocol" }
+reconciler = { path = "../../crates/reconciler" }
 risk-engine = { path = "../../crates/risk-engine" }
 runtime-ops = { path = "../../crates/runtime-ops" }
 serde.workspace = true

--- a/services/runtime-rs/src/lib.rs
+++ b/services/runtime-rs/src/lib.rs
@@ -18,6 +18,7 @@ use portfolio_ledger::{
     PortfolioLedger, PortfolioLedgerConfig, PortfolioLedgerError, PortfolioLedgerSnapshot,
 };
 use protocol::{RuntimeDeploymentRecord, RuntimeDeploymentState, RuntimeRunRecord};
+use reconciler::{Reconciler, ReconcilerConfig, ReconcilerError, ReconcilerSnapshot};
 use risk_engine::{
     should_pause_runtime, RiskAssessmentInput, RiskEngine, RiskEngineConfig, RiskEngineError,
     RiskEngineSnapshot,
@@ -51,6 +52,7 @@ pub struct RuntimeAppState {
     portfolio_ledger: PortfolioLedger,
     risk_engine: RiskEngine,
     execution_planner: ExecutionPlanner,
+    reconciler: Reconciler,
 }
 
 impl RuntimeAppState {
@@ -79,6 +81,8 @@ impl RuntimeAppState {
         let execution_planner =
             ExecutionPlanner::new(ExecutionPlannerConfig::new(config.database_url.clone()))
                 .expect("execution planner to initialize");
+        let reconciler = Reconciler::new(ReconcilerConfig::new(config.database_url.clone()))
+            .expect("reconciler to initialize");
         let exec_client = ExecClient::new(ExecClientConfig {
             api_base: config.worker_api_base.clone(),
             submit_path: config.worker_execution_plan_path.clone(),
@@ -96,6 +100,7 @@ impl RuntimeAppState {
             portfolio_ledger,
             risk_engine,
             execution_planner,
+            reconciler,
         }
     }
 
@@ -128,6 +133,10 @@ impl RuntimeAppState {
     fn execution_planner_snapshot(&self) -> ExecutionPlannerSnapshot {
         self.execution_planner.snapshot_now()
     }
+
+    fn reconciler_snapshot(&self) -> ReconcilerSnapshot {
+        self.reconciler.snapshot_now()
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -150,6 +159,7 @@ pub struct RuntimeHealthResponse {
     pub portfolio_ledger: PortfolioLedgerSnapshot,
     pub risk_engine: RiskEngineSnapshot,
     pub execution_planner: ExecutionPlannerSnapshot,
+    pub reconciler: ReconcilerSnapshot,
     pub supported_strategies: Vec<String>,
 }
 
@@ -167,6 +177,7 @@ pub struct RuntimeMetricsResponse {
     pub portfolio_ledger: PortfolioLedgerSnapshot,
     pub risk_engine: RiskEngineSnapshot,
     pub execution_planner: ExecutionPlannerSnapshot,
+    pub reconciler: ReconcilerSnapshot,
     pub supported_strategies: Vec<String>,
 }
 
@@ -174,6 +185,7 @@ pub struct RuntimeMetricsResponse {
 #[serde(rename_all = "camelCase")]
 struct RuntimeShadowEvaluationRequest {
     pub trigger: Option<ShadowEvaluationTrigger>,
+    pub observed_ledger_snapshot: Option<protocol::RuntimeLedgerSnapshot>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
@@ -223,6 +235,10 @@ pub fn app(config: RuntimeConfig) -> Router {
             get(execution_plans_handler),
         )
         .route(
+            &format!("{INTERNAL_RUNTIME_PREFIX}/reconciliations"),
+            get(reconciliations_handler),
+        )
+        .route(
             &format!("{INTERNAL_RUNTIME_PREFIX}/risk"),
             get(risk_handler),
         )
@@ -242,12 +258,14 @@ fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
     let portfolio_ledger = state.portfolio_ledger_snapshot();
     let risk_engine = state.risk_engine_snapshot();
     let execution_planner = state.execution_planner_snapshot();
+    let reconciler = state.reconciler_snapshot();
     let status = if feed_gateway.status == "healthy"
         && feature_cache.status == "healthy"
         && strategy_registry.status == "healthy"
         && portfolio_ledger.status == "healthy"
         && risk_engine.status == "healthy"
         && execution_planner.status == "healthy"
+        && reconciler.status == "healthy"
     {
         snapshot.status
     } else {
@@ -271,6 +289,7 @@ fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
         portfolio_ledger,
         risk_engine,
         execution_planner,
+        reconciler,
         supported_strategies: SUPPORTED_STRATEGIES
             .iter()
             .map(|strategy| strategy.as_key().to_string())
@@ -291,6 +310,7 @@ fn metrics_response(state: &RuntimeAppState) -> RuntimeMetricsResponse {
         portfolio_ledger: state.portfolio_ledger_snapshot(),
         risk_engine: state.risk_engine_snapshot(),
         execution_planner: state.execution_planner_snapshot(),
+        reconciler: state.reconciler_snapshot(),
         supported_strategies: SUPPORTED_STRATEGIES
             .iter()
             .map(|strategy| strategy.as_key().to_string())
@@ -480,6 +500,7 @@ async fn evaluate_deployment_handler(
     } else {
         parse_json_body::<RuntimeShadowEvaluationRequest>(&body, "invalid-runtime-evaluation")?
     };
+    let observed_ledger_override = request.observed_ledger_snapshot.clone();
     let result = state
         .strategy_registry
         .evaluate_shadow_trigger(
@@ -507,6 +528,8 @@ async fn evaluate_deployment_handler(
         .map_err(map_registry_error)?;
     let mut execution_plan = None;
     let mut coordination = None;
+    let mut reconciliation = None;
+    let mut observed_ledger_snapshot = None;
     let mut coordinated_run = run.clone();
     let ledger_snapshot = state
         .portfolio_ledger
@@ -528,6 +551,15 @@ async fn evaluate_deployment_handler(
                         )
                     })?,
             );
+            reconciliation = state
+                .reconciler
+                .get_result_by_run_id(&coordinated_run.run_id)
+                .map_err(map_reconciler_error)?;
+            observed_ledger_snapshot = state
+                .reconciler
+                .get_wallet_observation_by_run_id(&coordinated_run.run_id)
+                .map_err(map_reconciler_error)?
+                .map(|record| record.snapshot);
         } else {
             let planning = state
                 .execution_planner
@@ -545,19 +577,85 @@ async fn evaluate_deployment_handler(
                 .submit_plan(&plan)
                 .await
                 .map_err(map_exec_client_error)?;
+            state
+                .reconciler
+                .record_submit_attempt(
+                    &plan,
+                    &submit.submit_request_id,
+                    submit.accepted,
+                    &submit.source,
+                )
+                .map_err(map_reconciler_error)?;
             coordinated_run = state
                 .strategy_registry
                 .apply_execution_plan(
                     &coordinated_run.run_id,
                     &plan.plan_id,
-                    if plan.dry_run {
-                        None
-                    } else {
-                        Some(plan.idempotency_key.as_str())
-                    },
-                    plan.dry_run,
+                    &submit.submit_request_id,
                 )
                 .map_err(map_registry_error)?;
+            let receipt = state
+                .reconciler
+                .record_synthetic_receipt(
+                    &plan,
+                    &submit.submit_request_id,
+                    &submit.source,
+                    "accepted",
+                    &["execution coordination accepted"],
+                )
+                .map_err(map_reconciler_error)?;
+            coordinated_run = state
+                .strategy_registry
+                .apply_receipt(&coordinated_run.run_id, &receipt.receipt_id)
+                .map_err(map_registry_error)?;
+            let observed_ledger =
+                observed_ledger_override.unwrap_or_else(|| ledger_snapshot.clone());
+            state
+                .reconciler
+                .record_wallet_observation(
+                    &deployment_id,
+                    &coordinated_run.run_id,
+                    "runtime-rs",
+                    &observed_ledger,
+                )
+                .map_err(map_reconciler_error)?;
+            let reconciliation_outcome = state
+                .reconciler
+                .reconcile_and_store(&reconciler::ReconciliationInput {
+                    deployment_id: deployment_id.clone(),
+                    run_id: coordinated_run.run_id.clone(),
+                    plan: plan.clone(),
+                    receipt,
+                    expected_ledger: ledger_snapshot.clone(),
+                    observed_ledger: observed_ledger.clone(),
+                })
+                .map_err(map_reconciler_error)?;
+            let reconciliation_failure_code = match reconciliation_outcome.result.status {
+                protocol::RuntimeReconciliationStatus::Passed => None,
+                protocol::RuntimeReconciliationStatus::NeedsManualReview => {
+                    Some("reconciliation-needs-manual-review")
+                }
+                protocol::RuntimeReconciliationStatus::Failed => Some("reconciliation-failed"),
+            };
+            let reconciliation_failure_message =
+                reconciliation_outcome.result.notes.last().cloned();
+            coordinated_run = state
+                .strategy_registry
+                .apply_reconciliation_result(
+                    &coordinated_run.run_id,
+                    reconciliation_outcome.result.status.clone(),
+                    reconciliation_failure_code,
+                    reconciliation_failure_message.as_deref(),
+                )
+                .map_err(map_registry_error)?;
+            if reconciliation_outcome.should_apply_correction {
+                state
+                    .portfolio_ledger
+                    .apply_observed_snapshot(&deployment_id, &observed_ledger)
+                    .map_err(map_ledger_error)?;
+            }
+            reconciliation = Some(reconciliation_outcome.result);
+            observed_ledger_snapshot = Some(observed_ledger);
             execution_plan = Some(plan);
             coordination = Some(submit);
         }
@@ -588,6 +686,8 @@ async fn evaluate_deployment_handler(
         ledger_snapshot,
         execution_plan,
         coordination,
+        reconciliation,
+        observed_ledger_snapshot,
     }))
 }
 
@@ -656,6 +756,32 @@ async fn execution_plans_handler(
     ))
 }
 
+async fn reconciliations_handler(
+    headers: HeaderMap,
+    Query(query): Query<RuntimeDeploymentQuery>,
+    State(state): State<RuntimeAppState>,
+) -> HandlerResult {
+    authorize_internal_request(&headers, &state)?;
+    let deployment_id = require_deployment_id(query)?;
+    let bundle = state
+        .reconciler
+        .bundle_for_deployment(&deployment_id)
+        .map_err(map_reconciler_error)?;
+    Ok(OkJson::with_status(
+        StatusCode::OK,
+        json!({
+            "ok": true,
+            "source": "runtime-rs",
+            "deploymentId": deployment_id,
+            "submitAttempts": bundle.submit_attempts,
+            "receipts": bundle.receipts,
+            "walletObservations": bundle.wallet_observations,
+            "results": bundle.results,
+            "thresholds": bundle.thresholds,
+        }),
+    ))
+}
+
 async fn positions_handler(
     headers: HeaderMap,
     Query(query): Query<RuntimeDeploymentQuery>,
@@ -710,6 +836,8 @@ struct ShadowEvaluationResponse {
     ledger_snapshot: protocol::RuntimeLedgerSnapshot,
     execution_plan: Option<protocol::RuntimeExecutionPlan>,
     coordination: Option<ExecSubmitResponse>,
+    reconciliation: Option<protocol::RuntimeReconciliationResult>,
+    observed_ledger_snapshot: Option<protocol::RuntimeLedgerSnapshot>,
 }
 
 fn shadow_evaluation_json(payload: ShadowEvaluationResponse) -> JsonPayload {
@@ -730,6 +858,8 @@ fn shadow_evaluation_json(payload: ShadowEvaluationResponse) -> JsonPayload {
             "ledger": payload.ledger_snapshot,
             "executionPlan": payload.execution_plan,
             "coordination": payload.coordination,
+            "reconciliation": payload.reconciliation,
+            "observedLedger": payload.observed_ledger_snapshot,
         }),
     )
 }
@@ -1004,6 +1134,36 @@ fn map_execution_planner_error(error: ExecutionPlannerError) -> JsonPayload {
         ExecutionPlannerError::Serialization(error) => error_json(
             StatusCode::INTERNAL_SERVER_ERROR,
             "runtime-execution-plan-error",
+            json!({ "reason": error.to_string() }),
+        ),
+    }
+}
+
+fn map_reconciler_error(error: ReconcilerError) -> JsonPayload {
+    match error {
+        ReconcilerError::InvalidNumericValue { field, value } => error_json(
+            StatusCode::BAD_REQUEST,
+            "invalid-reconciliation-number",
+            json!({ "field": field, "value": value }),
+        ),
+        ReconcilerError::ResultNotFound { run_id } => error_json(
+            StatusCode::NOT_FOUND,
+            "reconciliation-not-found",
+            json!({ "runId": run_id }),
+        ),
+        ReconcilerError::Io(error) => error_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "runtime-reconciliation-error",
+            json!({ "reason": error.to_string() }),
+        ),
+        ReconcilerError::Storage(error) => error_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "runtime-reconciliation-error",
+            json!({ "reason": error.to_string() }),
+        ),
+        ReconcilerError::Serialization(error) => error_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "runtime-reconciliation-error",
             json!({ "reason": error.to_string() }),
         ),
     }
@@ -1324,6 +1484,7 @@ mod tests {
                                 "ok": true,
                                 "accepted": true,
                                 "source": "test-stub",
+                                "submitRequestId": "submit_runtime_123",
                                 "coordination": {
                                     "planId": plan.plan_id,
                                     "deploymentId": plan.deployment_id,
@@ -1430,6 +1591,8 @@ mod tests {
         assert_eq!(payload.risk_engine.verdict_count, 0);
         assert_eq!(payload.execution_planner.status, "healthy");
         assert_eq!(payload.execution_planner.plan_count, 0);
+        assert_eq!(payload.reconciler.status, "healthy");
+        assert_eq!(payload.reconciler.reconciliation_count, 0);
         assert!(payload.internal_service_auth_configured);
     }
 
@@ -1461,6 +1624,7 @@ mod tests {
         assert_eq!(payload.portfolio_ledger.status, "healthy");
         assert_eq!(payload.risk_engine.status, "healthy");
         assert_eq!(payload.execution_planner.status, "healthy");
+        assert_eq!(payload.reconciler.status, "healthy");
     }
 
     #[tokio::test]
@@ -1548,7 +1712,27 @@ mod tests {
             evaluation_payload["executionPlan"]["deploymentId"],
             json!("deployment_123")
         );
+        assert_eq!(
+            evaluation_payload["run"]["submitRequestId"],
+            json!("submit_runtime_123")
+        );
+        assert_eq!(
+            evaluation_payload["run"]["receiptId"],
+            evaluation_payload["reconciliation"]["receiptId"]
+        );
         assert_eq!(evaluation_payload["coordination"]["accepted"], json!(true));
+        assert_eq!(
+            evaluation_payload["coordination"]["submitRequestId"],
+            json!("submit_runtime_123")
+        );
+        assert_eq!(
+            evaluation_payload["reconciliation"]["status"],
+            json!("passed")
+        );
+        assert_eq!(
+            evaluation_payload["observedLedger"]["totals"]["equityUsd"],
+            json!("1000.00")
+        );
 
         let duplicate_response = router
             .clone()
@@ -1602,6 +1786,7 @@ mod tests {
         assert_eq!(risk_payload["verdicts"].as_array().expect("array").len(), 1);
 
         let plans_response = router
+            .clone()
             .oneshot(
                 Request::builder()
                     .uri("/api/internal/runtime/execution-plans?deploymentId=deployment_123")
@@ -1614,6 +1799,128 @@ mod tests {
         assert_eq!(plans_response.status(), StatusCode::OK);
         let plans_payload = read_json(plans_response).await;
         assert_eq!(plans_payload["plans"].as_array().expect("array").len(), 1);
+
+        let reconciliations_response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/api/internal/runtime/reconciliations?deploymentId=deployment_123")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(reconciliations_response.status(), StatusCode::OK);
+        let reconciliations_payload = read_json(reconciliations_response).await;
+        assert_eq!(
+            reconciliations_payload["submitAttempts"]
+                .as_array()
+                .expect("array")
+                .len(),
+            1
+        );
+        assert_eq!(
+            reconciliations_payload["receipts"]
+                .as_array()
+                .expect("array")
+                .len(),
+            1
+        );
+        assert_eq!(
+            reconciliations_payload["walletObservations"]
+                .as_array()
+                .expect("array")
+                .len(),
+            1
+        );
+        assert_eq!(
+            reconciliations_payload["results"]
+                .as_array()
+                .expect("array")
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn applies_small_reconciliation_drift_corrections() {
+        let worker_api_base = spawn_exec_coordination_stub().await;
+        let router = app(test_config_with_worker_api_base(Some(&worker_api_base)));
+        let deployment =
+            runtime_deployment("deployment_drift", "sleeve_alpha", "1000.00", "125.00");
+
+        let create_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/deployments")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(deployment.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(create_response.status(), StatusCode::CREATED);
+
+        let evaluate_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/deployments/deployment_drift/evaluate")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "observedLedgerSnapshot": {
+                                "schemaVersion": "v1",
+                                "snapshotId": "wallet_drift_1",
+                                "deploymentId": "deployment_drift",
+                                "sleeveId": "sleeve_alpha",
+                                "asOf": "2026-03-08T15:00:10Z",
+                                "balances": [
+                                    {
+                                        "mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                                        "symbol": "USDC",
+                                        "decimals": 6,
+                                        "freeAtomic": "874500000",
+                                        "reservedAtomic": "125000000",
+                                        "priceUsd": "1.00"
+                                    }
+                                ],
+                                "positions": [],
+                                "totals": {
+                                    "equityUsd": "999.50",
+                                    "reservedUsd": "125.00",
+                                    "availableUsd": "874.50",
+                                    "realizedPnlUsd": "0.00",
+                                    "unrealizedPnlUsd": "0.00"
+                                }
+                            }
+                        })
+                        .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(evaluate_response.status(), StatusCode::CREATED);
+        let evaluation_payload = read_json(evaluate_response).await;
+        assert_eq!(
+            evaluation_payload["reconciliation"]["correctionApplied"],
+            json!(true)
+        );
+        assert_eq!(
+            evaluation_payload["ledger"]["totals"]["equityUsd"],
+            json!("999.50")
+        );
+        assert_eq!(
+            evaluation_payload["ledger"]["totals"]["availableUsd"],
+            json!("874.50")
+        );
+        assert_eq!(evaluation_payload["run"]["state"], json!("completed"));
     }
 
     #[tokio::test]

--- a/tests/unit/worker_runtime_internal_routes.test.ts
+++ b/tests/unit/worker_runtime_internal_routes.test.ts
@@ -182,6 +182,7 @@ describe("worker runtime internal routes", () => {
       ok: true,
       accepted: true,
       source: "stub",
+      submitRequestId: "submit_plan_123",
       coordination: {
         planId: "plan_123",
         deploymentId: "deployment_123",


### PR DESCRIPTION
## Summary
- add a repo-owned `reconciler` crate for submit attempts, receipts, wallet observations, and persisted reconciliation results
- drive runtime-rs shadow evaluations through submit -> receipt -> reconciliation transitions with optional small-drift auto-correction
- expose reconciliation state in runtime health/metrics and add an internal worker/runtime route contract for `submitRequestId`

## Testing
- `cargo fmt --all && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace && bun run lint && bun run typecheck && bun test tests/unit/worker_runtime_internal_routes.test.ts`

Fixes #268
