### PR TITLE
Add strategy-lab workflow contract

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -70,6 +70,40 @@ When a run starts, add `agent-running`. When the PR is ready for review, remove
   gate.
 - Do not push directly to `dev` or `main`.
 
+## Strategy Lab Lifecycle
+
+The strategy-lab program adds explicit promotion states for strategies and
+separate onboarding states for venues and assets.
+
+Strategy promotion states:
+
+- `candidate`
+- `draft`
+- `shadow`
+- `paper`
+- `limited_live`
+- `broad_live`
+- `paused`
+- `deprecated`
+
+Venue and asset onboarding states stay separate from strategy promotion so the
+repo can distinguish a weak strategy from an unready venue or asset:
+
+- `candidate`
+- `integrated`
+- `shadow_ready`
+- `paper_ready`
+- `limited_live_ready`
+- `broad_live_ready`
+- `paused`
+- `deprecated`
+
+See:
+
+- `docs/product-specs/strategy-lab-prd.md`
+- `docs/exec-plans/active/strategy-lab-rollout.md`
+- `docs/reliability/strategy-lab-ops-runbook.md`
+
 ## Validation Requirements
 
 Always run the smallest relevant validation set and report the exact commands in
@@ -93,6 +127,15 @@ focused test suite is clearly sufficient. Examples:
 - deployment or environment changes: include the relevant smoke checks and any
   branch-specific verification notes
 
+For strategy-lab work, add the evaluation commands that match the promotion
+target. Examples:
+
+- candidate or draft docs-only: `bun run lint`
+- shadow readiness: relevant replay, backtest, or contract suites
+- paper readiness: paper simulation and scorecard checks
+- limited-live or broad-live promotion: canary or live-readiness checks and
+  explicit rollout notes
+
 ## Proof Bundle Requirements
 
 Every PR must include a proof bundle in its summary comment or description. The
@@ -107,6 +150,17 @@ bundle must include:
 
 If a proof item is not applicable, say so explicitly instead of omitting it.
 
+Strategy-lab proof bundles must also include the evidence bundle relevant to
+the target state transition:
+
+- source provenance and publication dates for `candidate` or `draft`
+- StrategySpec, replay, and backtest evidence for `shadow`
+- paper scorecards, cost assumptions, and reproducibility manifests for
+  `paper`
+- canary plans, risk budgets, venue and asset readiness, and named human
+  approval for `limited_live`
+- soak summaries and drift review for `broad_live`
+
 ## Approval Posture
 
 - This repo is operated in a high-trust mode for engineering execution.
@@ -115,6 +169,16 @@ If a proof item is not applicable, say so explicitly instead of omitting it.
   later issue.
 - Prefer reversible changes and call out any deployment or rollout risk in the
   PR summary.
+
+Money-state approval boundaries:
+
+- Merging a PR does not authorize real-money promotion by itself.
+- `shadow` may begin only after human-reviewed code merge.
+- `paper` requires explicit operator approval.
+- `limited_live` requires explicit human approval, allowlist changes, kill
+  controls, and bounded canary notes.
+- `broad_live` requires successful limited-live evidence and explicit human
+  approval.
 
 ## Secret Boundaries
 

