### PR TITLE
[Phase 6] Add advanced template pack: breakout, macro rotation, and volatility targeting

### DIFF
--- a/crates/execution-planner/src/lib.rs
+++ b/crates/execution-planner/src/lib.rs
@@ -71,6 +71,15 @@ struct StrategyTradeDecision {
     notional_cents: i64,
 }
 
+const BREAKOUT_SIGNAL_THRESHOLD_BPS: f64 = 15.0;
+const BREAKOUT_CONFIRMATION_THRESHOLD_BPS: f64 = 10.0;
+const MACRO_ROTATION_REGIME_THRESHOLD_BPS: f64 = 12.0;
+const VOLATILITY_TARGET_LOW_THRESHOLD_BPS: f64 = 12.0;
+const VOLATILITY_TARGET_MEDIUM_THRESHOLD_BPS: f64 = 20.0;
+const VOLATILITY_TARGET_LOW_BPS: i64 = 7_500;
+const VOLATILITY_TARGET_MEDIUM_BPS: i64 = 5_000;
+const VOLATILITY_TARGET_HIGH_BPS: i64 = 2_500;
+
 #[derive(Debug, Error)]
 pub enum ExecutionPlannerError {
     #[error("storage io error: {0}")]
@@ -360,18 +369,45 @@ fn strategy_trade_decision(
     input: &ExecutionPlannerInput,
 ) -> Result<StrategyTradeDecision, ExecutionPlannerError> {
     let base_notional_cents = desired_notional_cents(&input.deployment)?;
-    let signal = input
+    let short_signal = input
         .feature_snapshot
         .short_return_bps
         .as_deref()
         .map(|value| parse_signed_decimal("featureSnapshot.shortReturnBps", value))
         .transpose()?
         .unwrap_or(0.0);
+    let long_signal = input
+        .feature_snapshot
+        .long_return_bps
+        .as_deref()
+        .map(|value| parse_signed_decimal("featureSnapshot.longReturnBps", value))
+        .transpose()?
+        .unwrap_or(short_signal);
+    let realized_volatility_bps = input
+        .feature_snapshot
+        .realized_volatility_bps
+        .as_deref()
+        .map(|value| parse_decimal("featureSnapshot.realizedVolatilityBps", value))
+        .transpose()?
+        .unwrap_or(0.0);
     match input.deployment.strategy_key.as_str() {
         "threshold_rebalance" => threshold_rebalance_decision(input, base_notional_cents),
         "twap" => Ok(twap_decision(input, base_notional_cents)),
-        "trend_following" => Ok(signal_following_decision(signal, base_notional_cents)),
-        "mean_reversion" => Ok(mean_reversion_decision(signal, base_notional_cents)),
+        "trend_following" => Ok(signal_following_decision(short_signal, base_notional_cents)),
+        "mean_reversion" => Ok(mean_reversion_decision(short_signal, base_notional_cents)),
+        "breakout" => Ok(breakout_decision(
+            short_signal,
+            long_signal,
+            base_notional_cents,
+        )),
+        "macro_rotation" => Ok(macro_rotation_decision(
+            short_signal,
+            long_signal,
+            base_notional_cents,
+        )),
+        "volatility_target" => {
+            volatility_target_decision(input, realized_volatility_bps, base_notional_cents)
+        }
         _ => Ok(StrategyTradeDecision {
             action: RuntimeExecutionAction::Buy,
             direction: SwapDirection::BuyBase,
@@ -412,6 +448,115 @@ fn mean_reversion_decision(signal: f64, notional_cents: i64) -> StrategyTradeDec
     }
 }
 
+fn breakout_decision(
+    short_signal: f64,
+    long_signal: f64,
+    notional_cents: i64,
+) -> StrategyTradeDecision {
+    if short_signal >= BREAKOUT_SIGNAL_THRESHOLD_BPS
+        && long_signal >= BREAKOUT_CONFIRMATION_THRESHOLD_BPS
+    {
+        return StrategyTradeDecision {
+            action: RuntimeExecutionAction::Buy,
+            direction: SwapDirection::BuyBase,
+            notional_cents,
+        };
+    }
+
+    if short_signal <= -BREAKOUT_SIGNAL_THRESHOLD_BPS
+        && long_signal <= -BREAKOUT_CONFIRMATION_THRESHOLD_BPS
+    {
+        return StrategyTradeDecision {
+            action: RuntimeExecutionAction::Sell,
+            direction: SwapDirection::SellBase,
+            notional_cents,
+        };
+    }
+
+    noop_decision(
+        RuntimeExecutionAction::Buy,
+        if short_signal >= 0.0 {
+            SwapDirection::BuyBase
+        } else {
+            SwapDirection::SellBase
+        },
+    )
+}
+
+fn macro_rotation_decision(
+    short_signal: f64,
+    long_signal: f64,
+    notional_cents: i64,
+) -> StrategyTradeDecision {
+    if long_signal >= MACRO_ROTATION_REGIME_THRESHOLD_BPS && short_signal >= 0.0 {
+        return StrategyTradeDecision {
+            action: RuntimeExecutionAction::Buy,
+            direction: SwapDirection::BuyBase,
+            notional_cents,
+        };
+    }
+
+    if long_signal <= -MACRO_ROTATION_REGIME_THRESHOLD_BPS && short_signal <= 0.0 {
+        return StrategyTradeDecision {
+            action: RuntimeExecutionAction::Sell,
+            direction: SwapDirection::SellBase,
+            notional_cents,
+        };
+    }
+
+    noop_decision(
+        RuntimeExecutionAction::Buy,
+        if long_signal >= 0.0 {
+            SwapDirection::BuyBase
+        } else {
+            SwapDirection::SellBase
+        },
+    )
+}
+
+fn volatility_target_decision(
+    input: &ExecutionPlannerInput,
+    realized_volatility_bps: f64,
+    notional_cents: i64,
+) -> Result<StrategyTradeDecision, ExecutionPlannerError> {
+    let equity_cents = parse_non_negative_usd_cents(
+        "ledgerSnapshot.totals.equityUsd",
+        &input.ledger_snapshot.totals.equity_usd,
+    )?;
+    let base_exposure_cents = current_base_exposure_cents(input, &input.deployment.pair.base_mint)?;
+    let target_bps = if realized_volatility_bps <= VOLATILITY_TARGET_LOW_THRESHOLD_BPS {
+        VOLATILITY_TARGET_LOW_BPS
+    } else if realized_volatility_bps <= VOLATILITY_TARGET_MEDIUM_THRESHOLD_BPS {
+        VOLATILITY_TARGET_MEDIUM_BPS
+    } else {
+        VOLATILITY_TARGET_HIGH_BPS
+    };
+    let target_base_cents = (equity_cents * target_bps) / 10_000;
+    let delta_cents = target_base_cents - base_exposure_cents;
+    let trade_cents = notional_cents.min(delta_cents.abs());
+
+    if trade_cents == 0 {
+        return Ok(noop_decision(
+            RuntimeExecutionAction::Rebalance,
+            if delta_cents >= 0 {
+                SwapDirection::BuyBase
+            } else {
+                SwapDirection::SellBase
+            },
+        ));
+    }
+
+    Ok(StrategyTradeDecision {
+        action: RuntimeExecutionAction::Rebalance,
+        direction: if delta_cents >= 0 {
+            SwapDirection::BuyBase
+        } else {
+            SwapDirection::SellBase
+        },
+        notional_cents: trade_cents,
+    })
+}
+
 fn twap_decision(input: &ExecutionPlannerInput, notional_cents: i64) -> StrategyTradeDecision {
     let divisor = i64::from(input.deployment.policy.max_concurrent_runs.max(1));
     let per_run_notional = (notional_cents / divisor).max(1);
@@ -430,6 +575,17 @@ fn twap_decision(input: &ExecutionPlannerInput, notional_cents: i64) -> Strategy
             direction: SwapDirection::BuyBase,
             notional_cents: per_run_notional,
         }
+    }
+}
+
+fn noop_decision(
+    action: RuntimeExecutionAction,
+    direction: SwapDirection,
+) -> StrategyTradeDecision {
+    StrategyTradeDecision {
+        action,
+        direction,
+        notional_cents: 0,
     }
 }
 
@@ -1018,6 +1174,21 @@ mod tests {
         input
     }
 
+    fn input_with_feature_snapshot(
+        run_id: &str,
+        strategy_key: &str,
+        mode: RuntimeMode,
+        lane: RuntimeLane,
+        short_return_bps: &str,
+        long_return_bps: &str,
+        realized_volatility_bps: &str,
+    ) -> ExecutionPlannerInput {
+        let mut input = input(run_id, strategy_key, mode, lane, short_return_bps);
+        input.feature_snapshot.long_return_bps = Some(long_return_bps.to_string());
+        input.feature_snapshot.realized_volatility_bps = Some(realized_volatility_bps.to_string());
+        input
+    }
+
     #[test]
     fn builds_shadow_dca_plans_deterministically() {
         let planner = planner("shadow-dca");
@@ -1237,5 +1408,72 @@ mod tests {
             result.plan.slices[0].input_mint,
             "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
         );
+    }
+
+    #[test]
+    fn breakout_waits_for_directional_confirmation() {
+        let planner = planner("breakout-confirmation");
+        let result = planner
+            .plan_and_store(&input_with_feature_snapshot(
+                "run_11",
+                "breakout",
+                RuntimeMode::Shadow,
+                RuntimeLane::Safe,
+                "24.0",
+                "-2.0",
+                "18.0",
+            ))
+            .expect("plan to store");
+
+        assert_eq!(result.plan.slices[0].action, RuntimeExecutionAction::Buy);
+        assert_eq!(result.plan.slices[0].input_amount_atomic, "0");
+        assert_eq!(result.plan.slices[0].notional_usd, "0.00");
+    }
+
+    #[test]
+    fn macro_rotation_sells_in_negative_regime() {
+        let planner = planner("macro-rotation-sell");
+        let result = planner
+            .plan_and_store(&input_with_feature_snapshot(
+                "run_12",
+                "macro_rotation",
+                RuntimeMode::Paper,
+                RuntimeLane::Safe,
+                "-4.0",
+                "-18.0",
+                "18.0",
+            ))
+            .expect("plan to store");
+
+        assert_eq!(result.plan.slices[0].action, RuntimeExecutionAction::Sell);
+        assert_eq!(
+            result.plan.slices[0].input_mint,
+            "So11111111111111111111111111111111111111112"
+        );
+    }
+
+    #[test]
+    fn volatility_target_reduces_base_when_realized_volatility_is_high() {
+        let planner = planner("volatility-target-sell");
+        let result = planner
+            .plan_and_store(&input_with_ledger_snapshot(
+                "run_13",
+                "volatility_target",
+                RuntimeMode::Live,
+                RuntimeLane::Safe,
+                "0.0",
+                ledger_snapshot_with_balances("400000000", "35000000", "100"),
+            ))
+            .expect("plan to store");
+
+        assert_eq!(
+            result.plan.slices[0].action,
+            RuntimeExecutionAction::Rebalance
+        );
+        assert_eq!(
+            result.plan.slices[0].input_mint,
+            "So11111111111111111111111111111111111111112"
+        );
+        assert_eq!(result.plan.slices[0].notional_usd, "5.00");
     }
 }

