### PR TITLE
Add runtime operator portal surfaces

### DIFF
--- a/.github/workflows/deploy-portal.yml
+++ b/.github/workflows/deploy-portal.yml
@@ -82,6 +82,8 @@ jobs:
             --scope guivercelpro
             --token "$VERCEL_TOKEN"
             --yes
+            --env "NEXT_PUBLIC_EDGE_API_BASE=${{ steps.lane.outputs.edge_api_base }}"
+            --env "NEXT_PUBLIC_SITE_URL=${{ steps.lane.outputs.site_url }}"
             --build-env "NEXT_PUBLIC_EDGE_API_BASE=${{ steps.lane.outputs.edge_api_base }}"
             --build-env "NEXT_PUBLIC_SITE_URL=${{ steps.lane.outputs.site_url }}"
           )

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -81,6 +81,8 @@ jobs:
               --scope guivercelpro \
               --token "$VERCEL_TOKEN" \
               --yes \
+              --env "NEXT_PUBLIC_EDGE_API_BASE=${{ steps.preview.outputs.worker_url }}" \
+              --env "NEXT_PUBLIC_SITE_URL=https://trader-ralph.com" \
               --build-env "NEXT_PUBLIC_EDGE_API_BASE=${{ steps.preview.outputs.worker_url }}" \
               --build-env "NEXT_PUBLIC_SITE_URL=https://trader-ralph.com"
           )"

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -116,6 +116,8 @@ jobs:
               --token "$VERCEL_TOKEN" \
               --prod \
               --yes \
+              --env "NEXT_PUBLIC_EDGE_API_BASE=https://api.trader-ralph.com" \
+              --env "NEXT_PUBLIC_SITE_URL=https://trader-ralph.com" \
               --build-env "NEXT_PUBLIC_EDGE_API_BASE=https://api.trader-ralph.com" \
               --build-env "NEXT_PUBLIC_SITE_URL=https://trader-ralph.com"
           )"

--- a/apps/portal/app/api/runtime/operator/route.ts
+++ b/apps/portal/app/api/runtime/operator/route.ts
@@ -6,7 +6,7 @@ import {
   safeParseRuntimeDeploymentRecord,
   safeParseRuntimeLedgerSnapshot,
   safeParseRuntimeRunRecord,
-} from "../../../../../worker/src/runtime_contracts";
+} from "../../../../lib/runtime-contracts";
 
 const LOCAL_EDGE_API_BASE = "http://127.0.0.1:8888";
 const BEARER_RE = /^bearer\s+/i;

--- a/apps/portal/app/api/runtime/operator/route.ts
+++ b/apps/portal/app/api/runtime/operator/route.ts
@@ -23,6 +23,15 @@ type RuntimeControls = {
   shadowOnlyReason: string | null;
 };
 
+function parseCsvSet(value: string | undefined): Set<string> {
+  return new Set(
+    String(value ?? "")
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  );
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
@@ -54,6 +63,31 @@ function resolveAdminToken(): string {
   return String(
     process.env.RUNTIME_OPERATOR_ADMIN_TOKEN ?? process.env.ADMIN_TOKEN ?? "",
   ).trim();
+}
+
+function isAuthorizedRuntimeOperator(
+  payload: Record<string, unknown>,
+): boolean {
+  const user = isRecord(payload.user) ? payload.user : null;
+  if (!user) return false;
+
+  const allowedUserIds = parseCsvSet(
+    process.env.RUNTIME_OPERATOR_USER_ALLOWLIST,
+  );
+  const allowedPrivyUserIds = parseCsvSet(
+    process.env.RUNTIME_OPERATOR_PRIVY_USER_ALLOWLIST,
+  );
+  if (allowedUserIds.size === 0 && allowedPrivyUserIds.size === 0) {
+    return false;
+  }
+
+  const userId = readString(user.id);
+  if (userId && allowedUserIds.has(userId)) return true;
+
+  const privyUserId = readString(user.privyUserId);
+  if (privyUserId && allowedPrivyUserIds.has(privyUserId)) return true;
+
+  return false;
 }
 
 async function requestWorkerJson(input: {
@@ -238,6 +272,12 @@ export async function GET(request: Request) {
       status: sessionResult.status,
     });
   }
+  if (!isAuthorizedRuntimeOperator(sessionResult.payload)) {
+    return NextResponse.json(
+      { ok: false, error: "operator-access-required" },
+      { status: 403 },
+    );
+  }
 
   const adminToken = resolveAdminToken();
   if (!adminToken) {
@@ -299,6 +339,12 @@ export async function POST(request: Request) {
     return NextResponse.json(sessionResult.payload, {
       status: sessionResult.status,
     });
+  }
+  if (!isAuthorizedRuntimeOperator(sessionResult.payload)) {
+    return NextResponse.json(
+      { ok: false, error: "operator-access-required" },
+      { status: 403 },
+    );
   }
 
   const adminToken = resolveAdminToken();

--- a/apps/portal/app/api/runtime/operator/route.ts
+++ b/apps/portal/app/api/runtime/operator/route.ts
@@ -1,0 +1,337 @@
+import { NextResponse } from "next/server";
+import {
+  type RuntimeDeploymentRecord,
+  type RuntimeLedgerSnapshot,
+  type RuntimeRunRecord,
+  safeParseRuntimeDeploymentRecord,
+  safeParseRuntimeLedgerSnapshot,
+  safeParseRuntimeRunRecord,
+} from "../../../../../worker/src/runtime_contracts";
+
+const LOCAL_EDGE_API_BASE = "http://127.0.0.1:8888";
+const BEARER_RE = /^bearer\s+/i;
+
+type WorkerJsonResult = {
+  status: number;
+  payload: Record<string, unknown>;
+};
+
+type RuntimeControls = {
+  enabled: boolean;
+  disabledReason: string | null;
+  shadowOnly: boolean;
+  shadowOnlyReason: string | null;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return normalized ? normalized : null;
+}
+
+function readBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function normalizeAuthHeader(value: string | null): string | null {
+  const token = String(value ?? "").trim();
+  if (!token) return null;
+  return BEARER_RE.test(token) ? token : `Bearer ${token}`;
+}
+
+function resolveEdgeApiBase(): string {
+  const configured = String(process.env.NEXT_PUBLIC_EDGE_API_BASE ?? "")
+    .trim()
+    .replace(/\/+$/, "");
+  if (configured) return configured;
+  return process.env.NODE_ENV === "production" ? "" : LOCAL_EDGE_API_BASE;
+}
+
+function resolveAdminToken(): string {
+  return String(
+    process.env.RUNTIME_OPERATOR_ADMIN_TOKEN ?? process.env.ADMIN_TOKEN ?? "",
+  ).trim();
+}
+
+async function requestWorkerJson(input: {
+  path: string;
+  method?: "GET" | "POST";
+  authHeader: string;
+  body?: unknown;
+}): Promise<WorkerJsonResult> {
+  const base = resolveEdgeApiBase();
+  if (!base) {
+    return {
+      status: 503,
+      payload: { ok: false, error: "missing NEXT_PUBLIC_EDGE_API_BASE" },
+    };
+  }
+
+  const response = await fetch(`${base}${input.path}`, {
+    method: input.method ?? "GET",
+    headers: {
+      authorization: input.authHeader,
+      ...(input.body !== undefined
+        ? { "content-type": "application/json" }
+        : {}),
+    },
+    ...(input.body !== undefined ? { body: JSON.stringify(input.body) } : {}),
+    cache: "no-store",
+  });
+  const payload = (await response.json().catch(() => null)) as unknown;
+  return {
+    status: response.status,
+    payload:
+      isRecord(payload) && Object.keys(payload).length > 0
+        ? payload
+        : { ok: false, error: `http-${response.status}` },
+  };
+}
+
+async function validateOperatorSession(
+  userAuthHeader: string,
+): Promise<WorkerJsonResult> {
+  return await requestWorkerJson({
+    path: "/api/me",
+    authHeader: userAuthHeader,
+  });
+}
+
+function parseDeployments(value: unknown): RuntimeDeploymentRecord[] {
+  if (!Array.isArray(value)) return [];
+  const deployments: RuntimeDeploymentRecord[] = [];
+  for (const entry of value) {
+    const parsed = safeParseRuntimeDeploymentRecord(entry);
+    if (parsed.success) deployments.push(parsed.data);
+  }
+  return deployments;
+}
+
+function parseRuns(value: unknown): RuntimeRunRecord[] {
+  if (!Array.isArray(value)) return [];
+  const runs: RuntimeRunRecord[] = [];
+  for (const entry of value) {
+    const parsed = safeParseRuntimeRunRecord(entry);
+    if (parsed.success) runs.push(parsed.data);
+  }
+  return runs;
+}
+
+function parseLedgerSnapshot(value: unknown): RuntimeLedgerSnapshot | null {
+  const parsed = safeParseRuntimeLedgerSnapshot(value);
+  return parsed.success ? parsed.data : null;
+}
+
+function normalizeControls(value: unknown): RuntimeControls {
+  const controls = isRecord(value) ? value : {};
+  return {
+    enabled: readBoolean(controls.enabled, true),
+    disabledReason: readString(controls.disabledReason),
+    shadowOnly: readBoolean(controls.shadowOnly, true),
+    shadowOnlyReason:
+      readString(controls.shadowOnlyReason) ?? "live-rollout-pending",
+  };
+}
+
+function parsePnl(value: unknown): {
+  asOf: string | null;
+  totals: RuntimeLedgerSnapshot["totals"];
+} | null {
+  const payload = isRecord(value) ? value : {};
+  const totals = isRecord(payload.totals) ? payload.totals : null;
+  if (!totals) return null;
+  return {
+    asOf: readString(payload.asOf),
+    totals: {
+      equityUsd: readString(totals.equityUsd) ?? "0.00",
+      reservedUsd: readString(totals.reservedUsd) ?? "0.00",
+      availableUsd: readString(totals.availableUsd) ?? "0.00",
+      realizedPnlUsd: readString(totals.realizedPnlUsd) ?? "0.00",
+      unrealizedPnlUsd: readString(totals.unrealizedPnlUsd) ?? "0.00",
+    },
+  };
+}
+
+function normalizeRuntimeSnapshot(payload: Record<string, unknown>) {
+  const runtime = isRecord(payload.runtime) ? payload.runtime : {};
+  return {
+    ok: readBoolean(runtime.ok, false),
+    source: readString(runtime.source) ?? "worker",
+    integration: isRecord(runtime.integration) ? runtime.integration : {},
+    health: isRecord(runtime.health) ? runtime.health : null,
+    deployments: parseDeployments(runtime.deployments),
+    controls: normalizeControls(runtime.controls),
+    canary: isRecord(runtime.canary) ? runtime.canary : null,
+    error: readString(runtime.error),
+  };
+}
+
+function firstDeploymentId(
+  deployments: RuntimeDeploymentRecord[],
+): string | null {
+  return deployments[0]?.deploymentId ?? null;
+}
+
+async function loadRuntimeDetail(
+  deploymentId: string,
+  adminAuthHeader: string,
+): Promise<{
+  detail: {
+    deploymentId: string;
+    deployment: RuntimeDeploymentRecord | null;
+    runs: RuntimeRunRecord[];
+    positions: RuntimeLedgerSnapshot | null;
+    pnl: {
+      asOf: string | null;
+      totals: RuntimeLedgerSnapshot["totals"];
+    } | null;
+    scorecard: Record<string, unknown> | null;
+  } | null;
+  error: string | null;
+}> {
+  const result = await requestWorkerJson({
+    path: `/api/admin/ops/runtime/deployments/${encodeURIComponent(deploymentId)}`,
+    authHeader: adminAuthHeader,
+  });
+  if (result.status < 200 || result.status >= 300) {
+    return {
+      detail: null,
+      error: readString(result.payload.error) ?? `http-${result.status}`,
+    };
+  }
+  const parsedDeployment = isRecord(result.payload.deployment)
+    ? safeParseRuntimeDeploymentRecord(result.payload.deployment)
+    : null;
+
+  return {
+    detail: {
+      deploymentId,
+      deployment: parsedDeployment?.success ? parsedDeployment.data : null,
+      runs: parseRuns(result.payload.runs),
+      positions: parseLedgerSnapshot(result.payload.positions),
+      pnl: parsePnl(result.payload.pnl),
+      scorecard: isRecord(result.payload.scorecard)
+        ? result.payload.scorecard
+        : null,
+    },
+    error: null,
+  };
+}
+
+export async function GET(request: Request) {
+  const userAuthHeader = normalizeAuthHeader(
+    request.headers.get("authorization"),
+  );
+  if (!userAuthHeader) {
+    return NextResponse.json(
+      { ok: false, error: "auth-required" },
+      { status: 401 },
+    );
+  }
+
+  const sessionResult = await validateOperatorSession(userAuthHeader);
+  if (sessionResult.status < 200 || sessionResult.status >= 300) {
+    return NextResponse.json(sessionResult.payload, {
+      status: sessionResult.status,
+    });
+  }
+
+  const adminToken = resolveAdminToken();
+  if (!adminToken) {
+    return NextResponse.json(
+      { ok: false, error: "missing RUNTIME_OPERATOR_ADMIN_TOKEN" },
+      { status: 503 },
+    );
+  }
+
+  const snapshotResult = await requestWorkerJson({
+    path: "/api/admin/ops/runtime",
+    authHeader: `Bearer ${adminToken}`,
+  });
+  if (snapshotResult.status < 200 || snapshotResult.status >= 300) {
+    return NextResponse.json(snapshotResult.payload, {
+      status: snapshotResult.status,
+    });
+  }
+
+  const runtime = normalizeRuntimeSnapshot(snapshotResult.payload);
+  const url = new URL(request.url);
+  const selectedDeploymentId =
+    readString(url.searchParams.get("deploymentId")) ??
+    firstDeploymentId(runtime.deployments);
+
+  let detail: Awaited<ReturnType<typeof loadRuntimeDetail>>["detail"] = null;
+  let detailError: string | null = null;
+  if (selectedDeploymentId) {
+    const detailResult = await loadRuntimeDetail(
+      selectedDeploymentId,
+      `Bearer ${adminToken}`,
+    );
+    detail = detailResult.detail;
+    detailError = detailResult.error;
+  }
+
+  return NextResponse.json({
+    ok: true,
+    runtime,
+    selectedDeploymentId,
+    detail,
+    detailError,
+  });
+}
+
+export async function POST(request: Request) {
+  const userAuthHeader = normalizeAuthHeader(
+    request.headers.get("authorization"),
+  );
+  if (!userAuthHeader) {
+    return NextResponse.json(
+      { ok: false, error: "auth-required" },
+      { status: 401 },
+    );
+  }
+
+  const sessionResult = await validateOperatorSession(userAuthHeader);
+  if (sessionResult.status < 200 || sessionResult.status >= 300) {
+    return NextResponse.json(sessionResult.payload, {
+      status: sessionResult.status,
+    });
+  }
+
+  const adminToken = resolveAdminToken();
+  if (!adminToken) {
+    return NextResponse.json(
+      { ok: false, error: "missing RUNTIME_OPERATOR_ADMIN_TOKEN" },
+      { status: 503 },
+    );
+  }
+
+  const payloadRaw = (await request.json().catch(() => null)) as unknown;
+  const payload = isRecord(payloadRaw) ? payloadRaw : {};
+  const deploymentId = readString(payload.deploymentId);
+  const action = readString(payload.action);
+  if (!deploymentId || !action) {
+    return NextResponse.json(
+      { ok: false, error: "invalid-runtime-operator-action" },
+      { status: 400 },
+    );
+  }
+  if (action !== "pause" && action !== "resume" && action !== "kill") {
+    return NextResponse.json(
+      { ok: false, error: "invalid-runtime-operator-action" },
+      { status: 400 },
+    );
+  }
+
+  const result = await requestWorkerJson({
+    path: `/api/admin/ops/runtime/deployments/${encodeURIComponent(
+      deploymentId,
+    )}/${action}`,
+    method: "POST",
+    authHeader: `Bearer ${adminToken}`,
+  });
+  return NextResponse.json(result.payload, { status: result.status });
+}

--- a/apps/portal/app/edge-api-runtime-bridge.tsx
+++ b/apps/portal/app/edge-api-runtime-bridge.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect } from "react";
+
+type RuntimeWindow = Window & {
+  __TRADER_RALPH_EDGE_API_BASE__?: string;
+};
+
+const CLIENT_EDGE_API_BASE = String(process.env.NEXT_PUBLIC_EDGE_API_BASE ?? "")
+  .trim()
+  .replace(/\/+$/, "");
+
+export function EdgeApiRuntimeBridge() {
+  useEffect(() => {
+    if (!CLIENT_EDGE_API_BASE || typeof window === "undefined") return;
+    (window as RuntimeWindow).__TRADER_RALPH_EDGE_API_BASE__ =
+      CLIENT_EDGE_API_BASE;
+  }, []);
+
+  return null;
+}

--- a/apps/portal/app/layout.tsx
+++ b/apps/portal/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Instrument_Sans, JetBrains_Mono } from "next/font/google";
+import { EdgeApiRuntimeBridge } from "./edge-api-runtime-bridge";
 import "./globals.css";
 import { Providers } from "./providers";
 import { ThemeProvider } from "./theme-provider";