--- a/docs/exec-plans/active/strategy-lab-rollout.md
+++ b/docs/exec-plans/active/strategy-lab-rollout.md
@@ -1,0 +1,86 @@
+# Strategy Lab Rollout Plan
+
+**Status:** Active  
+**Backlog owner:** GitHub issue epic `#304`
+
+## Rollout principles
+
+- Build through the current harness flow only.
+- Keep the Worker as the public edge for all operator and promotion controls.
+- Treat strategy, venue, and asset promotion as separate state machines.
+- Do not mark downstream issues `agent-ready` until dependency gates are
+  stable.
+- Stop at bounded limited-live validation before any broader live expansion.
+
+## Phase map
+
+| Phase | Issues | Deliverables | Exit gate |
+| --- | --- | --- | --- |
+| 0 | `#305`, `#306`, `#307` | Workflow contract, research registry, StrategySpec and plugin ABI | Research lifecycle and strategy ABI are explicit and backward-compatible |
+| 1 | `#308` to `#313` | Source intake, venue model, asset registry, data lake, cost models, feature catalog | Research inputs and evaluation substrate are reproducible |
+| 2 | `#314` to `#317` | Backtesting, paper simulator, scorecards, reproducibility bundles | Candidate evaluation is leakage-resistant and auditable |
+| 3 | `#318` to `#321` | Agentic retrieval, synthesis, triage, safety gates | Agent-generated candidates are bounded by explicit policy |
+| 4 | `#322` to `#325` | Promotion orchestration, onboarding canaries, expanded budgets, operator controls | Candidate to limited-live promotion is explicit and reversible |
+| 5 | `#326`, `#327` | First end-to-end pilot and post-live drift handling | One new strategy and one new venue or asset complete bounded live validation |
+
+## Phase-specific notes
+
+### Phase 0
+
+- Docs and contract work only.
+- No runtime behavior should widen in this phase.
+- Strategy, venue, and asset states must be explicit before implementation
+  begins.
+
+### Phase 1
+
+- Research intake and substrate only.
+- No strategy may reach money states from this phase alone.
+- Venue and asset adapters must fail closed when capability coverage is weak.
+
+### Phase 2
+
+- Evaluation only.
+- Backtests and paper runs must be reproducible from snapshot identifiers and
+  manifests.
+- Do not promote based on raw return without cost and robustness evidence.
+
+### Phase 3
+
+- Agentic discovery may generate candidates, not money-state promotions.
+- Newly synthesized strategies must clear policy and evidence gates before they
+  can reach shadow or paper.
+
+### Phase 4
+
+- Promotion logic becomes first-class.
+- Limited-live remains tiny-notional, allowlisted, and human-gated.
+- Venue and asset canaries must stay independent from strategy promotion where
+  possible.
+
+### Phase 5
+
+- Prove the system with one genuinely new strategy and one genuinely new venue
+  or asset.
+- Treat drift and rollback drills as part of the pilot, not a later cleanup.
+
+## Rollback posture
+
+- Use pause, kill, demotion, and allowlist removal before code rollback where
+  possible.
+- Revert the last merged PR when a code rollback is required.
+- Do not widen the public Worker contract as part of rollback.
+
+## Verification expectations
+
+Every issue in this program must preserve:
+
+- `bun run lint`
+- the smallest relevant validation set for the changed surface
+- explicit proof-bundle evidence in the PR
+
+UI or operator-surface issues also require browser proof through
+`bun run harness:proof`.
+
+Any issue that affects real-money promotion or canary behavior must also attach
+the relevant paper or live-canary evidence and risk notes.

