### PR TITLE
Add runtime allocator coordination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,6 +953,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "runtime-allocator"
+version = "0.1.0"
+dependencies = [
+ "protocol",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "runtime-ops"
 version = "0.1.0"
 dependencies = [
@@ -975,6 +988,7 @@ dependencies = [
  "protocol",
  "reconciler",
  "risk-engine",
+ "runtime-allocator",
  "runtime-ops",
  "runtime-scorecards",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "crates/portfolio-ledger",
   "crates/protocol",
   "crates/reconciler",
+  "crates/runtime-allocator",
   "crates/risk-engine",
   "crates/runtime-scorecards",
   "crates/runtime-ops",

--- a/apps/portal/app/api/runtime/operator/route.ts
+++ b/apps/portal/app/api/runtime/operator/route.ts
@@ -245,6 +245,9 @@ async function loadRuntimeDetail(
       deploymentId,
       deployment: parsedDeployment?.success ? parsedDeployment.data : null,
       runs: parseRuns(result.payload.runs),
+      allocator: isRecord(result.payload.allocator)
+        ? result.payload.allocator
+        : null,
       positions: parseLedgerSnapshot(result.payload.positions),
       pnl: parsePnl(result.payload.pnl),
       scorecard: isRecord(result.payload.scorecard)

--- a/apps/portal/app/api/runtime/operator/route.ts
+++ b/apps/portal/app/api/runtime/operator/route.ts
@@ -217,6 +217,7 @@ async function loadRuntimeDetail(
     deploymentId: string;
     deployment: RuntimeDeploymentRecord | null;
     runs: RuntimeRunRecord[];
+    allocator: Record<string, unknown> | null;
     positions: RuntimeLedgerSnapshot | null;
     pnl: {
       asOf: string | null;

--- a/apps/portal/app/proof/runtime/page.tsx
+++ b/apps/portal/app/proof/runtime/page.tsx
@@ -158,6 +158,30 @@ function buildPayload(selectedDeploymentId: string): RuntimeOperatorApiPayload {
           failureMessage: undefined,
         },
       ],
+      allocator: {
+        currentDecision: {
+          deploymentId: deployment.deploymentId,
+          grantedAllocatedUsd: deployment.capital.allocatedUsd,
+          grantedReservedUsd: deployment.capital.reservedUsd,
+          priorityRank: deployment.mode === "live" ? 1 : 2,
+          constrained: false,
+        },
+        decisions: [
+          {
+            deploymentId: deployment.deploymentId,
+            grantedAllocatedUsd: deployment.capital.allocatedUsd,
+            grantedReservedUsd: deployment.capital.reservedUsd,
+            priorityRank: deployment.mode === "live" ? 1 : 2,
+            constrained: false,
+          },
+        ],
+        sleeve: {
+          sleeveId: deployment.sleeveId,
+          equityUsd: deployment.mode === "live" ? "25.00" : "320.00",
+          reservedUsd: deployment.capital.reservedUsd,
+          availableUsd: deployment.capital.availableUsd,
+        },
+      },
       positions: {
         schemaVersion: "v1",
         snapshotId: `ledger_${deployment.deploymentId}`,

--- a/apps/portal/app/terminal/runtime/runtime-operator-view.tsx
+++ b/apps/portal/app/terminal/runtime/runtime-operator-view.tsx
@@ -284,6 +284,128 @@ function renderPromotion(detail: RuntimeOperatorDetail | null) {
   );
 }
 
+function renderAllocator(detail: RuntimeOperatorDetail | null) {
+  const allocator = isRecord(detail?.allocator) ? detail?.allocator : {};
+  const currentDecision = isRecord(allocator.currentDecision)
+    ? allocator.currentDecision
+    : null;
+  const sleeve = isRecord(allocator.sleeve) ? allocator.sleeve : null;
+  const peerGrants = Array.isArray(currentDecision?.peerGrants)
+    ? currentDecision.peerGrants
+    : [];
+
+  if (!currentDecision) {
+    return (
+      <div className="rounded border border-dashed border-border p-4 text-sm text-muted">
+        Allocator evidence not available yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+        {summaryItem(
+          "Grant allocated",
+          `${readString(currentDecision.grantedAllocatedUsd) ?? "0.00"} USD`,
+        )}
+        {summaryItem(
+          "Grant reserved",
+          `${readString(currentDecision.grantedReservedUsd) ?? "0.00"} USD`,
+        )}
+        {summaryItem(
+          "Priority rank",
+          readString(currentDecision.priorityRank) ??
+            String(currentDecision.priorityRank ?? "n/a"),
+        )}
+        {summaryItem(
+          "Decision",
+          readBoolean(currentDecision.constrained, false)
+            ? "constrained"
+            : "full grant",
+        )}
+        {summaryItem(
+          "Sleeve equity",
+          `${readString(currentDecision.sleeveEquityUsd) ?? "0.00"} USD`,
+        )}
+      </div>
+      <div className="grid gap-3 lg:grid-cols-[1.1fr_0.9fr]">
+        <div className="rounded border border-border bg-surface/80 p-4">
+          <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+            Peer grants
+          </p>
+          <div className="mt-3 space-y-3">
+            {peerGrants.length === 0 ? (
+              <p className="text-sm text-muted">
+                No peer grant records available.
+              </p>
+            ) : (
+              peerGrants.map((grant, index) => {
+                const record = isRecord(grant) ? grant : {};
+                const constrained = readBoolean(record.constrained, false);
+                return (
+                  <div
+                    key={`${readString(record.deploymentId) ?? "peer"}:${index}`}
+                    className="rounded border border-border bg-paper/70 p-3"
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <p className="font-mono text-xs text-muted">
+                        {readString(record.deploymentId) ?? "unknown"}
+                      </p>
+                      <span
+                        className={`inline-flex rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.24em] ${statusClasses(
+                          constrained ? "blocked" : "pass",
+                        )}`}
+                      >
+                        {constrained ? "constrained" : "full grant"}
+                      </span>
+                    </div>
+                    <div className="mt-2 grid gap-2 text-xs text-muted sm:grid-cols-3">
+                      <p>
+                        requested{" "}
+                        {readString(record.requestedAllocatedUsd) ?? "--"} USD
+                      </p>
+                      <p>
+                        granted {readString(record.grantedAllocatedUsd) ?? "--"}{" "}
+                        USD
+                      </p>
+                      <p>
+                        reserved {readString(record.grantedReservedUsd) ?? "--"}{" "}
+                        USD
+                      </p>
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </div>
+        <div className="rounded border border-border bg-surface/80 p-4">
+          <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+            Sleeve coordination
+          </p>
+          {sleeve ? (
+            <div className="mt-3 space-y-3 text-sm">
+              <p className="text-muted">
+                {readString(sleeve.sleeveId) ?? "unknown sleeve"}
+              </p>
+              <div className="grid gap-2 text-xs text-muted">
+                <p>equity {readString(sleeve.equityUsd) ?? "0.00"} USD</p>
+                <p>reserved {readString(sleeve.reservedUsd) ?? "0.00"} USD</p>
+                <p>available {readString(sleeve.availableUsd) ?? "0.00"} USD</p>
+              </div>
+            </div>
+          ) : (
+            <p className="mt-3 text-sm text-muted">
+              Sleeve summary unavailable.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function RuntimeOperatorView({
   authenticated,
   loading,
@@ -492,6 +614,18 @@ export function RuntimeOperatorView({
                 )}
               </div>
             ) : null}
+          </section>
+
+          <section className="card p-5">
+            <div className="mb-4">
+              <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                Capital coordination
+              </p>
+              <h2 className="mt-2 text-lg font-semibold text-ink">
+                Allocator grants and sleeve priority
+              </h2>
+            </div>
+            {renderAllocator(detail)}
           </section>
 
           <section className="card p-5">

--- a/apps/portal/app/terminal/runtime/types.ts
+++ b/apps/portal/app/terminal/runtime/types.ts
@@ -28,6 +28,7 @@ export type RuntimeOperatorDetail = {
   deploymentId: string;
   deployment: RuntimeDeploymentRecord | null;
   runs: RuntimeRunRecord[];
+  allocator: Record<string, unknown> | null;
   positions: RuntimeLedgerSnapshot | null;
   pnl: {
     asOf: string | null;

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -144,6 +144,7 @@ import {
   handleRuntimeInternalRoute,
   type RuntimeControlAction,
   readRuntimeAdminSnapshot,
+  readRuntimeAllocatorSummary,
   readRuntimeDeployment,
   readRuntimeDeploymentRuns,
   readRuntimePnlSummary,
@@ -2273,12 +2274,14 @@ const worker = {
         const [
           deploymentResult,
           runsResult,
+          allocatorResult,
           positionsResult,
           pnlResult,
           scorecardResult,
         ] = await Promise.all([
           readRuntimeDeployment(env, runtimeDetailDeploymentId),
           readRuntimeDeploymentRuns(env, runtimeDetailDeploymentId),
+          readRuntimeAllocatorSummary(env, runtimeDetailDeploymentId),
           readRuntimePositionSnapshot(env, runtimeDetailDeploymentId),
           readRuntimePnlSummary(env, runtimeDetailDeploymentId),
           readRuntimeScorecard(env, runtimeDetailDeploymentId),
@@ -2287,6 +2290,7 @@ const worker = {
           [
             deploymentResult,
             runsResult,
+            allocatorResult,
             positionsResult,
             pnlResult,
             scorecardResult,
@@ -2310,6 +2314,21 @@ const worker = {
             runs: Array.isArray(runsResult.payload.runs)
               ? runsResult.payload.runs
               : [],
+            allocator: isRecord(allocatorResult.payload)
+              ? {
+                  currentDecision: isRecord(
+                    allocatorResult.payload.currentDecision,
+                  )
+                    ? allocatorResult.payload.currentDecision
+                    : null,
+                  decisions: Array.isArray(allocatorResult.payload.decisions)
+                    ? allocatorResult.payload.decisions
+                    : [],
+                  sleeve: isRecord(allocatorResult.payload.sleeve)
+                    ? allocatorResult.payload.sleeve
+                    : null,
+                }
+              : null,
             positions: isRecord(positionsResult.payload.snapshot)
               ? positionsResult.payload.snapshot
               : null,

--- a/apps/worker/src/runtime_internal.ts
+++ b/apps/worker/src/runtime_internal.ts
@@ -24,6 +24,7 @@ const INTERNAL_RUNTIME_DEPLOYMENTS_PREFIX = `${INTERNAL_RUNTIME_PREFIX}/deployme
 const INTERNAL_RUNTIME_RUNS_PREFIX = `${INTERNAL_RUNTIME_PREFIX}/runs/`;
 const INTERNAL_RUNTIME_EXECUTION_PLANS_PATH = `${INTERNAL_RUNTIME_PREFIX}/execution-plans`;
 const INTERNAL_RUNTIME_SCORECARDS_PATH = `${INTERNAL_RUNTIME_PREFIX}/scorecards`;
+const INTERNAL_RUNTIME_ALLOCATOR_PATH = `${INTERNAL_RUNTIME_PREFIX}/allocator`;
 const FIXTURE_TIMESTAMP = "2026-03-07T00:00:00.000Z";
 const FIXTURE_BASE_MINT = "So11111111111111111111111111111111111111112";
 const FIXTURE_QUOTE_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
@@ -306,6 +307,13 @@ function createRuntimeScorecardFixture(deploymentId: string) {
         concentrationRejectCount: 0,
         killSwitchPauseCount: 0,
       },
+      allocator: {
+        decisionCount: 3,
+        fullGrantCount: 3,
+        constrainedCount: 0,
+        zeroGrantCount: 0,
+        fullGrantRateBps: 10000,
+      },
     },
     promotionGates: [
       {
@@ -346,6 +354,70 @@ function createRuntimeScorecardFixture(deploymentId: string) {
   };
 }
 
+function createRuntimeAllocatorFixture(deploymentId: string) {
+  return {
+    ok: true,
+    source: "stub",
+    deploymentId,
+    sleeveId: "sleeve_alpha",
+    currentDecision: {
+      schemaVersion: RUNTIME_PROTOCOL_SCHEMA_VERSION,
+      decisionId: `alloc_${deploymentId}`,
+      runId: `run_${deploymentId}`,
+      deploymentId,
+      sleeveId: "sleeve_alpha",
+      decidedAt: FIXTURE_TIMESTAMP,
+      sleeveEquityUsd: "1000.00",
+      totalRequestedAllocatedUsd: "1000.00",
+      totalGrantedAllocatedUsd: "1000.00",
+      totalRequestedReservedUsd: "250.00",
+      totalGrantedReservedUsd: "250.00",
+      requestedAllocatedUsd: "1000.00",
+      grantedAllocatedUsd: "1000.00",
+      requestedReservedUsd: "125.00",
+      grantedReservedUsd: "125.00",
+      grantedAvailableUsd: "875.00",
+      priorityRank: 1,
+      priorityScore: 136,
+      constrained: false,
+      peerGrants: [
+        {
+          deploymentId,
+          strategyKey: "dca",
+          mode: "shadow",
+          state: "shadow",
+          priorityRank: 1,
+          priorityScore: 136,
+          requestedAllocatedUsd: "1000.00",
+          grantedAllocatedUsd: "1000.00",
+          requestedReservedUsd: "125.00",
+          grantedReservedUsd: "125.00",
+          constrained: false,
+        },
+      ],
+    },
+    decisions: [],
+    sleeve: {
+      sleeveId: "sleeve_alpha",
+      equityUsd: "1000.00",
+      reservedUsd: "125.00",
+      availableUsd: "875.00",
+      quoteMint: FIXTURE_QUOTE_MINT,
+      quoteSymbol: "USDC",
+      deployments: [
+        {
+          deploymentId,
+          strategyKey: "dca",
+          state: "shadow",
+          allocatedUsd: "1000.00",
+          reservedUsd: "125.00",
+          availableUsd: "875.00",
+        },
+      ],
+    },
+  };
+}
+
 function createRuntimeHealthFixture() {
   return {
     serviceName: DEFAULT_RUNTIME_SERVICE,
@@ -373,6 +445,13 @@ function createRuntimeHealthFixture() {
       status: "healthy",
       deploymentCount: 1,
       runCount: 0,
+      lastError: null,
+    },
+    allocator: {
+      status: "healthy",
+      decisionCount: 1,
+      constrainedDecisionCount: 0,
+      latestDecisionAt: FIXTURE_TIMESTAMP,
       lastError: null,
     },
   };
@@ -414,6 +493,7 @@ function buildRuntimeHealthPayload(env: Env, service: string) {
       positions: `${INTERNAL_RUNTIME_PREFIX}/positions`,
       pnl: `${INTERNAL_RUNTIME_PREFIX}/pnl`,
       scorecards: INTERNAL_RUNTIME_SCORECARDS_PATH,
+      allocator: INTERNAL_RUNTIME_ALLOCATOR_PATH,
       executionPlans: INTERNAL_RUNTIME_EXECUTION_PLANS_PATH,
       health: `${INTERNAL_RUNTIME_PREFIX}/health`,
     },
@@ -716,6 +796,19 @@ export async function readRuntimeScorecard(
   });
 }
 
+export async function readRuntimeAllocatorSummary(
+  env: Env,
+  deploymentId: string,
+): Promise<RuntimeInternalJsonResult> {
+  return await dispatchRuntimeInternalJson({
+    env,
+    method: "GET",
+    pathname: `${INTERNAL_RUNTIME_ALLOCATOR_PATH}?deploymentId=${encodeURIComponent(
+      deploymentId,
+    )}`,
+  });
+}
+
 export async function readRuntimePositionSnapshot(
   env: Env,
   deploymentId: string,
@@ -767,6 +860,7 @@ export async function handleRuntimeInternalRoute(
     url.pathname === `${INTERNAL_RUNTIME_PREFIX}/positions` ||
     url.pathname === `${INTERNAL_RUNTIME_PREFIX}/pnl` ||
     url.pathname === INTERNAL_RUNTIME_SCORECARDS_PATH ||
+    url.pathname === INTERNAL_RUNTIME_ALLOCATOR_PATH ||
     url.pathname === INTERNAL_RUNTIME_EXECUTION_PLANS_PATH ||
     url.pathname.startsWith(INTERNAL_RUNTIME_DEPLOYMENTS_PREFIX) ||
     url.pathname.startsWith(INTERNAL_RUNTIME_RUNS_PREFIX);
@@ -988,6 +1082,15 @@ export async function handleRuntimeInternalRoute(
       deploymentId,
       report: createRuntimeScorecardFixture(deploymentId),
     });
+  }
+
+  if (
+    request.method === "GET" &&
+    url.pathname === INTERNAL_RUNTIME_ALLOCATOR_PATH
+  ) {
+    const deploymentId =
+      url.searchParams.get("deploymentId") ?? "deployment_fixture";
+    return json(createRuntimeAllocatorFixture(deploymentId));
   }
 
   if (

--- a/crates/portfolio-ledger/src/lib.rs
+++ b/crates/portfolio-ledger/src/lib.rs
@@ -42,6 +42,29 @@ pub struct PortfolioLedgerSnapshot {
     pub last_error: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SleeveDeploymentBudgetSnapshot {
+    pub deployment_id: String,
+    pub strategy_key: String,
+    pub state: String,
+    pub allocated_usd: String,
+    pub reserved_usd: String,
+    pub available_usd: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SleeveLedgerSnapshot {
+    pub sleeve_id: String,
+    pub equity_usd: String,
+    pub reserved_usd: String,
+    pub available_usd: String,
+    pub quote_mint: String,
+    pub quote_symbol: String,
+    pub deployments: Vec<SleeveDeploymentBudgetSnapshot>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LedgerSyncResult {
     pub snapshot: RuntimeLedgerSnapshot,
@@ -332,6 +355,38 @@ impl PortfolioLedger {
         deployment_id: &str,
     ) -> Result<RuntimeLedgerTotals, PortfolioLedgerError> {
         Ok(self.snapshot_for_deployment(deployment_id)?.totals)
+    }
+
+    pub fn sleeve_snapshot(
+        &self,
+        sleeve_id: &str,
+    ) -> Result<Option<SleeveLedgerSnapshot>, PortfolioLedgerError> {
+        let connection = self.open_connection()?;
+        let sleeve = load_sleeve_state(&connection, sleeve_id)?;
+        let Some(sleeve) = sleeve else {
+            return Ok(None);
+        };
+        let deployments = load_sleeve_deployment_states(&connection, sleeve_id)?;
+        let reserved_cents = deployments.iter().map(|deployment| deployment.reserved_cents).sum();
+        Ok(Some(SleeveLedgerSnapshot {
+            sleeve_id: sleeve.sleeve_id,
+            equity_usd: format_usd_cents(sleeve.equity_cents),
+            reserved_usd: format_usd_cents(reserved_cents),
+            available_usd: format_usd_cents(sleeve.equity_cents.saturating_sub(reserved_cents)),
+            quote_mint: sleeve.quote_mint,
+            quote_symbol: sleeve.quote_symbol,
+            deployments: deployments
+                .into_iter()
+                .map(|deployment| SleeveDeploymentBudgetSnapshot {
+                    deployment_id: deployment.deployment_id,
+                    strategy_key: deployment.strategy_key,
+                    state: deployment.state,
+                    allocated_usd: format_usd_cents(deployment.allocated_cents),
+                    reserved_usd: format_usd_cents(deployment.reserved_cents),
+                    available_usd: format_usd_cents(deployment.available_cents),
+                })
+                .collect(),
+        }))
     }
 
     #[must_use]
@@ -761,6 +816,38 @@ fn load_deployment_state(
         )
         .optional()
         .map_err(PortfolioLedgerError::from)
+}
+
+fn load_sleeve_deployment_states(
+    connection: &Connection,
+    sleeve_id: &str,
+) -> Result<Vec<DeploymentLedgerState>, PortfolioLedgerError> {
+    let mut statement = connection.prepare(
+        "SELECT deployment_id, sleeve_id, strategy_key, state, allocated_cents, reserved_cents, available_cents,
+                realized_pnl_cents, quote_mint, quote_symbol
+         FROM ledger_deployments
+         WHERE sleeve_id = ?1
+         ORDER BY deployment_id ASC",
+    )?;
+    let rows = statement.query_map(params![sleeve_id], |row| {
+        Ok(DeploymentLedgerState {
+            deployment_id: row.get(0)?,
+            sleeve_id: row.get(1)?,
+            strategy_key: row.get(2)?,
+            state: row.get(3)?,
+            allocated_cents: row.get(4)?,
+            reserved_cents: row.get(5)?,
+            available_cents: row.get(6)?,
+            realized_pnl_cents: row.get(7)?,
+            quote_mint: row.get(8)?,
+            quote_symbol: row.get(9)?,
+        })
+    })?;
+    let mut deployments = Vec::new();
+    for row in rows {
+        deployments.push(row?);
+    }
+    Ok(deployments)
 }
 
 fn sum_deployment_cents(
@@ -1280,5 +1367,41 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn returns_sleeve_snapshots_with_deployment_budgets() {
+        let ledger = ledger("sleeve-snapshot");
+        ledger
+            .sync_deployment(&deployment(
+                "deployment_alpha",
+                "sleeve_alpha",
+                "60.00",
+                "15.00",
+            ))
+            .expect("first deployment to sync");
+        ledger
+            .apply_sleeve_correction("sleeve_alpha", "100.00")
+            .expect("sleeve correction to apply");
+        ledger
+            .sync_deployment(&deployment(
+                "deployment_beta",
+                "sleeve_alpha",
+                "40.00",
+                "10.00",
+            ))
+            .expect("second deployment to sync");
+
+        let snapshot = ledger
+            .sleeve_snapshot("sleeve_alpha")
+            .expect("snapshot to load")
+            .expect("sleeve to exist");
+
+        assert_eq!(snapshot.equity_usd, "100.00");
+        assert_eq!(snapshot.reserved_usd, "25.00");
+        assert_eq!(snapshot.available_usd, "75.00");
+        assert_eq!(snapshot.deployments.len(), 2);
+        assert_eq!(snapshot.deployments[0].deployment_id, "deployment_alpha");
+        assert_eq!(snapshot.deployments[1].deployment_id, "deployment_beta");
     }
 }

--- a/crates/portfolio-ledger/src/lib.rs
+++ b/crates/portfolio-ledger/src/lib.rs
@@ -367,7 +367,10 @@ impl PortfolioLedger {
             return Ok(None);
         };
         let deployments = load_sleeve_deployment_states(&connection, sleeve_id)?;
-        let reserved_cents = deployments.iter().map(|deployment| deployment.reserved_cents).sum();
+        let reserved_cents = deployments
+            .iter()
+            .map(|deployment| deployment.reserved_cents)
+            .sum();
         Ok(Some(SleeveLedgerSnapshot {
             sleeve_id: sleeve.sleeve_id,
             equity_usd: format_usd_cents(sleeve.equity_cents),

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -441,12 +441,64 @@ pub struct RuntimeRiskScorecard {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub struct RuntimeAllocatorPeerGrant {
+    pub deployment_id: String,
+    pub strategy_key: String,
+    pub mode: RuntimeMode,
+    pub state: RuntimeDeploymentState,
+    pub priority_rank: u32,
+    pub priority_score: i64,
+    pub requested_allocated_usd: String,
+    pub granted_allocated_usd: String,
+    pub requested_reserved_usd: String,
+    pub granted_reserved_usd: String,
+    pub constrained: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeAllocatorDecisionRecord {
+    pub schema_version: String,
+    pub decision_id: String,
+    pub run_id: String,
+    pub deployment_id: String,
+    pub sleeve_id: String,
+    pub decided_at: String,
+    pub sleeve_equity_usd: String,
+    pub total_requested_allocated_usd: String,
+    pub total_granted_allocated_usd: String,
+    pub total_requested_reserved_usd: String,
+    pub total_granted_reserved_usd: String,
+    pub requested_allocated_usd: String,
+    pub granted_allocated_usd: String,
+    pub requested_reserved_usd: String,
+    pub granted_reserved_usd: String,
+    pub granted_available_usd: String,
+    pub priority_rank: u32,
+    pub priority_score: i64,
+    pub constrained: bool,
+    pub peer_grants: Vec<RuntimeAllocatorPeerGrant>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeAllocatorScorecard {
+    pub decision_count: u64,
+    pub full_grant_count: u64,
+    pub constrained_count: u64,
+    pub zero_grant_count: u64,
+    pub full_grant_rate_bps: u16,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct RuntimeScorecard {
     pub trigger_quality: RuntimeTriggerQualityScorecard,
     pub plan_quality: RuntimePlanQualityScorecard,
     pub expected_vs_observed: RuntimeExpectedObservedScorecard,
     pub pnl: RuntimePnlScorecard,
     pub risk: RuntimeRiskScorecard,
+    pub allocator: RuntimeAllocatorScorecard,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/runtime-allocator/Cargo.toml
+++ b/crates/runtime-allocator/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "runtime-allocator"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+protocol = { path = "../protocol" }
+rusqlite = { version = "0.37.0", features = ["bundled"] }
+serde.workspace = true
+serde_json.workspace = true
+sha2 = "0.10.9"
+thiserror.workspace = true
+time = { version = "=0.3.44", features = ["formatting", "parsing"] }

--- a/crates/runtime-allocator/src/lib.rs
+++ b/crates/runtime-allocator/src/lib.rs
@@ -1,0 +1,846 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use protocol::{
+    RuntimeAllocatorDecisionRecord, RuntimeAllocatorPeerGrant, RuntimeDeploymentRecord,
+    RuntimeDeploymentState, RuntimeLane, RuntimeMode, RUNTIME_PROTOCOL_SCHEMA_VERSION,
+};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeAllocatorConfig {
+    pub database_url: String,
+}
+
+impl RuntimeAllocatorConfig {
+    #[must_use]
+    pub fn new(database_url: impl Into<String>) -> Self {
+        Self {
+            database_url: database_url.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeAllocator {
+    database_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeAllocatorInput {
+    pub run_id: String,
+    pub deployment: RuntimeDeploymentRecord,
+    pub sleeve_equity_usd: String,
+    pub sleeve_deployments: Vec<RuntimeDeploymentRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeAllocatorResult {
+    pub decision: RuntimeAllocatorDecisionRecord,
+    pub effective_deployment: RuntimeDeploymentRecord,
+    pub created: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeAllocatorSnapshot {
+    pub status: String,
+    pub decision_count: u64,
+    pub constrained_decision_count: u64,
+    pub latest_decision_at: Option<String>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum RuntimeAllocatorError {
+    #[error("storage io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("storage error: {0}")]
+    Storage(#[from] rusqlite::Error),
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("invalid usd amount for {field}: {value}")]
+    InvalidUsdAmount { field: &'static str, value: String },
+    #[error("allocator decision {run_id} not found")]
+    DecisionNotFound { run_id: String },
+}
+
+impl RuntimeAllocator {
+    pub fn new(config: RuntimeAllocatorConfig) -> Result<Self, RuntimeAllocatorError> {
+        let requested_path = normalize_database_path(&config.database_url);
+        match Self::initialize_at_path(requested_path.clone()) {
+            Ok(allocator) => Ok(allocator),
+            Err(error) if should_fallback_to_tmp(&requested_path, &error) => {
+                Self::initialize_at_path(fallback_database_path())
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    pub fn allocate_and_store(
+        &self,
+        input: &RuntimeAllocatorInput,
+    ) -> Result<RuntimeAllocatorResult, RuntimeAllocatorError> {
+        let mut connection = self.open_connection()?;
+        let transaction = connection.transaction()?;
+
+        if let Some(existing) = load_decision_by_run_id(&transaction, &input.run_id)? {
+            let effective_deployment = apply_grant(&input.deployment, &existing);
+            transaction.commit()?;
+            return Ok(RuntimeAllocatorResult {
+                decision: existing,
+                effective_deployment,
+                created: false,
+            });
+        }
+
+        let decision = build_decision(input)?;
+        persist_decision(&transaction, &decision)?;
+        transaction.commit()?;
+
+        Ok(RuntimeAllocatorResult {
+            effective_deployment: apply_grant(&input.deployment, &decision),
+            decision,
+            created: true,
+        })
+    }
+
+    pub fn list_decisions_for_deployment(
+        &self,
+        deployment_id: &str,
+    ) -> Result<Vec<RuntimeAllocatorDecisionRecord>, RuntimeAllocatorError> {
+        let connection = self.open_connection()?;
+        let mut statement = connection.prepare(
+            "SELECT record_json
+             FROM allocator_decisions
+             WHERE deployment_id = ?1
+             ORDER BY decided_at DESC, decision_id DESC",
+        )?;
+        let rows = statement.query_map(params![deployment_id], |row| row.get::<_, String>(0))?;
+        let mut decisions = Vec::new();
+        for row in rows {
+            decisions.push(deserialize_json(&row?)?);
+        }
+        Ok(decisions)
+    }
+
+    pub fn list_decisions_for_sleeve(
+        &self,
+        sleeve_id: &str,
+    ) -> Result<Vec<RuntimeAllocatorDecisionRecord>, RuntimeAllocatorError> {
+        let connection = self.open_connection()?;
+        let mut statement = connection.prepare(
+            "SELECT record_json
+             FROM allocator_decisions
+             WHERE sleeve_id = ?1
+             ORDER BY decided_at DESC, decision_id DESC",
+        )?;
+        let rows = statement.query_map(params![sleeve_id], |row| row.get::<_, String>(0))?;
+        let mut decisions = Vec::new();
+        for row in rows {
+            decisions.push(deserialize_json(&row?)?);
+        }
+        Ok(decisions)
+    }
+
+    pub fn latest_decision_for_deployment(
+        &self,
+        deployment_id: &str,
+    ) -> Result<Option<RuntimeAllocatorDecisionRecord>, RuntimeAllocatorError> {
+        let connection = self.open_connection()?;
+        let raw = connection
+            .query_row(
+                "SELECT record_json
+                 FROM allocator_decisions
+                 WHERE deployment_id = ?1
+                 ORDER BY decided_at DESC, decision_id DESC
+                 LIMIT 1",
+                params![deployment_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        Ok(raw.map(|value| deserialize_json(&value)).transpose()?)
+    }
+
+    #[must_use]
+    pub fn snapshot_now(&self) -> RuntimeAllocatorSnapshot {
+        match self.snapshot_counts() {
+            Ok((decision_count, constrained_decision_count, latest_decision_at)) => {
+                RuntimeAllocatorSnapshot {
+                    status: "healthy".to_string(),
+                    decision_count,
+                    constrained_decision_count,
+                    latest_decision_at,
+                    last_error: None,
+                }
+            }
+            Err(error) => RuntimeAllocatorSnapshot {
+                status: "degraded".to_string(),
+                decision_count: 0,
+                constrained_decision_count: 0,
+                latest_decision_at: None,
+                last_error: Some(error.to_string()),
+            },
+        }
+    }
+
+    fn snapshot_counts(&self) -> Result<(u64, u64, Option<String>), RuntimeAllocatorError> {
+        let connection = self.open_connection()?;
+        let decision_count = connection.query_row(
+            "SELECT COUNT(*) FROM allocator_decisions",
+            [],
+            |row| row.get::<_, u64>(0),
+        )?;
+        let constrained_decision_count = connection.query_row(
+            "SELECT COUNT(*) FROM allocator_decisions WHERE constrained = 1",
+            [],
+            |row| row.get::<_, u64>(0),
+        )?;
+        let latest_decision_at = connection
+            .query_row(
+                "SELECT decided_at
+                 FROM allocator_decisions
+                 ORDER BY decided_at DESC, decision_id DESC
+                 LIMIT 1",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        Ok((decision_count, constrained_decision_count, latest_decision_at))
+    }
+
+    fn open_connection(&self) -> Result<Connection, RuntimeAllocatorError> {
+        let connection = Connection::open(&self.database_path)?;
+        connection.busy_timeout(std::time::Duration::from_secs(5))?;
+        connection.pragma_update(None, "foreign_keys", "ON")?;
+        Ok(connection)
+    }
+
+    fn initialize_at_path(database_path: PathBuf) -> Result<Self, RuntimeAllocatorError> {
+        if database_path != Path::new(":memory:") {
+            if let Some(parent) = database_path
+                .parent()
+                .filter(|path| !path.as_os_str().is_empty())
+            {
+                fs::create_dir_all(parent)?;
+            }
+        }
+        let allocator = Self { database_path };
+        let connection = allocator.open_connection()?;
+        initialize_schema(&connection)?;
+        Ok(allocator)
+    }
+}
+
+fn initialize_schema(connection: &Connection) -> Result<(), rusqlite::Error> {
+    connection.execute_batch(
+        "CREATE TABLE IF NOT EXISTS allocator_decisions (
+            decision_id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL UNIQUE,
+            deployment_id TEXT NOT NULL,
+            sleeve_id TEXT NOT NULL,
+            constrained INTEGER NOT NULL,
+            decided_at TEXT NOT NULL,
+            record_json TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_allocator_decisions_deployment_decided
+            ON allocator_decisions (deployment_id, decided_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_allocator_decisions_sleeve_decided
+            ON allocator_decisions (sleeve_id, decided_at DESC);",
+    )
+}
+
+fn build_decision(
+    input: &RuntimeAllocatorInput,
+) -> Result<RuntimeAllocatorDecisionRecord, RuntimeAllocatorError> {
+    let sleeve_equity_cents =
+        parse_non_negative_usd_cents("sleeveEquityUsd", &input.sleeve_equity_usd)?;
+    let mut peers = input
+        .sleeve_deployments
+        .iter()
+        .map(|deployment| RankedDeployment {
+            deployment: deployment.clone(),
+            priority_score: allocator_priority_score(deployment),
+        })
+        .collect::<Vec<_>>();
+    peers.sort_by(|left, right| {
+        right
+            .priority_score
+            .cmp(&left.priority_score)
+            .then_with(|| left.deployment.deployment_id.cmp(&right.deployment.deployment_id))
+    });
+
+    let mut total_requested_allocated_cents = 0_i64;
+    let mut total_requested_reserved_cents = 0_i64;
+    for peer in &peers {
+        total_requested_allocated_cents += parse_non_negative_usd_cents(
+            "capital.allocatedUsd",
+            &peer.deployment.capital.allocated_usd,
+        )?;
+        total_requested_reserved_cents += effective_reserved_cents(&peer.deployment)?;
+    }
+
+    let mut remaining_cents = sleeve_equity_cents;
+    let mut peer_grants = Vec::with_capacity(peers.len());
+    for (index, peer) in peers.iter().enumerate() {
+        let requested_allocated_cents = parse_non_negative_usd_cents(
+            "capital.allocatedUsd",
+            &peer.deployment.capital.allocated_usd,
+        )?;
+        let requested_reserved_cents = effective_reserved_cents(&peer.deployment)?;
+        let granted_allocated_cents = if deployment_is_eligible_for_grant(&peer.deployment) {
+            requested_allocated_cents.min(remaining_cents)
+        } else {
+            0
+        };
+        remaining_cents = remaining_cents.saturating_sub(granted_allocated_cents);
+        let granted_reserved_cents = requested_reserved_cents.min(granted_allocated_cents);
+        peer_grants.push(RuntimeAllocatorPeerGrant {
+            deployment_id: peer.deployment.deployment_id.clone(),
+            strategy_key: peer.deployment.strategy_key.clone(),
+            mode: peer.deployment.mode.clone(),
+            state: peer.deployment.state.clone(),
+            priority_rank: (index + 1) as u32,
+            priority_score: peer.priority_score,
+            requested_allocated_usd: format_usd_cents(requested_allocated_cents),
+            granted_allocated_usd: format_usd_cents(granted_allocated_cents),
+            requested_reserved_usd: format_usd_cents(requested_reserved_cents),
+            granted_reserved_usd: format_usd_cents(granted_reserved_cents),
+            constrained: granted_allocated_cents < requested_allocated_cents
+                || granted_reserved_cents < requested_reserved_cents,
+        });
+    }
+
+    let target_grant = peer_grants
+        .iter()
+        .find(|grant| grant.deployment_id == input.deployment.deployment_id)
+        .cloned()
+        .ok_or_else(|| RuntimeAllocatorError::DecisionNotFound {
+            run_id: input.run_id.clone(),
+        })?;
+    let mut total_granted_allocated_cents = 0_i64;
+    let mut total_granted_reserved_cents = 0_i64;
+    for grant in &peer_grants {
+        total_granted_allocated_cents +=
+            parse_non_negative_usd_cents("grantedAllocatedUsd", &grant.granted_allocated_usd)?;
+        total_granted_reserved_cents +=
+            parse_non_negative_usd_cents("grantedReservedUsd", &grant.granted_reserved_usd)?;
+    }
+    let target_granted_allocated_cents = parse_non_negative_usd_cents(
+        "grantedAllocatedUsd",
+        &target_grant.granted_allocated_usd,
+    )?;
+    let target_granted_reserved_cents = parse_non_negative_usd_cents(
+        "grantedReservedUsd",
+        &target_grant.granted_reserved_usd,
+    )?;
+
+    Ok(RuntimeAllocatorDecisionRecord {
+        schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+        decision_id: build_decision_id(&input.run_id),
+        run_id: input.run_id.clone(),
+        deployment_id: input.deployment.deployment_id.clone(),
+        sleeve_id: input.deployment.sleeve_id.clone(),
+        decided_at: now_rfc3339(),
+        sleeve_equity_usd: format_usd_cents(sleeve_equity_cents),
+        total_requested_allocated_usd: format_usd_cents(total_requested_allocated_cents),
+        total_granted_allocated_usd: format_usd_cents(total_granted_allocated_cents),
+        total_requested_reserved_usd: format_usd_cents(total_requested_reserved_cents),
+        total_granted_reserved_usd: format_usd_cents(total_granted_reserved_cents),
+        requested_allocated_usd: target_grant.requested_allocated_usd.clone(),
+        granted_allocated_usd: target_grant.granted_allocated_usd.clone(),
+        requested_reserved_usd: target_grant.requested_reserved_usd.clone(),
+        granted_reserved_usd: target_grant.granted_reserved_usd.clone(),
+        granted_available_usd: format_usd_cents(
+            target_granted_allocated_cents.saturating_sub(target_granted_reserved_cents),
+        ),
+        priority_rank: target_grant.priority_rank,
+        priority_score: target_grant.priority_score,
+        constrained: target_grant.constrained,
+        peer_grants,
+    })
+}
+
+fn apply_grant(
+    deployment: &RuntimeDeploymentRecord,
+    decision: &RuntimeAllocatorDecisionRecord,
+) -> RuntimeDeploymentRecord {
+    let mut effective = deployment.clone();
+    effective.capital.allocated_usd = decision.granted_allocated_usd.clone();
+    effective.capital.reserved_usd = decision.granted_reserved_usd.clone();
+    effective.capital.available_usd = decision.granted_available_usd.clone();
+    effective
+}
+
+fn persist_decision(
+    connection: &Connection,
+    decision: &RuntimeAllocatorDecisionRecord,
+) -> Result<(), RuntimeAllocatorError> {
+    connection.execute(
+        "INSERT INTO allocator_decisions (
+            decision_id,
+            run_id,
+            deployment_id,
+            sleeve_id,
+            constrained,
+            decided_at,
+            record_json
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            &decision.decision_id,
+            &decision.run_id,
+            &decision.deployment_id,
+            &decision.sleeve_id,
+            if decision.constrained { 1 } else { 0 },
+            &decision.decided_at,
+            serialize_json(decision)?,
+        ],
+    )?;
+    Ok(())
+}
+
+fn load_decision_by_run_id(
+    connection: &Connection,
+    run_id: &str,
+) -> Result<Option<RuntimeAllocatorDecisionRecord>, RuntimeAllocatorError> {
+    let raw = connection
+        .query_row(
+            "SELECT record_json
+             FROM allocator_decisions
+             WHERE run_id = ?1",
+            params![run_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    Ok(raw.map(|value| deserialize_json(&value)).transpose()?)
+}
+
+#[derive(Debug, Clone)]
+struct RankedDeployment {
+    deployment: RuntimeDeploymentRecord,
+    priority_score: i64,
+}
+
+fn deployment_is_eligible_for_grant(deployment: &RuntimeDeploymentRecord) -> bool {
+    matches!(
+        deployment.state,
+        RuntimeDeploymentState::Shadow
+            | RuntimeDeploymentState::Paper
+            | RuntimeDeploymentState::Live
+    )
+}
+
+fn allocator_priority_score(deployment: &RuntimeDeploymentRecord) -> i64 {
+    let override_score = deployment
+        .tags
+        .iter()
+        .find_map(|tag| parse_allocator_priority_override(tag))
+        .unwrap_or(0);
+    override_score
+        + mode_priority(&deployment.mode)
+        + lane_priority(&deployment.lane)
+        + strategy_priority(&deployment.strategy_key)
+}
+
+fn parse_allocator_priority_override(tag: &str) -> Option<i64> {
+    let trimmed = tag.trim();
+    let raw = trimmed.strip_prefix("allocator:priority=")?;
+    match raw {
+        "critical" => Some(1_000),
+        "high" => Some(750),
+        "normal" => Some(500),
+        "low" => Some(250),
+        _ => raw.parse::<i64>().ok(),
+    }
+}
+
+fn mode_priority(mode: &RuntimeMode) -> i64 {
+    match mode {
+        RuntimeMode::Live => 300,
+        RuntimeMode::Paper => 200,
+        RuntimeMode::Shadow => 100,
+    }
+}
+
+fn lane_priority(lane: &RuntimeLane) -> i64 {
+    match lane {
+        RuntimeLane::Safe => 30,
+        RuntimeLane::Protected => 20,
+        RuntimeLane::Fast => 10,
+    }
+}
+
+fn strategy_priority(strategy_key: &str) -> i64 {
+    match strategy_key {
+        "threshold_rebalance" => 9,
+        "volatility_target" => 8,
+        "macro_rotation" => 7,
+        "dca" => 6,
+        "twap" => 5,
+        "breakout" => 4,
+        "trend_following" => 3,
+        "mean_reversion" => 2,
+        _ => 1,
+    }
+}
+
+fn effective_reserved_cents(
+    deployment: &RuntimeDeploymentRecord,
+) -> Result<i64, RuntimeAllocatorError> {
+    let reserved_cents =
+        parse_non_negative_usd_cents("capital.reservedUsd", &deployment.capital.reserved_usd)?;
+    Ok(
+        if matches!(
+            deployment.state,
+            RuntimeDeploymentState::Killed | RuntimeDeploymentState::Archived
+        ) {
+            0
+        } else {
+            reserved_cents
+        },
+    )
+}
+
+fn build_decision_id(run_id: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(run_id.as_bytes());
+    let digest = hasher.finalize();
+    format!("alloc_{}", hex_encode(&digest[..12]))
+}
+
+fn normalize_database_path(database_url: &str) -> PathBuf {
+    let trimmed = database_url.trim();
+    if trimmed.is_empty() {
+        return PathBuf::from(".tmp/runtime-rs/runtime-allocator.sqlite3");
+    }
+    if let Some(stripped) = trimmed.strip_prefix("sqlite://") {
+        return PathBuf::from(stripped);
+    }
+    if let Some(stripped) = trimmed.strip_prefix("file:") {
+        return PathBuf::from(stripped);
+    }
+    PathBuf::from(trimmed)
+}
+
+fn fallback_database_path() -> PathBuf {
+    std::env::temp_dir()
+        .join("runtime-rs")
+        .join("runtime-allocator.sqlite3")
+}
+
+fn should_fallback_to_tmp(database_path: &Path, error: &RuntimeAllocatorError) -> bool {
+    if database_path == Path::new(":memory:") || database_path == fallback_database_path() {
+        return false;
+    }
+
+    match error {
+        RuntimeAllocatorError::Io(inner) => inner.kind() == std::io::ErrorKind::PermissionDenied,
+        RuntimeAllocatorError::Storage(inner) => {
+            matches!(
+                inner,
+                rusqlite::Error::SqliteFailure(code, _)
+                    if code.code == rusqlite::ErrorCode::CannotOpen
+            )
+        }
+        RuntimeAllocatorError::Serialization(_)
+        | RuntimeAllocatorError::InvalidUsdAmount { .. }
+        | RuntimeAllocatorError::DecisionNotFound { .. } => false,
+    }
+}
+
+fn parse_usd_cents(field: &'static str, value: &str) -> Result<i64, RuntimeAllocatorError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(RuntimeAllocatorError::InvalidUsdAmount {
+            field,
+            value: trimmed.to_string(),
+        });
+    }
+
+    let (sign, digits) = if let Some(rest) = trimmed.strip_prefix('-') {
+        (-1_i64, rest)
+    } else if let Some(rest) = trimmed.strip_prefix('+') {
+        (1_i64, rest)
+    } else {
+        (1_i64, trimmed)
+    };
+
+    let (whole_raw, fraction_raw) = digits.split_once('.').unwrap_or((digits, ""));
+    if whole_raw.is_empty()
+        || !whole_raw.chars().all(|character| character.is_ascii_digit())
+        || !fraction_raw
+            .chars()
+            .all(|character| character.is_ascii_digit())
+    {
+        return Err(RuntimeAllocatorError::InvalidUsdAmount {
+            field,
+            value: trimmed.to_string(),
+        });
+    }
+
+    let whole = whole_raw
+        .parse::<i64>()
+        .map_err(|_| RuntimeAllocatorError::InvalidUsdAmount {
+            field,
+            value: trimmed.to_string(),
+        })?;
+    let fraction_bytes = fraction_raw.as_bytes();
+    let tenths = fraction_bytes
+        .first()
+        .map(|digit| i64::from(digit - b'0'))
+        .unwrap_or(0);
+    let hundredths = fraction_bytes
+        .get(1)
+        .map(|digit| i64::from(digit - b'0'))
+        .unwrap_or(0);
+    let mut fraction = tenths * 10 + hundredths;
+    if fraction_bytes.get(2).is_some_and(|digit| *digit >= b'5') {
+        fraction += 1;
+    }
+
+    let cents = whole
+        .checked_mul(100)
+        .and_then(|value| value.checked_add(fraction))
+        .ok_or_else(|| RuntimeAllocatorError::InvalidUsdAmount {
+            field,
+            value: trimmed.to_string(),
+        })?;
+    Ok(sign * cents)
+}
+
+fn parse_non_negative_usd_cents(
+    field: &'static str,
+    value: &str,
+) -> Result<i64, RuntimeAllocatorError> {
+    let cents = parse_usd_cents(field, value)?;
+    if cents < 0 {
+        return Err(RuntimeAllocatorError::InvalidUsdAmount {
+            field,
+            value: value.trim().to_string(),
+        });
+    }
+    Ok(cents)
+}
+
+fn format_usd_cents(value: i64) -> String {
+    let sign = if value < 0 { "-" } else { "" };
+    let absolute = value.abs();
+    format!("{sign}{}.{:02}", absolute / 100, absolute % 100)
+}
+
+fn serialize_json<T: Serialize>(value: &T) -> Result<String, serde_json::Error> {
+    serde_json::to_string(value)
+}
+
+fn deserialize_json<T: for<'de> Deserialize<'de>>(raw: &str) -> Result<T, serde_json::Error> {
+    serde_json::from_str(raw)
+}
+
+fn hex_encode(input: &[u8]) -> String {
+    let mut output = String::with_capacity(input.len() * 2);
+    for byte in input {
+        use std::fmt::Write as _;
+        let _ = write!(&mut output, "{byte:02x}");
+    }
+    output
+}
+
+fn now_rfc3339() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .expect("current time to format")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use protocol::{
+        RuntimeCapital, RuntimeDeploymentState, RuntimeLane, RuntimeMode, RuntimePair,
+        RuntimePolicy,
+    };
+
+    use super::*;
+
+    fn temp_database_url(test_name: &str) -> String {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        std::env::temp_dir()
+            .join(format!("runtime-allocator-{test_name}-{unique}.sqlite3"))
+            .display()
+            .to_string()
+    }
+
+    fn allocator(test_name: &str) -> RuntimeAllocator {
+        RuntimeAllocator::new(RuntimeAllocatorConfig::new(temp_database_url(test_name)))
+            .expect("allocator to initialize")
+    }
+
+    fn deployment(
+        deployment_id: &str,
+        strategy_key: &str,
+        mode: RuntimeMode,
+        lane: RuntimeLane,
+        allocated_usd: &str,
+        reserved_usd: &str,
+        tags: &[&str],
+    ) -> RuntimeDeploymentRecord {
+        RuntimeDeploymentRecord {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            deployment_id: deployment_id.to_string(),
+            strategy_key: strategy_key.to_string(),
+            sleeve_id: "sleeve_alpha".to_string(),
+            owner_user_id: "user_123".to_string(),
+            pair: RuntimePair {
+                symbol: "SOL/USDC".to_string(),
+                base_mint: "So11111111111111111111111111111111111111112".to_string(),
+                quote_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+            },
+            mode,
+            state: RuntimeDeploymentState::Shadow,
+            lane,
+            created_at: "2026-03-10T18:00:00Z".to_string(),
+            updated_at: "2026-03-10T18:00:00Z".to_string(),
+            promoted_at: None,
+            paused_at: None,
+            killed_at: None,
+            policy: RuntimePolicy {
+                max_notional_usd: reserved_usd.to_string(),
+                daily_loss_limit_usd: "25.00".to_string(),
+                max_slippage_bps: 50,
+                max_concurrent_runs: 1,
+                rebalance_tolerance_bps: 100,
+            },
+            capital: RuntimeCapital {
+                allocated_usd: allocated_usd.to_string(),
+                reserved_usd: reserved_usd.to_string(),
+                available_usd: "0.00".to_string(),
+            },
+            tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn allocates_full_grants_when_capacity_is_available() {
+        let allocator = allocator("full-grant");
+        let alpha = deployment(
+            "deployment_alpha",
+            "dca",
+            RuntimeMode::Paper,
+            RuntimeLane::Safe,
+            "60.00",
+            "15.00",
+            &[],
+        );
+        let beta = deployment(
+            "deployment_beta",
+            "threshold_rebalance",
+            RuntimeMode::Shadow,
+            RuntimeLane::Safe,
+            "40.00",
+            "10.00",
+            &[],
+        );
+
+        let result = allocator
+            .allocate_and_store(&RuntimeAllocatorInput {
+                run_id: "run_alpha".to_string(),
+                deployment: alpha.clone(),
+                sleeve_equity_usd: "100.00".to_string(),
+                sleeve_deployments: vec![alpha, beta],
+            })
+            .expect("decision to store");
+
+        assert!(result.created);
+        assert_eq!(result.decision.granted_allocated_usd, "60.00");
+        assert_eq!(result.decision.granted_reserved_usd, "15.00");
+        assert!(!result.decision.constrained);
+    }
+
+    #[test]
+    fn clamps_lower_priority_deployments_when_requests_exceed_capacity() {
+        let allocator = allocator("clamped");
+        let high = deployment(
+            "deployment_high",
+            "threshold_rebalance",
+            RuntimeMode::Live,
+            RuntimeLane::Safe,
+            "60.00",
+            "25.00",
+            &[],
+        );
+        let low = deployment(
+            "deployment_low",
+            "trend_following",
+            RuntimeMode::Shadow,
+            RuntimeLane::Fast,
+            "50.00",
+            "20.00",
+            &[],
+        );
+
+        let result = allocator
+            .allocate_and_store(&RuntimeAllocatorInput {
+                run_id: "run_low".to_string(),
+                deployment: low.clone(),
+                sleeve_equity_usd: "80.00".to_string(),
+                sleeve_deployments: vec![low, high],
+            })
+            .expect("decision to store");
+
+        assert!(result.created);
+        assert_eq!(result.decision.granted_allocated_usd, "20.00");
+        assert_eq!(result.decision.granted_reserved_usd, "20.00");
+        assert!(result.decision.constrained);
+        assert_eq!(result.decision.priority_rank, 2);
+        assert_eq!(result.decision.peer_grants[0].deployment_id, "deployment_high");
+        assert_eq!(
+            result.effective_deployment.capital.allocated_usd,
+            "20.00"
+        );
+    }
+
+    #[test]
+    fn honors_explicit_priority_tag_overrides() {
+        let allocator = allocator("priority-tag");
+        let normal = deployment(
+            "deployment_normal",
+            "threshold_rebalance",
+            RuntimeMode::Live,
+            RuntimeLane::Safe,
+            "55.00",
+            "20.00",
+            &[],
+        );
+        let boosted = deployment(
+            "deployment_boosted",
+            "mean_reversion",
+            RuntimeMode::Shadow,
+            RuntimeLane::Fast,
+            "55.00",
+            "20.00",
+            &["allocator:priority=critical"],
+        );
+
+        let result = allocator
+            .allocate_and_store(&RuntimeAllocatorInput {
+                run_id: "run_boosted".to_string(),
+                deployment: boosted.clone(),
+                sleeve_equity_usd: "60.00".to_string(),
+                sleeve_deployments: vec![normal, boosted],
+            })
+            .expect("decision to store");
+
+        assert_eq!(result.decision.priority_rank, 1);
+        assert_eq!(result.decision.granted_allocated_usd, "55.00");
+        assert!(!result.decision.constrained);
+    }
+}

--- a/crates/runtime-allocator/src/lib.rs
+++ b/crates/runtime-allocator/src/lib.rs
@@ -192,11 +192,10 @@ impl RuntimeAllocator {
 
     fn snapshot_counts(&self) -> Result<(u64, u64, Option<String>), RuntimeAllocatorError> {
         let connection = self.open_connection()?;
-        let decision_count = connection.query_row(
-            "SELECT COUNT(*) FROM allocator_decisions",
-            [],
-            |row| row.get::<_, u64>(0),
-        )?;
+        let decision_count =
+            connection.query_row("SELECT COUNT(*) FROM allocator_decisions", [], |row| {
+                row.get::<_, u64>(0)
+            })?;
         let constrained_decision_count = connection.query_row(
             "SELECT COUNT(*) FROM allocator_decisions WHERE constrained = 1",
             [],
@@ -212,7 +211,11 @@ impl RuntimeAllocator {
                 |row| row.get::<_, String>(0),
             )
             .optional()?;
-        Ok((decision_count, constrained_decision_count, latest_decision_at))
+        Ok((
+            decision_count,
+            constrained_decision_count,
+            latest_decision_at,
+        ))
     }
 
     fn open_connection(&self) -> Result<Connection, RuntimeAllocatorError> {
@@ -273,7 +276,11 @@ fn build_decision(
         right
             .priority_score
             .cmp(&left.priority_score)
-            .then_with(|| left.deployment.deployment_id.cmp(&right.deployment.deployment_id))
+            .then_with(|| {
+                left.deployment
+                    .deployment_id
+                    .cmp(&right.deployment.deployment_id)
+            })
     });
 
     let mut total_requested_allocated_cents = 0_i64;
@@ -332,14 +339,10 @@ fn build_decision(
         total_granted_reserved_cents +=
             parse_non_negative_usd_cents("grantedReservedUsd", &grant.granted_reserved_usd)?;
     }
-    let target_granted_allocated_cents = parse_non_negative_usd_cents(
-        "grantedAllocatedUsd",
-        &target_grant.granted_allocated_usd,
-    )?;
-    let target_granted_reserved_cents = parse_non_negative_usd_cents(
-        "grantedReservedUsd",
-        &target_grant.granted_reserved_usd,
-    )?;
+    let target_granted_allocated_cents =
+        parse_non_negative_usd_cents("grantedAllocatedUsd", &target_grant.granted_allocated_usd)?;
+    let target_granted_reserved_cents =
+        parse_non_negative_usd_cents("grantedReservedUsd", &target_grant.granted_reserved_usd)?;
 
     Ok(RuntimeAllocatorDecisionRecord {
         schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
@@ -573,7 +576,9 @@ fn parse_usd_cents(field: &'static str, value: &str) -> Result<i64, RuntimeAlloc
 
     let (whole_raw, fraction_raw) = digits.split_once('.').unwrap_or((digits, ""));
     if whole_raw.is_empty()
-        || !whole_raw.chars().all(|character| character.is_ascii_digit())
+        || !whole_raw
+            .chars()
+            .all(|character| character.is_ascii_digit())
         || !fraction_raw
             .chars()
             .all(|character| character.is_ascii_digit())
@@ -801,11 +806,11 @@ mod tests {
         assert_eq!(result.decision.granted_reserved_usd, "20.00");
         assert!(result.decision.constrained);
         assert_eq!(result.decision.priority_rank, 2);
-        assert_eq!(result.decision.peer_grants[0].deployment_id, "deployment_high");
         assert_eq!(
-            result.effective_deployment.capital.allocated_usd,
-            "20.00"
+            result.decision.peer_grants[0].deployment_id,
+            "deployment_high"
         );
+        assert_eq!(result.effective_deployment.capital.allocated_usd, "20.00");
     }
 
     #[test]

--- a/crates/runtime-scorecards/src/lib.rs
+++ b/crates/runtime-scorecards/src/lib.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use protocol::{
+    RuntimeAllocatorDecisionRecord, RuntimeAllocatorScorecard,
     RuntimeDeploymentRecord, RuntimeDeploymentState, RuntimeExecutionPlan,
     RuntimeExpectedObservedScorecard, RuntimeLedgerSnapshot, RuntimeMode,
     RuntimePlanQualityScorecard, RuntimePnlScorecard, RuntimePromotionGateCheck,
@@ -53,6 +54,7 @@ pub struct RuntimeScorecardInput {
     pub runs: Vec<RuntimeRunRecord>,
     pub verdicts: Vec<RuntimeRiskVerdict>,
     pub plans: Vec<RuntimeExecutionPlan>,
+    pub allocator_decisions: Vec<RuntimeAllocatorDecisionRecord>,
     pub submit_attempt_count: u64,
     pub receipt_count: u64,
     pub reconciliations: Vec<RuntimeReconciliationResult>,
@@ -188,6 +190,22 @@ fn build_scorecard(
                 .any(|reason| reason.code == "kill_switch_active")
         })
         .count() as u64;
+    let allocator_decision_count = input.allocator_decisions.len() as u64;
+    let allocator_full_grant_count = input
+        .allocator_decisions
+        .iter()
+        .filter(|decision| !decision.constrained)
+        .count() as u64;
+    let allocator_constrained_count = input
+        .allocator_decisions
+        .iter()
+        .filter(|decision| decision.constrained)
+        .count() as u64;
+    let allocator_zero_grant_count = input
+        .allocator_decisions
+        .iter()
+        .filter(|decision| decision.granted_reserved_usd == "0.00")
+        .count() as u64;
 
     let latest_ledger = latest_ledger_snapshot(input);
     let (
@@ -270,6 +288,16 @@ fn build_scorecard(
             stale_feature_reject_count,
             concentration_reject_count,
             kill_switch_pause_count,
+        },
+        allocator: RuntimeAllocatorScorecard {
+            decision_count: allocator_decision_count,
+            full_grant_count: allocator_full_grant_count,
+            constrained_count: allocator_constrained_count,
+            zero_grant_count: allocator_zero_grant_count,
+            full_grant_rate_bps: ratio_bps(
+                allocator_full_grant_count,
+                allocator_decision_count,
+            ),
         },
     })
 }
@@ -354,6 +382,14 @@ fn shadow_to_paper_gate(
             scorecard.trigger_quality.stale_feature_reject_count,
             config.signal_max_stale_feature_rejects,
             "Signal-driven templates require fresh feature inputs for every shadow evidence run.",
+        ));
+    }
+    if allocator_coordination_required(&input.deployment) {
+        checks.push(maximum_check(
+            "shadow-allocator-zero-grant-runs",
+            scorecard.allocator.zero_grant_count,
+            0,
+            "Allocator zero-grant outcomes block promotion until sleeve coordination is stable.",
         ));
     }
 
@@ -463,6 +499,20 @@ fn paper_to_live_gate(
             "Signal-driven templates require fresh feature inputs for every paper evidence run.",
         ));
     }
+    if allocator_coordination_required(&input.deployment) {
+        checks.push(maximum_check(
+            "paper-allocator-constrained-runs",
+            scorecard.allocator.constrained_count,
+            0,
+            "Allocator-constrained paper runs block bounded live promotion.",
+        ));
+        checks.push(maximum_check(
+            "paper-allocator-zero-grant-runs",
+            scorecard.allocator.zero_grant_count,
+            0,
+            "Allocator zero-grant paper runs block bounded live promotion.",
+        ));
+    }
 
     Ok(gate_from_checks(
         RuntimeMode::Paper,
@@ -508,6 +558,13 @@ fn advanced_strategy_requires_extended_evidence(deployment: &RuntimeDeploymentRe
     matches!(
         deployment.strategy_key.as_str(),
         "breakout" | "macro_rotation" | "volatility_target"
+    )
+}
+
+fn allocator_coordination_required(deployment: &RuntimeDeploymentRecord) -> bool {
+    !matches!(
+        deployment.state,
+        RuntimeDeploymentState::Killed | RuntimeDeploymentState::Archived
     )
 }
 
@@ -701,6 +758,13 @@ fn build_proof_artifact_markdown(
     markdown.push_str(&format!(
         "- Risk verdicts: {} allow, {} reject, {} pause\n",
         scorecard.risk.allow_count, scorecard.risk.reject_count, scorecard.risk.pause_count,
+    ));
+    markdown.push_str(&format!(
+        "- Allocator: {} decisions, {} constrained, {} zero-grant ({})\n",
+        scorecard.allocator.decision_count,
+        scorecard.allocator.constrained_count,
+        scorecard.allocator.zero_grant_count,
+        format_bps(scorecard.allocator.full_grant_rate_bps),
     ));
     markdown.push_str(&format!(
         "- Latest PnL: total {}, realized {}, unrealized {}, max drawdown {}\n",
@@ -965,6 +1029,7 @@ mod tests {
                 runs,
                 verdicts,
                 plans,
+                allocator_decisions: vec![],
                 submit_attempt_count: 3,
                 receipt_count: 3,
                 reconciliations,
@@ -1052,6 +1117,7 @@ mod tests {
                 runs,
                 verdicts,
                 plans,
+                allocator_decisions: vec![],
                 submit_attempt_count: 5,
                 receipt_count: 5,
                 reconciliations,
@@ -1141,6 +1207,7 @@ mod tests {
                 runs,
                 verdicts,
                 plans,
+                allocator_decisions: vec![],
                 submit_attempt_count: 5,
                 receipt_count: 5,
                 reconciliations,
@@ -1221,6 +1288,7 @@ mod tests {
                 runs,
                 verdicts,
                 plans,
+                allocator_decisions: vec![],
                 submit_attempt_count: 2,
                 receipt_count: 2,
                 reconciliations,
@@ -1303,6 +1371,7 @@ mod tests {
                 runs,
                 verdicts,
                 plans,
+                allocator_decisions: vec![],
                 submit_attempt_count: 4,
                 receipt_count: 4,
                 reconciliations,
@@ -1379,6 +1448,7 @@ mod tests {
                 runs,
                 verdicts,
                 plans,
+                allocator_decisions: vec![],
                 submit_attempt_count: 3,
                 receipt_count: 3,
                 reconciliations,
@@ -1461,6 +1531,7 @@ mod tests {
                 runs,
                 verdicts,
                 plans,
+                allocator_decisions: vec![],
                 submit_attempt_count: 6,
                 receipt_count: 6,
                 reconciliations,
@@ -1486,6 +1557,78 @@ mod tests {
             .iter()
             .any(|check| check.gate_id == "paper-advanced-min-runs"
                 && check.status == RuntimePromotionGateStatus::Pass));
+    }
+
+    #[test]
+    fn blocks_live_promotion_when_allocator_constrains_paper_runs() {
+        let deployment = deployment(
+            "deployment_allocator_paper",
+            RuntimeMode::Paper,
+            RuntimeDeploymentState::Paper,
+        );
+        let runs = (1..=5)
+            .map(|index| {
+                run(
+                    &format!("run_allocator_{index}"),
+                    RuntimeRunState::Completed,
+                    trigger("operator"),
+                )
+            })
+            .collect::<Vec<_>>();
+        let verdicts = runs
+            .iter()
+            .map(|run| allow_verdict(&deployment, run))
+            .collect::<Vec<_>>();
+        let plans = runs
+            .iter()
+            .map(|run| plan(&deployment, run, true, false))
+            .collect::<Vec<_>>();
+        let reconciliations = runs
+            .iter()
+            .map(|run| reconciliation(&deployment, run, RuntimeReconciliationStatus::Passed, false))
+            .collect::<Vec<_>>();
+        let snapshots = vec![ledger_snapshot(
+            &deployment,
+            "1000.00",
+            "5.00",
+            "995.00",
+            "1.00",
+            "0.00",
+            "2026-03-08T10:00:00Z",
+        )];
+        let allocator_decisions = vec![
+            allocator_decision(&deployment, &runs[0], false, "25.00", "5.00"),
+            allocator_decision(&deployment, &runs[1], true, "20.00", "4.00"),
+        ];
+
+        let report = build_readiness_report(
+            &RuntimeScorecardConfig::default(),
+            &RuntimeScorecardInput {
+                deployment,
+                runs,
+                verdicts,
+                plans,
+                allocator_decisions,
+                submit_attempt_count: 5,
+                receipt_count: 5,
+                reconciliations,
+                observed_ledger_snapshots: snapshots.clone(),
+                latest_ledger_snapshot: snapshots.last().cloned(),
+            },
+        )
+        .expect("report to build");
+
+        assert_eq!(report.scorecard.allocator.decision_count, 2);
+        assert_eq!(report.scorecard.allocator.constrained_count, 1);
+        assert_eq!(
+            report.promotion_gates[1].status,
+            RuntimePromotionGateStatus::Blocked
+        );
+        assert!(report.promotion_gates[1]
+            .checks
+            .iter()
+            .any(|check| check.gate_id == "paper-allocator-constrained-runs"
+                && check.status == RuntimePromotionGateStatus::Blocked));
     }
 
     fn deployment(
@@ -1709,6 +1852,45 @@ mod tests {
             position_delta_usd: "0.00".to_string(),
             notes: vec![],
             correction_applied,
+        }
+    }
+
+    fn allocator_decision(
+        deployment: &RuntimeDeploymentRecord,
+        run: &RuntimeRunRecord,
+        constrained: bool,
+        granted_allocated_usd: &str,
+        granted_reserved_usd: &str,
+    ) -> RuntimeAllocatorDecisionRecord {
+        RuntimeAllocatorDecisionRecord {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            decision_id: format!("alloc_{}", run.run_id),
+            run_id: run.run_id.clone(),
+            deployment_id: deployment.deployment_id.clone(),
+            sleeve_id: deployment.sleeve_id.clone(),
+            decided_at: "2026-03-08T10:00:00Z".to_string(),
+            sleeve_equity_usd: "1000.00".to_string(),
+            total_requested_allocated_usd: "1000.00".to_string(),
+            total_granted_allocated_usd: "1000.00".to_string(),
+            total_requested_reserved_usd: "25.00".to_string(),
+            total_granted_reserved_usd: if constrained {
+                "24.00".to_string()
+            } else {
+                "25.00".to_string()
+            },
+            requested_allocated_usd: deployment.capital.allocated_usd.clone(),
+            granted_allocated_usd: granted_allocated_usd.to_string(),
+            requested_reserved_usd: deployment.capital.reserved_usd.clone(),
+            granted_reserved_usd: granted_reserved_usd.to_string(),
+            granted_available_usd: if constrained {
+                "16.00".to_string()
+            } else {
+                "20.00".to_string()
+            },
+            priority_rank: 1,
+            priority_score: 100,
+            constrained,
+            peer_grants: vec![],
         }
     }
 

--- a/crates/runtime-scorecards/src/lib.rs
+++ b/crates/runtime-scorecards/src/lib.rs
@@ -1,14 +1,14 @@
 use std::collections::HashMap;
 
 use protocol::{
-    RuntimeAllocatorDecisionRecord, RuntimeAllocatorScorecard,
-    RuntimeDeploymentRecord, RuntimeDeploymentState, RuntimeExecutionPlan,
-    RuntimeExpectedObservedScorecard, RuntimeLedgerSnapshot, RuntimeMode,
-    RuntimePlanQualityScorecard, RuntimePnlScorecard, RuntimePromotionGateCheck,
-    RuntimePromotionGateDecision, RuntimePromotionGateStatus, RuntimePromotionReadinessReport,
-    RuntimeReconciliationResult, RuntimeReconciliationStatus, RuntimeRiskDecision,
-    RuntimeRiskScorecard, RuntimeRiskVerdict, RuntimeRunRecord, RuntimeRunState, RuntimeScorecard,
-    RuntimeTriggerQualityScorecard, RUNTIME_PROTOCOL_SCHEMA_VERSION,
+    RuntimeAllocatorDecisionRecord, RuntimeAllocatorScorecard, RuntimeDeploymentRecord,
+    RuntimeDeploymentState, RuntimeExecutionPlan, RuntimeExpectedObservedScorecard,
+    RuntimeLedgerSnapshot, RuntimeMode, RuntimePlanQualityScorecard, RuntimePnlScorecard,
+    RuntimePromotionGateCheck, RuntimePromotionGateDecision, RuntimePromotionGateStatus,
+    RuntimePromotionReadinessReport, RuntimeReconciliationResult, RuntimeReconciliationStatus,
+    RuntimeRiskDecision, RuntimeRiskScorecard, RuntimeRiskVerdict, RuntimeRunRecord,
+    RuntimeRunState, RuntimeScorecard, RuntimeTriggerQualityScorecard,
+    RUNTIME_PROTOCOL_SCHEMA_VERSION,
 };
 use thiserror::Error;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
@@ -294,10 +294,7 @@ fn build_scorecard(
             full_grant_count: allocator_full_grant_count,
             constrained_count: allocator_constrained_count,
             zero_grant_count: allocator_zero_grant_count,
-            full_grant_rate_bps: ratio_bps(
-                allocator_full_grant_count,
-                allocator_decision_count,
-            ),
+            full_grant_rate_bps: ratio_bps(allocator_full_grant_count, allocator_decision_count),
         },
     })
 }

--- a/docs/design-docs/autonomous-runtime-architecture.md
+++ b/docs/design-docs/autonomous-runtime-architecture.md
@@ -36,11 +36,14 @@ The design goal is simple:
 
 1. Runtime-rs ingests feeds and computes features.
 2. The strategy engine evaluates triggers and produces a deterministic run key.
-3. The risk engine evaluates freshness, exposure, reservation, and lane rules.
-4. The execution planner turns desired state into execution plans.
-5. The exec client coordinates submit, status, and receipt handling through
+3. The runtime allocator coordinates sleeve-level capital across peer
+   deployments and records an auditable grant decision.
+4. The risk engine evaluates freshness, exposure, reservation, and lane rules
+   against the coordinated deployment budget.
+5. The execution planner turns desired state into execution plans.
+6. The exec client coordinates submit, status, and receipt handling through
    private Worker-facing paths that preserve the existing domain contract.
-6. The reconciler updates runtime state and publishes derived read models as
+7. The reconciler updates runtime state and publishes derived read models as
    needed for terminal and admin surfaces.
 
 ## Runtime modules
@@ -72,6 +75,13 @@ The design goal is simple:
 - positions,
 - cost basis and PnL attribution,
 - capital availability checks.
+
+### `runtime_allocator`
+
+- sleeve-level capital coordination across deployments,
+- deterministic grant ordering and peer budget snapshots,
+- auditable allocator decisions for scorecards and operator review,
+- explicit failure signals when a deployment is capital-constrained.
 
 ### `risk_engine`
 
@@ -147,6 +157,7 @@ The first private route family is intentionally small:
 - `GET /api/internal/runtime/positions`
 - `GET /api/internal/runtime/pnl`
 - `GET /api/internal/runtime/scorecards`
+- `GET /api/internal/runtime/allocator`
 - `GET /api/internal/runtime/health`
 - `POST /api/internal/runtime/execution-plans`
 
@@ -181,8 +192,8 @@ Operator-facing runtime controls stay on the Worker boundary:
   shared schemas, fixtures, and contract tests are required before Worker and
   runtime coordination is allowed in production.
 - Capital leakage:
-  logical sleeve reservations prevent one deployment from spending another
-  deployment's capital in v1.
+  logical sleeve reservations plus allocator grants prevent one deployment from
+  spending another deployment's capital in v1.
 
 ## Related ADRs
 

--- a/docs/exec-plans/active/autonomous-runtime-rollout.md
+++ b/docs/exec-plans/active/autonomous-runtime-rollout.md
@@ -22,7 +22,7 @@
 | 3 | `#265`, `#266`, `#267` | Ledger, reservations, risk engine, execution planner, paper trading | Paper scorecards stable, unsafe orders rejected, proof bundle artifacts complete |
 | 4 | `#268`, `#269`, `#270`, `#271` | Reconciliation loop, scorecards, ops controls, first live runtime canary | Reconciliation passes, runtime canary stable, rollback controls verified |
 | 5 | `#272`, `#273`, `#274` | Operator visibility, managed template packs 1 and 2 | First live template pack is supportable and incident playbooks are proven |
-| 6 | `#275`, `#276` | Advanced templates and multi-strategy capital coordination | Strategy interaction is stable and capital control remains deterministic |
+| 6 | `#275`, `#276` | Advanced templates, allocator scorecards, and multi-strategy capital coordination | Strategy interaction is stable, allocator pressure is visible, and capital control remains deterministic |
 
 ## Phase-specific rollout notes
 
@@ -71,6 +71,9 @@
   without widening the public contract; promotion stays bounded to the same
   single-slice safe-lane live bridge, with extended shadow and paper evidence
   windows.
+- Phase 6 pack 2 adds sleeve-level allocator coordination and allocator
+  scorecards; paper constrained or zero-grant runs are live-promotion blockers
+  until capital budgets or priorities are corrected.
 - Do not treat phase 5 completion as arbitrary-strategy support; phase 6 still
   covers advanced templates and multi-strategy capital coordination.
 
@@ -90,3 +93,6 @@ Every issue in this program must preserve:
 
 UI or operator-surface issues also require browser proof through
 `bun run harness:proof`.
+
+Phase 6 allocator work must also include auditable allocator decisions and
+runtime/operator evidence showing sleeve coordination behavior.

--- a/docs/reliability/autonomous-runtime-ops-runbook.md
+++ b/docs/reliability/autonomous-runtime-ops-runbook.md
@@ -69,6 +69,7 @@ Verify:
 - feed freshness,
 - feature freshness and ingest lag,
 - strategy registry health and deployment/run counts,
+- allocator pressure and zero-grant behavior,
 - reconciliation backlog,
 - runtime canary status.
 
@@ -95,6 +96,9 @@ curl -fsS https://ralph-runtime-rs.fly.dev/api/internal/runtime/health \
   -H "authorization: Bearer ${RUNTIME_INTERNAL_SERVICE_TOKEN}"
 
 curl -fsS https://ralph-runtime-rs.fly.dev/api/internal/runtime/runs/<deployment-id> \
+  -H "authorization: Bearer ${RUNTIME_INTERNAL_SERVICE_TOKEN}"
+
+curl -fsS "https://ralph-runtime-rs.fly.dev/api/internal/runtime/allocator?deploymentId=<deployment-id>" \
   -H "authorization: Bearer ${RUNTIME_INTERNAL_SERVICE_TOKEN}"
 ```
 
@@ -204,6 +208,37 @@ For advanced templates, also verify:
 - no stale-feature rejects appear in the current promotion window
 - the replay artifact attached to the PR covers the same template and market
   regime being promoted
+- allocator scorecards show no paper zero-grant or constrained runs for the
+  candidate deployment
+
+### Review allocator pressure
+
+Use allocator review when:
+
+- multiple deployments share the same sleeve,
+- paper scorecards show constrained or zero-grant runs,
+- operators are considering a priority override before live rollout.
+
+Expected effect:
+
+- the current deployment grant and peer grants are inspectable,
+- sleeve equity pressure is explicit before any live promotion decision,
+- operator changes remain reversible through deployment edits or pause actions.
+
+Control-plane inspection path:
+
+```bash
+curl -fsS https://api.trader-ralph.com/api/admin/ops/runtime \
+  -H "authorization: Bearer ${ADMIN_TOKEN}"
+```
+
+Operator rules:
+
+- use the deployment tag `allocator:priority=<integer>` only with explicit
+  human review
+- prefer reducing allocated capital or pausing peers before raising priority
+- do not promote a deployment while allocator contention is still visible in
+  paper evidence
 
 Control-plane command:
 

--- a/services/runtime-rs/Cargo.toml
+++ b/services/runtime-rs/Cargo.toml
@@ -14,6 +14,7 @@ portfolio-ledger = { path = "../../crates/portfolio-ledger" }
 protocol = { path = "../../crates/protocol" }
 reconciler = { path = "../../crates/reconciler" }
 risk-engine = { path = "../../crates/risk-engine" }
+runtime-allocator = { path = "../../crates/runtime-allocator" }
 runtime-scorecards = { path = "../../crates/runtime-scorecards" }
 runtime-ops = { path = "../../crates/runtime-ops" }
 serde.workspace = true

--- a/services/runtime-rs/README.md
+++ b/services/runtime-rs/README.md
@@ -47,6 +47,19 @@ Promotion for advanced templates is stricter again:
 - replay evidence must cover the exact template behavior that would reach the
   bounded live bridge
 
+Allocator coordination now sits in front of risk and planning for any sleeve
+with multiple runtime deployments:
+
+- each evaluation records an auditable allocator decision for the deployment
+  and its peers in the same sleeve
+- allocator grants clamp requested allocated and reserved capital to the
+  current sleeve equity before risk and planning run
+- allocator priority is deterministic by mode, lane, strategy key, and
+  deployment id, with an operator escape hatch through the deployment tag
+  `allocator:priority=<integer>`
+- allocator scorecards surface constrained and zero-grant runs so live
+  promotion fails closed when capital contention appears in paper mode
+
 The bounded live bridge remains intentionally narrow in v1:
 
 - live runtime execution is allowlisted with
@@ -146,6 +159,7 @@ Route surface:
 - `GET /api/internal/runtime/positions?deploymentId=:deploymentId`
 - `GET /api/internal/runtime/pnl?deploymentId=:deploymentId`
 - `GET /api/internal/runtime/scorecards?deploymentId=:deploymentId`
+- `GET /api/internal/runtime/allocator?deploymentId=:deploymentId`
 
 Example shadow evaluation flow:
 
@@ -181,6 +195,17 @@ Operators should use the Worker as the public control plane:
 - `POST /api/admin/ops/runtime/deployments/:deploymentId/kill`
 - `POST /api/admin/ops/controls` with `runtime.shadowOnly=true` to keep the
   runtime shadow-only until live rollout is explicitly enabled in a later issue
+
+The runtime operator surface now includes allocator details for a deployment:
+
+- current grant allocated and reserved USD,
+- priority rank and priority score,
+- constrained versus full-grant status,
+- peer grants inside the same sleeve,
+- sleeve equity and aggregate grant totals.
+
+Operators should treat repeated constrained or zero-grant paper runs as a
+promotion blocker until capital budgets or priorities are corrected.
 
 The default runtime control baseline is:
 

--- a/services/runtime-rs/src/lib.rs
+++ b/services/runtime-rs/src/lib.rs
@@ -25,6 +25,9 @@ use risk_engine::{
     should_pause_runtime, RiskAssessmentInput, RiskEngine, RiskEngineConfig, RiskEngineError,
     RiskEngineSnapshot,
 };
+use runtime_allocator::{
+    RuntimeAllocator, RuntimeAllocatorConfig, RuntimeAllocatorError, RuntimeAllocatorSnapshot,
+};
 use runtime_ops::{health_snapshot, RuntimeConfig};
 use runtime_scorecards::{
     build_readiness_report, RuntimeScorecardConfig, RuntimeScorecardError, RuntimeScorecardInput,
@@ -66,6 +69,7 @@ pub struct RuntimeAppState {
     feature_cache: Arc<RwLock<FeatureCache>>,
     strategy_registry: StrategyRegistry,
     portfolio_ledger: PortfolioLedger,
+    runtime_allocator: RuntimeAllocator,
     risk_engine: RiskEngine,
     execution_planner: ExecutionPlanner,
     reconciler: Reconciler,
@@ -89,6 +93,9 @@ impl RuntimeAppState {
         let portfolio_ledger =
             PortfolioLedger::new(PortfolioLedgerConfig::new(config.database_url.clone()))
                 .expect("portfolio ledger to initialize");
+        let runtime_allocator =
+            RuntimeAllocator::new(RuntimeAllocatorConfig::new(config.database_url.clone()))
+                .expect("runtime allocator to initialize");
         let risk_engine = RiskEngine::new(RiskEngineConfig::new(
             config.database_url.clone(),
             config.feature_stale_after_ms,
@@ -114,6 +121,7 @@ impl RuntimeAppState {
             feature_cache,
             strategy_registry,
             portfolio_ledger,
+            runtime_allocator,
             risk_engine,
             execution_planner,
             reconciler,
@@ -146,6 +154,10 @@ impl RuntimeAppState {
         self.risk_engine.snapshot_now()
     }
 
+    fn runtime_allocator_snapshot(&self) -> RuntimeAllocatorSnapshot {
+        self.runtime_allocator.snapshot_now()
+    }
+
     fn execution_planner_snapshot(&self) -> ExecutionPlannerSnapshot {
         self.execution_planner.snapshot_now()
     }
@@ -173,6 +185,7 @@ pub struct RuntimeHealthResponse {
     pub feature_cache: FeatureCacheSnapshot,
     pub strategy_registry: StrategyRegistrySnapshot,
     pub portfolio_ledger: PortfolioLedgerSnapshot,
+    pub allocator: RuntimeAllocatorSnapshot,
     pub risk_engine: RiskEngineSnapshot,
     pub execution_planner: ExecutionPlannerSnapshot,
     pub reconciler: ReconcilerSnapshot,
@@ -191,6 +204,7 @@ pub struct RuntimeMetricsResponse {
     pub feature_cache: FeatureCacheSnapshot,
     pub strategy_registry: StrategyRegistrySnapshot,
     pub portfolio_ledger: PortfolioLedgerSnapshot,
+    pub allocator: RuntimeAllocatorSnapshot,
     pub risk_engine: RiskEngineSnapshot,
     pub execution_planner: ExecutionPlannerSnapshot,
     pub reconciler: ReconcilerSnapshot,
@@ -208,6 +222,13 @@ struct RuntimeShadowEvaluationRequest {
 #[serde(rename_all = "camelCase")]
 struct RuntimeDeploymentQuery {
     pub deployment_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct RuntimeAllocatorQuery {
+    pub deployment_id: Option<String>,
+    pub sleeve_id: Option<String>,
 }
 
 pub fn app(config: RuntimeConfig) -> Router {
@@ -259,6 +280,10 @@ pub fn app(config: RuntimeConfig) -> Router {
             get(scorecards_handler),
         )
         .route(
+            &format!("{INTERNAL_RUNTIME_PREFIX}/allocator"),
+            get(allocator_handler),
+        )
+        .route(
             &format!("{INTERNAL_RUNTIME_PREFIX}/risk"),
             get(risk_handler),
         )
@@ -276,6 +301,7 @@ fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
     let feature_cache = state.feature_cache_snapshot();
     let strategy_registry = state.strategy_registry_snapshot();
     let portfolio_ledger = state.portfolio_ledger_snapshot();
+    let allocator = state.runtime_allocator_snapshot();
     let risk_engine = state.risk_engine_snapshot();
     let execution_planner = state.execution_planner_snapshot();
     let reconciler = state.reconciler_snapshot();
@@ -283,6 +309,7 @@ fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
         && feature_cache.status == "healthy"
         && strategy_registry.status == "healthy"
         && portfolio_ledger.status == "healthy"
+        && allocator.status == "healthy"
         && risk_engine.status == "healthy"
         && execution_planner.status == "healthy"
         && reconciler.status == "healthy"
@@ -307,6 +334,7 @@ fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
         feature_cache,
         strategy_registry,
         portfolio_ledger,
+        allocator,
         risk_engine,
         execution_planner,
         reconciler,
@@ -328,6 +356,7 @@ fn metrics_response(state: &RuntimeAppState) -> RuntimeMetricsResponse {
         feature_cache: state.feature_cache_snapshot(),
         strategy_registry: state.strategy_registry_snapshot(),
         portfolio_ledger: state.portfolio_ledger_snapshot(),
+        allocator: state.runtime_allocator_snapshot(),
         risk_engine: state.risk_engine_snapshot(),
         execution_planner: state.execution_planner_snapshot(),
         reconciler: state.reconciler_snapshot(),
@@ -549,16 +578,46 @@ async fn evaluate_deployment_handler(
             request.trigger,
         )
         .map_err(map_registry_error)?;
+    let ledger_snapshot = state
+        .portfolio_ledger
+        .snapshot_for_deployment(&deployment_id)
+        .map_err(map_ledger_error)?;
+    let sleeve_snapshot = state
+        .portfolio_ledger
+        .sleeve_snapshot(&result.deployment.sleeve_id)
+        .map_err(map_ledger_error)?
+        .ok_or_else(|| {
+            error_json(
+                StatusCode::NOT_FOUND,
+                "sleeve-not-found",
+                json!({ "sleeveId": result.deployment.sleeve_id }),
+            )
+        })?;
+    let sleeve_deployments = state
+        .strategy_registry
+        .list_deployments()
+        .map_err(map_registry_error)?
+        .into_iter()
+        .filter(|deployment| deployment.sleeve_id == result.deployment.sleeve_id)
+        .collect::<Vec<_>>();
+    let allocation = state
+        .runtime_allocator
+        .allocate_and_store(&runtime_allocator::RuntimeAllocatorInput {
+            run_id: result.run.run_id.clone(),
+            deployment: result.deployment.clone(),
+            sleeve_equity_usd: sleeve_snapshot.equity_usd.clone(),
+            sleeve_deployments,
+        })
+        .map_err(map_allocator_error)?;
+    let coordinated_deployment = allocation.effective_deployment.clone();
+    let allocator_decision = Some(allocation.decision.clone());
     let assessment = state
         .risk_engine
         .assess_and_store(&RiskAssessmentInput {
-            deployment: result.deployment.clone(),
+            deployment: coordinated_deployment.clone(),
             run: result.run.clone(),
             feature_snapshot: result.feature_snapshot.clone(),
-            ledger_snapshot: state
-                .portfolio_ledger
-                .snapshot_for_deployment(&deployment_id)
-                .map_err(map_ledger_error)?,
+            ledger_snapshot: ledger_snapshot.clone(),
             kill_switch_active: deployment_has_kill_switch(&result.deployment),
         })
         .map_err(map_risk_error)?;
@@ -571,10 +630,6 @@ async fn evaluate_deployment_handler(
     let mut reconciliation = None;
     let mut observed_ledger_snapshot = None;
     let mut coordinated_run = run.clone();
-    let ledger_snapshot = state
-        .portfolio_ledger
-        .snapshot_for_deployment(&deployment_id)
-        .map_err(map_ledger_error)?;
 
     if assessment.verdict.verdict == protocol::RuntimeRiskDecision::Allow {
         if let Some(plan_id) = coordinated_run.execution_plan_id.as_deref() {
@@ -604,7 +659,7 @@ async fn evaluate_deployment_handler(
             let planning = state
                 .execution_planner
                 .plan_and_store(&ExecutionPlannerInput {
-                    deployment: result.deployment.clone(),
+                    deployment: coordinated_deployment.clone(),
                     run: coordinated_run.clone(),
                     feature_snapshot: result.feature_snapshot.clone(),
                     ledger_snapshot: ledger_snapshot.clone(),
@@ -747,6 +802,7 @@ async fn evaluate_deployment_handler(
         risk_verdict: assessment.verdict,
         feature_snapshot: result.feature_snapshot,
         ledger_snapshot,
+        allocator_decision,
         execution_plan,
         coordination,
         reconciliation,
@@ -879,6 +935,10 @@ async fn scorecards_handler(
         .reconciler
         .bundle_for_deployment(&deployment_id)
         .map_err(map_reconciler_error)?;
+    let allocator_decisions = state
+        .runtime_allocator
+        .list_decisions_for_deployment(&deployment_id)
+        .map_err(map_allocator_error)?;
     let latest_ledger_snapshot = state
         .portfolio_ledger
         .snapshot_for_deployment(&deployment_id)
@@ -890,6 +950,7 @@ async fn scorecards_handler(
             runs,
             verdicts,
             plans,
+            allocator_decisions,
             submit_attempt_count: reconciliation_bundle.submit_attempts.len() as u64,
             receipt_count: reconciliation_bundle.receipts.len() as u64,
             reconciliations: reconciliation_bundle.results,
@@ -958,6 +1019,76 @@ async fn pnl_handler(
     ))
 }
 
+async fn allocator_handler(
+    headers: HeaderMap,
+    Query(query): Query<RuntimeAllocatorQuery>,
+    State(state): State<RuntimeAppState>,
+) -> HandlerResult {
+    authorize_internal_request(&headers, &state)?;
+
+    if let Some(deployment_id) = query.deployment_id.filter(|value| !value.trim().is_empty()) {
+        let deployment = state
+            .strategy_registry
+            .get_deployment(&deployment_id)
+            .map_err(map_registry_error)?
+            .ok_or_else(|| {
+                error_json(
+                    StatusCode::NOT_FOUND,
+                    "deployment-not-found",
+                    json!({ "deploymentId": deployment_id }),
+                )
+            })?;
+        let decisions = state
+            .runtime_allocator
+            .list_decisions_for_deployment(&deployment_id)
+            .map_err(map_allocator_error)?;
+        let sleeve = state
+            .portfolio_ledger
+            .sleeve_snapshot(&deployment.sleeve_id)
+            .map_err(map_ledger_error)?;
+        return Ok(OkJson::with_status(
+            StatusCode::OK,
+            json!({
+                "ok": true,
+                "source": "runtime-rs",
+                "deploymentId": deployment_id,
+                "sleeveId": deployment.sleeve_id,
+                "currentDecision": decisions.first(),
+                "decisions": decisions,
+                "sleeve": sleeve,
+            }),
+        ));
+    }
+
+    if let Some(sleeve_id) = query.sleeve_id.filter(|value| !value.trim().is_empty()) {
+        let decisions = state
+            .runtime_allocator
+            .list_decisions_for_sleeve(&sleeve_id)
+            .map_err(map_allocator_error)?;
+        let sleeve = state
+            .portfolio_ledger
+            .sleeve_snapshot(&sleeve_id)
+            .map_err(map_ledger_error)?;
+        return Ok(OkJson::with_status(
+            StatusCode::OK,
+            json!({
+                "ok": true,
+                "source": "runtime-rs",
+                "sleeveId": sleeve_id,
+                "currentDecision": decisions.first(),
+                "decisions": decisions,
+                "sleeve": sleeve,
+            }),
+        ));
+    }
+
+    Err(error_json(
+        StatusCode::BAD_REQUEST,
+        "allocator-query-required",
+        json!({ "fields": ["deploymentId", "sleeveId"] }),
+    ))
+}
+
 struct ShadowEvaluationResponse {
     created: bool,
     deployment: RuntimeDeploymentRecord,
@@ -965,6 +1096,7 @@ struct ShadowEvaluationResponse {
     risk_verdict: protocol::RuntimeRiskVerdict,
     feature_snapshot: feature_cache::DerivedMarketFeatureSnapshot,
     ledger_snapshot: protocol::RuntimeLedgerSnapshot,
+    allocator_decision: Option<protocol::RuntimeAllocatorDecisionRecord>,
     execution_plan: Option<protocol::RuntimeExecutionPlan>,
     coordination: Option<ExecSubmitResponse>,
     reconciliation: Option<protocol::RuntimeReconciliationResult>,
@@ -987,6 +1119,7 @@ fn shadow_evaluation_json(payload: ShadowEvaluationResponse) -> JsonPayload {
             "riskVerdict": payload.risk_verdict,
             "featureSnapshot": payload.feature_snapshot,
             "ledger": payload.ledger_snapshot,
+            "allocatorDecision": payload.allocator_decision,
             "executionPlan": payload.execution_plan,
             "coordination": payload.coordination,
             "reconciliation": payload.reconciliation,
@@ -1347,6 +1480,36 @@ fn map_exec_client_error(error: ExecClientError) -> JsonPayload {
             "message": error.message,
         }),
     )
+}
+
+fn map_allocator_error(error: RuntimeAllocatorError) -> JsonPayload {
+    match error {
+        RuntimeAllocatorError::InvalidUsdAmount { field, value } => error_json(
+            StatusCode::BAD_REQUEST,
+            "invalid-allocator-amount",
+            json!({ "field": field, "value": value }),
+        ),
+        RuntimeAllocatorError::DecisionNotFound { run_id } => error_json(
+            StatusCode::NOT_FOUND,
+            "allocator-decision-not-found",
+            json!({ "runId": run_id }),
+        ),
+        RuntimeAllocatorError::Io(error) => error_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "runtime-allocator-error",
+            json!({ "reason": error.to_string() }),
+        ),
+        RuntimeAllocatorError::Storage(error) => error_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "runtime-allocator-error",
+            json!({ "reason": error.to_string() }),
+        ),
+        RuntimeAllocatorError::Serialization(error) => error_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "runtime-allocator-error",
+            json!({ "reason": error.to_string() }),
+        ),
+    }
 }
 
 fn deployment_has_kill_switch(deployment: &RuntimeDeploymentRecord) -> bool {
@@ -1859,6 +2022,8 @@ mod tests {
         assert_eq!(payload.strategy_registry.deployment_count, 0);
         assert_eq!(payload.portfolio_ledger.status, "healthy");
         assert_eq!(payload.portfolio_ledger.deployment_count, 0);
+        assert_eq!(payload.allocator.status, "healthy");
+        assert_eq!(payload.allocator.decision_count, 0);
         assert_eq!(payload.risk_engine.status, "healthy");
         assert_eq!(payload.risk_engine.verdict_count, 0);
         assert_eq!(payload.execution_planner.status, "healthy");
@@ -1894,6 +2059,7 @@ mod tests {
         assert_eq!(payload.feature_cache.total_market_samples, 1);
         assert_eq!(payload.strategy_registry.status, "healthy");
         assert_eq!(payload.portfolio_ledger.status, "healthy");
+        assert_eq!(payload.allocator.status, "healthy");
         assert_eq!(payload.risk_engine.status, "healthy");
         assert_eq!(payload.execution_planner.status, "healthy");
         assert_eq!(payload.reconciler.status, "healthy");
@@ -1998,6 +2164,10 @@ mod tests {
         );
         assert_eq!(
             evaluation_payload["ledger"]["totals"]["reservedUsd"],
+            json!("125.00")
+        );
+        assert_eq!(
+            evaluation_payload["allocatorDecision"]["grantedReservedUsd"],
             json!("125.00")
         );
         assert_eq!(evaluation_payload["executionPlan"]["lane"], json!("safe"));
@@ -2157,6 +2327,10 @@ mod tests {
             json!(1)
         );
         assert_eq!(
+            scorecards_payload["report"]["scorecard"]["allocator"]["decisionCount"],
+            json!(1)
+        );
+        assert_eq!(
             scorecards_payload["report"]["promotionGates"][0]["targetMode"],
             json!("paper")
         );
@@ -2164,6 +2338,29 @@ mod tests {
             .as_str()
             .expect("markdown")
             .contains("Runtime Promotion Readiness"));
+
+        let allocator_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/internal/runtime/allocator?deploymentId=deployment_123")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(allocator_response.status(), StatusCode::OK);
+        let allocator_payload = read_json(allocator_response).await;
+        assert_eq!(allocator_payload["deploymentId"], json!("deployment_123"));
+        assert_eq!(
+            allocator_payload["currentDecision"]["deploymentId"],
+            json!("deployment_123")
+        );
+        assert_eq!(
+            allocator_payload["sleeve"]["availableUsd"],
+            json!("875.00")
+        );
     }
 
     #[tokio::test]

--- a/services/runtime-rs/src/lib.rs
+++ b/services/runtime-rs/src/lib.rs
@@ -2357,10 +2357,7 @@ mod tests {
             allocator_payload["currentDecision"]["deploymentId"],
             json!("deployment_123")
         );
-        assert_eq!(
-            allocator_payload["sleeve"]["availableUsd"],
-            json!("875.00")
-        );
+        assert_eq!(allocator_payload["sleeve"]["availableUsd"], json!("875.00"));
     }
 
     #[tokio::test]

--- a/tests/unit/worker_runtime_internal_routes.test.ts
+++ b/tests/unit/worker_runtime_internal_routes.test.ts
@@ -268,6 +268,7 @@ describe("worker runtime internal routes", () => {
         executionPlans: "/api/internal/runtime/execution-plans",
         health: "/api/internal/runtime/health",
         scorecards: "/api/internal/runtime/scorecards",
+        allocator: "/api/internal/runtime/allocator",
       },
     });
   });
@@ -674,6 +675,39 @@ describe("worker runtime internal routes", () => {
       sourceMode: "shadow",
       targetMode: "paper",
       status: "pass",
+    });
+  });
+
+  test("returns stubbed runtime allocator decisions", async () => {
+    const env = createWorkerLiveEnv();
+
+    const response = await worker.fetch(
+      new Request(
+        "http://localhost/api/internal/runtime/allocator?deploymentId=deployment_123",
+        {
+          headers: {
+            authorization: "Bearer runtime-service-secret",
+          },
+        },
+      ),
+      env,
+      createExecutionContextStub(),
+    );
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload).toMatchObject({
+      ok: true,
+      source: "stub",
+      deploymentId: "deployment_123",
+      currentDecision: {
+        deploymentId: "deployment_123",
+        grantedReservedUsd: "125.00",
+      },
+      sleeve: {
+        sleeveId: "sleeve_alpha",
+        availableUsd: "875.00",
+      },
     });
   });
 });


### PR DESCRIPTION
## Summary
- add a runtime allocator crate that coordinates sleeve capital across deployments and persists auditable allocator decisions
- integrate allocator grants into runtime-rs evaluation, scorecards, Worker runtime bridges, and the runtime operator UI
- document allocator routes, priority overrides, and promotion/ops expectations for multi-strategy coordination

## Validation
- `cargo test --workspace`
- `bun run lint`
- `bun run typecheck`
- `bun test tests/unit/worker_runtime_internal_routes.test.ts`
- `bun run harness:proof`

## Results
- `cargo test --workspace`: passed
- `bun run lint`: passed
- `bun run typecheck`: passed
- `bun test tests/unit/worker_runtime_internal_routes.test.ts`: passed
- `bun run harness:proof`: passed against `http://localhost:3180`

## Proof bundle
- local harness URLs:
  - portal: `http://localhost:3180`
  - worker health: `http://127.0.0.1:8980/api/health`
- browser proof summary: `/Users/guillaumebibeau-laviolette/github/serious-trader-ralph/.tmp/harness-proof/serious-trader-ralph-dd6d2404-2026-03-10T18-50-02-406Z/summary.md`
- browser proof report: `/Users/guillaumebibeau-laviolette/github/serious-trader-ralph/.tmp/harness-proof/serious-trader-ralph-dd6d2404-2026-03-10T18-50-02-406Z/playwright-report.json`
- screenshots:
  - `/Users/guillaumebibeau-laviolette/github/serious-trader-ralph/.tmp/harness-proof/serious-trader-ralph-dd6d2404-2026-03-10T18-50-02-406Z/screenshots/runtime-operator-home.png`
  - `/Users/guillaumebibeau-laviolette/github/serious-trader-ralph/.tmp/harness-proof/serious-trader-ralph-dd6d2404-2026-03-10T18-50-02-406Z/screenshots/runtime-operator-paused.png`
- runtime health verification used during local proof:
  - `bun run harness:status` reported portal and worker healthy for worktree `serious-trader-ralph-dd6d2404`

## Risk notes
- runtime allocator only affects the internal runtime path; the Worker remains the only public API boundary
- allocator priority overrides require explicit `allocator:priority=<integer>` deployment tags and human review
- runtime support inside local harness remains optional and disabled by default

Fixes #276
