### PR TITLE
[Phase 4] Add runtime ops controls and dashboards

### DIFF
--- a/.github/workflows/ops-dashboard.yml
+++ b/.github/workflows/ops-dashboard.yml
@@ -56,7 +56,13 @@ jobs:
             "https://api.trader-ralph.com/api/admin/ops/controls" \
             > .tmp/ops-dashboard/controls-envelope.json
 
+          curl -fsS \
+            -H "authorization: Bearer ${ADMIN_TOKEN}" \
+            "https://api.trader-ralph.com/api/admin/ops/runtime" \
+            > .tmp/ops-dashboard/runtime-envelope.json
+
           jq '.controls' .tmp/ops-dashboard/controls-envelope.json > .tmp/ops-dashboard/controls.json
+          jq '.runtime' .tmp/ops-dashboard/runtime-envelope.json > .tmp/ops-dashboard/runtime.json
 
       - name: Build ops dashboard
         env:
@@ -69,6 +75,7 @@ jobs:
             --execution .tmp/ops-dashboard/execution.json
             --canary .tmp/ops-dashboard/canary.json
             --controls .tmp/ops-dashboard/controls.json
+            --runtime .tmp/ops-dashboard/runtime.json
             --output-json .tmp/ops-dashboard/dashboard.json
             --output-markdown .tmp/ops-dashboard/dashboard.md
           )

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -132,7 +132,13 @@ import { enforcePolicy, normalizePolicy } from "./policy";
 import { createPrivySolanaWallet } from "./privy";
 import { gatherMarketSnapshot } from "./research";
 import { json, okCors, withCors } from "./response";
-import { handleRuntimeInternalRoute } from "./runtime_internal";
+import {
+  applyRuntimeDeploymentControl,
+  handleRuntimeInternalRoute,
+  type RuntimeControlAction,
+  readRuntimeAdminSnapshot,
+  readRuntimeDeployment,
+} from "./runtime_internal";
 import { SolanaRpc } from "./solana_rpc";
 import type { Env, ExecutionConfig } from "./types";
 import type { UserRow } from "./users_db";
@@ -417,7 +423,45 @@ function parseOpsControlPatch(
     }
   }
 
+  if (isRecord(value.runtime)) {
+    patch.runtime = {};
+    if (value.runtime.enabled !== undefined) {
+      patch.runtime.enabled = readBooleanEnv(value.runtime.enabled, true);
+    }
+    if (value.runtime.disabledReason !== undefined) {
+      patch.runtime.disabledReason = readOptionalString(
+        value.runtime.disabledReason,
+      );
+    }
+    if (value.runtime.shadowOnly !== undefined) {
+      patch.runtime.shadowOnly = readBooleanEnv(value.runtime.shadowOnly, true);
+    }
+    if (value.runtime.shadowOnlyReason !== undefined) {
+      patch.runtime.shadowOnlyReason = readOptionalString(
+        value.runtime.shadowOnlyReason,
+      );
+    }
+  }
+
   return patch;