--- a/docs/product-specs/strategy-lab-prd.md
+++ b/docs/product-specs/strategy-lab-prd.md
@@ -1,0 +1,201 @@
+# PRD: Trader Ralph Strategy Lab
+
+**Status:** Accepted for repo planning  
+**Date:** 2026-03-10  
+**Audience:** product, engineering, infra, ops, and harness execution
+
+## Summary
+
+Trader Ralph can now run a bounded managed-strategy stack through the harness,
+the Worker boundary, and the autonomous runtime. What it does not yet have is
+a repo-owned system for:
+
+- tracking the latest strategy and venue research with provenance,
+- converting research into candidate strategies, venues, and assets,
+- evaluating those candidates with reproducible evidence,
+- promoting them through shadow, paper, and bounded real-money states.
+
+The strategy-lab program keeps the current architecture intact:
+
+- the Worker remains the only public API boundary,
+- the harness remains the only supported delivery workflow,
+- new real-money capability stays human-gated and reversible.
+
+## Problem
+
+Without a repo-owned research-to-production contract, new strategy ideas,
+venues, and assets will be handled ad hoc. That creates four failure modes:
+
+- research provenance becomes untraceable,
+- strategy evaluation becomes irreproducible,
+- venue and asset onboarding become inconsistent,
+- real-money promotion can happen without explicit evidence boundaries.
+
+## Goals
+
+### Primary goals
+
+- Ingest current research with citations, dates, and provenance.
+- Convert research into candidate StrategySpecs and evaluation plans.
+- Support new strategies, venues, and assets through the same harness workflow.
+- Make promotion from candidate to limited live explicit, auditable, and
+  reversible.
+- Keep new real-money rollouts bounded by canaries, scorecards, and human
+  approval.
+
+### Non-goals for v1
+
+- fully unsupervised broad live rollout,
+- arbitrary user-authored executable code in production,
+- bypassing the Worker boundary for research or promotion controls,
+- promoting a new strategy, venue, or asset directly to broad live from a
+  research brief.
+
+## Product principles
+
+- One harness, one delivery model:
+  issue -> PR preview -> `main` -> bounded production rollout.
+- Research is a first-class artifact:
+  source provenance, experiment manifests, and scorecards must survive review.
+- Promotion is stateful:
+  candidate, shadow, paper, and real-money states are explicit objects, not
+  comments or tribal knowledge.
+- Money gates are human gates:
+  the system may prepare and validate, but humans must authorize real-money
+  promotion.
+- Rollback must be faster than rollout:
+  every production-facing state requires a pause, demotion, or kill path.
+
+## Strategy promotion states
+
+| State | Meaning | Wallet mutation | Entry requirements | Exit or rollback path |
+| --- | --- | --- | --- | --- |
+| `candidate` | Research hypothesis exists but no runtime-ready implementation is assumed | none | source provenance, hypothesis, expected mechanism, candidate issue | archive, supersede, or promote to `draft` |
+| `draft` | StrategySpec, evaluation plan, and implementation scope exist | none | candidate evidence plus StrategySpec draft, feature requirements, failure modes | demote to `candidate`, archive, or promote to `shadow` |
+| `shadow` | Runtime evaluates the strategy without mutating wallets | none | merged implementation PR, replay or backtest coverage, shadow-safe defaults, operator sign-off for shadow activation | pause, demote to `draft`, or promote to `paper` |
+| `paper` | Runtime uses production-like lifecycle with synthetic execution only | none | shadow scorecards, paper simulator readiness, cost model coverage, explicit operator approval | pause, demote to `shadow`, or promote to `limited_live` |
+| `limited_live` | Strategy is allowlisted for bounded real-money validation | bounded real money | paper scorecards, limited-live policy, canary plan, risk budgets, explicit human approval | kill, pause, demote to `paper`, or remove from allowlist |
+| `broad_live` | Strategy is eligible for broader live use under current policy | real money | successful limited-live canary and soak, operator review, explicit human approval | demote to `limited_live`, pause, or kill |
+| `paused` | Strategy is intentionally blocked while evidence and state remain inspectable | state-dependent | manual or automatic pause action | resume to prior non-terminal state with approval |
+| `deprecated` | Strategy remains auditable but is no longer eligible for promotion or execution | none | operator or policy decision | no promotion; replace with a new candidate if needed |
+
+## Venue and asset onboarding states
+
+Venue and asset onboarding must be tracked separately from strategy promotion so
+the repo can answer whether a strategy is weak versus whether a venue or asset
+is not ready.
+
+| State | Meaning | Required evidence | Rollback path |
+| --- | --- | --- | --- |
+| `candidate` | Venue or asset is known to the research registry but not yet trusted for runtime use | source provenance, metadata draft, risk notes | archive or supersede |
+| `integrated` | Canonical metadata, mappings, and adapter hooks exist | schema coverage, precision rules, identifier mappings, test fixtures | demote to `candidate` or disable |
+| `shadow_ready` | Safe for non-mutating replay and shadow evaluation | data coverage, replay fixtures, feature support, adapter validation | demote to `integrated` |
+| `paper_ready` | Safe for production-like paper simulation | cost model coverage, paper lifecycle coverage, reconciliation expectations | demote to `shadow_ready` |
+| `limited_live_ready` | Safe for tiny-notional bounded live validation | explicit allowlist, readiness gates, kill switch, bounded canary plan | remove from allowlist or pause |
+| `broad_live_ready` | Eligible for broader use under current policy | successful limited-live canary and soak, operator approval | demote to `limited_live_ready` |
+| `paused` | Temporarily blocked due to drift, venue issues, or policy | pause action and incident context | resume with approval |
+| `deprecated` | No longer supported for new promotion work | deprecation decision and replacement path where relevant | no promotion |
+
+## Evidence bundles by transition
+
+### Candidate -> Draft
+
+Required bundle:
+
+- source citations with exact URLs and dates,
+- strategy or market hypothesis,
+- expected edge mechanism,
+- initial venue and asset assumptions,
+- known failure modes and disqualifiers.
+
+### Draft -> Shadow
+
+Required bundle:
+
+- StrategySpec or equivalent runtime contract,
+- implementation PR with human review,
+- deterministic replay or backtest fixtures,
+- feature requirements and parameter surface,
+- shadow activation notes and kill posture.
+
+### Shadow -> Paper
+
+Required bundle:
+
+- shadow scorecards and replay evidence,
+- cost model assumptions,
+- reproducibility manifest,
+- paper execution plan,
+- operator sign-off for paper activation.
+
+### Paper -> Limited Live
+
+Required bundle:
+
+- paper scorecards with promotion gates,
+- venue and asset readiness evidence,
+- risk budget and allocator review,
+- limited-live canary plan,
+- explicit human approval recorded in issue, PR, or operator record.
+
+### Limited Live -> Broad Live
+
+Required bundle:
+
+- limited-live canary output,
+- soak summary,
+- observed-versus-modeled cost comparison,
+- drift and incident review,
+- explicit human approval for broader rollout.
+
+## Approval boundaries
+
+- Merging a PR never authorizes real-money promotion by itself.
+- New strategy, venue, or asset code may enter `shadow` only after human review
+  on the implementation PR.
+- `paper` requires explicit operator approval even though it does not mutate
+  wallets.
+- `limited_live` requires explicit human approval, allowlist changes, kill
+  controls, and a bounded canary plan.
+- `broad_live` requires a successful limited-live soak and explicit human
+  approval.
+- Any production-facing state may be paused or killed automatically by policy,
+  but resume requires human review.
+
+## GitHub and harness workflow
+
+Research-to-production work must stay on the existing harness path:
+
+1. Open or refine a GitHub issue with explicit lifecycle state and evidence
+   target.
+2. Mark it `harness` and `agent-ready` only when dependencies are actually
+   merged and the scope fits one PR.
+3. Branch from `main` with `codex/issue-<number>-<slug>`.
+4. Implement the narrowest slice needed for the target transition.
+5. Attach a proof bundle with exact validations and the relevant research,
+   replay, paper, or canary artifacts.
+6. Stop at human review before merge.
+7. Treat post-merge runtime activation and money-state promotion as separate
+   operator actions with their own evidence requirements.
+
+## Rollback posture
+
+- `candidate` and `draft` rollback is issue-level:
+  demote, archive, or supersede the candidate.
+- `shadow` rollback is runtime-level:
+  pause or demote without wallet mutation.
+- `paper` rollback is runtime-level:
+  pause or demote while preserving paper receipts and scorecards.
+- `limited_live` rollback is policy-level and runtime-level:
+  kill the deployment, remove from allowlists, pause venue or asset readiness,
+  and revert code when needed.
+- `broad_live` rollback starts by demoting to `limited_live`, then pausing or
+  killing as needed.
+
+## Success criteria for the program
+
+- Strategy, venue, and asset states are explicit and queryable.
+- Evidence bundles are attached to every promotion transition.
+- New strategies, venues, and assets can reach bounded real-money validation
+  without bypassing the Worker boundary or the harness workflow.
+- Real-money promotion remains human-gated and reversible.