--- a/crates/execution-planner/src/lib.rs
+++ b/crates/execution-planner/src/lib.rs
@@ -381,15 +381,13 @@ fn strategy_trade_decision(
         .long_return_bps
         .as_deref()
         .map(|value| parse_signed_decimal("featureSnapshot.longReturnBps", value))
-        .transpose()?
-        .unwrap_or(short_signal);
+        .transpose()?;
     let realized_volatility_bps = input
         .feature_snapshot
         .realized_volatility_bps
         .as_deref()
         .map(|value| parse_decimal("featureSnapshot.realizedVolatilityBps", value))
-        .transpose()?
-        .unwrap_or(0.0);
+        .transpose()?;
     match input.deployment.strategy_key.as_str() {
         "threshold_rebalance" => threshold_rebalance_decision(input, base_notional_cents),
         "twap" => Ok(twap_decision(input, base_notional_cents)),
@@ -450,9 +448,20 @@ fn mean_reversion_decision(signal: f64, notional_cents: i64) -> StrategyTradeDec
 
 fn breakout_decision(
     short_signal: f64,
-    long_signal: f64,
+    long_signal: Option<f64>,
     notional_cents: i64,
 ) -> StrategyTradeDecision {
+    let Some(long_signal) = long_signal else {
+        return noop_decision(
+            RuntimeExecutionAction::Buy,
+            if short_signal >= 0.0 {
+                SwapDirection::BuyBase
+            } else {
+                SwapDirection::SellBase
+            },
+        );
+    };
+
     if short_signal >= BREAKOUT_SIGNAL_THRESHOLD_BPS
         && long_signal >= BREAKOUT_CONFIRMATION_THRESHOLD_BPS
     {
@@ -485,9 +494,20 @@ fn breakout_decision(
 
 fn macro_rotation_decision(
     short_signal: f64,
-    long_signal: f64,
+    long_signal: Option<f64>,
     notional_cents: i64,
 ) -> StrategyTradeDecision {
+    let Some(long_signal) = long_signal else {
+        return noop_decision(
+            RuntimeExecutionAction::Buy,
+            if short_signal >= 0.0 {
+                SwapDirection::BuyBase
+            } else {
+                SwapDirection::SellBase
+            },
+        );
+    };
+
     if long_signal >= MACRO_ROTATION_REGIME_THRESHOLD_BPS && short_signal >= 0.0 {
         return StrategyTradeDecision {
             action: RuntimeExecutionAction::Buy,
@@ -516,7 +536,7 @@ fn macro_rotation_decision(
 
 fn volatility_target_decision(
     input: &ExecutionPlannerInput,
-    realized_volatility_bps: f64,
+    realized_volatility_bps: Option<f64>,
     notional_cents: i64,
 ) -> Result<StrategyTradeDecision, ExecutionPlannerError> {
     let equity_cents = parse_non_negative_usd_cents(
@@ -524,6 +544,16 @@ fn volatility_target_decision(
         &input.ledger_snapshot.totals.equity_usd,
     )?;
     let base_exposure_cents = current_base_exposure_cents(input, &input.deployment.pair.base_mint)?;
+    let Some(realized_volatility_bps) = realized_volatility_bps else {
+        return Ok(noop_decision(
+            RuntimeExecutionAction::Rebalance,
+            if base_exposure_cents > 0 {
+                SwapDirection::SellBase
+            } else {
+                SwapDirection::BuyBase
+            },
+        ));
+    };
     let target_bps = if realized_volatility_bps <= VOLATILITY_TARGET_LOW_THRESHOLD_BPS {
         VOLATILITY_TARGET_LOW_BPS
     } else if realized_volatility_bps <= VOLATILITY_TARGET_MEDIUM_THRESHOLD_BPS {
@@ -1189,6 +1219,19 @@ mod tests {
         input
     }
 
+    fn input_with_missing_feature_windows(
+        run_id: &str,
+        strategy_key: &str,
+        mode: RuntimeMode,
+        lane: RuntimeLane,
+        short_return_bps: &str,
+    ) -> ExecutionPlannerInput {
+        let mut input = input(run_id, strategy_key, mode, lane, short_return_bps);
+        input.feature_snapshot.long_return_bps = None;
+        input.feature_snapshot.realized_volatility_bps = None;
+        input
+    }
+
     #[test]
     fn builds_shadow_dca_plans_deterministically() {
         let planner = planner("shadow-dca");
@@ -1431,11 +1474,28 @@ mod tests {
     }
 
     #[test]
+    fn breakout_noops_without_long_window_confirmation() {
+        let planner = planner("breakout-no-long-window");
+        let result = planner
+            .plan_and_store(&input_with_missing_feature_windows(
+                "run_12",
+                "breakout",
+                RuntimeMode::Shadow,
+                RuntimeLane::Safe,
+                "24.0",
+            ))
+            .expect("plan to store");
+
+        assert_eq!(result.plan.slices[0].input_amount_atomic, "0");
+        assert_eq!(result.plan.slices[0].notional_usd, "0.00");
+    }
+
+    #[test]
     fn macro_rotation_sells_in_negative_regime() {
         let planner = planner("macro-rotation-sell");
         let result = planner
             .plan_and_store(&input_with_feature_snapshot(
-                "run_12",
+                "run_13",
                 "macro_rotation",
                 RuntimeMode::Paper,
                 RuntimeLane::Safe,
@@ -1457,7 +1517,7 @@ mod tests {
         let planner = planner("volatility-target-sell");
         let result = planner
             .plan_and_store(&input_with_ledger_snapshot(
-                "run_13",
+                "run_14",
                 "volatility_target",
                 RuntimeMode::Live,
                 RuntimeLane::Safe,
@@ -1475,5 +1535,26 @@ mod tests {
             "So11111111111111111111111111111111111111112"
         );
         assert_eq!(result.plan.slices[0].notional_usd, "5.00");
+    }
+
+    #[test]
+    fn volatility_target_noops_without_realized_volatility() {
+        let planner = planner("volatility-target-no-vol");
+        let result = planner
+            .plan_and_store(&input_with_missing_feature_windows(
+                "run_15",
+                "volatility_target",
+                RuntimeMode::Paper,
+                RuntimeLane::Safe,
+                "0.0",
+            ))
+            .expect("plan to store");
+
+        assert_eq!(
+            result.plan.slices[0].action,
+            RuntimeExecutionAction::Rebalance
+        );
+        assert_eq!(result.plan.slices[0].input_amount_atomic, "0");
+        assert_eq!(result.plan.slices[0].notional_usd, "0.00");
     }
 }

--- a/crates/runtime-scorecards/src/lib.rs
+++ b/crates/runtime-scorecards/src/lib.rs
@@ -16,6 +16,8 @@ use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 pub struct RuntimeScorecardConfig {
     pub shadow_min_runs: u64,
     pub paper_min_runs: u64,
+    pub advanced_shadow_min_runs: u64,
+    pub advanced_paper_min_runs: u64,
     pub required_plan_coverage_bps: u16,
     pub required_reconciliation_pass_bps: u16,
     pub shadow_max_failed_runs: u64,
@@ -31,6 +33,8 @@ impl Default for RuntimeScorecardConfig {
         Self {
             shadow_min_runs: 3,
             paper_min_runs: 5,
+            advanced_shadow_min_runs: 5,
+            advanced_paper_min_runs: 7,
             required_plan_coverage_bps: 10_000,
             required_reconciliation_pass_bps: 10_000,
             shadow_max_failed_runs: 0,
@@ -336,7 +340,15 @@ fn shadow_to_paper_gate(
             "Pause verdicts must be zero before paper promotion.",
         ),
     ];
-    if signal_strategy_requires_fresh_features(&input.deployment) {
+    if advanced_strategy_requires_extended_evidence(&input.deployment) {
+        checks.push(minimum_check(
+            "shadow-advanced-min-runs",
+            scorecard.trigger_quality.total_runs,
+            config.advanced_shadow_min_runs,
+            "Advanced templates require a wider shadow evidence window before paper promotion.",
+        ));
+    }
+    if feature_driven_strategy_requires_fresh_features(&input.deployment) {
         checks.push(maximum_check(
             "shadow-signal-max-stale-feature-rejects",
             scorecard.trigger_quality.stale_feature_reject_count,
@@ -435,7 +447,15 @@ fn paper_to_live_gate(
             "Observed drawdown must stay within the deployment daily loss limit.",
         ),
     ];
-    if signal_strategy_requires_fresh_features(&input.deployment) {
+    if advanced_strategy_requires_extended_evidence(&input.deployment) {
+        checks.push(minimum_check(
+            "paper-advanced-min-runs",
+            scorecard.trigger_quality.total_runs,
+            config.advanced_paper_min_runs,
+            "Advanced templates require a wider paper evidence window before bounded live promotion.",
+        ));
+    }
+    if feature_driven_strategy_requires_fresh_features(&input.deployment) {
         checks.push(maximum_check(
             "paper-signal-max-stale-feature-rejects",
             scorecard.trigger_quality.stale_feature_reject_count,
@@ -477,10 +497,17 @@ fn not_applicable_gate(
     }
 }
 
-fn signal_strategy_requires_fresh_features(deployment: &RuntimeDeploymentRecord) -> bool {
+fn feature_driven_strategy_requires_fresh_features(deployment: &RuntimeDeploymentRecord) -> bool {
     matches!(
         deployment.strategy_key.as_str(),
-        "trend_following" | "mean_reversion"
+        "trend_following" | "mean_reversion" | "breakout" | "macro_rotation" | "volatility_target"
+    )
+}
+
+fn advanced_strategy_requires_extended_evidence(deployment: &RuntimeDeploymentRecord) -> bool {
+    matches!(
+        deployment.strategy_key.as_str(),
+        "breakout" | "macro_rotation" | "volatility_target"
     )
 }
 
@@ -1296,6 +1323,169 @@ mod tests {
                 |check| check.gate_id == "paper-signal-max-stale-feature-rejects"
                     && check.status == RuntimePromotionGateStatus::Blocked
             ));
+    }
+
+    #[test]
+    fn blocks_breakout_shadow_promotion_without_extended_evidence_window() {
+        let deployment = deployment_with_strategy(
+            "deployment_breakout_shadow",
+            "breakout",
+            RuntimeMode::Shadow,
+            RuntimeDeploymentState::Shadow,
+        );
+        let runs = vec![
+            run(
+                "run_breakout_shadow_1",
+                RuntimeRunState::Completed,
+                trigger("signal"),
+            ),
+            run(
+                "run_breakout_shadow_2",
+                RuntimeRunState::Completed,
+                trigger("signal"),
+            ),
+            run(
+                "run_breakout_shadow_3",
+                RuntimeRunState::Completed,
+                trigger("signal"),
+            ),
+        ];
+        let verdicts = runs
+            .iter()
+            .map(|run| allow_verdict(&deployment, run))
+            .collect::<Vec<_>>();
+        let plans = runs
+            .iter()
+            .map(|run| plan(&deployment, run, true, true))
+            .collect::<Vec<_>>();
+        let reconciliations = runs
+            .iter()
+            .map(|run| reconciliation(&deployment, run, RuntimeReconciliationStatus::Passed, false))
+            .collect::<Vec<_>>();
+        let snapshots = vec![ledger_snapshot(
+            &deployment,
+            "1000.00",
+            "0.00",
+            "1000.00",
+            "1.00",
+            "0.00",
+            "2026-03-08T10:00:00Z",
+        )];
+
+        let report = build_readiness_report(
+            &RuntimeScorecardConfig::default(),
+            &RuntimeScorecardInput {
+                deployment,
+                runs,
+                verdicts,
+                plans,
+                submit_attempt_count: 3,
+                receipt_count: 3,
+                reconciliations,
+                observed_ledger_snapshots: snapshots.clone(),
+                latest_ledger_snapshot: snapshots.last().cloned(),
+            },
+        )
+        .expect("report to build");
+
+        assert_eq!(
+            report.promotion_gates[0].status,
+            RuntimePromotionGateStatus::Blocked
+        );
+        assert!(report.promotion_gates[0]
+            .checks
+            .iter()
+            .any(|check| check.gate_id == "shadow-advanced-min-runs"
+                && check.status == RuntimePromotionGateStatus::Blocked));
+    }
+
+    #[test]
+    fn blocks_volatility_target_live_promotion_on_stale_feature_rejects() {
+        let deployment = deployment_with_strategy(
+            "deployment_vol_target_paper",
+            "volatility_target",
+            RuntimeMode::Paper,
+            RuntimeDeploymentState::Paper,
+        );
+        let runs = (1..=7)
+            .map(|index| {
+                run(
+                    &format!("run_vol_target_{index}"),
+                    RuntimeRunState::Completed,
+                    trigger("signal"),
+                )
+            })
+            .collect::<Vec<_>>();
+        let verdicts = vec![
+            allow_verdict(&deployment, &runs[0]),
+            allow_verdict(&deployment, &runs[1]),
+            allow_verdict(&deployment, &runs[2]),
+            allow_verdict(&deployment, &runs[3]),
+            allow_verdict(&deployment, &runs[4]),
+            allow_verdict(&deployment, &runs[5]),
+            stale_feature_reject_verdict(&deployment, &runs[6]),
+        ];
+        let plans = runs[..6]
+            .iter()
+            .map(|run| plan(&deployment, run, true, false))
+            .collect::<Vec<_>>();
+        let reconciliations = runs[..6]
+            .iter()
+            .map(|run| reconciliation(&deployment, run, RuntimeReconciliationStatus::Passed, false))
+            .collect::<Vec<_>>();
+        let snapshots = vec![
+            ledger_snapshot(
+                &deployment,
+                "1000.00",
+                "5.00",
+                "995.00",
+                "1.00",
+                "0.00",
+                "2026-03-08T10:00:00Z",
+            ),
+            ledger_snapshot(
+                &deployment,
+                "1003.00",
+                "5.00",
+                "998.00",
+                "2.00",
+                "0.50",
+                "2026-03-08T10:05:00Z",
+            ),
+        ];
+
+        let report = build_readiness_report(
+            &RuntimeScorecardConfig::default(),
+            &RuntimeScorecardInput {
+                deployment,
+                runs,
+                verdicts,
+                plans,
+                submit_attempt_count: 6,
+                receipt_count: 6,
+                reconciliations,
+                observed_ledger_snapshots: snapshots.clone(),
+                latest_ledger_snapshot: snapshots.last().cloned(),
+            },
+        )
+        .expect("report to build");
+
+        assert_eq!(
+            report.promotion_gates[1].status,
+            RuntimePromotionGateStatus::Blocked
+        );
+        assert!(report.promotion_gates[1]
+            .checks
+            .iter()
+            .any(
+                |check| check.gate_id == "paper-signal-max-stale-feature-rejects"
+                    && check.status == RuntimePromotionGateStatus::Blocked
+            ));
+        assert!(report.promotion_gates[1]
+            .checks
+            .iter()
+            .any(|check| check.gate_id == "paper-advanced-min-runs"
+                && check.status == RuntimePromotionGateStatus::Pass));
     }
 
     fn deployment(

--- a/crates/strategy-core/src/lib.rs
+++ b/crates/strategy-core/src/lib.rs
@@ -5,6 +5,9 @@ pub enum StrategyKind {
     Twap,
     TrendFollowing,
     MeanReversion,
+    Breakout,
+    MacroRotation,
+    VolatilityTarget,
 }
 
 impl StrategyKind {
@@ -16,16 +19,22 @@ impl StrategyKind {
             Self::Twap => "twap",
             Self::TrendFollowing => "trend_following",
             Self::MeanReversion => "mean_reversion",
+            Self::Breakout => "breakout",
+            Self::MacroRotation => "macro_rotation",
+            Self::VolatilityTarget => "volatility_target",
         }
     }
 }
 
-pub const SUPPORTED_STRATEGIES: [StrategyKind; 5] = [
+pub const SUPPORTED_STRATEGIES: [StrategyKind; 8] = [
     StrategyKind::Dca,
     StrategyKind::ThresholdRebalance,
     StrategyKind::Twap,
     StrategyKind::TrendFollowing,
     StrategyKind::MeanReversion,
+    StrategyKind::Breakout,
+    StrategyKind::MacroRotation,
+    StrategyKind::VolatilityTarget,
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -61,6 +70,9 @@ mod tests {
                 "twap",
                 "trend_following",
                 "mean_reversion",
+                "breakout",
+                "macro_rotation",
+                "volatility_target",
             ],
         );
     }

--- a/docs/exec-plans/active/autonomous-runtime-rollout.md
+++ b/docs/exec-plans/active/autonomous-runtime-rollout.md
@@ -67,6 +67,10 @@
 - Phase 5 pack 2 adds `trend_following` and `mean_reversion`, but promotion is
   gated on replay evidence across opposing return regimes and zero
   stale-feature rejects in scorecards.
+- Phase 6 pack 1 adds `breakout`, `macro_rotation`, and `volatility_target`
+  without widening the public contract; promotion stays bounded to the same
+  single-slice safe-lane live bridge, with extended shadow and paper evidence
+  windows.
 - Do not treat phase 5 completion as arbitrary-strategy support; phase 6 still
   covers advanced templates and multi-strategy capital coordination.
 

--- a/docs/reliability/autonomous-runtime-ops-runbook.md
+++ b/docs/reliability/autonomous-runtime-ops-runbook.md
@@ -45,6 +45,18 @@ Pack 2 signal-driven templates add more rollout evidence requirements:
 - operators should treat any freshness degradation as an immediate reason to
   pause signal-driven deployments
 
+Pack 3 advanced templates inherit the same bounded live bridge and add tighter
+promotion criteria:
+
+- `breakout`: replay evidence must show confirmation on both clean breakout and
+  failed-breakout windows
+- `macro_rotation`: replay evidence must show positive and negative long-window
+  regime shifts without mixed-regime churn
+- `volatility_target`: replay evidence must show both risk-add and risk-reduce
+  behavior as realized volatility moves across thresholds
+- advanced templates need at least five shadow runs and seven paper runs before
+  bounded live promotion
+
 ## Routine operator actions
 
 ### Inspect health
@@ -181,8 +193,17 @@ Required checks before enabling:
 
 - deployment id is present in `RUNTIME_MANAGED_LIVE_DEPLOYMENT_IDS`
 - deployment lane is `safe`
-- deployment strategy is one of `dca`, `threshold_rebalance`, or `twap`
+- deployment strategy is one managed template with merged replay and scorecard
+  coverage for its pack
 - current plan shape is still single-slice in live mode
+
+For advanced templates, also verify:
+
+- the scorecard shows `shadow-advanced-min-runs` and `paper-advanced-min-runs`
+  as passing before promotion
+- no stale-feature rejects appear in the current promotion window
+- the replay artifact attached to the PR covers the same template and market
+  regime being promoted
 
 Control-plane command:
 

--- a/services/runtime-rs/README.md
+++ b/services/runtime-rs/README.md
@@ -23,12 +23,29 @@ Pack 2 signal-driven managed strategy semantics extend the same runtime path:
 - `mean_reversion`: fades the short-window return direction from the feature
   cache
 
+Pack 3 advanced managed templates stay on the same deterministic runtime path:
+
+- `breakout`: requires short-window momentum plus long-window confirmation
+  before it opens or exits risk
+- `macro_rotation`: rotates exposure from the long-window regime and avoids
+  mixed-regime churn
+- `volatility_target`: scales target base exposure from realized volatility and
+  rebalances toward that budget
+
 Promotion for signal-driven templates is intentionally stricter:
 
 - replay evidence must show expected behavior across both positive and negative
   return windows
 - scorecards must keep stale-feature rejects at zero before promotion
 - fresh feature inputs are required for every shadow and paper evidence run
+
+Promotion for advanced templates is stricter again:
+
+- shadow promotion requires an extended five-run evidence window
+- paper promotion requires an extended seven-run evidence window
+- stale-feature rejects must still remain at zero across the promotion window
+- replay evidence must cover the exact template behavior that would reach the
+  bounded live bridge
 
 The bounded live bridge remains intentionally narrow in v1:
 

--- a/services/runtime-rs/src/lib.rs
+++ b/services/runtime-rs/src/lib.rs
@@ -2508,6 +2508,231 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn breakout_replay_buys_in_shadow_mode() {
+        let worker_api_base = spawn_exec_coordination_stub().await;
+        let fixture_path = write_replay_fixture("breakout-up", &["140.00", "141.80", "144.60"]);
+        let router = app(test_config_with_runtime(
+            Some(&worker_api_base),
+            Some(&fixture_path),
+        ));
+        let deployment = runtime_deployment_with_strategy(
+            "deployment_breakout_shadow",
+            "sleeve_alpha",
+            "breakout",
+            "1000.00",
+            "5.00",
+        );
+
+        let create_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/deployments")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(deployment.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(create_response.status(), StatusCode::CREATED);
+
+        let evaluate_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/deployments/deployment_breakout_shadow/evaluate")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(evaluate_response.status(), StatusCode::CREATED);
+        let evaluation_payload = read_json(evaluate_response).await;
+        assert_eq!(
+            evaluation_payload["executionPlan"]["slices"][0]["action"],
+            json!("buy")
+        );
+        assert_eq!(
+            evaluation_payload["executionPlan"]["simulateOnly"],
+            json!(true)
+        );
+        assert_eq!(evaluation_payload["coordination"]["accepted"], json!(true));
+    }
+
+    #[tokio::test]
+    async fn macro_rotation_replay_sells_in_paper_mode() {
+        let worker_api_base = spawn_exec_coordination_stub().await;
+        let fixture_path = write_replay_fixture("macro-down", &["144.60", "141.80", "140.00"]);
+        let router = app(test_config_with_runtime(
+            Some(&worker_api_base),
+            Some(&fixture_path),
+        ));
+        let mut deployment = runtime_deployment_with_strategy(
+            "deployment_macro_paper",
+            "sleeve_alpha",
+            "macro_rotation",
+            "1000.00",
+            "5.00",
+        );
+        deployment["mode"] = json!("paper");
+        deployment["state"] = json!("paper");
+
+        let create_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/deployments")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(deployment.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(create_response.status(), StatusCode::CREATED);
+
+        let evaluate_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/deployments/deployment_macro_paper/evaluate")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(evaluate_response.status(), StatusCode::CREATED);
+        let evaluation_payload = read_json(evaluate_response).await;
+        assert_eq!(
+            evaluation_payload["executionPlan"]["slices"][0]["action"],
+            json!("sell")
+        );
+        assert_eq!(evaluation_payload["executionPlan"]["dryRun"], json!(true));
+        assert_eq!(evaluation_payload["coordination"]["accepted"], json!(true));
+    }
+
+    #[tokio::test]
+    async fn volatility_target_replay_sells_on_bounded_live_path() {
+        let worker_api_base = spawn_exec_coordination_stub().await;
+        let fixture_path = write_replay_fixture(
+            "vol-target-live",
+            &["140.00", "150.00", "136.00", "151.00", "135.00"],
+        );
+        let state = RuntimeAppState::new(test_config_with_runtime(
+            Some(&worker_api_base),
+            Some(&fixture_path),
+        ));
+        let mut deployment = runtime_deployment_with_strategy(
+            "deployment_vol_target_live",
+            "sleeve_alpha",
+            "volatility_target",
+            "1000.00",
+            "5.00",
+        );
+        deployment["mode"] = json!("live");
+        deployment["state"] = json!("live");
+        let deployment: RuntimeDeploymentRecord =
+            serde_json::from_value(deployment).expect("deployment");
+        state
+            .strategy_registry
+            .upsert_deployment(&deployment)
+            .expect("deployment to store");
+        state
+            .portfolio_ledger
+            .sync_deployment(&deployment)
+            .expect("ledger to sync");
+        let observed_ledger: protocol::RuntimeLedgerSnapshot = serde_json::from_value(json!({
+            "schemaVersion": "v1",
+            "snapshotId": "wallet_vol_target_live_1",
+            "deploymentId": "deployment_vol_target_live",
+            "sleeveId": "sleeve_alpha",
+            "asOf": "2026-03-10T19:00:10Z",
+            "balances": [
+                {
+                    "mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "freeAtomic": "35000000",
+                    "reservedAtomic": "5000000",
+                    "priceUsd": "1.00"
+                },
+                {
+                    "mint": "So11111111111111111111111111111111111111112",
+                    "symbol": "SOL",
+                    "decimals": 9,
+                    "freeAtomic": "400000000",
+                    "reservedAtomic": "0",
+                    "priceUsd": "150.00"
+                }
+            ],
+            "positions": [
+                {
+                    "instrumentId": "SOL/USDC",
+                    "side": "long",
+                    "quantityAtomic": "400000000",
+                    "entryPriceUsd": "149.00",
+                    "markPriceUsd": "150.00",
+                    "unrealizedPnlUsd": "0.40"
+                }
+            ],
+            "totals": {
+                "equityUsd": "100.00",
+                "reservedUsd": "5.00",
+                "availableUsd": "95.00",
+                "realizedPnlUsd": "0.00",
+                "unrealizedPnlUsd": "0.40"
+            }
+        }))
+        .expect("observed ledger");
+        state
+            .portfolio_ledger
+            .apply_observed_snapshot("deployment_vol_target_live", &observed_ledger)
+            .expect("observed snapshot to apply");
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "authorization",
+            HeaderValue::from_static("Bearer runtime-service-secret"),
+        );
+        let (status, Json(evaluation_payload)) = evaluate_deployment_handler(
+            headers,
+            Path("deployment_vol_target_live".to_string()),
+            State(state),
+            Bytes::from(
+                json!({
+                    "observedLedgerSnapshot": observed_ledger,
+                })
+                .to_string(),
+            ),
+        )
+        .await
+        .expect("response");
+
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(
+            evaluation_payload["executionPlan"]["slices"][0]["action"],
+            json!("rebalance")
+        );
+        assert_eq!(
+            evaluation_payload["executionPlan"]["slices"][0]["inputMint"],
+            json!("So11111111111111111111111111111111111111112")
+        );
+        assert_eq!(evaluation_payload["executionPlan"]["dryRun"], json!(false));
+        assert_eq!(evaluation_payload["coordination"]["accepted"], json!(true));
+    }
+
+    #[tokio::test]
     async fn applies_small_reconciliation_drift_corrections() {
         let worker_api_base = spawn_exec_coordination_stub().await;
         let router = app(test_config_with_worker_api_base(Some(&worker_api_base)));


### PR DESCRIPTION
## Summary
- add breakout, macro rotation, and volatility-target strategy support to the shared runtime stack
- add replay coverage plus stricter promotion gates for the advanced managed template pack
- update runtime docs and rollout/runbook guidance for the new bounded live criteria

## Validation
- cargo test --workspace
- bun run lint
- bun run typecheck

Fixes #275