@@ -33,6 +34,7 @@ export default function RootLayout({
       className={`${display.variable} ${mono.variable}`}
     >
       <body>
+        <EdgeApiRuntimeBridge />
         <ThemeProvider>
           <Providers>{children}</Providers>
         </ThemeProvider>

--- a/apps/portal/app/proof/runtime/page.tsx
+++ b/apps/portal/app/proof/runtime/page.tsx
@@ -235,7 +235,7 @@ function buildPayload(selectedDeploymentId: string): RuntimeOperatorApiPayload {
 }
 
 export default function RuntimeProofPage() {
-  const [selectedDeploymentId, setSelectedDeploymentId] = useState(
+  const [selectedDeploymentId, setSelectedDeploymentId] = useState<string>(
     DEPLOYMENTS[0].deploymentId,
   );
   const [actionPending, setActionPending] =

--- a/apps/portal/app/proof/runtime/page.tsx
+++ b/apps/portal/app/proof/runtime/page.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { useState } from "react";
+import { RuntimeOperatorView } from "../../terminal/runtime/runtime-operator-view";
+import type {
+  RuntimeControlAction,
+  RuntimeOperatorApiPayload,
+} from "../../terminal/runtime/types";
+
+const FIXTURE_TIME = "2026-03-09T14:10:00.000Z";
+const SOL_MINT = "So11111111111111111111111111111111111111112";
+const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+const DEPLOYMENTS = [
+  {
+    schemaVersion: "v1",
+    deploymentId: "runtime_canary_live_dca",
+    strategyKey: "dca",
+    sleeveId: "sleeve_runtime_canary",
+    ownerUserId: "user_operator",
+    pair: {
+      symbol: "SOL/USDC",
+      baseMint: SOL_MINT,
+      quoteMint: USDC_MINT,
+    },
+    mode: "live",
+    state: "live",
+    lane: "safe",
+    createdAt: FIXTURE_TIME,
+    updatedAt: FIXTURE_TIME,
+    promotedAt: FIXTURE_TIME,
+    pausedAt: undefined,
+    killedAt: undefined,
+    policy: {
+      maxNotionalUsd: "5.00",
+      dailyLossLimitUsd: "25.00",
+      maxSlippageBps: 50,
+      maxConcurrentRuns: 1,
+      rebalanceToleranceBps: 100,
+    },
+    capital: {
+      allocatedUsd: "25.00",
+      reservedUsd: "5.00",
+      availableUsd: "20.00",
+    },
+    tags: ["runtime-canary", "proof"],
+  },
+  {
+    schemaVersion: "v1",
+    deploymentId: "deployment_mean_reversion_paper",
+    strategyKey: "mean_reversion",
+    sleeveId: "sleeve_beta",
+    ownerUserId: "user_operator",
+    pair: {
+      symbol: "SOL/USDC",
+      baseMint: SOL_MINT,
+      quoteMint: USDC_MINT,
+    },
+    mode: "paper",
+    state: "paper",
+    lane: "safe",
+    createdAt: FIXTURE_TIME,
+    updatedAt: FIXTURE_TIME,
+    promotedAt: FIXTURE_TIME,
+    pausedAt: undefined,
+    killedAt: undefined,
+    policy: {
+      maxNotionalUsd: "40.00",
+      dailyLossLimitUsd: "60.00",
+      maxSlippageBps: 50,
+      maxConcurrentRuns: 2,
+      rebalanceToleranceBps: 80,
+    },
+    capital: {
+      allocatedUsd: "320.00",
+      reservedUsd: "40.00",
+      availableUsd: "280.00",
+    },
+    tags: ["managed-template", "proof"],
+  },
+] as const;
+
+function buildPayload(selectedDeploymentId: string): RuntimeOperatorApiPayload {
+  const deployment =
+    DEPLOYMENTS.find(
+      (candidate) => candidate.deploymentId === selectedDeploymentId,
+    ) ?? DEPLOYMENTS[0];
+  return {
+    ok: true,
+    runtime: {
+      ok: true,
+      source: "proof-fixture",
+      integration: {
+        stubModeEnabled: false,
+        runtimeBaseUrl: "https://ralph-runtime-rs.fly.dev",
+      },
+      health: {
+        status: "healthy",
+        feedGateway: {
+          maxMarketAgeMs: 2100,
+        },
+        featureCache: {
+          maxFeatureAgeMs: 2600,
+        },
+      },
+      deployments: [...DEPLOYMENTS],
+      controls: {
+        enabled: true,
+        disabledReason: null,
+        shadowOnly: false,
+        shadowOnlyReason: null,
+      },
+      canary: {
+        ok: true,
+        state: {
+          disabled: false,
+          disabledReason: null,
+        },
+        latestRuns: [
+          {
+            status: "success",
+            reconciliationStatus: "passed",
+          },
+        ],
+      },
+      error: null,
+    },
+    selectedDeploymentId: deployment.deploymentId,
+    detail: {
+      deploymentId: deployment.deploymentId,
+      deployment: { ...deployment },
+      runs: [
+        {
+          schemaVersion: "v1",
+          runId: `run_${deployment.deploymentId}`,
+          deploymentId: deployment.deploymentId,
+          runKey: `${deployment.deploymentId}:${FIXTURE_TIME}`,
+          trigger: {
+            kind: "signal",
+            source: "proof-page",
+            observedAt: FIXTURE_TIME,
+            reason: "browser-proof",
+          },
+          state: deployment.mode === "live" ? "completed" : "planned",
+          plannedAt: FIXTURE_TIME,
+          updatedAt: FIXTURE_TIME,
+          riskVerdictId: `risk_${deployment.deploymentId}`,
+          executionPlanId: `plan_${deployment.deploymentId}`,
+          submitRequestId:
+            deployment.mode === "live"
+              ? `submit_${deployment.deploymentId}`
+              : undefined,
+          receiptId:
+            deployment.mode === "live"
+              ? `receipt_${deployment.deploymentId}`
+              : undefined,
+          failureCode: undefined,
+          failureMessage: undefined,
+        },
+      ],
+      positions: {
+        schemaVersion: "v1",
+        snapshotId: `ledger_${deployment.deploymentId}`,
+        deploymentId: deployment.deploymentId,
+        sleeveId: deployment.sleeveId,
+        asOf: FIXTURE_TIME,
+        balances: [
+          {
+            mint: USDC_MINT,
+            symbol: "USDC",
+            decimals: 6,
+            freeAtomic: "20000000",
+            reservedAtomic: "5000000",
+            priceUsd: "1.00",
+          },
+          {
+            mint: SOL_MINT,
+            symbol: "SOL",
+            decimals: 9,
+            freeAtomic: "1058167243",
+            reservedAtomic: "0",
+            priceUsd: "171.20",
+          },
+        ],
+        positions: [
+          {
+            instrumentId: "SOL/USDC",
+            side: "long",
+            quantityAtomic: "31500000",
+            entryPriceUsd: "168.40",
+            markPriceUsd: "171.20",
+            unrealizedPnlUsd: "0.88",
+          },
+        ],
+        totals: {
+          equityUsd: deployment.capital.allocatedUsd,
+          reservedUsd: deployment.capital.reservedUsd,
+          availableUsd: deployment.capital.availableUsd,
+          realizedPnlUsd: "1.72",
+          unrealizedPnlUsd: "0.88",
+        },
+      },
+      pnl: {
+        asOf: FIXTURE_TIME,
+        totals: {
+          equityUsd: deployment.capital.allocatedUsd,
+          reservedUsd: deployment.capital.reservedUsd,
+          availableUsd: deployment.capital.availableUsd,
+          realizedPnlUsd: "1.72",
+          unrealizedPnlUsd: "0.88",
+        },
+      },
+      scorecard: {
+        deploymentId: deployment.deploymentId,
+        generatedAt: FIXTURE_TIME,
+        scorecard: {
+          triggerQuality: {
+            totalRuns: 4,
+          },
+        },
+        promotionGates: [
+          {
+            targetMode: deployment.mode === "live" ? "live" : "paper",
+            status: deployment.mode === "live" ? "pass" : "blocked",
+            summary:
+              deployment.mode === "live"
+                ? "Bounded live canary remains healthy."
+                : "Paper deployment still waiting on live approval.",
+          },
+        ],
+      },
+    },
+    detailError: null,
+  };
+}
+
+export default function RuntimeProofPage() {
+  const [selectedDeploymentId, setSelectedDeploymentId] = useState(
+    DEPLOYMENTS[0].deploymentId,
+  );
+  const [actionPending, setActionPending] =
+    useState<RuntimeControlAction | null>(null);
+  const [payload, setPayload] = useState<RuntimeOperatorApiPayload>(() =>
+    buildPayload(DEPLOYMENTS[0].deploymentId),
+  );
+
+  function updateDeploymentState(nextState: "paused" | "live" | "killed") {
+    const nextPayload = buildPayload(selectedDeploymentId);
+    if (nextPayload.detail?.deployment) {
+      nextPayload.detail.deployment.state = nextState;
+    }
+    setPayload(nextPayload);
+  }
+
+  return (
+    <main data-testid="runtime-operator-proof-page">
+      <RuntimeOperatorView
+        authenticated
+        loading={false}
+        error={null}
+        payload={payload}
+        actionPending={actionPending}
+        onRefresh={() => setPayload(buildPayload(selectedDeploymentId))}
+        onSelectDeployment={(deploymentId) => {
+          setSelectedDeploymentId(deploymentId);
+          setPayload(buildPayload(deploymentId));
+        }}
+        onControl={(action) => {
+          setActionPending(action);
+          if (action === "pause") updateDeploymentState("paused");
+          if (action === "resume") updateDeploymentState("live");
+          if (action === "kill") updateDeploymentState("killed");
+          window.setTimeout(() => setActionPending(null), 50);
+        }}
+      />
+    </main>
+  );
+}

--- a/apps/portal/app/terminal/components/dashboard-header.tsx
+++ b/apps/portal/app/terminal/components/dashboard-header.tsx
@@ -139,6 +139,12 @@ export function DashboardHeader({
           >
             Refresh
           </button>
+          <Link
+            className={cn(BTN_SECONDARY, "h-8 shrink-0 px-4 text-xs")}
+            href="/terminal/runtime"
+          >
+            Runtime
+          </Link>
           <button
             className={cn(BTN_SECONDARY, "h-8 shrink-0 px-4 text-xs")}
             onClick={logout}

--- a/apps/portal/app/terminal/runtime/page.tsx
+++ b/apps/portal/app/terminal/runtime/page.tsx
@@ -1,0 +1,5 @@
+import { RuntimeOperatorClient } from "./runtime-operator-client";
+
+export default function RuntimeOperatorPage() {
+  return <RuntimeOperatorClient />;
+}

--- a/apps/portal/app/terminal/runtime/runtime-operator-client.tsx
+++ b/apps/portal/app/terminal/runtime/runtime-operator-client.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { usePrivy } from "@privy-io/react-auth";
+import { useEffect, useState, useTransition } from "react";
+import { RuntimeOperatorView } from "./runtime-operator-view";
+import type { RuntimeControlAction, RuntimeOperatorApiPayload } from "./types";
+
+async function readJson<T>(response: Response): Promise<T | null> {
+  return (await response.json().catch(() => null)) as T | null;
+}
+
+async function fetchRuntimeOperatorPayload(input: {
+  accessToken: string;
+  deploymentId?: string;
+}): Promise<RuntimeOperatorApiPayload> {
+  const query = input.deploymentId
+    ? `?deploymentId=${encodeURIComponent(input.deploymentId)}`
+    : "";
+  const response = await fetch(`/api/runtime/operator${query}`, {
+    headers: {
+      authorization: `Bearer ${input.accessToken}`,
+    },
+    cache: "no-store",
+  });
+  const body = await readJson<RuntimeOperatorApiPayload & { error?: string }>(
+    response,
+  );
+  if (!response.ok || !body?.ok) {
+    throw new Error(body?.error ?? `http-${response.status}`);
+  }
+  return body;
+}
+
+export function RuntimeOperatorClient() {
+  const { ready, authenticated, getAccessToken } = usePrivy();
+  const [payload, setPayload] = useState<RuntimeOperatorApiPayload | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [actionPending, setActionPending] =
+    useState<RuntimeControlAction | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  async function loadOperatorView(deploymentId?: string) {
+    const token = await getAccessToken();
+    if (!token) {
+      setPayload(null);
+      setError("operator-auth-token-unavailable");
+      return;
+    }
+    const body = await fetchRuntimeOperatorPayload({
+      accessToken: token,
+      deploymentId,
+    });
+    setPayload(body);
+    setError(null);
+  }
+
+  async function runControl(action: RuntimeControlAction) {
+    const deploymentId = payload?.selectedDeploymentId;
+    if (!deploymentId) return;
+
+    const token = await getAccessToken();
+    if (!token) {
+      setError("operator-auth-token-unavailable");
+      return;
+    }
+
+    setActionPending(action);
+    try {
+      const response = await fetch("/api/runtime/operator", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          deploymentId,
+          action,
+        }),
+      });
+      const body = await readJson<{ ok?: boolean; error?: string }>(response);
+      if (!response.ok || body?.ok === false) {
+        setError(body?.error ?? `http-${response.status}`);
+        return;
+      }
+      await loadOperatorView(deploymentId);
+    } finally {
+      setActionPending(null);
+    }
+  }
+
+  useEffect(() => {
+    if (!ready) return;
+    if (!authenticated) {
+      setPayload(null);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    startTransition(() => {
+      void getAccessToken()
+        .then((token) => {
+          if (!token) {
+            setPayload(null);
+            setError("operator-auth-token-unavailable");
+            return null;
+          }
+          return fetchRuntimeOperatorPayload({ accessToken: token });
+        })
+        .then((nextPayload) => {
+          if (cancelled || !nextPayload) return;
+          setPayload(nextPayload);
+          setError(null);
+        })
+        .catch((cause) => {
+          if (cancelled) return;
+          setError(
+            cause instanceof Error
+              ? cause.message
+              : "runtime-operator-load-failed",
+          );
+        });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [authenticated, ready, getAccessToken]);
+
+  return (
+    <RuntimeOperatorView
+      authenticated={authenticated}
+      loading={!ready || isPending}
+      error={error}
+      payload={payload}
+      actionPending={actionPending}
+      onRefresh={() => {
+        startTransition(() => {
+          void loadOperatorView(
+            payload?.selectedDeploymentId ?? undefined,
+          ).catch((cause) => {
+            setError(
+              cause instanceof Error
+                ? cause.message
+                : "runtime-operator-refresh-failed",
+            );
+          });
+        });
+      }}
+      onSelectDeployment={(deploymentId) => {
+        startTransition(() => {
+          void loadOperatorView(deploymentId).catch((cause) => {
+            setError(
+              cause instanceof Error
+                ? cause.message
+                : "runtime-operator-select-failed",
+            );
+          });
+        });
+      }}
+      onControl={(action) => {
+        startTransition(() => {
+          void runControl(action).catch((cause) => {
+            setError(
+              cause instanceof Error
+                ? cause.message
+                : "runtime-operator-control-failed",
+            );
+          });
+        });
+      }}
+    />
+  );
+}

--- a/apps/portal/app/terminal/runtime/runtime-operator-view.tsx
+++ b/apps/portal/app/terminal/runtime/runtime-operator-view.tsx
@@ -1,0 +1,536 @@
+"use client";
+
+import Link from "next/link";
+import { BTN_PRIMARY, BTN_SECONDARY, formatTick } from "../../lib";
+import type {
+  RuntimeControlAction,
+  RuntimeOperatorApiPayload,
+  RuntimeOperatorDetail,
+  RuntimeOperatorSnapshot,
+} from "./types";
+
+type RuntimeOperatorViewProps = {
+  authenticated: boolean;
+  loading: boolean;
+  error: string | null;
+  payload: RuntimeOperatorApiPayload | null;
+  actionPending: RuntimeControlAction | null;
+  onRefresh?: () => void;
+  onSelectDeployment?: (deploymentId: string) => void;
+  onControl?: (action: RuntimeControlAction) => void;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return normalized ? normalized : null;
+}
+
+function readBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function statusClasses(status: string | null): string {
+  switch (status) {
+    case "healthy":
+    case "pass":
+    case "success":
+    case "passed":
+    case "live":
+      return "border-emerald-500/40 bg-emerald-500/10 text-emerald-200";
+    case "paused":
+    case "paper":
+    case "shadow":
+    case "blocked":
+      return "border-amber-500/40 bg-amber-500/10 text-amber-200";
+    case "failed":
+    case "killed":
+      return "border-rose-500/40 bg-rose-500/10 text-rose-200";
+    default:
+      return "border-border bg-surface text-muted";
+  }
+}
+
+function summaryItem(label: string, value: string) {
+  return (
+    <div className="rounded border border-border bg-surface/80 p-3">
+      <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+        {label}
+      </p>
+      <p className="mt-2 text-sm font-medium text-ink">{value}</p>
+    </div>
+  );
+}
+
+function renderHealthSummary(snapshot: RuntimeOperatorSnapshot | null) {
+  const health = isRecord(snapshot?.health) ? snapshot?.health : {};
+  const feedGateway = isRecord(health.feedGateway) ? health.feedGateway : {};
+  const featureCache = isRecord(health.featureCache) ? health.featureCache : {};
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      {summaryItem("Runtime", readString(health.status) ?? "unknown")}
+      {summaryItem(
+        "Feed age",
+        `${readString(feedGateway.maxMarketAgeMs) ?? String(feedGateway.maxMarketAgeMs ?? "n/a")} ms`,
+      )}
+      {summaryItem(
+        "Feature age",
+        `${readString(featureCache.maxFeatureAgeMs) ?? String(featureCache.maxFeatureAgeMs ?? "n/a")} ms`,
+      )}
+      {summaryItem("Deployments", String(snapshot?.deployments.length ?? 0))}
+    </div>
+  );
+}
+
+function renderCanarySummary(snapshot: RuntimeOperatorSnapshot | null) {
+  const canary = isRecord(snapshot?.canary) ? snapshot?.canary : {};
+  const state = isRecord(canary.state) ? canary.state : {};
+  const latestRuns = Array.isArray(canary.latestRuns) ? canary.latestRuns : [];
+  const latestRun = isRecord(latestRuns[0]) ? latestRuns[0] : {};
+  return (
+    <div className="grid gap-3 sm:grid-cols-3">
+      {summaryItem(
+        "Canary",
+        readBoolean(canary.ok, false) ? "online" : "offline",
+      )}
+      {summaryItem(
+        "Latest status",
+        readString(latestRun.status) ??
+          readString(state.disabledReason) ??
+          "n/a",
+      )}
+      {summaryItem(
+        "Reconciliation",
+        readString(latestRun.reconciliationStatus) ?? "n/a",
+      )}
+    </div>
+  );
+}
+
+function renderRuns(detail: RuntimeOperatorDetail | null) {
+  if (!detail || detail.runs.length === 0) {
+    return (
+      <div className="rounded border border-dashed border-border p-4 text-sm text-muted">
+        No runtime runs recorded yet.
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-3">
+      {detail.runs.slice(0, 6).map((run) => (
+        <article
+          key={run.runId}
+          className="rounded border border-border bg-surface/80 p-4"
+        >
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <p className="font-mono text-xs text-muted">{run.runId}</p>
+              <p className="mt-1 text-sm font-medium text-ink">
+                {run.trigger.kind} from {run.trigger.source}
+              </p>
+              <p className="mt-1 text-xs text-muted">
+                {run.failureCode ?? run.failureMessage ?? "healthy run"}
+              </p>
+            </div>
+            <span
+              className={`inline-flex rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.24em] ${statusClasses(
+                run.state,
+              )}`}
+            >
+              {run.state.replaceAll("_", " ")}
+            </span>
+          </div>
+          <div className="mt-3 grid gap-2 text-xs text-muted sm:grid-cols-3">
+            <p>planned {formatTick(run.plannedAt)}</p>
+            <p>updated {formatTick(run.updatedAt)}</p>
+            <p>{run.submitRequestId ?? run.receiptId ?? "no receipt yet"}</p>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function renderPositions(detail: RuntimeOperatorDetail | null) {
+  const snapshot = detail?.positions;
+  if (!snapshot) {
+    return (
+      <div className="rounded border border-dashed border-border p-4 text-sm text-muted">
+        Position snapshot unavailable.
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+        {summaryItem("Equity", `${snapshot.totals.equityUsd} USD`)}
+        {summaryItem("Reserved", `${snapshot.totals.reservedUsd} USD`)}
+        {summaryItem("Available", `${snapshot.totals.availableUsd} USD`)}
+        {summaryItem("Realized", `${snapshot.totals.realizedPnlUsd} USD`)}
+        {summaryItem("Unrealized", `${snapshot.totals.unrealizedPnlUsd} USD`)}
+      </div>
+      <div className="grid gap-3 lg:grid-cols-[1.2fr_0.8fr]">
+        <div className="rounded border border-border bg-surface/80 p-4">
+          <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+            Positions
+          </p>
+          <div className="mt-3 space-y-3">
+            {snapshot.positions.length === 0 ? (
+              <p className="text-sm text-muted">
+                No live positions in this sleeve.
+              </p>
+            ) : (
+              snapshot.positions.map((position) => (
+                <div
+                  key={`${position.instrumentId}:${position.side}`}
+                  className="rounded border border-border bg-paper/70 p-3"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="text-sm font-medium text-ink">
+                      {position.instrumentId}
+                    </p>
+                    <span className="text-xs uppercase tracking-[0.24em] text-muted">
+                      {position.side}
+                    </span>
+                  </div>
+                  <div className="mt-2 grid gap-2 text-xs text-muted sm:grid-cols-3">
+                    <p>qty {position.quantityAtomic}</p>
+                    <p>entry {position.entryPriceUsd ?? "--"} USD</p>
+                    <p>uPnL {position.unrealizedPnlUsd ?? "--"} USD</p>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+        <div className="rounded border border-border bg-surface/80 p-4">
+          <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+            Balances
+          </p>
+          <div className="mt-3 space-y-3">
+            {snapshot.balances.map((balance) => (
+              <div
+                key={balance.mint}
+                className="rounded border border-border bg-paper/70 p-3 text-sm"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <p className="font-medium text-ink">{balance.symbol}</p>
+                  <p className="text-muted">{balance.priceUsd ?? "--"} USD</p>
+                </div>
+                <div className="mt-2 grid gap-2 text-xs text-muted">
+                  <p>free {balance.freeAtomic}</p>
+                  <p>reserved {balance.reservedAtomic}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function renderPromotion(detail: RuntimeOperatorDetail | null) {
+  const report = isRecord(detail?.scorecard) ? detail?.scorecard : {};
+  const promotionGates = Array.isArray(report.promotionGates)
+    ? report.promotionGates
+    : [];
+  if (promotionGates.length === 0) {
+    return (
+      <div className="rounded border border-dashed border-border p-4 text-sm text-muted">
+        Promotion evidence not available yet.
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-3">
+      {promotionGates.map((gate) => {
+        const gateRecord = isRecord(gate) ? gate : {};
+        const gateId = readString(gateRecord.gateId) ?? "promotion-gate";
+        const targetMode = readString(gateRecord.targetMode) ?? "unknown";
+        const status = readString(gateRecord.status) ?? "unknown";
+        const summary =
+          readString(gateRecord.summary) ?? "No summary available.";
+        return (
+          <article
+            key={`${gateId}:${targetMode}:${status}`}
+            className="rounded border border-border bg-surface/80 p-4"
+          >
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                  Promotion gate
+                </p>
+                <h3 className="mt-2 text-sm font-medium text-ink">
+                  target {targetMode}
+                </h3>
+              </div>
+              <span
+                className={`inline-flex rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.24em] ${statusClasses(
+                  status,
+                )}`}
+              >
+                {status.replaceAll("_", " ")}
+              </span>
+            </div>
+            <p className="mt-3 text-sm text-muted">{summary}</p>
+          </article>
+        );
+      })}
+    </div>
+  );
+}
+
+export function RuntimeOperatorView({
+  authenticated,
+  loading,
+  error,
+  payload,
+  actionPending,
+  onRefresh,
+  onSelectDeployment,
+  onControl,
+}: RuntimeOperatorViewProps) {
+  const runtime = payload?.runtime ?? null;
+  const detail = payload?.detail ?? null;
+  const selectedDeploymentId = payload?.selectedDeploymentId ?? null;
+
+  if (!authenticated) {
+    return (
+      <section className="mx-auto w-[min(1320px,94vw)] py-10">
+        <div className="card p-8">
+          <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+            Runtime operator
+          </p>
+          <h1 className="mt-3 text-2xl font-semibold tracking-tight text-ink">
+            Sign in required
+          </h1>
+          <p className="mt-3 max-w-[54ch] text-sm text-muted">
+            Runtime deployments are only available to authenticated operators.
+          </p>
+          <div className="mt-6 flex gap-3">
+            <Link className={BTN_PRIMARY} href="/login">
+              Open login
+            </Link>
+            <Link className={BTN_SECONDARY} href="/terminal">
+              Back to terminal
+            </Link>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mx-auto w-[min(1380px,95vw)] space-y-6 py-8">
+      <header className="card p-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="max-w-[60ch]">
+            <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+              Runtime operator
+            </p>
+            <h1 className="mt-3 text-2xl font-semibold tracking-tight text-ink">
+              Runtime deployments, runs, and live controls
+            </h1>
+            <p className="mt-3 text-sm text-muted">
+              Auth-gated view of runtime health, rollout state, scorecards,
+              positions, and deployment controls.
+            </p>
+          </div>
+          <div className="flex gap-3">
+            <button
+              className={BTN_SECONDARY}
+              onClick={onRefresh}
+              type="button"
+              disabled={loading}
+            >
+              {loading ? "Refreshing..." : "Refresh"}
+            </button>
+            <Link className={BTN_SECONDARY} href="/terminal">
+              Terminal
+            </Link>
+          </div>
+        </div>
+        {error ? (
+          <div className="mt-4 rounded border border-rose-500/40 bg-rose-500/10 p-4 text-sm text-rose-200">
+            {error}
+          </div>
+        ) : null}
+        {payload?.detailError ? (
+          <div className="mt-4 rounded border border-amber-500/40 bg-amber-500/10 p-4 text-sm text-amber-200">
+            {payload.detailError}
+          </div>
+        ) : null}
+      </header>
+
+      <div className="grid gap-6 xl:grid-cols-[320px_minmax(0,1fr)]">
+        <aside className="card p-4">
+          <div className="rounded border border-border bg-surface/80 p-4">
+            <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+              Runtime controls
+            </p>
+            <div className="mt-3 space-y-3 text-sm">
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted">enabled</span>
+                <span
+                  className={`inline-flex rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.24em] ${statusClasses(
+                    runtime?.controls.enabled ? "healthy" : "failed",
+                  )}`}
+                >
+                  {runtime?.controls.enabled ? "enabled" : "disabled"}
+                </span>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted">shadow only</span>
+                <span
+                  className={`inline-flex rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.24em] ${statusClasses(
+                    runtime?.controls.shadowOnly ? "shadow" : "live",
+                  )}`}
+                >
+                  {runtime?.controls.shadowOnly ? "on" : "off"}
+                </span>
+              </div>
+              <p className="text-xs text-muted">
+                {runtime?.controls.disabledReason ??
+                  runtime?.controls.shadowOnlyReason ??
+                  "runtime controls healthy"}
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-4 space-y-3">
+            {runtime?.deployments.length ? (
+              runtime.deployments.map((deployment) => {
+                const active = deployment.deploymentId === selectedDeploymentId;
+                return (
+                  <button
+                    key={deployment.deploymentId}
+                    className={`w-full rounded border p-4 text-left transition-colors ${
+                      active
+                        ? "border-ink bg-ink text-surface"
+                        : "border-border bg-surface/80 text-ink hover:bg-paper"
+                    }`}
+                    onClick={() =>
+                      onSelectDeployment?.(deployment.deploymentId)
+                    }
+                    type="button"
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <p className="font-medium">{deployment.strategyKey}</p>
+                      <span className="text-[10px] uppercase tracking-[0.24em] opacity-75">
+                        {deployment.state}
+                      </span>
+                    </div>
+                    <p className="mt-2 font-mono text-xs opacity-80">
+                      {deployment.deploymentId}
+                    </p>
+                    <p className="mt-2 text-xs opacity-80">
+                      {deployment.pair.symbol} · {deployment.mode} ·{" "}
+                      {deployment.lane}
+                    </p>
+                  </button>
+                );
+              })
+            ) : (
+              <div className="rounded border border-dashed border-border p-4 text-sm text-muted">
+                No runtime deployments found.
+              </div>
+            )}
+          </div>
+        </aside>
+
+        <div className="space-y-6">
+          <section className="card p-4">{renderHealthSummary(runtime)}</section>
+          <section className="card p-4">{renderCanarySummary(runtime)}</section>
+
+          <section className="card p-5">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                  Selected deployment
+                </p>
+                <h2 className="mt-2 text-lg font-semibold text-ink">
+                  {detail?.deployment?.deploymentId ?? "No deployment selected"}
+                </h2>
+                <p className="mt-2 text-sm text-muted">
+                  {detail?.deployment
+                    ? `${detail.deployment.strategyKey} on ${detail.deployment.pair.symbol} in ${detail.deployment.mode} mode`
+                    : "Choose a deployment to inspect runs, positions, and scorecards."}
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-3">
+                {(["pause", "resume", "kill"] as const).map((action) => (
+                  <button
+                    key={action}
+                    className={action === "kill" ? BTN_PRIMARY : BTN_SECONDARY}
+                    onClick={() => onControl?.(action)}
+                    type="button"
+                    disabled={!detail?.deployment || loading}
+                  >
+                    {actionPending === action
+                      ? `${action}...`
+                      : action.charAt(0).toUpperCase() + action.slice(1)}
+                  </button>
+                ))}
+              </div>
+            </div>
+            {detail?.deployment ? (
+              <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+                {summaryItem("State", detail.deployment.state)}
+                {summaryItem("Mode", detail.deployment.mode)}
+                {summaryItem("Lane", detail.deployment.lane)}
+                {summaryItem(
+                  "Reserved",
+                  `${detail.deployment.capital.reservedUsd} USD`,
+                )}
+                {summaryItem(
+                  "Max notional",
+                  `${detail.deployment.policy.maxNotionalUsd} USD`,
+                )}
+              </div>
+            ) : null}
+          </section>
+
+          <section className="card p-5">
+            <div className="mb-4">
+              <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                Positions and PnL
+              </p>
+              <h2 className="mt-2 text-lg font-semibold text-ink">
+                Sleeve state and live balances
+              </h2>
+            </div>
+            {renderPositions(detail)}
+          </section>
+
+          <section className="card p-5">
+            <div className="mb-4">
+              <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                Recent runs
+              </p>
+              <h2 className="mt-2 text-lg font-semibold text-ink">
+                Latest runtime evaluations
+              </h2>
+            </div>
+            {renderRuns(detail)}
+          </section>
+
+          <section className="card p-5">
+            <div className="mb-4">
+              <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                Promotion evidence
+              </p>
+              <h2 className="mt-2 text-lg font-semibold text-ink">
+                Scorecards and rollout gates
+              </h2>
+            </div>
+            {renderPromotion(detail)}
+          </section>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/portal/app/terminal/runtime/types.ts
+++ b/apps/portal/app/terminal/runtime/types.ts
@@ -2,7 +2,7 @@ import type {
   RuntimeDeploymentRecord,
   RuntimeLedgerSnapshot,
   RuntimeRunRecord,
-} from "../../../../worker/src/runtime_contracts";
+} from "../../../lib/runtime-contracts";
 
 export type RuntimeControlAction = "pause" | "resume" | "kill";
 

--- a/apps/portal/app/terminal/runtime/types.ts
+++ b/apps/portal/app/terminal/runtime/types.ts
@@ -1,0 +1,45 @@
+import type {
+  RuntimeDeploymentRecord,
+  RuntimeLedgerSnapshot,
+  RuntimeRunRecord,
+} from "../../../../worker/src/runtime_contracts";
+
+export type RuntimeControlAction = "pause" | "resume" | "kill";
+
+export type RuntimeOperatorControls = {
+  enabled: boolean;
+  disabledReason: string | null;
+  shadowOnly: boolean;
+  shadowOnlyReason: string | null;
+};
+
+export type RuntimeOperatorSnapshot = {
+  ok: boolean;
+  source: string;
+  integration: Record<string, unknown>;
+  health: Record<string, unknown> | null;
+  deployments: RuntimeDeploymentRecord[];
+  controls: RuntimeOperatorControls;
+  canary: Record<string, unknown> | null;
+  error: string | null;
+};
+
+export type RuntimeOperatorDetail = {
+  deploymentId: string;
+  deployment: RuntimeDeploymentRecord | null;
+  runs: RuntimeRunRecord[];
+  positions: RuntimeLedgerSnapshot | null;
+  pnl: {
+    asOf: string | null;
+    totals: RuntimeLedgerSnapshot["totals"];
+  } | null;
+  scorecard: Record<string, unknown> | null;
+};
+
+export type RuntimeOperatorApiPayload = {
+  ok: boolean;
+  runtime: RuntimeOperatorSnapshot;
+  selectedDeploymentId: string | null;
+  detail: RuntimeOperatorDetail | null;
+  detailError: string | null;
+};

--- a/apps/portal/lib/runtime-contracts.ts
+++ b/apps/portal/lib/runtime-contracts.ts
@@ -1,0 +1,369 @@
+export type RuntimeDeploymentRecord = {
+  schemaVersion?: string;
+  deploymentId: string;
+  strategyKey: string;
+  sleeveId: string;
+  ownerUserId: string;
+  pair: {
+    symbol: string;
+    baseMint: string;
+    quoteMint: string;
+  };
+  mode: string;
+  state: string;
+  lane: string;
+  createdAt: string;
+  updatedAt: string;
+  promotedAt?: string;
+  pausedAt?: string;
+  killedAt?: string;
+  policy: {
+    maxNotionalUsd: string;
+    dailyLossLimitUsd: string;
+    maxSlippageBps: number;
+    maxConcurrentRuns: number;
+    rebalanceToleranceBps: number;
+  };
+  capital: {
+    allocatedUsd: string;
+    reservedUsd: string;
+    availableUsd: string;
+  };
+  tags: readonly string[];
+};
+
+export type RuntimeRunRecord = {
+  schemaVersion?: string;
+  runId: string;
+  deploymentId: string;
+  runKey: string;
+  trigger: {
+    kind: string;
+    source: string;
+    observedAt?: string;
+    featureSnapshotId?: string;
+    reason?: string;
+  };
+  state: string;
+  plannedAt: string;
+  updatedAt: string;
+  riskVerdictId?: string;
+  executionPlanId?: string;
+  submitRequestId?: string;
+  receiptId?: string;
+  failureCode?: string;
+  failureMessage?: string;
+};
+
+export type RuntimeLedgerSnapshot = {
+  schemaVersion?: string;
+  snapshotId: string;
+  deploymentId: string;
+  sleeveId: string;
+  asOf: string;
+  balances: ReadonlyArray<{
+    mint: string;
+    symbol: string;
+    decimals: number;
+    freeAtomic: string;
+    reservedAtomic: string;
+    priceUsd?: string;
+  }>;
+  positions: ReadonlyArray<{
+    instrumentId: string;
+    side: string;
+    quantityAtomic: string;
+    entryPriceUsd?: string;
+    markPriceUsd?: string;
+    unrealizedPnlUsd?: string;
+  }>;
+  totals: {
+    equityUsd: string;
+    reservedUsd: string;
+    availableUsd: string;
+    realizedPnlUsd: string;
+    unrealizedPnlUsd: string;
+  };
+};
+
+type ParseSuccess<T> = {
+  success: true;
+  data: T;
+};
+
+type ParseFailure = {
+  success: false;
+  error: string;
+};
+
+type ParseResult<T> = ParseSuccess<T> | ParseFailure;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return readString(value) ?? undefined;
+}
+
+function readNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => Boolean(readString(entry)));
+}
+
+function fail<T>(error: string): ParseResult<T> {
+  return { success: false, error };
+}
+
+export function safeParseRuntimeDeploymentRecord(
+  value: unknown,
+): ParseResult<RuntimeDeploymentRecord> {
+  if (!isRecord(value)) return fail("deployment-not-object");
+  const pair = isRecord(value.pair) ? value.pair : null;
+  const policy = isRecord(value.policy) ? value.policy : null;
+  const capital = isRecord(value.capital) ? value.capital : null;
+  if (!pair || !policy || !capital) return fail("deployment-missing-nested");
+  const deploymentId = readString(value.deploymentId);
+  const strategyKey = readString(value.strategyKey);
+  const sleeveId = readString(value.sleeveId);
+  const ownerUserId = readString(value.ownerUserId);
+  const symbol = readString(pair.symbol);
+  const baseMint = readString(pair.baseMint);
+  const quoteMint = readString(pair.quoteMint);
+  const mode = readString(value.mode);
+  const state = readString(value.state);
+  const lane = readString(value.lane);
+  const createdAt = readString(value.createdAt);
+  const updatedAt = readString(value.updatedAt);
+  const maxNotionalUsd = readString(policy.maxNotionalUsd);
+  const dailyLossLimitUsd = readString(policy.dailyLossLimitUsd);
+  const maxSlippageBps = readNumber(policy.maxSlippageBps);
+  const maxConcurrentRuns = readNumber(policy.maxConcurrentRuns);
+  const rebalanceToleranceBps = readNumber(policy.rebalanceToleranceBps);
+  const allocatedUsd = readString(capital.allocatedUsd);
+  const reservedUsd = readString(capital.reservedUsd);
+  const availableUsd = readString(capital.availableUsd);
+  if (
+    !deploymentId ||
+    !strategyKey ||
+    !sleeveId ||
+    !ownerUserId ||
+    !symbol ||
+    !baseMint ||
+    !quoteMint ||
+    !mode ||
+    !state ||
+    !lane ||
+    !createdAt ||
+    !updatedAt ||
+    !maxNotionalUsd ||
+    !dailyLossLimitUsd ||
+    maxSlippageBps === null ||
+    maxConcurrentRuns === null ||
+    rebalanceToleranceBps === null ||
+    !allocatedUsd ||
+    !reservedUsd ||
+    !availableUsd
+  ) {
+    return fail("deployment-invalid");
+  }
+
+  return {
+    success: true,
+    data: {
+      deploymentId,
+      schemaVersion: readOptionalString(value.schemaVersion),
+      strategyKey,
+      sleeveId,
+      ownerUserId,
+      pair: {
+        symbol,
+        baseMint,
+        quoteMint,
+      },
+      mode,
+      state,
+      lane,
+      createdAt,
+      updatedAt,
+      promotedAt: readOptionalString(value.promotedAt),
+      pausedAt: readOptionalString(value.pausedAt),
+      killedAt: readOptionalString(value.killedAt),
+      policy: {
+        maxNotionalUsd,
+        dailyLossLimitUsd,
+        maxSlippageBps,
+        maxConcurrentRuns,
+        rebalanceToleranceBps,
+      },
+      capital: {
+        allocatedUsd,
+        reservedUsd,
+        availableUsd,
+      },
+      tags: readStringArray(value.tags),
+    },
+  };
+}
+
+export function safeParseRuntimeRunRecord(
+  value: unknown,
+): ParseResult<RuntimeRunRecord> {
+  if (!isRecord(value)) return fail("run-not-object");
+  const trigger = isRecord(value.trigger) ? value.trigger : null;
+  if (!trigger) return fail("run-trigger-missing");
+  const runId = readString(value.runId);
+  const deploymentId = readString(value.deploymentId);
+  const runKey = readString(value.runKey);
+  const kind = readString(trigger.kind);
+  const source = readString(trigger.source);
+  const state = readString(value.state);
+  const plannedAt = readString(value.plannedAt);
+  const updatedAt = readString(value.updatedAt);
+  if (
+    !runId ||
+    !deploymentId ||
+    !runKey ||
+    !kind ||
+    !source ||
+    !state ||
+    !plannedAt ||
+    !updatedAt
+  ) {
+    return fail("run-invalid");
+  }
+
+  return {
+    success: true,
+    data: {
+      runId,
+      schemaVersion: readOptionalString(value.schemaVersion),
+      deploymentId,
+      runKey,
+      trigger: {
+        kind,
+        source,
+        observedAt: readOptionalString(trigger.observedAt),
+        featureSnapshotId: readOptionalString(trigger.featureSnapshotId),
+        reason: readOptionalString(trigger.reason),
+      },
+      state,
+      plannedAt,
+      updatedAt,
+      riskVerdictId: readOptionalString(value.riskVerdictId),
+      executionPlanId: readOptionalString(value.executionPlanId),
+      submitRequestId: readOptionalString(value.submitRequestId),
+      receiptId: readOptionalString(value.receiptId),
+      failureCode: readOptionalString(value.failureCode),
+      failureMessage: readOptionalString(value.failureMessage),
+    },
+  };
+}
+
+export function safeParseRuntimeLedgerSnapshot(
+  value: unknown,
+): ParseResult<RuntimeLedgerSnapshot> {
+  if (!isRecord(value)) return fail("snapshot-not-object");
+  const totals = isRecord(value.totals) ? value.totals : null;
+  if (!totals) return fail("snapshot-totals-missing");
+  const snapshotId = readString(value.snapshotId);
+  const deploymentId = readString(value.deploymentId);
+  const sleeveId = readString(value.sleeveId);
+  const asOf = readString(value.asOf);
+  const equityUsd = readString(totals.equityUsd);
+  const reservedUsd = readString(totals.reservedUsd);
+  const availableUsd = readString(totals.availableUsd);
+  const realizedPnlUsd = readString(totals.realizedPnlUsd);
+  const unrealizedPnlUsd = readString(totals.unrealizedPnlUsd);
+  if (
+    !snapshotId ||
+    !deploymentId ||
+    !sleeveId ||
+    !asOf ||
+    !equityUsd ||
+    !reservedUsd ||
+    !availableUsd ||
+    !realizedPnlUsd ||
+    !unrealizedPnlUsd
+  ) {
+    return fail("snapshot-invalid");
+  }
+
+  const balances = Array.isArray(value.balances)
+    ? value.balances.flatMap((entry) => {
+        if (!isRecord(entry)) return [];
+        const mint = readString(entry.mint);
+        const symbol = readString(entry.symbol);
+        const decimals = readNumber(entry.decimals);
+        const freeAtomic = readString(entry.freeAtomic);
+        const reservedAtomic = readString(entry.reservedAtomic);
+        if (
+          !mint ||
+          !symbol ||
+          decimals === null ||
+          !freeAtomic ||
+          !reservedAtomic
+        ) {
+          return [];
+        }
+        return [
+          {
+            mint,
+            symbol,
+            decimals,
+            freeAtomic,
+            reservedAtomic,
+            priceUsd: readOptionalString(entry.priceUsd),
+          },
+        ];
+      })
+    : [];
+
+  const positions = Array.isArray(value.positions)
+    ? value.positions.flatMap((entry) => {
+        if (!isRecord(entry)) return [];
+        const instrumentId = readString(entry.instrumentId);
+        const side = readString(entry.side);
+        const quantityAtomic = readString(entry.quantityAtomic);
+        if (!instrumentId || !side || !quantityAtomic) return [];
+        return [
+          {
+            instrumentId,
+            side,
+            quantityAtomic,
+            entryPriceUsd: readOptionalString(entry.entryPriceUsd),
+            markPriceUsd: readOptionalString(entry.markPriceUsd),
+            unrealizedPnlUsd: readOptionalString(entry.unrealizedPnlUsd),
+          },
+        ];
+      })
+    : [];
+
+  return {
+    success: true,
+    data: {
+      snapshotId,
+      schemaVersion: readOptionalString(value.schemaVersion),
+      deploymentId,
+      sleeveId,
+      asOf,
+      balances,
+      positions,
+      totals: {
+        equityUsd,
+        reservedUsd,
+        availableUsd,
+        realizedPnlUsd,
+        unrealizedPnlUsd,
+      },
+    },
+  };
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -145,6 +145,10 @@ import {
   type RuntimeControlAction,
   readRuntimeAdminSnapshot,
   readRuntimeDeployment,
+  readRuntimeDeploymentRuns,
+  readRuntimePnlSummary,
+  readRuntimePositionSnapshot,
+  readRuntimeScorecard,
 } from "./runtime_internal";
 import { SolanaRpc } from "./solana_rpc";
 import type { Env, ExecutionConfig } from "./types";
@@ -475,6 +479,18 @@ function parseRuntimeAdminControlPath(pathname: string): {
     deploymentId: decodedDeploymentId,
     action,
   };
+}
+
+function parseRuntimeAdminDetailPath(pathname: string): string | null {
+  const prefix = "/api/admin/ops/runtime/deployments/";
+  if (!pathname.startsWith(prefix)) return null;
+  const suffix = pathname.slice(prefix.length);
+  if (!suffix || suffix.includes("/")) return null;
+  try {
+    return decodeURIComponent(suffix);
+  } catch {
+    return null;
+  }
 }
 
 function newExecutionAttemptId(): string {
@@ -2237,6 +2253,75 @@ const worker = {
               controls: controls.runtime,
               canary,
             },
+          }),
+          env,
+        );
+      }
+
+      const runtimeDetailDeploymentId =
+        request.method === "GET"
+          ? parseRuntimeAdminDetailPath(url.pathname)
+          : null;
+      if (request.method === "GET" && runtimeDetailDeploymentId) {
+        const auth = authorizeAdminRoute(request, env);
+        if (!auth.ok) {
+          return withCors(
+            json({ ok: false, error: auth.error }, { status: auth.status }),
+            env,
+          );
+        }
+        const [
+          deploymentResult,
+          runsResult,
+          positionsResult,
+          pnlResult,
+          scorecardResult,
+        ] = await Promise.all([
+          readRuntimeDeployment(env, runtimeDetailDeploymentId),
+          readRuntimeDeploymentRuns(env, runtimeDetailDeploymentId),
+          readRuntimePositionSnapshot(env, runtimeDetailDeploymentId),
+          readRuntimePnlSummary(env, runtimeDetailDeploymentId),
+          readRuntimeScorecard(env, runtimeDetailDeploymentId),
+        ]);
+        const failedResult =
+          [
+            deploymentResult,
+            runsResult,
+            positionsResult,
+            pnlResult,
+            scorecardResult,
+          ].find((result) => !result.ok) ?? null;
+        if (failedResult) {
+          return withCors(
+            json(failedResult.payload, { status: failedResult.status }),
+            env,
+          );
+        }
+        return withCors(
+          json({
+            ok: true,
+            source:
+              readOptionalString(deploymentResult.payload.source) ??
+              "runtime-rs",
+            deploymentId: runtimeDetailDeploymentId,
+            deployment: isRecord(deploymentResult.payload.deployment)
+              ? deploymentResult.payload.deployment
+              : null,
+            runs: Array.isArray(runsResult.payload.runs)
+              ? runsResult.payload.runs
+              : [],
+            positions: isRecord(positionsResult.payload.snapshot)
+              ? positionsResult.payload.snapshot
+              : null,
+            pnl: isRecord(pnlResult.payload.totals)
+              ? {
+                  asOf: readOptionalString(pnlResult.payload.asOf),
+                  totals: pnlResult.payload.totals,
+                }
+              : null,
+            scorecard: isRecord(scorecardResult.payload.report)
+              ? scorecardResult.payload.report
+              : null,
           }),
           env,
         );

--- a/apps/worker/src/runtime_internal.ts
+++ b/apps/worker/src/runtime_internal.ts
@@ -716,6 +716,32 @@ export async function readRuntimeScorecard(
   });
 }
 
+export async function readRuntimePositionSnapshot(
+  env: Env,
+  deploymentId: string,
+): Promise<RuntimeInternalJsonResult> {
+  return await dispatchRuntimeInternalJson({
+    env,
+    method: "GET",
+    pathname: `${INTERNAL_RUNTIME_PREFIX}/positions?deploymentId=${encodeURIComponent(
+      deploymentId,
+    )}`,
+  });
+}
+
+export async function readRuntimePnlSummary(
+  env: Env,
+  deploymentId: string,
+): Promise<RuntimeInternalJsonResult> {
+  return await dispatchRuntimeInternalJson({
+    env,
+    method: "GET",
+    pathname: `${INTERNAL_RUNTIME_PREFIX}/pnl?deploymentId=${encodeURIComponent(
+      deploymentId,
+    )}`,
+  });
+}
+
 export async function applyRuntimeDeploymentControl(input: {
   env: Env;
   deploymentId: string;

--- a/tests/browser/harness-proof.spec.ts
+++ b/tests/browser/harness-proof.spec.ts
@@ -166,3 +166,28 @@ test("proof route exercises market render, trade validation, and receipt drilldo
   await expect(inspector.getByText(`signature: ${SIGNATURE}`)).toBeVisible();
   await captureCheckpoint(page, "receipt-drawer.png");
 });
+
+test("runtime operator proof shows deployment detail and control affordances", async ({
+  page,
+}) => {
+  await page.goto("/proof/runtime");
+
+  await expect(page.getByTestId("runtime-operator-proof-page")).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: /Runtime deployments/i }),
+  ).toBeVisible();
+  await captureCheckpoint(page, "runtime-operator-home.png");
+
+  await page.getByRole("button", { name: /mean_reversion/i }).click();
+  await expect(
+    page.getByRole("heading", {
+      name: "deployment_mean_reversion_paper",
+    }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "Pause" }).click();
+  await expect(
+    page.getByText("paused", { exact: false }).first(),
+  ).toBeVisible();
+  await captureCheckpoint(page, "runtime-operator-paused.png");
+});

--- a/tests/unit/portal_runtime_operator_route.test.ts
+++ b/tests/unit/portal_runtime_operator_route.test.ts
@@ -1,0 +1,353 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { GET, POST } from "../../apps/portal/app/api/runtime/operator/route";
+
+const ORIGINAL_ENV = {
+  NEXT_PUBLIC_EDGE_API_BASE: process.env.NEXT_PUBLIC_EDGE_API_BASE,
+  RUNTIME_OPERATOR_ADMIN_TOKEN: process.env.RUNTIME_OPERATOR_ADMIN_TOKEN,
+  ADMIN_TOKEN: process.env.ADMIN_TOKEN,
+  NODE_ENV: process.env.NODE_ENV,
+};
+
+const originalFetch = globalThis.fetch;
+const FIXTURE_TIME = "2026-03-09T14:10:00.000Z";
+const SOL_MINT = "So11111111111111111111111111111111111111112";
+const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+function runtimeDeploymentFixture() {
+  return {
+    schemaVersion: "v1",
+    deploymentId: "runtime_canary_live_dca",
+    strategyKey: "dca",
+    sleeveId: "sleeve_runtime_canary",
+    ownerUserId: "user_operator",
+    pair: {
+      symbol: "SOL/USDC",
+      baseMint: SOL_MINT,
+      quoteMint: USDC_MINT,
+    },
+    mode: "live",
+    state: "live",
+    lane: "safe",
+    createdAt: FIXTURE_TIME,
+    updatedAt: FIXTURE_TIME,
+    promotedAt: FIXTURE_TIME,
+    policy: {
+      maxNotionalUsd: "5.00",
+      dailyLossLimitUsd: "25.00",
+      maxSlippageBps: 50,
+      maxConcurrentRuns: 1,
+      rebalanceToleranceBps: 100,
+    },
+    capital: {
+      allocatedUsd: "25.00",
+      reservedUsd: "5.00",
+      availableUsd: "20.00",
+    },
+    tags: ["runtime-canary"],
+  };
+}
+
+function runtimeRunFixture() {
+  return {
+    schemaVersion: "v1",
+    runId: "run_runtime_canary_live_dca",
+    deploymentId: "runtime_canary_live_dca",
+    runKey: `runtime_canary_live_dca:${FIXTURE_TIME}`,
+    trigger: {
+      kind: "canary",
+      source: "worker-runtime-canary",
+      observedAt: FIXTURE_TIME,
+      reason: "post_deploy",
+    },
+    state: "completed",
+    plannedAt: FIXTURE_TIME,
+    updatedAt: FIXTURE_TIME,
+    riskVerdictId: "risk_1",
+    executionPlanId: "plan_1",
+    submitRequestId: "submit_1",
+    receiptId: "receipt_1",
+  };
+}
+
+function runtimeLedgerFixture() {
+  return {
+    schemaVersion: "v1",
+    snapshotId: "ledger_runtime_canary_live_dca",
+    deploymentId: "runtime_canary_live_dca",
+    sleeveId: "sleeve_runtime_canary",
+    asOf: FIXTURE_TIME,
+    balances: [
+      {
+        mint: USDC_MINT,
+        symbol: "USDC",
+        decimals: 6,
+        freeAtomic: "20000000",
+        reservedAtomic: "5000000",
+        priceUsd: "1.00",
+      },
+    ],
+    positions: [],
+    totals: {
+      equityUsd: "25.00",
+      reservedUsd: "5.00",
+      availableUsd: "20.00",
+      realizedPnlUsd: "1.00",
+      unrealizedPnlUsd: "0.00",
+    },
+  };
+}
+
+afterEach(() => {
+  process.env.NEXT_PUBLIC_EDGE_API_BASE =
+    ORIGINAL_ENV.NEXT_PUBLIC_EDGE_API_BASE;
+  process.env.RUNTIME_OPERATOR_ADMIN_TOKEN =
+    ORIGINAL_ENV.RUNTIME_OPERATOR_ADMIN_TOKEN;
+  process.env.ADMIN_TOKEN = ORIGINAL_ENV.ADMIN_TOKEN;
+  process.env.NODE_ENV = ORIGINAL_ENV.NODE_ENV;
+  globalThis.fetch = originalFetch;
+});
+
+describe("portal runtime operator route", () => {
+  test("requires operator auth", async () => {
+    process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
+
+    const response = await GET(
+      new Request("https://www.trader-ralph.com/api/runtime/operator"),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "auth-required",
+    });
+  });
+
+  test("fails closed when the admin token is missing", async () => {
+    process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
+    process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "";
+    process.env.ADMIN_TOKEN = "";
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/api/me")) {
+        return new Response(JSON.stringify({ ok: true, user: { id: "u_1" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const response = await GET(
+      new Request("https://www.trader-ralph.com/api/runtime/operator", {
+        headers: {
+          authorization: "Bearer user-token",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "missing RUNTIME_OPERATOR_ADMIN_TOKEN",
+    });
+  });
+
+  test("returns runtime snapshot and selected deployment detail", async () => {
+    process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
+    process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";
+
+    const seenAuthHeaders: string[] = [];
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url = String(input);
+      seenAuthHeaders.push(
+        String(
+          (init?.headers as Record<string, string> | undefined)
+            ?.authorization ?? "",
+        ),
+      );
+      if (url.endsWith("/api/me")) {
+        return new Response(JSON.stringify({ ok: true, user: { id: "u_1" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.endsWith("/api/admin/ops/runtime")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            runtime: {
+              ok: true,
+              source: "runtime-rs",
+              integration: {
+                stubModeEnabled: false,
+              },
+              health: {
+                status: "healthy",
+              },
+              deployments: [runtimeDeploymentFixture()],
+              controls: {
+                enabled: true,
+                disabledReason: null,
+                shadowOnly: false,
+                shadowOnlyReason: null,
+              },
+              canary: {
+                ok: true,
+              },
+              error: null,
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (
+        url.endsWith(
+          "/api/admin/ops/runtime/deployments/runtime_canary_live_dca",
+        )
+      ) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            deploymentId: "runtime_canary_live_dca",
+            deployment: runtimeDeploymentFixture(),
+            runs: [runtimeRunFixture()],
+            positions: runtimeLedgerFixture(),
+            pnl: {
+              asOf: FIXTURE_TIME,
+              totals: runtimeLedgerFixture().totals,
+            },
+            scorecard: {
+              deploymentId: "runtime_canary_live_dca",
+              promotionGates: [
+                {
+                  targetMode: "live",
+                  status: "pass",
+                  summary: "bounded live canary remains healthy",
+                },
+              ],
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const response = await GET(
+      new Request("https://www.trader-ralph.com/api/runtime/operator", {
+        headers: {
+          authorization: "Bearer user-token",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      selectedDeploymentId: "runtime_canary_live_dca",
+      runtime: {
+        ok: true,
+        deployments: [
+          {
+            deploymentId: "runtime_canary_live_dca",
+            state: "live",
+          },
+        ],
+      },
+      detail: {
+        deploymentId: "runtime_canary_live_dca",
+        deployment: {
+          deploymentId: "runtime_canary_live_dca",
+        },
+        runs: [
+          {
+            deploymentId: "runtime_canary_live_dca",
+          },
+        ],
+        positions: {
+          totals: {
+            equityUsd: "25.00",
+          },
+        },
+        pnl: {
+          totals: {
+            reservedUsd: "5.00",
+          },
+        },
+      },
+    });
+    expect(seenAuthHeaders).toEqual([
+      "Bearer user-token",
+      "Bearer operator-admin",
+      "Bearer operator-admin",
+    ]);
+  });
+
+  test("forwards runtime deployment control actions", async () => {
+    process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
+    process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";
+
+    let capturedMethod = "";
+    let capturedAuthorization = "";
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url = String(input);
+      if (url.endsWith("/api/me")) {
+        return new Response(JSON.stringify({ ok: true, user: { id: "u_1" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (
+        url.endsWith(
+          "/api/admin/ops/runtime/deployments/runtime_canary_live_dca/pause",
+        )
+      ) {
+        capturedMethod = String(init?.method ?? "");
+        capturedAuthorization = String(
+          (init?.headers as Record<string, string> | undefined)
+            ?.authorization ?? "",
+        );
+        return new Response(JSON.stringify({ ok: true, action: "pause" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const response = await POST(
+      new Request("https://www.trader-ralph.com/api/runtime/operator", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer user-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          deploymentId: "runtime_canary_live_dca",
+          action: "pause",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(capturedMethod).toBe("POST");
+    expect(capturedAuthorization).toBe("Bearer operator-admin");
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      action: "pause",
+    });
+  });
+});

--- a/tests/unit/portal_runtime_operator_route.test.ts
+++ b/tests/unit/portal_runtime_operator_route.test.ts
@@ -4,6 +4,9 @@ import { GET, POST } from "../../apps/portal/app/api/runtime/operator/route";
 const ORIGINAL_ENV = {
   NEXT_PUBLIC_EDGE_API_BASE: process.env.NEXT_PUBLIC_EDGE_API_BASE,
   RUNTIME_OPERATOR_ADMIN_TOKEN: process.env.RUNTIME_OPERATOR_ADMIN_TOKEN,
+  RUNTIME_OPERATOR_USER_ALLOWLIST: process.env.RUNTIME_OPERATOR_USER_ALLOWLIST,
+  RUNTIME_OPERATOR_PRIVY_USER_ALLOWLIST:
+    process.env.RUNTIME_OPERATOR_PRIVY_USER_ALLOWLIST,
   ADMIN_TOKEN: process.env.ADMIN_TOKEN,
   NODE_ENV: process.env.NODE_ENV,
 };
@@ -102,6 +105,10 @@ afterEach(() => {
     ORIGINAL_ENV.NEXT_PUBLIC_EDGE_API_BASE;
   process.env.RUNTIME_OPERATOR_ADMIN_TOKEN =
     ORIGINAL_ENV.RUNTIME_OPERATOR_ADMIN_TOKEN;
+  process.env.RUNTIME_OPERATOR_USER_ALLOWLIST =
+    ORIGINAL_ENV.RUNTIME_OPERATOR_USER_ALLOWLIST;
+  process.env.RUNTIME_OPERATOR_PRIVY_USER_ALLOWLIST =
+    ORIGINAL_ENV.RUNTIME_OPERATOR_PRIVY_USER_ALLOWLIST;
   process.env.ADMIN_TOKEN = ORIGINAL_ENV.ADMIN_TOKEN;
   process.env.NODE_ENV = ORIGINAL_ENV.NODE_ENV;
   globalThis.fetch = originalFetch;
@@ -125,6 +132,7 @@ describe("portal runtime operator route", () => {
   test("fails closed when the admin token is missing", async () => {
     process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
     process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "";
+    process.env.RUNTIME_OPERATOR_USER_ALLOWLIST = "u_1";
     process.env.ADMIN_TOKEN = "";
 
     globalThis.fetch = (async (input: RequestInfo | URL) => {
@@ -153,9 +161,42 @@ describe("portal runtime operator route", () => {
     });
   });
 
+  test("requires an operator allowlist match before serving admin data", async () => {
+    process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
+    process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";
+    process.env.RUNTIME_OPERATOR_USER_ALLOWLIST = "u_operator";
+    process.env.RUNTIME_OPERATOR_PRIVY_USER_ALLOWLIST = "";
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/api/me")) {
+        return new Response(JSON.stringify({ ok: true, user: { id: "u_1" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const response = await GET(
+      new Request("https://www.trader-ralph.com/api/runtime/operator", {
+        headers: {
+          authorization: "Bearer user-token",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "operator-access-required",
+    });
+  });
+
   test("returns runtime snapshot and selected deployment detail", async () => {
     process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
     process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";
+    process.env.RUNTIME_OPERATOR_USER_ALLOWLIST = "u_1";
 
     const seenAuthHeaders: string[] = [];
     globalThis.fetch = (async (
@@ -296,6 +337,7 @@ describe("portal runtime operator route", () => {
   test("forwards runtime deployment control actions", async () => {
     process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
     process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";
+    process.env.RUNTIME_OPERATOR_USER_ALLOWLIST = "u_1";
 
     let capturedMethod = "";
     let capturedAuthorization = "";

--- a/tests/unit/worker_ops_controls_route.test.ts
+++ b/tests/unit/worker_ops_controls_route.test.ts
@@ -315,6 +315,63 @@ describe("worker ops controls routes", () => {
     }
   });
 
+  test("returns runtime deployment detail bundles for operator surfaces", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/deployments/deployment_shadow_fixture",
+          {
+            headers: {
+              authorization: "Bearer admin-secret",
+            },
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        ok: true,
+        deploymentId: "deployment_shadow_fixture",
+        deployment: {
+          deploymentId: "deployment_shadow_fixture",
+          state: "shadow",
+        },
+        runs: [
+          {
+            deploymentId: "deployment_shadow_fixture",
+            state: "planned",
+          },
+        ],
+        positions: {
+          deploymentId: "deployment_shadow_fixture",
+          totals: {
+            equityUsd: "1088.00",
+            reservedUsd: "125.00",
+          },
+        },
+        pnl: {
+          totals: {
+            realizedPnlUsd: "10.00",
+            unrealizedPnlUsd: "3.00",
+          },
+        },
+        scorecard: {
+          deploymentId: "deployment_shadow_fixture",
+          scorecard: {
+            triggerQuality: {
+              totalRuns: 3,
+            },
+          },
+        },
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
   test("blocks runtime resumes when the global runtime kill switch is enabled", async () => {
     const { env, sqlite } = createOpsEnv();
     try {


### PR DESCRIPTION
## Summary
- add a Worker admin detail bundle for runtime deployments so operator pages can read runs, positions, PnL, and scorecards through the existing control plane
- add an auth-gated portal runtime operator surface plus a proof route that reuses the same UI components
- extend browser proof and unit coverage for the new operator proxy and Worker admin detail path

## Validation
- bun test tests/unit/worker_ops_controls_route.test.ts tests/unit/portal_runtime_operator_route.test.ts
- bun run typecheck
- bun run lint
- bun run harness:proof

Fixes #272