--- a/docs/reliability/strategy-lab-ops-runbook.md
+++ b/docs/reliability/strategy-lab-ops-runbook.md
@@ -1,0 +1,116 @@
+# Strategy Lab Ops Runbook
+
+## Purpose
+
+This runbook defines how operators should control candidate strategies, venues,
+and assets as they move from research to bounded real-money validation.
+
+## Operating model
+
+- The Worker remains the public edge and the operator control surface.
+- Strategy-lab promotion states are separate from runtime deployment states.
+- Human review remains mandatory before any real-money promotion.
+- Pause, demotion, and kill actions should happen before code rollback where
+  possible.
+
+## Production-facing states and required controls
+
+| State | Required controls | Minimum operator checks | Immediate rollback path |
+| --- | --- | --- | --- |
+| `paper` | paper-only runtime path, scorecards, reproducibility bundle | paper scorecards, cost assumptions, venue or asset readiness | pause or demote to `shadow` |
+| `limited_live` | allowlist, bounded notional, kill switch, venue or asset readiness gate | paper evidence, canary plan, allocator and risk review, explicit human approval | kill deployment, remove from allowlist, demote to `paper` |
+| `broad_live` | successful limited-live soak, drift monitoring, rollback drills | limited-live soak summary, cost drift review, operator approval | demote to `limited_live`, pause, or kill |
+
+## Required evidence before real-money promotion
+
+- reproducibility bundle tied to exact code and data revisions,
+- shadow and paper scorecards for the candidate,
+- venue and asset readiness state for every real-money dependency,
+- risk budget and allocator review where capital contention exists,
+- a bounded canary plan with kill controls,
+- explicit human approval recorded in the issue, PR, or operator record.
+
+## Routine operator actions
+
+### Review candidate readiness
+
+Confirm:
+
+- the candidate state is correct,
+- the required evidence bundle is attached,
+- venue and asset readiness states are sufficient,
+- no open incident blocks promotion.
+
+### Approve paper promotion
+
+Use paper when:
+
+- replay and shadow evidence are stable,
+- cost models exist,
+- paper execution will still remain wallet-safe.
+
+Expected effect:
+
+- candidate remains non-monetary,
+- paper receipts and scorecards become first-class evidence,
+- later limited-live decisions can compare modeled versus observed behavior.
+
+### Approve limited-live promotion
+
+Use limited live only when:
+
+- the candidate has cleared paper scorecards,
+- venue and asset readiness are at least `limited_live_ready`,
+- the canary plan is tiny-notional and reversible,
+- a named human approves the promotion.
+
+Expected effect:
+
+- the strategy is allowlisted for bounded real-money validation only,
+- drift and canary results become new evidence,
+- operators retain immediate pause and kill paths.
+
+### Demote or pause a candidate
+
+Use pause or demotion when:
+
+- evidence weakens,
+- venue or asset health degrades,
+- allocator pressure changes materially,
+- operator confidence is lost.
+
+Expected effect:
+
+- no broader promotion occurs,
+- prior evidence remains auditable,
+- later resume requires explicit human review.
+
+### Kill a limited-live candidate
+
+Use kill when:
+
+- live canary behavior is unsafe,
+- venue or asset assumptions break,
+- reconciliation or observed costs diverge materially,
+- the strategy enters a state that policy disallows.
+
+Expected effect:
+
+- bounded live execution stops immediately,
+- allowlists and readiness states can be tightened,
+- follow-up requires human review and updated evidence.
+
+## Rollback order of operations
+
+1. Pause or kill the candidate deployment.
+2. Remove the strategy, venue, or asset from the relevant allowlist.
+3. Demote the promotion state in the operator record.
+4. Trigger code rollback only if the incident is code-driven.
+5. Preserve all evidence and incident notes for later review.
+
+## Required drills
+
+- limited-live kill drill before calling a new real-money path ready,
+- demotion drill from `broad_live` to `limited_live`,
+- venue or asset-specific disable drill,
+- evidence reconstruction drill from stored manifests and scorecards.

