### PR TITLE
[Phase 5] Ship managed template pack 2: trend following and mean reversion

### DIFF
--- a/crates/execution-planner/src/lib.rs
+++ b/crates/execution-planner/src/lib.rs
@@ -1218,4 +1218,24 @@ mod tests {
         );
         assert_eq!(result.plan.slices[0].notional_usd, "2.50");
     }
+
+    #[test]
+    fn mean_reversion_buys_after_negative_signal() {
+        let planner = planner("mean-reversion-buy");
+        let result = planner
+            .plan_and_store(&input(
+                "run_10",
+                "mean_reversion",
+                RuntimeMode::Paper,
+                RuntimeLane::Safe,
+                "-12.0",
+            ))
+            .expect("plan to store");
+
+        assert_eq!(result.plan.slices[0].action, RuntimeExecutionAction::Buy);
+        assert_eq!(
+            result.plan.slices[0].input_mint,
+            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        );
+    }
 }

--- a/crates/runtime-scorecards/src/lib.rs
+++ b/crates/runtime-scorecards/src/lib.rs
@@ -23,6 +23,7 @@ pub struct RuntimeScorecardConfig {
     pub shadow_max_pause_verdicts: u64,
     pub paper_max_pause_verdicts: u64,
     pub paper_max_correction_count: u64,
+    pub signal_max_stale_feature_rejects: u64,
 }
 
 impl Default for RuntimeScorecardConfig {
@@ -37,6 +38,7 @@ impl Default for RuntimeScorecardConfig {
             shadow_max_pause_verdicts: 0,
             paper_max_pause_verdicts: 0,
             paper_max_correction_count: 0,
+            signal_max_stale_feature_rejects: 0,
         }
     }
 }
@@ -295,7 +297,7 @@ fn shadow_to_paper_gate(
         );
     }
 
