### PR TITLE
Recover runtime canary after transient deploy failures

### DIFF
--- a/apps/worker/src/runtime_canary.ts
+++ b/apps/worker/src/runtime_canary.ts
@@ -58,6 +58,11 @@ const RUNTIME_CANARY_DEFAULT_DEPLOYMENT_ID = "runtime_canary_live_dca";
 const RUNTIME_CANARY_OWNER_USER_ID = "system:runtime-canary";
 const RUNTIME_CANARY_SLEEVE_ID = "sleeve_runtime_canary";
 const RUNTIME_CANARY_ACTIVE_REGION = "ord";
+const RUNTIME_CANARY_RETRYABLE_DISABLE_REASONS = new Set([
+  "deployment-not-runnable",
+  "deployment-not-shadow",
+  "runtime-deployment-unavailable",
+]);
 const USDC_DECIMALS = 6;
 const SOL_DECIMALS = 9;
 
@@ -548,6 +553,40 @@ function runtimeCanaryDisabledReason(
     disabled: true,
     disabledReason: error,
   };
+}
+
+function isRetryableRuntimeCanaryDisableReason(
+  reason: string | null | undefined,
+): boolean {
+  const normalized = String(reason ?? "")
+    .trim()
+    .toLowerCase();
+  return RUNTIME_CANARY_RETRYABLE_DISABLE_REASONS.has(normalized);
+}
+
+function canAutoRecoverRuntimeCanaryRun(input: {
+  state: RuntimeCanaryStateRecord | null;
+  triggerSource: RuntimeCanaryTriggerSource;
+}): boolean {
+  return (
+    input.triggerSource === "post_deploy" &&
+    Boolean(input.state?.disabled) &&
+    isRetryableRuntimeCanaryDisableReason(input.state?.disabledReason)
+  );
+}
+
+function runtimeCanaryFailureStatePatch(input: {
+  state: RuntimeCanaryStateRecord | null;
+  triggerSource: RuntimeCanaryTriggerSource;
+  error: string;
+}) {
+  if (
+    input.triggerSource === "post_deploy" &&
+    isRetryableRuntimeCanaryDisableReason(input.error)
+  ) {
+    return undefined;
+  }
+  return runtimeCanaryDisabledReason(input.state, input.error);
 }
 
 async function buildRuntimeCanarySnapshot(
@@ -1117,7 +1156,7 @@ export async function runRuntimeCanary(input: {
 }): Promise<RuntimeCanaryRunResponse> {
   const { env, triggerSource } = input;
   const config = readRuntimeCanaryConfig(env);
-  const state = await getRuntimeCanaryState(env.WAITLIST_DB);
+  let state = await getRuntimeCanaryState(env.WAITLIST_DB);
   const opsControls = await readOpsControlSnapshot(env);
 
   if (!config.enabled) {
@@ -1142,14 +1181,25 @@ export async function runRuntimeCanary(input: {
     };
   }
   if (state?.disabled) {
-    return {
-      ok: false,
-      status: "disabled",
-      triggerSource,
-      run: null,
-      state,
-      error: state.disabledReason ?? "runtime-canary-disabled",
-    };
+    if (canAutoRecoverRuntimeCanaryRun({ state, triggerSource })) {
+      state = await updateRuntimeCanaryState(
+        env.WAITLIST_DB,
+        {
+          disabled: false,
+          disabledReason: null,
+        },
+        new Date().toISOString(),
+      );
+    } else {
+      return {
+        ok: false,
+        status: "disabled",
+        triggerSource,
+        run: null,
+        state,
+        error: state.disabledReason ?? "runtime-canary-disabled",
+      };
+    }
   }
 
   const wallet = await ensureRuntimeCanaryWallet(env, config);
@@ -1258,7 +1308,11 @@ export async function runRuntimeCanary(input: {
     return await finalizeRuntimeCanaryRun(env, {
       runId,
       status: "failed",
-      statePatch: runtimeCanaryDisabledReason(state, error),
+      statePatch: runtimeCanaryFailureStatePatch({
+        state,
+        triggerSource,
+        error,
+      }),
       runPatch: {
         runtimeDeploymentState: deploymentStateFromPayload(evaluation.payload),
         errorCode: "runtime-canary-evaluation-failed",

--- a/apps/worker/src/runtime_internal.ts
+++ b/apps/worker/src/runtime_internal.ts
@@ -443,6 +443,19 @@ function controlActionFromPath(pathname: string): {
   return null;
 }
 
+function runtimeEvaluateDeploymentIdFromPath(pathname: string): string | null {
+  if (!pathname.startsWith(INTERNAL_RUNTIME_DEPLOYMENTS_PREFIX)) {
+    return null;
+  }
+  const suffix = pathname.slice(INTERNAL_RUNTIME_DEPLOYMENTS_PREFIX.length);
+  const evaluateSuffix = "/evaluate";
+  if (!suffix.endsWith(evaluateSuffix)) {
+    return null;
+  }
+  const deploymentId = suffix.slice(0, -evaluateSuffix.length);
+  return deploymentId && !deploymentId.includes("/") ? deploymentId : null;
+}
+
 async function dispatchRuntimeInternalJson(input: {
   env: Env;
   method: string;
@@ -530,6 +543,48 @@ function runtimeErrorFromPayload(
     readStringOrNull(payload.message) ??
     fallback
   );
+}
+
+function createRuntimeEvaluationFixture(deploymentId: string) {
+  const deployment = createRuntimeDeploymentFixture(deploymentId);
+  return {
+    ok: true,
+    source: "stub",
+    deployment,
+    run: {
+      schemaVersion: RUNTIME_PROTOCOL_SCHEMA_VERSION,
+      runId: `run_${deploymentId}`,
+      deploymentId,
+      runKey: `${deploymentId}:${FIXTURE_TIMESTAMP}`,
+      trigger: {
+        kind: "canary",
+        source: "runtime-internal-fixture",
+        observedAt: FIXTURE_TIMESTAMP,
+        reason: "post_deploy",
+      },
+      state: "completed",
+      plannedAt: FIXTURE_TIMESTAMP,
+      submittedAt: FIXTURE_TIMESTAMP,
+      completedAt: FIXTURE_TIMESTAMP,
+      updatedAt: FIXTURE_TIMESTAMP,
+      executionPlanId: `plan_${deploymentId}`,
+    },
+    coordination: {
+      planId: `plan_${deploymentId}`,
+      deploymentId,
+      runId: `run_${deploymentId}`,
+      mode: deployment.mode,
+      lane: deployment.lane,
+      sliceCount: 1,
+      submitRequestId: `submit_${deploymentId}`,
+    },
+    reconciliation: {
+      receiptId: `receipt_${deploymentId}`,
+      status: "passed",
+      driftUsd: "0.00",
+      autoCorrected: false,
+    },
+  };
 }
 
 export async function readRuntimeAdminSnapshot(
@@ -814,6 +869,13 @@ export async function handleRuntimeInternalRoute(
   }
 
   if (request.method === "POST") {
+    const evaluateDeploymentId = runtimeEvaluateDeploymentIdFromPath(
+      url.pathname,
+    );
+    if (evaluateDeploymentId) {
+      return json(createRuntimeEvaluationFixture(evaluateDeploymentId));
+    }
+
     const control = controlActionFromPath(url.pathname);
     if (control) {
       return json({

--- a/tests/unit/worker_runtime_canary_route.test.ts
+++ b/tests/unit/worker_runtime_canary_route.test.ts
@@ -174,4 +174,115 @@ describe("worker runtime canary admin routes", () => {
       sqlite.close();
     }
   });
+
+  test("allows post-deploy runs to recover transient disabled state", async () => {
+    const { env, sqlite } = createRuntimeCanaryEnv();
+    try {
+      sqlite
+        .query(
+          `insert into runtime_canary_state (
+            state_key,
+            schema_version,
+            deployment_id,
+            wallet_id,
+            wallet_address,
+            disabled,
+            disabled_reason,
+            created_at,
+            updated_at
+          ) values (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          "mainnet",
+          "v1",
+          "runtime_canary_live_dca",
+          "wallet_fixture",
+          "BHHLtSgm43YiJLe5gXstq3hojYswDNTnbLxp6hxAAUKz",
+          1,
+          "deployment-not-shadow",
+          "2026-03-09T14:34:43.242Z",
+          "2026-03-09T14:34:44.988Z",
+        );
+
+      const response = await worker.fetch(
+        new Request("http://localhost/api/admin/runtime/canary/run", {
+          method: "POST",
+          headers: {
+            authorization: "Bearer admin-secret",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ trigger: "post_deploy" }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        ok: true,
+        status: "success",
+        triggerSource: "post_deploy",
+        state: {
+          disabled: false,
+          disabledReason: null,
+        },
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("keeps manual runs blocked when the runtime canary is disabled", async () => {
+    const { env, sqlite } = createRuntimeCanaryEnv();
+    try {
+      sqlite
+        .query(
+          `insert into runtime_canary_state (
+            state_key,
+            schema_version,
+            deployment_id,
+            wallet_id,
+            wallet_address,
+            disabled,
+            disabled_reason,
+            created_at,
+            updated_at
+          ) values (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          "mainnet",
+          "v1",
+          "runtime_canary_live_dca",
+          "wallet_fixture",
+          "BHHLtSgm43YiJLe5gXstq3hojYswDNTnbLxp6hxAAUKz",
+          1,
+          "deployment-not-shadow",
+          "2026-03-09T14:34:43.242Z",
+          "2026-03-09T14:34:44.988Z",
+        );
+
+      const response = await worker.fetch(
+        new Request("http://localhost/api/admin/runtime/canary/run", {
+          method: "POST",
+          headers: {
+            authorization: "Bearer admin-secret",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ trigger: "manual" }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        ok: false,
+        status: "disabled",
+        triggerSource: "manual",
+        error: "deployment-not-shadow",
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- allow `post_deploy` runtime canary runs to auto-recover from transient rollout-order disable reasons like `deployment-not-shadow`
- keep manual runs blocked while the canary is intentionally disabled
- add stub runtime deployment evaluation support so the recovery path is covered under the harness tests

## Validation
- bun test tests/unit/worker_runtime_canary_route.test.ts tests/unit/worker_runtime_internal_routes.test.ts
- bun run lint
- bun run typecheck