--- a/docs/repository-verification-index.md
+++ b/docs/repository-verification-index.md
@@ -89,7 +89,10 @@ Current required secret names:
 
 - Cloudflare: `CLOUDFLARE_API_TOKEN`
 - Vercel: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`
+- Fly: `FLY_API_TOKEN`
 - Admin routes: `ADMIN_TOKEN`
+- Runtime deploy and canary support:
+  `RUNTIME_INTERNAL_SERVICE_TOKEN`, `RUNTIME_DATABASE_URL`
 - Integration and live test inputs vary by suite and may include
   `RPC_ENDPOINT`, `BALANCE_RPC_ENDPOINT`, `JUPITER_API_KEY`,
   `WALLET_PRIVATE_KEY`, and provider-specific read keys.

--- a/docs/repository-verification-index.md
+++ b/docs/repository-verification-index.md
@@ -11,7 +11,8 @@ how to verify or roll back the main operating paths.
 | Portal | Next.js marketing, login, and terminal UI | `apps/portal` |
 | Worker | Cloudflare Worker API boundary for x402, execution, discovery, and auth-adjacent routes | `apps/worker` |
 | Runtime control plane | Bun CLI, agent runtime, tools, policies, and journals | `src` |
-| Autonomous runtime (planned) | Rust hot path for always-on automation, reconciliation, and portfolio state | `docs/product-specs/autonomous-runtime-prd.md`, `docs/design-docs/autonomous-runtime-architecture.md` |
+| Autonomous runtime | Rust hot path for always-on automation, reconciliation, and portfolio state | `services/runtime-rs`, `docs/product-specs/autonomous-runtime-prd.md`, `docs/design-docs/autonomous-runtime-architecture.md` |
+| Strategy lab | Research-to-production workflow for new strategies, venues, and assets | `docs/product-specs/strategy-lab-prd.md`, `docs/exec-plans/active/strategy-lab-rollout.md` |
 | Tests | Unit, integration, and terminal execution suites | `tests` |
 | Public contracts | Execution docs, schemas, fixtures, and runbooks | `docs/execution` |
 | Agent registry | Lane metadata and operator runbook | `docs/agent-registry` |
@@ -62,10 +63,12 @@ Autonomous runtime planning surfaces:
 - ADRs: `docs/design-docs/adrs/`
 - Ops runbook: `docs/reliability/autonomous-runtime-ops-runbook.md`
 - Rollout plan: `docs/exec-plans/active/autonomous-runtime-rollout.md`
+- Strategy-lab product spec: `docs/product-specs/strategy-lab-prd.md`
+- Strategy-lab rollout plan: `docs/exec-plans/active/strategy-lab-rollout.md`
+- Strategy-lab ops runbook: `docs/reliability/strategy-lab-ops-runbook.md`
 
-The runtime service is not deployed yet. Until `#258` to `#261` land, runtime
-verification is documentation-only and the live stack remains portal plus
-Worker.
+The runtime service is deployed on Fly and verified independently from the
+portal and Worker lanes.
 
 Current workflow files:
 