+}
+
+function parseRuntimeAdminControlPath(pathname: string): {
+  deploymentId: string;
+  action: RuntimeControlAction;
+} | null {
+  const prefix = "/api/admin/ops/runtime/deployments/";
+  if (!pathname.startsWith(prefix)) return null;
+  const suffix = pathname.slice(prefix.length);
+  const [deploymentId, action, extra] = suffix.split("/");
+  if (!deploymentId || extra) return null;
+  if (action !== "pause" && action !== "resume" && action !== "kill") {
+    return null;
+  }
+  return {
+    deploymentId: decodeURIComponent(deploymentId),
+    action,
+  };
 }
 
 function newExecutionAttemptId(): string {
@@ -2094,6 +2138,105 @@ const worker = {
 
       if (
         request.method === "GET" &&
+        url.pathname === "/api/admin/ops/runtime"
+      ) {
+        const auth = authorizeAdminRoute(request, env);
+        if (!auth.ok) {
+          return withCors(
+            json({ ok: false, error: auth.error }, { status: auth.status }),
+            env,
+          );
+        }
+        const controls = await readOpsControlSnapshot(env);
+        const runtime = await readRuntimeAdminSnapshot(env);
+        return withCors(
+          json({
+            ok: true,
+            runtime: {
+              ...runtime,
+              controls: controls.runtime,
+            },
+          }),
+          env,
+        );
+      }
+
+      const runtimeControl =
+        request.method === "POST"
+          ? parseRuntimeAdminControlPath(url.pathname)
+          : null;
+      if (request.method === "POST" && runtimeControl) {
+        const auth = authorizeAdminRoute(request, env);
+        if (!auth.ok) {
+          return withCors(
+            json({ ok: false, error: auth.error }, { status: auth.status }),
+            env,
+          );
+        }
+        const controls = await readOpsControlSnapshot(env);
+        if (runtimeControl.action === "resume") {
+          if (!controls.runtime.enabled) {
+            return withCors(
+              json(
+                {
+                  ok: false,
+                  error: "runtime-disabled",
+                  deploymentId: runtimeControl.deploymentId,
+                  controls: controls.runtime,
+                },
+                { status: 409 },
+              ),
+              env,
+            );
+          }
+
+          const deploymentResult = await readRuntimeDeployment(
+            env,
+            runtimeControl.deploymentId,
+          );
+          if (!deploymentResult.ok) {
+            return withCors(
+              json(deploymentResult.payload, {
+                status: deploymentResult.status,
+              }),
+              env,
+            );
+          }
+          const deployment = isRecord(deploymentResult.payload.deployment)
+            ? deploymentResult.payload.deployment
+            : null;
+          const deploymentMode = readOptionalString(deployment?.mode);
+          if (
+            controls.runtime.shadowOnly &&
+            deploymentMode &&
+            deploymentMode !== "shadow"
+          ) {
+            return withCors(
+              json(
+                {
+                  ok: false,
+                  error: "runtime-shadow-only",
+                  deploymentId: runtimeControl.deploymentId,
+                  mode: deploymentMode,
+                  controls: controls.runtime,
+                },
+                { status: 409 },
+              ),
+              env,
+            );
+          }
+        }
+
+        const result = await applyRuntimeDeploymentControl({
+          env,
+          deploymentId: runtimeControl.deploymentId,
+          action: runtimeControl.action,
+        });
+        return withCors(json(result.payload, { status: result.status }), env);
+      }
+
+      if (
+        request.method === "GET" &&
         url.pathname === "/api/admin/ops/dashboard"
       ) {
         const auth = authorizeAdminRoute(request, env);
@@ -2121,7 +2264,7 @@ const worker = {
           100,
           20_000,
         );
-        const [controls, execution, canary] = await Promise.all([
+        const [controls, execution, canary, runtime] = await Promise.all([
           readOpsControlSnapshot(env),
           readExecutionObservabilitySnapshot({
             db: env.WAITLIST_DB,
@@ -2130,6 +2273,7 @@ const worker = {
             thresholds: readExecObservabilityThresholds(env),
           }),
           readExecutionCanarySnapshot(env),
+          readRuntimeAdminSnapshot(env),
         ]);
         return withCors(
           json({
@@ -2138,6 +2282,10 @@ const worker = {
             controls,
             execution,
             canary,
+            runtime: {
+              ...runtime,
+              controls: controls.runtime,
+            },
           }),
           env,
         );

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -458,8 +458,14 @@ function parseRuntimeAdminControlPath(pathname: string): {
   if (action !== "pause" && action !== "resume" && action !== "kill") {
     return null;
   }
+  let decodedDeploymentId: string;
+  try {
+    decodedDeploymentId = decodeURIComponent(deploymentId);
+  } catch {
+    return null;
+  }
   return {
-    deploymentId: decodeURIComponent(deploymentId),
+    deploymentId: decodedDeploymentId,
     action,
   };
 }

--- a/apps/worker/src/ops_controls.ts
+++ b/apps/worker/src/ops_controls.ts
@@ -3,6 +3,7 @@ import type { Env } from "./types";
 
 const OPS_CONTROL_KV_KEY = "ops:controls:v1";
 const EXECUTION_LANES: ExecutionLane[] = ["fast", "protected", "safe"];
+const DEFAULT_RUNTIME_SHADOW_ONLY_REASON = "live-rollout-pending";
 
 type OpsControlJson = Record<string, unknown>;
 
@@ -16,6 +17,12 @@ export type OpsControlSnapshot = {
   canary: {
     enabled: boolean;
     disabledReason: string | null;
+  };
+  runtime: {
+    enabled: boolean;
+    disabledReason: string | null;
+    shadowOnly: boolean;
+    shadowOnlyReason: string | null;
   };
   metadata: {
     source: "default" | "kv";
@@ -33,6 +40,12 @@ export type OpsControlPatch = {
   canary?: {
     enabled?: boolean;
     disabledReason?: string | null;
+  };
+  runtime?: {
+    enabled?: boolean;
+    disabledReason?: string | null;
+    shadowOnly?: boolean;
+    shadowOnlyReason?: string | null;
   };
   updatedAt?: string;
   updatedBy?: string | null;
@@ -78,6 +91,12 @@ function defaultOpsControlSnapshot(): OpsControlSnapshot {
       enabled: true,
       disabledReason: null,
     },
+    runtime: {
+      enabled: true,
+      disabledReason: null,
+      shadowOnly: true,
+      shadowOnlyReason: DEFAULT_RUNTIME_SHADOW_ONLY_REASON,
+    },
     metadata: {
       source: "default",
       updatedAt: null,
@@ -114,6 +133,7 @@ function normalizeOpsControlSnapshot(
   }
   const execution = isRecord(value.execution) ? value.execution : {};
   const canary = isRecord(value.canary) ? value.canary : {};
+  const runtime = isRecord(value.runtime) ? value.runtime : {};
   const metadata = isRecord(value.metadata) ? value.metadata : {};
   return {
     schemaVersion: "v1",
@@ -129,6 +149,16 @@ function normalizeOpsControlSnapshot(
       disabledReason:
         readStringOrNull(canary.disabledReason) ??
         fallback.canary.disabledReason,
+    },
+    runtime: {
+      enabled: readBoolean(runtime.enabled, fallback.runtime.enabled),
+      disabledReason:
+        readStringOrNull(runtime.disabledReason) ??
+        fallback.runtime.disabledReason,
+      shadowOnly: readBoolean(runtime.shadowOnly, fallback.runtime.shadowOnly),
+      shadowOnlyReason:
+        readStringOrNull(runtime.shadowOnlyReason) ??
+        fallback.runtime.shadowOnlyReason,
     },
     metadata: {
       source,
@@ -176,6 +206,9 @@ export async function writeOpsControlSnapshot(
   const nextExecutionEnabled =
     patch.execution?.enabled ?? current.execution.enabled;
   const nextCanaryEnabled = patch.canary?.enabled ?? current.canary.enabled;
+  const nextRuntimeEnabled = patch.runtime?.enabled ?? current.runtime.enabled;
+  const nextRuntimeShadowOnly =
+    patch.runtime?.shadowOnly ?? current.runtime.shadowOnly;
   const next: OpsControlSnapshot = {
     schemaVersion: "v1",
     execution: {
@@ -199,6 +232,23 @@ export async function writeOpsControlSnapshot(
           : nextCanaryEnabled
             ? null
             : current.canary.disabledReason,
+    },
+    runtime: {
+      enabled: nextRuntimeEnabled,
+      disabledReason:
+        patch.runtime?.disabledReason !== undefined
+          ? readStringOrNull(patch.runtime.disabledReason)
+          : nextRuntimeEnabled
+            ? null
+            : current.runtime.disabledReason,
+      shadowOnly: nextRuntimeShadowOnly,
+      shadowOnlyReason:
+        patch.runtime?.shadowOnlyReason !== undefined
+          ? readStringOrNull(patch.runtime.shadowOnlyReason)
+          : nextRuntimeShadowOnly
+            ? (current.runtime.shadowOnlyReason ??
+              DEFAULT_RUNTIME_SHADOW_ONLY_REASON)
+            : null,
     },
     metadata: {
       source: "kv",
@@ -227,6 +277,12 @@ export async function resetOpsControlSnapshot(
     canary: {
       enabled: true,
       disabledReason: null,
+    },
+    runtime: {
+      enabled: true,
+      disabledReason: null,
+      shadowOnly: true,
+      shadowOnlyReason: DEFAULT_RUNTIME_SHADOW_ONLY_REASON,
     },
     updatedBy: updatedBy ?? null,
   });

--- a/apps/worker/src/runtime_internal.ts
+++ b/apps/worker/src/runtime_internal.ts
@@ -14,6 +14,8 @@ import type { Env } from "./types";
 
 const BEARER_RE = /^bearer\s+/i;
 const INTERNAL_RUNTIME_PREFIX = "/api/internal/runtime";
+const INTERNAL_RUNTIME_HEALTH_PATH = `${INTERNAL_RUNTIME_PREFIX}/health`;
+const INTERNAL_RUNTIME_DEPLOYMENTS_PATH = `${INTERNAL_RUNTIME_PREFIX}/deployments`;
 const INTERNAL_RUNTIME_DEPLOYMENTS_PREFIX = `${INTERNAL_RUNTIME_PREFIX}/deployments/`;
 const INTERNAL_RUNTIME_RUNS_PREFIX = `${INTERNAL_RUNTIME_PREFIX}/runs/`;
 const INTERNAL_RUNTIME_EXECUTION_PLANS_PATH = `${INTERNAL_RUNTIME_PREFIX}/execution-plans`;
@@ -23,7 +25,26 @@ const FIXTURE_BASE_MINT = "So11111111111111111111111111111111111111112";
 const FIXTURE_QUOTE_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 const DEFAULT_RUNTIME_SERVICE = "runtime-rs";
 
-type RuntimeControlAction = "pause" | "resume" | "kill";
+export type RuntimeControlAction = "pause" | "resume" | "kill";
+
+export type RuntimeInternalJsonResult = {
+  status: number;
+  ok: boolean;
+  payload: Record<string, unknown>;
+};
+
+export type RuntimeAdminSnapshot = {
+  ok: boolean;
+  source: string;
+  integration: {
+    stubModeEnabled: boolean;
+    runtimeBaseUrl: string | null;
+    serviceName: string;
+  };
+  health: Record<string, unknown> | null;
+  deployments: RuntimeDeploymentRecord[];
+  error: string | null;
+};
 
 function parseBearerToken(value: string | null): string | null {
   const raw = String(value ?? "").trim();
@@ -41,9 +62,28 @@ function configuredRuntimeServiceName(env: Env): string {
   return configured || DEFAULT_RUNTIME_SERVICE;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readStringOrNull(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return normalized ? normalized : null;
+}
+
 function readRuntimeServiceBaseUrl(env: Env): string | null {
   const raw = String(env.RUNTIME_INTERNAL_BASE_URL ?? "").trim();
   return raw || null;
+}
+
+function buildRuntimeIntegration(
+  env: Env,
+): RuntimeAdminSnapshot["integration"] {
+  return {
+    stubModeEnabled: isRuntimeStubModeEnabled(env),
+    runtimeBaseUrl: readRuntimeServiceBaseUrl(env),
+    serviceName: configuredRuntimeServiceName(env),
+  };
 }
 
 function authorizeRuntimeServiceRoute(
@@ -78,10 +118,32 @@ function authorizeRuntimeServiceRoute(
   };
 }
 
+function inferFixtureDeploymentMode(
+  deploymentId: string,
+): RuntimeDeploymentRecord["mode"] {
+  const normalized = deploymentId.trim().toLowerCase();
+  if (normalized.includes("live")) return "live";
+  if (normalized.includes("paper")) return "paper";
+  return "shadow";
+}
+
+function resumeStateForDeploymentId(
+  deploymentId: string,
+): RuntimeDeploymentRecord["state"] {
+  const mode = inferFixtureDeploymentMode(deploymentId);
+  if (mode === "paper") return "paper";
+  if (mode === "live") return "live";
+  return "shadow";
+}
+
 function createRuntimeDeploymentFixture(
   deploymentId: string,
-  state: RuntimeDeploymentRecord["state"] = "shadow",
+  state?: RuntimeDeploymentRecord["state"],
+  mode?: RuntimeDeploymentRecord["mode"],
 ): RuntimeDeploymentRecord {
+  const fixtureMode = mode ?? inferFixtureDeploymentMode(deploymentId);
+  const fixtureState =
+    state ?? (fixtureMode === "shadow" ? "shadow" : fixtureMode);
   return parseRuntimeDeploymentRecord({
     schemaVersion: RUNTIME_PROTOCOL_SCHEMA_VERSION,
     deploymentId,
@@ -93,13 +155,13 @@ function createRuntimeDeploymentFixture(
       baseMint: FIXTURE_BASE_MINT,
       quoteMint: FIXTURE_QUOTE_MINT,
     },
-    mode: state === "live" ? "live" : state === "paper" ? "paper" : "shadow",
-    state,
+    mode: fixtureMode,
+    state: fixtureState,
     lane: "safe",
     createdAt: FIXTURE_TIMESTAMP,
     updatedAt: FIXTURE_TIMESTAMP,
-    ...(state === "paused" ? { pausedAt: FIXTURE_TIMESTAMP } : {}),
-    ...(state === "killed" ? { killedAt: FIXTURE_TIMESTAMP } : {}),
+    ...(fixtureState === "paused" ? { pausedAt: FIXTURE_TIMESTAMP } : {}),
+    ...(fixtureState === "killed" ? { killedAt: FIXTURE_TIMESTAMP } : {}),
     policy: {
       maxNotionalUsd: "250.00",
       dailyLossLimitUsd: "35.00",
@@ -280,6 +342,38 @@ function createRuntimeScorecardFixture(deploymentId: string) {
   };
 }
 
+function createRuntimeHealthFixture() {
+  return {
+    serviceName: DEFAULT_RUNTIME_SERVICE,
+    status: "healthy",
+    environment: "local",
+    protocolVersion: RUNTIME_PROTOCOL_SCHEMA_VERSION,
+    marketAdapterStatus: "healthy",
+    feedBootstrapSource: "stub",
+    feedGateway: {
+      status: "healthy",
+      maxMarketAgeMs: 2400,
+      maxSlotAgeMs: 1700,
+      maxSlotGapObserved: 0,
+      staleMarketStreams: [],
+      staleSlotCommitments: [],
+    },
+    featureCache: {
+      status: "healthy",
+      maxFeatureAgeMs: 2600,
+      maxSlotAgeMs: 1800,
+      maxSlotGapObserved: 0,
+      staleFeatureKeys: [],
+    },
+    strategyRegistry: {
+      status: "healthy",
+      deploymentCount: 1,
+      runCount: 0,
+      lastError: null,
+    },
+  };
+}
+
 async function readJsonBody(request: Request): Promise<unknown> {
   try {
     return await request.json();
@@ -311,7 +405,7 @@ function buildRuntimeHealthPayload(env: Env, service: string) {
       runtimeBaseUrl: readRuntimeServiceBaseUrl(env),
     },
     routes: {
-      deployments: `${INTERNAL_RUNTIME_PREFIX}/deployments`,
+      deployments: INTERNAL_RUNTIME_DEPLOYMENTS_PATH,
       runs: `${INTERNAL_RUNTIME_PREFIX}/runs/:deploymentId`,
       positions: `${INTERNAL_RUNTIME_PREFIX}/positions`,
       pnl: `${INTERNAL_RUNTIME_PREFIX}/pnl`,
@@ -324,9 +418,10 @@ function buildRuntimeHealthPayload(env: Env, service: string) {
 
 function mapControlActionToState(
   action: RuntimeControlAction,
+  deploymentId: string,
 ): RuntimeDeploymentRecord["state"] {
   if (action === "pause") return "paused";
-  if (action === "resume") return "shadow";
+  if (action === "resume") return resumeStateForDeploymentId(deploymentId);
   return "killed";
 }
 
@@ -344,14 +439,193 @@ function controlActionFromPath(pathname: string): {
   return null;
 }
 
+async function dispatchRuntimeInternalJson(input: {
+  env: Env;
+  method: string;
+  pathname: string;
+  body?: unknown;
+}): Promise<RuntimeInternalJsonResult> {
+  const headers = new Headers({
+    authorization: `Bearer ${String(input.env.RUNTIME_INTERNAL_SERVICE_TOKEN ?? "").trim()}`,
+    accept: "application/json",
+  });
+  let body: string | undefined;
+  if (input.body !== undefined) {
+    headers.set("content-type", "application/json");
+    body = JSON.stringify(input.body);
+  }
+
+  let response: Response;
+  if (isRuntimeStubModeEnabled(input.env)) {
+    const url = new URL(input.pathname, "http://runtime-internal.local");
+    const request = new Request(url.toString(), {
+      method: input.method,
+      headers,
+      ...(body !== undefined ? { body } : {}),
+    });
+    response =
+      (await handleRuntimeInternalRoute(request, url, input.env)) ??
+      json({ ok: false, error: "runtime-route-not-handled" }, { status: 404 });
+  } else {
+    const baseUrl = readRuntimeServiceBaseUrl(input.env);
+    if (!baseUrl) {
+      response = runtimeInternalUnavailable(input.env);
+    } else {
+      try {
+        response = await fetch(new URL(input.pathname, baseUrl), {
+          method: input.method,
+          headers,
+          ...(body !== undefined ? { body } : {}),
+        });
+      } catch (error) {
+        response = json(
+          {
+            ok: false,
+            error: "runtime-integration-request-failed",
+            details: {
+              reason: error instanceof Error ? error.message : "unknown-error",
+            },
+          },
+          { status: 502 },
+        );
+      }
+    }
+  }
+
+  const payload = (await response.json().catch(() => null)) as unknown;
+  return {
+    status: response.status,
+    ok: response.ok,
+    payload: isRecord(payload)
+      ? payload
+      : {
+          ok: response.ok,
+          error: "invalid-runtime-json-response",
+          status: response.status,
+        },
+  };
+}
+
+function parseRuntimeDeploymentList(value: unknown): RuntimeDeploymentRecord[] {
+  if (!Array.isArray(value)) return [];
+  const deployments: RuntimeDeploymentRecord[] = [];
+  for (const entry of value) {
+    try {
+      deployments.push(parseRuntimeDeploymentRecord(entry));
+    } catch {}
+  }
+  return deployments;
+}
+
+function runtimeErrorFromPayload(
+  payload: Record<string, unknown>,
+  fallback: string,
+): string {
+  return (
+    readStringOrNull(payload.error) ??
+    readStringOrNull(payload.message) ??
+    fallback
+  );
+}
+
+export async function readRuntimeAdminSnapshot(
+  env: Env,
+): Promise<RuntimeAdminSnapshot> {
+  const integration = buildRuntimeIntegration(env);
+  const healthResult = await dispatchRuntimeInternalJson({
+    env,
+    method: "GET",
+    pathname: INTERNAL_RUNTIME_HEALTH_PATH,
+  });
+  if (!healthResult.ok) {
+    return {
+      ok: false,
+      source: "worker",
+      integration,
+      health: null,
+      deployments: [],
+      error: runtimeErrorFromPayload(
+        healthResult.payload,
+        "runtime-health-unavailable",
+      ),
+    };
+  }
+
+  const health = isRecord(healthResult.payload.health)
+    ? healthResult.payload.health
+    : integration.stubModeEnabled
+      ? createRuntimeHealthFixture()
+      : null;
+  const source =
+    readStringOrNull(healthResult.payload.source) ??
+    (integration.stubModeEnabled ? "stub" : "runtime-rs");
+
+  const deploymentsResult = await dispatchRuntimeInternalJson({
+    env,
+    method: "GET",
+    pathname: INTERNAL_RUNTIME_DEPLOYMENTS_PATH,
+  });
+  if (!deploymentsResult.ok) {
+    return {
+      ok: false,
+      source,
+      integration,
+      health,
+      deployments: [],
+      error: runtimeErrorFromPayload(
+        deploymentsResult.payload,
+        "runtime-deployments-unavailable",
+      ),
+    };
+  }
+
+  return {
+    ok: true,
+    source: readStringOrNull(deploymentsResult.payload.source) ?? source,
+    integration,
+    health,
+    deployments: parseRuntimeDeploymentList(
+      deploymentsResult.payload.deployments,
+    ),
+    error: null,
+  };
+}
+
+export async function readRuntimeDeployment(
+  env: Env,
+  deploymentId: string,
+): Promise<RuntimeInternalJsonResult> {
+  return await dispatchRuntimeInternalJson({
+    env,
+    method: "GET",
+    pathname: `${INTERNAL_RUNTIME_DEPLOYMENTS_PATH}/${encodeURIComponent(
+      deploymentId,
+    )}`,
+  });
+}
+
+export async function applyRuntimeDeploymentControl(input: {
+  env: Env;
+  deploymentId: string;
+  action: RuntimeControlAction;
+}): Promise<RuntimeInternalJsonResult> {
+  return await dispatchRuntimeInternalJson({
+    env: input.env,
+    method: "POST",
+    pathname: `${INTERNAL_RUNTIME_DEPLOYMENTS_PATH}/${encodeURIComponent(
+      input.deploymentId,
+    )}/${input.action}`,
+  });
+}
+
 export async function handleRuntimeInternalRoute(
   request: Request,
   url: URL,
   env: Env,
 ): Promise<Response | null> {
   const isRuntimeRoute =
-    url.pathname === `${INTERNAL_RUNTIME_PREFIX}/health` ||
-    url.pathname === `${INTERNAL_RUNTIME_PREFIX}/deployments` ||
+    url.pathname === INTERNAL_RUNTIME_HEALTH_PATH ||
+    url.pathname === INTERNAL_RUNTIME_DEPLOYMENTS_PATH ||
     url.pathname === `${INTERNAL_RUNTIME_PREFIX}/positions` ||
     url.pathname === `${INTERNAL_RUNTIME_PREFIX}/pnl` ||
     url.pathname === INTERNAL_RUNTIME_SCORECARDS_PATH ||
@@ -367,7 +641,7 @@ export async function handleRuntimeInternalRoute(
 
   if (
     request.method === "GET" &&
-    url.pathname === `${INTERNAL_RUNTIME_PREFIX}/health`
+    url.pathname === INTERNAL_RUNTIME_HEALTH_PATH
   ) {
     return json(buildRuntimeHealthPayload(env, auth.service));
   }
@@ -377,8 +651,21 @@ export async function handleRuntimeInternalRoute(
   }
 
   if (
+    request.method === "GET" &&
+    url.pathname === INTERNAL_RUNTIME_DEPLOYMENTS_PATH
+  ) {
+    const deploymentId =
+      url.searchParams.get("deploymentId") ?? "deployment_shadow_fixture";
+    return json({
+      ok: true,
+      source: "stub",
+      deployments: [createRuntimeDeploymentFixture(deploymentId)],
+    });
+  }
+
+  if (
     request.method === "POST" &&
-    url.pathname === `${INTERNAL_RUNTIME_PREFIX}/deployments`
+    url.pathname === INTERNAL_RUNTIME_DEPLOYMENTS_PATH
   ) {
     let deployment: RuntimeDeploymentRecord;
     try {
@@ -433,7 +720,7 @@ export async function handleRuntimeInternalRoute(
         action: control.action,
         deployment: createRuntimeDeploymentFixture(
           control.deploymentId,
-          mapControlActionToState(control.action),
+          mapControlActionToState(control.action, control.deploymentId),
         ),
       });
     }

--- a/crates/strategy-registry/src/lib.rs
+++ b/crates/strategy-registry/src/lib.rs
@@ -184,6 +184,23 @@ impl StrategyRegistry {
         load_deployment(&connection, deployment_id)
     }
 
+    pub fn list_deployments(&self) -> Result<Vec<RuntimeDeploymentRecord>, StrategyRegistryError> {
+        let connection = self.open_connection()?;
+        let mut statement = connection.prepare(
+            "SELECT record_json
+             FROM deployments
+             ORDER BY updated_at DESC, deployment_id DESC",
+        )?;
+
+        let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+        let mut deployments = Vec::new();
+        for row in rows {
+            deployments.push(deserialize_json(&row?)?);
+        }
+
+        Ok(deployments)
+    }
+
     pub fn transition_deployment(
         &self,
         deployment_id: &str,

--- a/docs/design-docs/autonomous-runtime-architecture.md
+++ b/docs/design-docs/autonomous-runtime-architecture.md
@@ -137,6 +137,7 @@ single-writer source of truth for automation.
 The first private route family is intentionally small:
 
 - `POST /api/internal/runtime/deployments`
+- `GET /api/internal/runtime/deployments`
 - `GET /api/internal/runtime/deployments/:id`
 - `POST /api/internal/runtime/deployments/:id/pause`
 - `POST /api/internal/runtime/deployments/:id/resume`
@@ -152,6 +153,15 @@ The first private route family is intentionally small:
 Transport starts as HTTP+JSON with service auth. Shared schemas and fixtures
 arrive in `#257`. In `#259`, control and inspection routes are fixture-backed
 stubs until later issues replace them with real runtime integration.
+
+Operator-facing runtime controls stay on the Worker boundary:
+
+- `GET /api/admin/ops/runtime`
+- `POST /api/admin/ops/runtime/deployments/:deploymentId/pause`
+- `POST /api/admin/ops/runtime/deployments/:deploymentId/resume`
+- `POST /api/admin/ops/runtime/deployments/:deploymentId/kill`
+- `POST /api/admin/ops/controls` with `runtime.shadowOnly=true` to keep live
+  promotion disabled until the dedicated rollout issue lands
 
 ## Harness compatibility requirements
 

--- a/docs/generated/runtime-api.md
+++ b/docs/generated/runtime-api.md
@@ -9,6 +9,7 @@ so Worker and runtime-rs do not invent separate shapes.
 | Route family | Canonical schema |
 | --- | --- |
 | `POST /api/internal/runtime/deployments` | `RuntimeDeploymentRecord` |
+| `GET /api/internal/runtime/deployments` | `RuntimeDeploymentRecord[]` |
 | `GET /api/internal/runtime/deployments/:id` | `RuntimeDeploymentRecord` |
 | `GET /api/internal/runtime/runs/:deploymentId` | `RuntimeRunRecord` |
 | `GET /api/internal/runtime/positions` | `RuntimeLedgerSnapshot` |

--- a/docs/reliability/autonomous-runtime-ops-runbook.md
+++ b/docs/reliability/autonomous-runtime-ops-runbook.md
@@ -66,6 +66,16 @@ curl -fsS https://ralph-runtime-rs.fly.dev/api/internal/runtime/runs/<deployment
   -H "authorization: Bearer ${RUNTIME_INTERNAL_SERVICE_TOKEN}"
 ```
 
+Worker control-plane inspection:
+
+```bash
+curl -fsS https://api.trader-ralph.com/api/admin/ops/runtime \
+  -H "authorization: Bearer ${ADMIN_TOKEN}"
+
+curl -fsS "https://api.trader-ralph.com/api/admin/ops/dashboard?windowMinutes=360&maxRequests=10000" \
+  -H "authorization: Bearer ${ADMIN_TOKEN}"
+```
+
 ### Pause a deployment
 
 Use pause when:
@@ -79,6 +89,14 @@ Expected effect:
 - new shadow evaluations stop,
 - reconciliation continues,
 - existing state remains inspectable.
+
+Control-plane command:
+
+```bash
+curl -fsS https://api.trader-ralph.com/api/admin/ops/runtime/deployments/<deployment-id>/pause \
+  -X POST \
+  -H "authorization: Bearer ${ADMIN_TOKEN}"
+```
 
 ### Kill a deployment
 
@@ -95,6 +113,45 @@ Expected effect:
 - deployment state is marked killed,
 - follow-up requires explicit human action.
 
+Control-plane command:
+
+```bash
+curl -fsS https://api.trader-ralph.com/api/admin/ops/runtime/deployments/<deployment-id>/kill \
+  -X POST \
+  -H "authorization: Bearer ${ADMIN_TOKEN}"
+```
+
+### Force shadow-only mode
+
+Use shadow-only when:
+
+- live rollout is still gated,
+- paper or live resumes must be blocked without disabling runtime inspection,
+- an incident requires investigation before wider runtime promotion.
+
+Expected effect:
+
+- runtime resumes through the Worker control plane are allowed only for shadow
+  deployments,
+- paper and live deployment resumes return `runtime-shadow-only`,
+- the ops dashboard reflects the current shadow-only reason.
+
+Control-plane command:
+
+```bash
+curl -fsS https://api.trader-ralph.com/api/admin/ops/controls \
+  -X POST \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "content-type: application/json" \
+  --data '{
+    "updatedBy": "runtime-ops-runbook",
+    "runtime": {
+      "shadowOnly": true,
+      "shadowOnlyReason": "incident-review"
+    }
+  }'
+```
+
 ## Incident classes
 
 ### Stale data incident
@@ -110,9 +167,12 @@ Response:
 
 1. Pause affected deployments.
 2. Confirm provider and socket health.
-3. Confirm `feature-stream-stale` or `feature-stream-missing` appears on the
+3. Pull `GET /api/admin/ops/runtime` and confirm the runtime lag lines
+   (`maxMarketAgeMs`, `maxFeatureAgeMs`, `maxSlotAgeMs`) identify the stale
+   source.
+4. Confirm `feature-stream-stale` or `feature-stream-missing` appears on the
    affected shadow evaluations.
-4. Keep the runtime canary disabled until freshness is restored.
+5. Keep the runtime canary disabled until freshness is restored.
 
 ### Reconciliation incident
 
@@ -127,6 +187,7 @@ Response:
 1. Kill affected deployments.
 2. Freeze further live promotion.
 3. Export reconciliation evidence and compare with chain and Worker receipts.
+4. Keep `runtime.shadowOnly=true` until reconciliation explains the drift.
 
 ### Region failover incident
 
@@ -146,6 +207,8 @@ Response:
 ## Rollback policy
 
 - Prefer pause or kill controls before code rollback.
+- Prefer `runtime.shadowOnly=true` before widening any rollout again after an
+  incident.
 - If code rollback is required, revert the offending PR and redeploy through the
   same harness flow.
 - Runtime-rs code rollback uses `.github/workflows/rollback-runtime-rs.yml`.

--- a/services/runtime-rs/README.md
+++ b/services/runtime-rs/README.md
@@ -88,6 +88,7 @@ Route surface:
 
 - `GET /api/internal/runtime/health`
 - `POST /api/internal/runtime/deployments`
+- `GET /api/internal/runtime/deployments`
 - `GET /api/internal/runtime/deployments/:deploymentId`
 - `POST /api/internal/runtime/deployments/:deploymentId/pause`
 - `POST /api/internal/runtime/deployments/:deploymentId/resume`
@@ -107,6 +108,9 @@ curl -fsS http://127.0.0.1:8081/api/internal/runtime/deployments \
   -H "content-type: application/json" \
   --data @docs/runtime-contracts/fixtures/runtime.deployment.valid.v1.json
 
+curl -fsS http://127.0.0.1:8081/api/internal/runtime/deployments \
+  -H "authorization: Bearer ${RUNTIME_INTERNAL_SERVICE_TOKEN}"
+
 curl -fsS http://127.0.0.1:8081/api/internal/runtime/deployments/dep_runtime_sol_usdc_shadow/evaluate \
   -X POST \
   -H "authorization: Bearer ${RUNTIME_INTERNAL_SERVICE_TOKEN}" \
@@ -119,6 +123,23 @@ curl -fsS http://127.0.0.1:8081/api/internal/runtime/runs/dep_runtime_sol_usdc_s
 curl -fsS "http://127.0.0.1:8081/api/internal/runtime/risk?deploymentId=dep_runtime_sol_usdc_shadow" \
   -H "authorization: Bearer ${RUNTIME_INTERNAL_SERVICE_TOKEN}"
 ```
+
+## Worker-admin ops surface
+
+Operators should use the Worker as the public control plane:
+
+- `GET /api/admin/ops/runtime`
+- `POST /api/admin/ops/runtime/deployments/:deploymentId/pause`
+- `POST /api/admin/ops/runtime/deployments/:deploymentId/resume`
+- `POST /api/admin/ops/runtime/deployments/:deploymentId/kill`
+- `POST /api/admin/ops/controls` with `runtime.shadowOnly=true` to keep the
+  runtime shadow-only until live rollout is explicitly enabled in a later issue
+
+The default runtime control baseline is:
+
+- `runtime.enabled=true`
+- `runtime.shadowOnly=true`
+- `runtime.shadowOnlyReason=live-rollout-pending`
 
 ## Fly foundation
 

--- a/services/runtime-rs/src/lib.rs
+++ b/services/runtime-rs/src/lib.rs
@@ -207,7 +207,7 @@ pub fn app(config: RuntimeConfig) -> Router {
         )
         .route(
             &format!("{INTERNAL_RUNTIME_PREFIX}/deployments"),
-            post(create_deployment_handler),
+            get(list_deployments_handler).post(create_deployment_handler),
         )
         .route(
             &format!("{INTERNAL_RUNTIME_PREFIX}/deployments/{{deployment_id}}"),
@@ -376,6 +376,25 @@ async fn create_deployment_handler(
             "created": result.created,
             "deployment": result.deployment,
             "ledger": ledger.snapshot,
+        }),
+    ))
+}
+
+async fn list_deployments_handler(
+    headers: HeaderMap,
+    State(state): State<RuntimeAppState>,
+) -> HandlerResult {
+    authorize_internal_request(&headers, &state)?;
+    let deployments = state
+        .strategy_registry
+        .list_deployments()
+        .map_err(map_registry_error)?;
+    Ok(OkJson::with_status(
+        StatusCode::OK,
+        json!({
+            "ok": true,
+            "source": "runtime-rs",
+            "deployments": deployments,
         }),
     ))
 }
@@ -1759,6 +1778,31 @@ mod tests {
         assert_eq!(
             create_payload["ledger"]["totals"]["reservedUsd"],
             json!("125.00")
+        );
+
+        let deployments_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/internal/runtime/deployments")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(deployments_response.status(), StatusCode::OK);
+        let deployments_payload = read_json(deployments_response).await;
+        assert_eq!(
+            deployments_payload["deployments"]
+                .as_array()
+                .expect("array")
+                .len(),
+            1
+        );
+        assert_eq!(
+            deployments_payload["deployments"][0]["deploymentId"],
+            json!("deployment_123")
         );
 
         let evaluate_response = router

--- a/src/bin/ops_dashboard.ts
+++ b/src/bin/ops_dashboard.ts
@@ -117,6 +117,7 @@ async function main(): Promise<void> {
   const executionPath = requireArg("--execution");
   const canaryPath = requireArg("--canary");
   const controlsPath = requireArg("--controls");
+  const runtimePath = readArg("--runtime");
   const outputJsonPath = requireArg("--output-json");
   const outputMarkdownPath = requireArg("--output-markdown");
   const runnerHeartbeatPath = readArg("--runner-heartbeat");
@@ -138,6 +139,7 @@ async function main(): Promise<void> {
     execution: readJsonFile(executionPath),
     canary: readJsonFile(canaryPath),
     controls: readJsonFile(controlsPath),
+    runtime: runtimePath ? readJsonFile(runtimePath) : { ok: false },
     previews,
     runner,
   };

--- a/src/ops/dashboard.ts
+++ b/src/ops/dashboard.ts
@@ -26,6 +26,7 @@ export type OpsDashboardSnapshot = {
   execution: Record<string, unknown>;
   canary: Record<string, unknown>;
   controls: Record<string, unknown>;
+  runtime: Record<string, unknown>;
   previews: PreviewHealthResult[];
   runner: RunnerHealthSnapshot;
 };
@@ -134,6 +135,7 @@ function formatCanarySummary(canary: Record<string, unknown>): string[] {
 function formatControlSummary(controls: Record<string, unknown>): string[] {
   const execution = isRecord(controls.execution) ? controls.execution : {};
   const canary = isRecord(controls.canary) ? controls.canary : {};
+  const runtime = isRecord(controls.runtime) ? controls.runtime : {};
   const lanes = isRecord(execution.lanes) ? execution.lanes : {};
   return [
     `- execution enabled: ${String(execution.enabled ?? true)}`,
@@ -141,6 +143,62 @@ function formatControlSummary(controls: Record<string, unknown>): string[] {
     `- lane toggles: fast=${String(lanes.fast ?? true)}, protected=${String(lanes.protected ?? true)}, safe=${String(lanes.safe ?? true)}`,
     `- canary enabled: ${String(canary.enabled ?? true)}`,
     `- canary disabledReason: ${readString(canary.disabledReason) ?? "n/a"}`,
+    `- runtime enabled: ${String(runtime.enabled ?? true)}`,
+    `- runtime shadowOnly: ${String(runtime.shadowOnly ?? true)}`,
+    `- runtime disabledReason: ${readString(runtime.disabledReason) ?? "n/a"}`,
+    `- runtime shadowOnlyReason: ${readString(runtime.shadowOnlyReason) ?? "n/a"}`,
+  ];
+}
+
+function formatRuntimeSummary(runtime: Record<string, unknown>): string[] {
+  const integration = isRecord(runtime.integration) ? runtime.integration : {};
+  const controls = isRecord(runtime.controls) ? runtime.controls : {};
+  const health = isRecord(runtime.health) ? runtime.health : {};
+  const feedGateway = isRecord(health.feedGateway) ? health.feedGateway : {};
+  const featureCache = isRecord(health.featureCache) ? health.featureCache : {};
+  const deployments = Array.isArray(runtime.deployments)
+    ? runtime.deployments.filter(isRecord)
+    : [];
+  const stateCounts = deployments.reduce<Record<string, number>>(
+    (acc, item) => {
+      const state = readString(item.state) ?? "unknown";
+      acc[state] = (acc[state] ?? 0) + 1;
+      return acc;
+    },
+    {},
+  );
+  const stateSummary =
+    Object.keys(stateCounts).length > 0
+      ? Object.entries(stateCounts)
+          .map(([state, count]) => `${state}=${count}`)
+          .join(", ")
+      : "none";
+  const staleCount =
+    (Array.isArray(feedGateway.staleMarketStreams)
+      ? feedGateway.staleMarketStreams.length
+      : 0) +
+    (Array.isArray(featureCache.staleFeatureKeys)
+      ? featureCache.staleFeatureKeys.length
+      : 0);
+  const maxSlotAgeMs = Math.max(
+    readNumber(feedGateway.maxSlotAgeMs) ?? 0,
+    readNumber(featureCache.maxSlotAgeMs) ?? 0,
+  );
+
+  return [
+    `- status: ${String(runtime.ok ?? false)}`,
+    `- source: ${readString(runtime.source) ?? "n/a"}`,
+    `- runtime enabled: ${String(controls.enabled ?? true)}`,
+    `- shadow only: ${String(controls.shadowOnly ?? true)}`,
+    `- shadowOnlyReason: ${readString(controls.shadowOnlyReason) ?? "n/a"}`,
+    `- integration: stub=${String(integration.stubModeEnabled ?? false)}, baseUrl=${readString(integration.runtimeBaseUrl) ?? "n/a"}`,
+    `- health status: ${readString(health.status) ?? "n/a"}`,
+    `- max market age ms: ${readNumber(feedGateway.maxMarketAgeMs) ?? "n/a"}`,
+    `- max feature age ms: ${readNumber(featureCache.maxFeatureAgeMs) ?? "n/a"}`,
+    `- max slot age ms: ${maxSlotAgeMs || "n/a"}`,
+    `- stale streams/features: ${staleCount}`,
+    `- deployments: total=${deployments.length}, states=${stateSummary}`,
+    `- error: ${readString(runtime.error) ?? "n/a"}`,
   ];
 }
 
@@ -168,6 +226,9 @@ export function buildOpsDashboardMarkdown(
     "",
     "## Controls",
     ...formatControlSummary(snapshot.controls),
+    "",
+    "## Runtime",
+    ...formatRuntimeSummary(snapshot.runtime),
     "",
     "## Preview Health",
     `- total previews: ${previewSummary.total}`,

--- a/tests/unit/ops_dashboard.test.ts
+++ b/tests/unit/ops_dashboard.test.ts
@@ -71,6 +71,49 @@ describe("ops dashboard helpers", () => {
           enabled: true,
           disabledReason: null,
         },
+        runtime: {
+          enabled: true,
+          disabledReason: null,
+          shadowOnly: true,
+          shadowOnlyReason: "live-rollout-pending",
+        },
+      },
+      runtime: {
+        ok: true,
+        source: "runtime-rs",
+        controls: {
+          enabled: true,
+          shadowOnly: true,
+          shadowOnlyReason: "live-rollout-pending",
+        },
+        integration: {
+          stubModeEnabled: false,
+          runtimeBaseUrl: "https://ralph-runtime-rs.fly.dev",
+        },
+        health: {
+          status: "healthy",
+          feedGateway: {
+            maxMarketAgeMs: 2400,
+            maxSlotAgeMs: 1700,
+            staleMarketStreams: [],
+          },
+          featureCache: {
+            maxFeatureAgeMs: 2600,
+            maxSlotAgeMs: 1800,
+            staleFeatureKeys: [],
+          },
+        },
+        deployments: [
+          {
+            deploymentId: "deployment_shadow",
+            state: "shadow",
+          },
+          {
+            deploymentId: "deployment_paused",
+            state: "paused",
+          },
+        ],
+        error: null,
       },
       previews: [
         {
@@ -93,6 +136,10 @@ describe("ops dashboard helpers", () => {
 
     expect(markdown).toContain("# Ops Dashboard");
     expect(markdown).toContain("## Execution");
+    expect(markdown).toContain("## Runtime");
+    expect(markdown).toContain(
+      "deployments: total=2, states=shadow=1, paused=1",
+    );
     expect(markdown).toContain("## Preview Health");
     expect(markdown).toContain("PR #247: portal=ok, worker=down");
     expect(markdown).toContain("## Runner Health");

--- a/tests/unit/worker_ops_controls_route.test.ts
+++ b/tests/unit/worker_ops_controls_route.test.ts
@@ -191,6 +191,12 @@ describe("worker ops controls routes", () => {
               enabled: false,
               disabledReason: "incident-123",
             },
+            runtime: {
+              enabled: false,
+              disabledReason: "runtime-incident-123",
+              shadowOnly: false,
+              shadowOnlyReason: null,
+            },
           }),
         }),
         env,
@@ -224,6 +230,168 @@ describe("worker ops controls routes", () => {
             enabled: true,
             disabledReason: null,
           },
+          runtime: {
+            enabled: true,
+            disabledReason: null,
+            shadowOnly: true,
+            shadowOnlyReason: "live-rollout-pending",
+          },
+        },
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("returns runtime admin snapshot with health, lag, and deployment state", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/admin/ops/runtime", {
+          headers: {
+            authorization: "Bearer admin-secret",
+          },
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        ok: true,
+        runtime: {
+          ok: true,
+          controls: {
+            enabled: true,
+            shadowOnly: true,
+            shadowOnlyReason: "live-rollout-pending",
+          },
+          integration: {
+            stubModeEnabled: true,
+          },
+          health: {
+            status: "healthy",
+            feedGateway: {
+              maxMarketAgeMs: expect.any(Number),
+            },
+            featureCache: {
+              maxFeatureAgeMs: expect.any(Number),
+            },
+          },
+          deployments: [
+            {
+              deploymentId: "deployment_shadow_fixture",
+              mode: "shadow",
+              state: "shadow",
+            },
+          ],
+        },
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("blocks runtime resumes when the global runtime kill switch is enabled", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const patchResponse = await worker.fetch(
+        new Request("http://localhost/api/admin/ops/controls", {
+          method: "POST",
+          headers: {
+            authorization: "Bearer admin-secret",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            runtime: {
+              enabled: false,
+              disabledReason: "runtime-incident-456",
+            },
+          }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(patchResponse.status).toBe(200);
+
+      const response = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/deployments/deployment_shadow_fixture/resume",
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+            },
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(409);
+      expect(await response.json()).toMatchObject({
+        ok: false,
+        error: "runtime-disabled",
+        deploymentId: "deployment_shadow_fixture",
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("blocks non-shadow runtime resumes while shadow-only mode is enabled", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/deployments/deployment_paper_fixture/resume",
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+            },
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(409);
+      expect(await response.json()).toMatchObject({
+        ok: false,
+        error: "runtime-shadow-only",
+        deploymentId: "deployment_paper_fixture",
+        mode: "paper",
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("proxies runtime deployment pause controls through the worker admin surface", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/deployments/deployment_shadow_fixture/pause",
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+            },
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        ok: true,
+        action: "pause",
+        deployment: {
+          deploymentId: "deployment_shadow_fixture",
+          state: "paused",
         },
       });
     } finally {
@@ -250,6 +418,10 @@ describe("worker ops controls routes", () => {
           execution: {
             enabled: true,
           },
+          runtime: {
+            enabled: true,
+            shadowOnly: true,
+          },
         },
         canary: {
           ok: true,
@@ -258,6 +430,14 @@ describe("worker ops controls routes", () => {
           totals: {
             accepted: 0,
           },
+        },
+        runtime: {
+          ok: true,
+          deployments: [
+            {
+              deploymentId: "deployment_shadow_fixture",
+            },
+          ],
         },
       });
     } finally {

--- a/tests/unit/worker_ops_controls_route.test.ts
+++ b/tests/unit/worker_ops_controls_route.test.ts
@@ -399,6 +399,33 @@ describe("worker ops controls routes", () => {
     }
   });
 
+  test("fails closed on malformed runtime admin deployment IDs", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/deployments/%E0%A4%A/resume",
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+            },
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toMatchObject({
+        ok: false,
+        error: "not-found",
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
   test("returns aggregated admin ops dashboard", async () => {
     const { env, sqlite } = createOpsEnv();
     try {

--- a/tests/unit/worker_ops_controls_store.test.ts
+++ b/tests/unit/worker_ops_controls_store.test.ts
@@ -24,6 +24,11 @@ describe("worker ops controls store", () => {
       canary: {
         enabled: true,
       },
+      runtime: {
+        enabled: true,
+        shadowOnly: true,
+        shadowOnlyReason: "live-rollout-pending",
+      },
       metadata: {
         source: "default",
       },


### PR DESCRIPTION
## Summary
- add worker-admin runtime ops controls, runtime dashboard aggregation, and shadow-only enforcement
- expose deployment listing from runtime-rs and wire it into the ops dashboard workflow
- document the runtime admin control plane and add unit/Rust coverage for the new routes

## Testing
- bun test tests/unit/worker_ops_controls_store.test.ts tests/unit/worker_ops_controls_route.test.ts tests/unit/ops_dashboard.test.ts tests/unit/worker_runtime_internal_routes.test.ts
- bun run lint
- bun run typecheck
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p runtime-rs