-    let checks = vec![
+    let mut checks = vec![
         exact_match_check(
             "shadow-state-active",
             input.deployment.state == RuntimeDeploymentState::Shadow,
@@ -334,6 +336,14 @@ fn shadow_to_paper_gate(
             "Pause verdicts must be zero before paper promotion.",
         ),
     ];
+    if signal_strategy_requires_fresh_features(&input.deployment) {
+        checks.push(maximum_check(
+            "shadow-signal-max-stale-feature-rejects",
+            scorecard.trigger_quality.stale_feature_reject_count,
+            config.signal_max_stale_feature_rejects,
+            "Signal-driven templates require fresh feature inputs for every shadow evidence run.",
+        ));
+    }
 
     gate_from_checks(
         RuntimeMode::Shadow,
@@ -368,7 +378,7 @@ fn paper_to_live_gate(
         "scorecard.pnl.maxDrawdownUsd",
         &scorecard.pnl.max_drawdown_usd,
     )?;
-    let checks = vec![
+    let mut checks = vec![
         exact_match_check(
             "paper-state-active",
             input.deployment.state == RuntimeDeploymentState::Paper,
@@ -425,6 +435,14 @@ fn paper_to_live_gate(
             "Observed drawdown must stay within the deployment daily loss limit.",
         ),
     ];
+    if signal_strategy_requires_fresh_features(&input.deployment) {
+        checks.push(maximum_check(
+            "paper-signal-max-stale-feature-rejects",
+            scorecard.trigger_quality.stale_feature_reject_count,
+            config.signal_max_stale_feature_rejects,
+            "Signal-driven templates require fresh feature inputs for every paper evidence run.",
+        ));
+    }
 
     Ok(gate_from_checks(
         RuntimeMode::Paper,
@@ -457,6 +475,13 @@ fn not_applicable_gate(
             message: message.to_string(),
         }],
     }
+}
+
+fn signal_strategy_requires_fresh_features(deployment: &RuntimeDeploymentRecord) -> bool {
+    matches!(
+        deployment.strategy_key.as_str(),
+        "trend_following" | "mean_reversion"
+    )
 }
 
 fn gate_from_checks(
@@ -1114,15 +1139,183 @@ mod tests {
                 && check.status == RuntimePromotionGateStatus::Blocked));
     }
 
+    #[test]
+    fn blocks_trend_following_shadow_promotion_on_stale_feature_rejects() {
+        let deployment = deployment_with_strategy(
+            "deployment_trend_shadow",
+            "trend_following",
+            RuntimeMode::Shadow,
+            RuntimeDeploymentState::Shadow,
+        );
+        let runs = vec![
+            run(
+                "run_trend_shadow_1",
+                RuntimeRunState::Completed,
+                trigger("signal"),
+            ),
+            run(
+                "run_trend_shadow_2",
+                RuntimeRunState::Completed,
+                trigger("signal"),
+            ),
+            run(
+                "run_trend_shadow_3",
+                RuntimeRunState::Completed,
+                trigger("signal"),
+            ),
+        ];
+        let verdicts = vec![
+            allow_verdict(&deployment, &runs[0]),
+            allow_verdict(&deployment, &runs[1]),
+            stale_feature_reject_verdict(&deployment, &runs[2]),
+        ];
+        let plans = runs[..2]
+            .iter()
+            .map(|run| plan(&deployment, run, true, true))
+            .collect::<Vec<_>>();
+        let reconciliations = runs[..2]
+            .iter()
+            .map(|run| reconciliation(&deployment, run, RuntimeReconciliationStatus::Passed, false))
+            .collect::<Vec<_>>();
+        let snapshots = vec![ledger_snapshot(
+            &deployment,
+            "1000.00",
+            "0.00",
+            "1000.00",
+            "1.00",
+            "0.00",
+            "2026-03-08T10:00:00Z",
+        )];
+
+        let report = build_readiness_report(
+            &RuntimeScorecardConfig::default(),
+            &RuntimeScorecardInput {
+                deployment,
+                runs,
+                verdicts,
+                plans,
+                submit_attempt_count: 2,
+                receipt_count: 2,
+                reconciliations,
+                observed_ledger_snapshots: snapshots.clone(),
+                latest_ledger_snapshot: snapshots.last().cloned(),
+            },
+        )
+        .expect("report to build");
+
+        assert_eq!(
+            report.promotion_gates[0].status,
+            RuntimePromotionGateStatus::Blocked
+        );
+        assert!(report.promotion_gates[0]
+            .checks
+            .iter()
+            .any(
+                |check| check.gate_id == "shadow-signal-max-stale-feature-rejects"
+                    && check.status == RuntimePromotionGateStatus::Blocked
+            ));
+    }
+
+    #[test]
+    fn blocks_mean_reversion_live_promotion_on_stale_feature_rejects() {
+        let deployment = deployment_with_strategy(
+            "deployment_mean_paper",
+            "mean_reversion",
+            RuntimeMode::Paper,
+            RuntimeDeploymentState::Paper,
+        );
+        let runs = (1..=5)
+            .map(|index| {
+                run(
+                    &format!("run_mean_paper_{index}"),
+                    RuntimeRunState::Completed,
+                    trigger("signal"),
+                )
+            })
+            .collect::<Vec<_>>();
+        let verdicts = vec![
+            allow_verdict(&deployment, &runs[0]),
+            allow_verdict(&deployment, &runs[1]),
+            allow_verdict(&deployment, &runs[2]),
+            allow_verdict(&deployment, &runs[3]),
+            stale_feature_reject_verdict(&deployment, &runs[4]),
+        ];
+        let plans = runs[..4]
+            .iter()
+            .map(|run| plan(&deployment, run, true, false))
+            .collect::<Vec<_>>();
+        let reconciliations = runs[..4]
+            .iter()
+            .map(|run| reconciliation(&deployment, run, RuntimeReconciliationStatus::Passed, false))
+            .collect::<Vec<_>>();
+        let snapshots = vec![
+            ledger_snapshot(
+                &deployment,
+                "1000.00",
+                "5.00",
+                "995.00",
+                "1.00",
+                "0.00",
+                "2026-03-08T10:00:00Z",
+            ),
+            ledger_snapshot(
+                &deployment,
+                "1001.00",
+                "5.00",
+                "996.00",
+                "1.50",
+                "0.25",
+                "2026-03-08T10:05:00Z",
+            ),
+        ];
+
+        let report = build_readiness_report(
+            &RuntimeScorecardConfig::default(),
+            &RuntimeScorecardInput {
+                deployment,
+                runs,
+                verdicts,
+                plans,
+                submit_attempt_count: 4,
+                receipt_count: 4,
+                reconciliations,
+                observed_ledger_snapshots: snapshots.clone(),
+                latest_ledger_snapshot: snapshots.last().cloned(),
+            },
+        )
+        .expect("report to build");
+
+        assert_eq!(
+            report.promotion_gates[1].status,
+            RuntimePromotionGateStatus::Blocked
+        );
+        assert!(report.promotion_gates[1]
+            .checks
+            .iter()
+            .any(
+                |check| check.gate_id == "paper-signal-max-stale-feature-rejects"
+                    && check.status == RuntimePromotionGateStatus::Blocked
+            ));
+    }
+
     fn deployment(
         deployment_id: &str,
+        mode: RuntimeMode,
+        state: RuntimeDeploymentState,
+    ) -> RuntimeDeploymentRecord {
+        deployment_with_strategy(deployment_id, "dca", mode, state)
+    }
+
+    fn deployment_with_strategy(
+        deployment_id: &str,
+        strategy_key: &str,
         mode: RuntimeMode,
         state: RuntimeDeploymentState,
     ) -> RuntimeDeploymentRecord {
         RuntimeDeploymentRecord {
             schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
             deployment_id: deployment_id.to_string(),
-            strategy_key: "dca".to_string(),
+            strategy_key: strategy_key.to_string(),
             sleeve_id: "sleeve_alpha".to_string(),
             owner_user_id: "user_123".to_string(),
             pair: RuntimePair {
@@ -1204,6 +1397,37 @@ mod tests {
                 reserved_usd: "5.00".to_string(),
                 concentration_bps: 500,
                 feature_age_ms: 500,
+            },
+            limits: RuntimeRiskLimits {
+                max_notional_usd: "25.00".to_string(),
+                max_reserved_usd: "25.00".to_string(),
+                max_concentration_bps: 3500,
+                stale_after_ms: 20_000,
+            },
+        }
+    }
+
+    fn stale_feature_reject_verdict(
+        deployment: &RuntimeDeploymentRecord,
+        run: &RuntimeRunRecord,
+    ) -> RuntimeRiskVerdict {
+        RuntimeRiskVerdict {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            verdict_id: format!("stale_{}", run.run_id),
+            deployment_id: deployment.deployment_id.clone(),
+            run_id: run.run_id.clone(),
+            decided_at: "2026-03-08T10:00:00Z".to_string(),
+            verdict: RuntimeRiskDecision::Reject,
+            reasons: vec![RuntimeRiskReason {
+                code: "feature_stale".to_string(),
+                message: "Feature snapshot is stale".to_string(),
+                severity: RuntimeRiskSeverity::Warn,
+            }],
+            observed: RuntimeRiskObserved {
+                requested_notional_usd: "5.00".to_string(),
+                reserved_usd: "5.00".to_string(),
+                concentration_bps: 500,
+                feature_age_ms: 25_000,
             },
             limits: RuntimeRiskLimits {
                 max_notional_usd: "25.00".to_string(),

--- a/docs/exec-plans/active/autonomous-runtime-rollout.md
+++ b/docs/exec-plans/active/autonomous-runtime-rollout.md
@@ -64,6 +64,9 @@
 - Phase 5 pack 1 is intentionally bounded to `dca`, `threshold_rebalance`, and
   `twap`, with live execution limited to allowlisted single-slice safe-lane
   deployments.
+- Phase 5 pack 2 adds `trend_following` and `mean_reversion`, but promotion is
+  gated on replay evidence across opposing return regimes and zero
+  stale-feature rejects in scorecards.
 - Do not treat phase 5 completion as arbitrary-strategy support; phase 6 still
   covers advanced templates and multi-strategy capital coordination.
 

--- a/docs/reliability/autonomous-runtime-ops-runbook.md
+++ b/docs/reliability/autonomous-runtime-ops-runbook.md
@@ -38,6 +38,13 @@ Until later phases land, live runtime execution must stay bounded by:
 - `safe` lane only
 - single-slice live execution plans only
 
+Pack 2 signal-driven templates add more rollout evidence requirements:
+
+- replay evidence must cover both rising and falling short-return windows
+- stale-feature rejects must stay at zero across the promotion window
+- operators should treat any freshness degradation as an immediate reason to
+  pause signal-driven deployments
+
 ## Routine operator actions
 
 ### Inspect health
@@ -215,6 +222,8 @@ Response:
 4. Confirm `feature-stream-stale` or `feature-stream-missing` appears on the
    affected shadow evaluations.
 5. Keep the runtime canary disabled until freshness is restored.
+6. Pause all signal-driven managed deployments until replay and scorecard
+   evidence are clean again.
 
 ### Reconciliation incident
 

--- a/services/runtime-rs/README.md
+++ b/services/runtime-rs/README.md
@@ -16,6 +16,20 @@ Pack 1 managed strategy semantics are now wired through the runtime contract:
 - `twap`: per-run slices derived from `maxConcurrentRuns`, with buy or sell
   direction chosen from current base exposure
 
+Pack 2 signal-driven managed strategy semantics extend the same runtime path:
+
+- `trend_following`: follows the short-window return direction from the feature
+  cache
+- `mean_reversion`: fades the short-window return direction from the feature
+  cache
+
+Promotion for signal-driven templates is intentionally stricter:
+
+- replay evidence must show expected behavior across both positive and negative
+  return windows
+- scorecards must keep stale-feature rejects at zero before promotion
+- fresh feature inputs are required for every shadow and paper evidence run
+
 The bounded live bridge remains intentionally narrow in v1:
 
 - live runtime execution is allowlisted with

--- a/services/runtime-rs/src/lib.rs
+++ b/services/runtime-rs/src/lib.rs
@@ -1584,6 +1584,7 @@ fn apply_fixture(
 #[cfg(test)]
 mod tests {
     use std::{
+        fs,
         sync::atomic::{AtomicU64, Ordering},
         time::{SystemTime, UNIX_EPOCH},
     };
@@ -1627,13 +1628,88 @@ mod tests {
     }
 
     fn test_config_with_worker_api_base(worker_api_base: Option<&str>) -> RuntimeConfig {
+        test_config_with_runtime(worker_api_base, None)
+    }
+
+    fn test_config_with_runtime(
+        worker_api_base: Option<&str>,
+        replay_fixture_path: Option<&str>,
+    ) -> RuntimeConfig {
         RuntimeConfig::from_lookup(|key| match key {
             "RUNTIME_INTERNAL_SERVICE_TOKEN" => Some("runtime-service-secret".to_string()),
             "RUNTIME_WORKER_API_BASE" => worker_api_base.map(str::to_string),
+            "RUNTIME_FEED_REPLAY_FIXTURE_PATH" => replay_fixture_path.map(str::to_string),
             "RUNTIME_DATABASE_URL" => Some(temp_database_url("config")),
             _ => None,
         })
         .expect("config to load")
+    }
+
+    fn write_replay_fixture(test_name: &str, prices: &[&str]) -> String {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let base_time = OffsetDateTime::now_utc() - time::Duration::seconds(10);
+        let path =
+            std::env::temp_dir().join(format!("runtime-rs-replay-{test_name}-{unique}.json"));
+        let market_events = prices
+            .iter()
+            .enumerate()
+            .map(|(index, price)| {
+                let observed_at = (base_time + time::Duration::seconds((index as i64) * 5))
+                    .format(&time::format_description::well_known::Rfc3339)
+                    .expect("timestamp");
+                market_adapters::MarketFeedEvent {
+                    source: "fixture.jupiter".to_string(),
+                    symbol: "SOL/USDC".to_string(),
+                    base_mint: "So11111111111111111111111111111111111111112".to_string(),
+                    quote_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+                    price_usd: (*price).to_string(),
+                    bid_price_usd: Some((*price).to_string()),
+                    ask_price_usd: Some((*price).to_string()),
+                    observed_at: observed_at.clone(),
+                    received_at: observed_at,
+                    sequence: 100 + index as u64,
+                }
+            })
+            .collect::<Vec<_>>();
+        let slot_observed_at = (base_time + time::Duration::seconds(10))
+            .format(&time::format_description::well_known::Rfc3339)
+            .expect("timestamp");
+        let fixture = FeedReplayFixture {
+            schema_version: "v1".to_string(),
+            market_events,
+            slot_events: vec![
+                market_adapters::SlotFeedEvent {
+                    source: "fixture.helius".to_string(),
+                    commitment: market_adapters::SlotCommitment::Processed,
+                    slot: 310_000_000,
+                    observed_at: slot_observed_at.clone(),
+                    sequence: 201,
+                },
+                market_adapters::SlotFeedEvent {
+                    source: "fixture.helius".to_string(),
+                    commitment: market_adapters::SlotCommitment::Confirmed,
+                    slot: 309_999_999,
+                    observed_at: slot_observed_at.clone(),
+                    sequence: 202,
+                },
+                market_adapters::SlotFeedEvent {
+                    source: "fixture.helius".to_string(),
+                    commitment: market_adapters::SlotCommitment::Finalized,
+                    slot: 309_999_998,
+                    observed_at: slot_observed_at,
+                    sequence: 203,
+                },
+            ],
+        };
+        fs::write(
+            &path,
+            serde_json::to_string(&fixture).expect("fixture to serialize"),
+        )
+        .expect("fixture to write");
+        path.display().to_string()
     }
 
     async fn spawn_exec_coordination_stub() -> String {
@@ -2249,6 +2325,186 @@ mod tests {
             evaluation_payload["coordination"]["submitRequestId"],
             json!("submit_runtime_123")
         );
+    }
+
+    #[tokio::test]
+    async fn trend_following_replay_buys_in_shadow_mode() {
+        let worker_api_base = spawn_exec_coordination_stub().await;
+        let fixture_path = write_replay_fixture("trend-up", &["140.00", "141.20", "142.80"]);
+        let router = app(test_config_with_runtime(
+            Some(&worker_api_base),
+            Some(&fixture_path),
+        ));
+        let deployment = runtime_deployment_with_strategy(
+            "deployment_trend_shadow",
+            "sleeve_alpha",
+            "trend_following",
+            "1000.00",
+            "5.00",
+        );
+
+        let create_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/deployments")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(deployment.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(create_response.status(), StatusCode::CREATED);
+
+        let evaluate_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/deployments/deployment_trend_shadow/evaluate")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(evaluate_response.status(), StatusCode::CREATED);
+        let evaluation_payload = read_json(evaluate_response).await;
+        assert_eq!(
+            evaluation_payload["executionPlan"]["slices"][0]["action"],
+            json!("buy")
+        );
+        assert_eq!(
+            evaluation_payload["executionPlan"]["simulateOnly"],
+            json!(true)
+        );
+        assert_eq!(evaluation_payload["coordination"]["accepted"], json!(true));
+    }
+
+    #[tokio::test]
+    async fn mean_reversion_replay_sells_in_paper_mode() {
+        let worker_api_base = spawn_exec_coordination_stub().await;
+        let fixture_path = write_replay_fixture("mean-up", &["140.00", "141.20", "142.80"]);
+        let router = app(test_config_with_runtime(
+            Some(&worker_api_base),
+            Some(&fixture_path),
+        ));
+        let mut deployment = runtime_deployment_with_strategy(
+            "deployment_mean_paper",
+            "sleeve_alpha",
+            "mean_reversion",
+            "1000.00",
+            "5.00",
+        );
+        deployment["mode"] = json!("paper");
+        deployment["state"] = json!("paper");
+
+        let create_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/deployments")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(deployment.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(create_response.status(), StatusCode::CREATED);
+
+        let evaluate_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/deployments/deployment_mean_paper/evaluate")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(evaluate_response.status(), StatusCode::CREATED);
+        let evaluation_payload = read_json(evaluate_response).await;
+        assert_eq!(
+            evaluation_payload["executionPlan"]["slices"][0]["action"],
+            json!("sell")
+        );
+        assert_eq!(evaluation_payload["executionPlan"]["dryRun"], json!(true));
+        assert_eq!(
+            evaluation_payload["executionPlan"]["simulateOnly"],
+            json!(false)
+        );
+        assert_eq!(evaluation_payload["coordination"]["accepted"], json!(true));
+    }
+
+    #[tokio::test]
+    async fn trend_following_replay_sells_on_bounded_live_path() {
+        let worker_api_base = spawn_exec_coordination_stub().await;
+        let fixture_path = write_replay_fixture("trend-down", &["142.80", "141.20", "140.00"]);
+        let router = app(test_config_with_runtime(
+            Some(&worker_api_base),
+            Some(&fixture_path),
+        ));
+        let mut deployment = runtime_deployment_with_strategy(
+            "deployment_trend_live",
+            "sleeve_alpha",
+            "trend_following",
+            "1000.00",
+            "5.00",
+        );
+        deployment["mode"] = json!("live");
+        deployment["state"] = json!("live");
+
+        let create_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/deployments")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(deployment.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(create_response.status(), StatusCode::CREATED);
+
+        let evaluate_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/deployments/deployment_trend_live/evaluate")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(evaluate_response.status(), StatusCode::CREATED);
+        let evaluation_payload = read_json(evaluate_response).await;
+        assert_eq!(
+            evaluation_payload["executionPlan"]["slices"][0]["action"],
+            json!("sell")
+        );
+        assert_eq!(evaluation_payload["executionPlan"]["dryRun"], json!(false));
+        assert_eq!(
+            evaluation_payload["executionPlan"]["simulateOnly"],
+            json!(false)
+        );
+        assert_eq!(evaluation_payload["coordination"]["accepted"], json!(true));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #274

## Summary
- extend runtime-rs replay coverage for `trend_following` and `mean_reversion` across shadow, paper, and bounded live paths
- add signal-template promotion gates that require zero stale-feature rejects before promotion
- document replay evidence and freshness expectations for signal-driven managed templates

## Validation
- `cargo test --workspace`
- `bun run lint`
- `bun run typecheck`

## Risk notes
- signal-driven templates stay on the same bounded managed runtime path as pack 1
- promotion is intentionally stricter: replay evidence must cover opposing short-return regimes and stale-feature rejects must remain zero
- any freshness degradation remains an operator pause condition for signal-driven deployments