@@ -79,6 +82,8 @@ Current workflow files:
 - Ops:
   - `.github/workflows/ops-dashboard.yml`
   - `.github/workflows/rollback-production.yml`
+  - `.github/workflows/deploy-runtime-rs.yml`
+  - `.github/workflows/rollback-runtime-rs.yml`
 
 Current required secret names:
 
@@ -202,6 +207,23 @@ Expected behavior:
 - one warm standby machine exists in `iad`,
 - `https://ralph-runtime-rs.fly.dev/health` returns `serviceName=runtime-rs`
   and `environment=production`.
+
+### 3d. Strategy-lab planning verification
+
+For docs-only strategy-lab work:
+
+```bash
+bun run lint
+```
+
+Verify:
+
+- strategy promotion states and venue or asset onboarding states are explicit,
+- approval boundaries between merge, shadow, paper, and real money are
+  documented,
+- evidence bundles are defined for every promotion transition,
+- rollback and kill posture exist for every production-facing state,
+- no docs introduce secrets or private operational tokens.
 
 ### 4. x402 and discovery verification
 


### PR DESCRIPTION
## Summary
- add the repo-owned strategy-lab product spec covering strategy, venue, and asset lifecycle states
- add a strategy-lab rollout plan and ops runbook for promotion, rollback, and real-money approval boundaries
- extend the root execution contract and verification index so the new research-to-production flow lives inside the existing harness model

## Validation
- `bun run lint`

## Results
- `bun run lint`: passed

## Proof bundle
- local or preview URLs: not applicable for this docs-only change
- browser artifacts: not applicable for this docs-only change
- benchmark delta: not applicable for this docs-only change
- primary artifacts:
  - `docs/product-specs/strategy-lab-prd.md`
  - `docs/exec-plans/active/strategy-lab-rollout.md`
  - `docs/reliability/strategy-lab-ops-runbook.md`
  - `WORKFLOW.md`
  - `docs/repository-verification-index.md`

## Risk notes
- docs-only issue; no runtime or Worker behavior changed
- the repo-level execution contract now explicitly states that PR merge alone never authorizes real-money promotion

Fixes #305
