### PR TITLE
Add strategy spec catalog and plugin ABI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "strategy-core",
  "thiserror",
  "time",
 ]
@@ -1215,6 +1216,10 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "strategy-core"
 version = "0.1.0"
+dependencies = [
+ "protocol",
+ "thiserror",
+]
 
 [[package]]
 name = "strategy-registry"

--- a/apps/worker/src/runtime_contracts.ts
+++ b/apps/worker/src/runtime_contracts.ts
@@ -13,6 +13,7 @@ export type {
   RuntimeRiskVerdict,
   RuntimeRunRecord,
   RuntimeRunState,
+  RuntimeStrategySpec,
 } from "../../../src/runtime/contracts/index.js";
 export {
   canTransitionRuntimeDeploymentState,
@@ -27,6 +28,7 @@ export {
   parseRuntimeResearchSourceRecord,
   parseRuntimeRiskVerdict,
   parseRuntimeRunRecord,
+  parseRuntimeStrategySpec,
   RUNTIME_DEPLOYMENT_STATE_TRANSITIONS,
   RUNTIME_PROTOCOL_SCHEMA_FAMILY,
   RUNTIME_PROTOCOL_SCHEMA_REGISTRY,
@@ -42,4 +44,5 @@ export {
   safeParseRuntimeResearchSourceRecord,
   safeParseRuntimeRiskVerdict,
   safeParseRuntimeRunRecord,
+  safeParseRuntimeStrategySpec,
 } from "../../../src/runtime/contracts/index.js";

--- a/crates/execution-planner/Cargo.toml
+++ b/crates/execution-planner/Cargo.toml
@@ -11,5 +11,6 @@ rusqlite = { version = "0.37.0", features = ["bundled"] }
 serde.workspace = true
 serde_json.workspace = true
 sha2 = "0.10.9"
+strategy-core = { path = "../strategy-core" }
 thiserror.workspace = true
 time = { version = "=0.3.44", features = ["formatting", "parsing"] }

--- a/crates/execution-planner/src/lib.rs
+++ b/crates/execution-planner/src/lib.rs
@@ -1,17 +1,20 @@
 use std::{
+    collections::BTreeMap,
     fs,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use feature_cache::DerivedMarketFeatureSnapshot;
 use protocol::{
     RuntimeDeploymentRecord, RuntimeExecutionAction, RuntimeExecutionPlan, RuntimeExecutionSlice,
     RuntimeLane, RuntimeLedgerBalance, RuntimeLedgerSnapshot, RuntimeMode, RuntimeRiskDecision,
-    RuntimeRiskVerdict, RuntimeRunRecord, RUNTIME_PROTOCOL_SCHEMA_VERSION,
+    RuntimeRiskVerdict, RuntimeRunRecord, RuntimeStrategySpec, RUNTIME_PROTOCOL_SCHEMA_VERSION,
 };
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use strategy_core::{StrategyCatalog, StrategyCatalogError, StrategyKind, SUPPORTED_STRATEGIES};
 use thiserror::Error;
 use time::OffsetDateTime;
 
@@ -32,6 +35,7 @@ impl ExecutionPlannerConfig {
 #[derive(Debug, Clone)]
 pub struct ExecutionPlanner {
     database_path: PathBuf,
+    strategy_plugins: Arc<StrategyPluginRegistry>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -59,16 +63,37 @@ pub struct ExecutionPlanningResult {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SwapDirection {
+pub enum SwapDirection {
     BuyBase,
     SellBase,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct StrategyTradeDecision {
-    action: RuntimeExecutionAction,
-    direction: SwapDirection,
-    notional_cents: i64,
+pub struct StrategyTradeDecision {
+    pub action: RuntimeExecutionAction,
+    pub direction: SwapDirection,
+    pub notional_cents: i64,
+}
+
+pub trait StrategyPlugin: Send + Sync + std::fmt::Debug {
+    fn spec(&self) -> &RuntimeStrategySpec;
+
+    fn trade_decision(
+        &self,
+        input: &ExecutionPlannerInput,
+    ) -> Result<StrategyTradeDecision, ExecutionPlannerError>;
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct StrategyPluginRegistry {
+    catalog: StrategyCatalog,
+    plugins: BTreeMap<String, Arc<dyn StrategyPlugin>>,
+}
+
+#[derive(Debug, Clone)]
+struct BuiltinStrategyPlugin {
+    spec: RuntimeStrategySpec,
+    planner: fn(&ExecutionPlannerInput) -> Result<StrategyTradeDecision, ExecutionPlannerError>,
 }
 
 const BREAKOUT_SIGNAL_THRESHOLD_BPS: f64 = 15.0;
@@ -79,6 +104,76 @@ const VOLATILITY_TARGET_MEDIUM_THRESHOLD_BPS: f64 = 20.0;
 const VOLATILITY_TARGET_LOW_BPS: i64 = 7_500;
 const VOLATILITY_TARGET_MEDIUM_BPS: i64 = 5_000;
 const VOLATILITY_TARGET_HIGH_BPS: i64 = 2_500;
+
+impl BuiltinStrategyPlugin {
+    fn new(kind: StrategyKind) -> Self {
+        Self {
+            spec: kind.spec(),
+            planner: match kind {
+                StrategyKind::Dca => dca_trade_decision,
+                StrategyKind::ThresholdRebalance => threshold_rebalance_trade_decision,
+                StrategyKind::Twap => twap_trade_decision,
+                StrategyKind::TrendFollowing => trend_following_trade_decision,
+                StrategyKind::MeanReversion => mean_reversion_trade_decision,
+                StrategyKind::Breakout => breakout_trade_decision,
+                StrategyKind::MacroRotation => macro_rotation_trade_decision,
+                StrategyKind::VolatilityTarget => volatility_target_trade_decision,
+            },
+        }
+    }
+}
+
+impl StrategyPlugin for BuiltinStrategyPlugin {
+    fn spec(&self) -> &RuntimeStrategySpec {
+        &self.spec
+    }
+
+    fn trade_decision(
+        &self,
+        input: &ExecutionPlannerInput,
+    ) -> Result<StrategyTradeDecision, ExecutionPlannerError> {
+        (self.planner)(input)
+    }
+}
+
+impl StrategyPluginRegistry {
+    pub fn builtin() -> Result<Self, ExecutionPlannerError> {
+        let mut registry = Self::default();
+        for strategy in SUPPORTED_STRATEGIES {
+            registry.register_plugin(BuiltinStrategyPlugin::new(strategy))?;
+        }
+        Ok(registry)
+    }
+
+    pub fn register_plugin<P>(&mut self, plugin: P) -> Result<(), ExecutionPlannerError>
+    where
+        P: StrategyPlugin + 'static,
+    {
+        let strategy_key = plugin.spec().strategy_key.clone();
+        self.catalog.register_spec(plugin.spec().clone())?;
+        self.plugins.insert(strategy_key, Arc::new(plugin));
+        Ok(())
+    }
+
+    #[must_use]
+    pub fn catalog(&self) -> StrategyCatalog {
+        self.catalog.clone()
+    }
+
+    #[must_use]
+    pub fn strategy_specs(&self) -> Vec<RuntimeStrategySpec> {
+        self.catalog.specs()
+    }
+
+    #[must_use]
+    pub fn supported_strategy_keys(&self) -> Vec<String> {
+        self.catalog.keys()
+    }
+
+    fn get(&self, strategy_key: &str) -> Option<&Arc<dyn StrategyPlugin>> {
+        self.plugins.get(strategy_key)
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum ExecutionPlannerError {
@@ -96,18 +191,39 @@ pub enum ExecutionPlannerError {
     RiskNotAllowed { verdict_id: String },
     #[error("execution plan {plan_id} not found")]
     PlanNotFound { plan_id: String },
+    #[error("unsupported strategy key: {0}")]
+    UnsupportedStrategy(String),
+    #[error(transparent)]
+    StrategyCatalog(#[from] StrategyCatalogError),
 }
 
 impl ExecutionPlanner {
     pub fn new(config: ExecutionPlannerConfig) -> Result<Self, ExecutionPlannerError> {
+        Self::with_plugins(config, StrategyPluginRegistry::builtin()?)
+    }
+
+    pub fn with_plugins(
+        config: ExecutionPlannerConfig,
+        strategy_plugins: StrategyPluginRegistry,
+    ) -> Result<Self, ExecutionPlannerError> {
         let requested_path = normalize_database_path(&config.database_url);
-        match Self::initialize_at_path(requested_path.clone()) {
+        match Self::initialize_at_path(requested_path.clone(), strategy_plugins.clone()) {
             Ok(planner) => Ok(planner),
             Err(error) if should_fallback_to_tmp(&requested_path, &error) => {
-                Self::initialize_at_path(fallback_database_path())
+                Self::initialize_at_path(fallback_database_path(), strategy_plugins)
             }
             Err(error) => Err(error),
         }
+    }
+
+    #[must_use]
+    pub fn supported_strategy_keys(&self) -> Vec<String> {
+        self.strategy_plugins.supported_strategy_keys()
+    }
+
+    #[must_use]
+    pub fn strategy_specs(&self) -> Vec<RuntimeStrategySpec> {
+        self.strategy_plugins.strategy_specs()
     }
 
     pub fn plan_and_store(
@@ -125,7 +241,7 @@ impl ExecutionPlanner {
             });
         }
 
-        let plan = build_plan(input)?;
+        let plan = build_plan(&self.strategy_plugins, input)?;
         persist_plan(&transaction, &plan)?;
         transaction.commit()?;
 
@@ -206,7 +322,10 @@ impl ExecutionPlanner {
         Ok(connection)
     }
 
-    fn initialize_at_path(database_path: PathBuf) -> Result<Self, ExecutionPlannerError> {
+    fn initialize_at_path(
+        database_path: PathBuf,
+        strategy_plugins: StrategyPluginRegistry,
+    ) -> Result<Self, ExecutionPlannerError> {
         if database_path != Path::new(":memory:") {
             if let Some(parent) = database_path
                 .parent()
@@ -215,7 +334,10 @@ impl ExecutionPlanner {
                 fs::create_dir_all(parent)?;
             }
         }
-        let planner = Self { database_path };
+        let planner = Self {
+            database_path,
+            strategy_plugins: Arc::new(strategy_plugins),
+        };
         let connection = planner.open_connection()?;
         initialize_schema(&connection)?;
         Ok(planner)
@@ -276,11 +398,14 @@ fn should_fallback_to_tmp(database_path: &Path, error: &ExecutionPlannerError) -
         | ExecutionPlannerError::InvalidUsdAmount { .. }
         | ExecutionPlannerError::InvalidNumericValue { .. }
         | ExecutionPlannerError::RiskNotAllowed { .. }
-        | ExecutionPlannerError::PlanNotFound { .. } => false,
+        | ExecutionPlannerError::PlanNotFound { .. }
+        | ExecutionPlannerError::UnsupportedStrategy(_)
+        | ExecutionPlannerError::StrategyCatalog(_) => false,
     }
 }
 
 fn build_plan(
+    strategy_plugins: &StrategyPluginRegistry,
     input: &ExecutionPlannerInput,
 ) -> Result<RuntimeExecutionPlan, ExecutionPlannerError> {
     if input.risk_verdict.verdict != RuntimeRiskDecision::Allow {
@@ -291,7 +416,7 @@ fn build_plan(
 
     let lane = selected_lane(&input.deployment);
     let (simulate_only, dry_run) = execution_flags(&input.deployment.mode);
-    let decision = strategy_trade_decision(input)?;
+    let decision = strategy_trade_decision(strategy_plugins, input)?;
     let mid_price = parse_decimal(
         "featureSnapshot.midPriceUsd",
         &input.feature_snapshot.mid_price_usd,
@@ -366,52 +491,118 @@ fn build_plan(
 }
 
 fn strategy_trade_decision(
+    strategy_plugins: &StrategyPluginRegistry,
     input: &ExecutionPlannerInput,
 ) -> Result<StrategyTradeDecision, ExecutionPlannerError> {
-    let base_notional_cents = desired_notional_cents(&input.deployment)?;
-    let short_signal = input
+    let plugin = strategy_plugins
+        .get(&input.deployment.strategy_key)
+        .ok_or_else(|| {
+            ExecutionPlannerError::UnsupportedStrategy(input.deployment.strategy_key.clone())
+        })?;
+    plugin.trade_decision(input)
+}
+
+fn dca_trade_decision(
+    input: &ExecutionPlannerInput,
+) -> Result<StrategyTradeDecision, ExecutionPlannerError> {
+    Ok(StrategyTradeDecision {
+        action: RuntimeExecutionAction::Buy,
+        direction: SwapDirection::BuyBase,
+        notional_cents: desired_notional_cents(&input.deployment)?,
+    })
+}
+
+fn threshold_rebalance_trade_decision(
+    input: &ExecutionPlannerInput,
+) -> Result<StrategyTradeDecision, ExecutionPlannerError> {
+    threshold_rebalance_decision(input, desired_notional_cents(&input.deployment)?)
+}
+
+fn twap_trade_decision(
+    input: &ExecutionPlannerInput,
+) -> Result<StrategyTradeDecision, ExecutionPlannerError> {
+    Ok(twap_decision(
+        input,
+        desired_notional_cents(&input.deployment)?,
+    ))
+}
+
+fn trend_following_trade_decision(
+    input: &ExecutionPlannerInput,
+) -> Result<StrategyTradeDecision, ExecutionPlannerError> {
+    Ok(signal_following_decision(
+        short_signal(input)?,
+        desired_notional_cents(&input.deployment)?,
+    ))
+}
+
+fn mean_reversion_trade_decision(
+    input: &ExecutionPlannerInput,
+) -> Result<StrategyTradeDecision, ExecutionPlannerError> {
+    Ok(mean_reversion_decision(
+        short_signal(input)?,
+        desired_notional_cents(&input.deployment)?,
+    ))
+}
+
+fn breakout_trade_decision(
+    input: &ExecutionPlannerInput,
+) -> Result<StrategyTradeDecision, ExecutionPlannerError> {
+    Ok(breakout_decision(
+        short_signal(input)?,
+        long_signal(input)?,
+        desired_notional_cents(&input.deployment)?,
+    ))
+}
+
+fn macro_rotation_trade_decision(
+    input: &ExecutionPlannerInput,
+) -> Result<StrategyTradeDecision, ExecutionPlannerError> {
+    Ok(macro_rotation_decision(
+        short_signal(input)?,
+        long_signal(input)?,
+        desired_notional_cents(&input.deployment)?,
+    ))
+}
+
+fn volatility_target_trade_decision(
+    input: &ExecutionPlannerInput,
+) -> Result<StrategyTradeDecision, ExecutionPlannerError> {
+    volatility_target_decision(
+        input,
+        realized_volatility_bps(input)?,
+        desired_notional_cents(&input.deployment)?,
+    )
+}
+
+fn short_signal(input: &ExecutionPlannerInput) -> Result<f64, ExecutionPlannerError> {
+    input
         .feature_snapshot
         .short_return_bps
         .as_deref()
         .map(|value| parse_signed_decimal("featureSnapshot.shortReturnBps", value))
-        .transpose()?
-        .unwrap_or(0.0);
-    let long_signal = input
+        .transpose()
+        .map(|value| value.unwrap_or(0.0))
+}
+
+fn long_signal(input: &ExecutionPlannerInput) -> Result<Option<f64>, ExecutionPlannerError> {
+    input
         .feature_snapshot
         .long_return_bps
         .as_deref()
         .map(|value| parse_signed_decimal("featureSnapshot.longReturnBps", value))
-        .transpose()?;
-    let realized_volatility_bps = input
+        .transpose()
+}
+
+fn realized_volatility_bps(
+    input: &ExecutionPlannerInput,
+) -> Result<Option<f64>, ExecutionPlannerError> {
+    input
         .feature_snapshot
         .realized_volatility_bps
         .as_deref()
         .map(|value| parse_decimal("featureSnapshot.realizedVolatilityBps", value))
-        .transpose()?;
-    match input.deployment.strategy_key.as_str() {
-        "threshold_rebalance" => threshold_rebalance_decision(input, base_notional_cents),
-        "twap" => Ok(twap_decision(input, base_notional_cents)),
-        "trend_following" => Ok(signal_following_decision(short_signal, base_notional_cents)),
-        "mean_reversion" => Ok(mean_reversion_decision(short_signal, base_notional_cents)),
-        "breakout" => Ok(breakout_decision(
-            short_signal,
-            long_signal,
-            base_notional_cents,
-        )),
-        "macro_rotation" => Ok(macro_rotation_decision(
-            short_signal,
-            long_signal,
-            base_notional_cents,
-        )),
-        "volatility_target" => {
-            volatility_target_decision(input, realized_volatility_bps, base_notional_cents)
-        }
-        _ => Ok(StrategyTradeDecision {
-            action: RuntimeExecutionAction::Buy,
-            direction: SwapDirection::BuyBase,
-            notional_cents: base_notional_cents,
-        }),
-    }
+        .transpose()
 }
 
 fn signal_following_decision(signal: f64, notional_cents: i64) -> StrategyTradeDecision {
@@ -956,10 +1147,33 @@ mod tests {
     use protocol::{
         RuntimeCapital, RuntimeDeploymentState, RuntimeLedgerTotals, RuntimePair, RuntimePolicy,
         RuntimeRiskLimits, RuntimeRiskObserved, RuntimeRiskReason, RuntimeRiskSeverity,
-        RuntimeRunState, RuntimeTrigger, RuntimeTriggerKind,
+        RuntimeRunState, RuntimeStrategySpec, RuntimeTrigger, RuntimeTriggerKind,
     };
+    use strategy_core::StrategyKind;
 
     use super::*;
+
+    #[derive(Debug)]
+    struct TestStrategyPlugin {
+        spec: RuntimeStrategySpec,
+    }
+
+    impl StrategyPlugin for TestStrategyPlugin {
+        fn spec(&self) -> &RuntimeStrategySpec {
+            &self.spec
+        }
+
+        fn trade_decision(
+            &self,
+            _input: &ExecutionPlannerInput,
+        ) -> Result<StrategyTradeDecision, ExecutionPlannerError> {
+            Ok(StrategyTradeDecision {
+                action: RuntimeExecutionAction::Buy,
+                direction: SwapDirection::BuyBase,
+                notional_cents: 1_234,
+            })
+        }
+    }
 
     fn temp_database_url(test_name: &str) -> String {
         let unique = SystemTime::now()
@@ -975,6 +1189,28 @@ mod tests {
     fn planner(test_name: &str) -> ExecutionPlanner {
         ExecutionPlanner::new(ExecutionPlannerConfig::new(temp_database_url(test_name)))
             .expect("planner to initialize")
+    }
+
+    fn planner_with_plugin(test_name: &str, strategy_key: &str) -> ExecutionPlanner {
+        let mut plugins = StrategyPluginRegistry::default();
+        plugins
+            .register_plugin(TestStrategyPlugin {
+                spec: custom_strategy_spec(strategy_key),
+            })
+            .expect("custom strategy plugin");
+        ExecutionPlanner::with_plugins(
+            ExecutionPlannerConfig::new(temp_database_url(test_name)),
+            plugins,
+        )
+        .expect("planner to initialize")
+    }
+
+    fn custom_strategy_spec(strategy_key: &str) -> RuntimeStrategySpec {
+        let mut spec = StrategyKind::Dca.spec();
+        spec.strategy_key = strategy_key.to_string();
+        spec.plugin_key = format!("test::{strategy_key}");
+        spec.title = "Custom strategy".to_string();
+        spec
     }
 
     fn deployment(
@@ -1251,6 +1487,28 @@ mod tests {
         assert!(result.plan.dry_run);
         assert_eq!(result.plan.slices[0].action, RuntimeExecutionAction::Buy);
         assert_eq!(result.plan.slices[0].input_amount_atomic, "5000000");
+    }
+
+    #[test]
+    fn can_register_custom_strategy_plugins() {
+        let planner = planner_with_plugin("custom-plugin", "custom_signal");
+        let result = planner
+            .plan_and_store(&input(
+                "run_custom",
+                "custom_signal",
+                RuntimeMode::Shadow,
+                RuntimeLane::Safe,
+                "0.0",
+            ))
+            .expect("custom plan to store");
+
+        assert!(result.created);
+        assert_eq!(result.plan.slices[0].action, RuntimeExecutionAction::Buy);
+        assert_eq!(result.plan.slices[0].input_amount_atomic, "12340000");
+        assert_eq!(
+            planner.supported_strategy_keys(),
+            vec!["custom_signal".to_string()]
+        );
     }
 
     #[test]

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -693,6 +693,117 @@ pub struct RuntimeResearchEvidenceBundleRecord {
     pub tags: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeStrategyCategory {
+    Allocation,
+    Signal,
+    Advanced,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeStrategyParameterKind {
+    Decimal,
+    Integer,
+    Bps,
+    Boolean,
+    Enum,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeStrategyAssetRole {
+    Base,
+    Quote,
+    Either,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeOnboardingState {
+    Candidate,
+    Integrated,
+    ShadowReady,
+    PaperReady,
+    LimitedLiveReady,
+    BroadLiveReady,
+    Paused,
+    Deprecated,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeStrategyVenueSupport {
+    pub venue_key: String,
+    pub onboarding_state: RuntimeOnboardingState,
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeStrategyAssetConstraint {
+    pub role: RuntimeStrategyAssetRole,
+    pub asset_keys: Vec<String>,
+    pub required: bool,
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeStrategyFeatureRequirement {
+    pub feature_key: String,
+    pub required: bool,
+    pub freshness_ms: Option<u64>,
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeStrategyParameterSpec {
+    pub key: String,
+    pub label: String,
+    pub kind: RuntimeStrategyParameterKind,
+    pub required: bool,
+    pub default_value: Option<String>,
+    pub min_value: Option<String>,
+    pub max_value: Option<String>,
+    pub allowed_values: Vec<String>,
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeStrategyPromotionPolicy {
+    pub requires_human_approval: bool,
+    pub shadow_min_runs: u32,
+    pub paper_min_runs: u32,
+    pub live_lane_allowlist: Vec<RuntimeLane>,
+    pub requires_fresh_features: bool,
+    pub limited_live_only: bool,
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeStrategySpec {
+    pub schema_version: String,
+    pub strategy_key: String,
+    pub title: String,
+    pub summary: String,
+    pub category: RuntimeStrategyCategory,
+    pub plugin_key: String,
+    pub default_lane: RuntimeLane,
+    pub supported_modes: Vec<RuntimeMode>,
+    pub lane_eligibility: Vec<RuntimeLane>,
+    pub supported_venues: Vec<RuntimeStrategyVenueSupport>,
+    pub asset_constraints: Vec<RuntimeStrategyAssetConstraint>,
+    pub feature_requirements: Vec<RuntimeStrategyFeatureRequirement>,
+    pub parameter_specs: Vec<RuntimeStrategyParameterSpec>,
+    pub promotion_policy: RuntimeStrategyPromotionPolicy,
+    pub tags: Vec<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use std::{fs, path::PathBuf};
@@ -742,6 +853,9 @@ mod tests {
             "runtime.research_evidence_bundle.valid.v1.json",
         ))
         .expect("research evidence bundle fixture to deserialize");
+        let strategy_spec: RuntimeStrategySpec =
+            serde_json::from_str(&read_fixture("runtime.strategy_spec.valid.v1.json"))
+                .expect("strategy spec fixture to deserialize");
 
         assert_eq!(deployment.schema_version, RUNTIME_PROTOCOL_SCHEMA_VERSION);
         assert_eq!(run.schema_version, RUNTIME_PROTOCOL_SCHEMA_VERSION);
@@ -756,9 +870,14 @@ mod tests {
         assert_eq!(source.schema_version, RUNTIME_PROTOCOL_SCHEMA_VERSION);
         assert_eq!(experiment.schema_version, RUNTIME_PROTOCOL_SCHEMA_VERSION);
         assert_eq!(evidence.schema_version, RUNTIME_PROTOCOL_SCHEMA_VERSION);
+        assert_eq!(
+            strategy_spec.schema_version,
+            RUNTIME_PROTOCOL_SCHEMA_VERSION
+        );
         assert_eq!(plan.slices.len(), 1);
         assert_eq!(experiment.dataset_snapshots.len(), 1);
         assert_eq!(evidence.artifacts.len(), 2);
+        assert_eq!(strategy_spec.strategy_key, "trend_following");
     }
 
     #[test]

--- a/crates/strategy-core/Cargo.toml
+++ b/crates/strategy-core/Cargo.toml
@@ -3,3 +3,7 @@ name = "strategy-core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+
+[dependencies]
+protocol = { path = "../protocol" }
+thiserror.workspace = true

--- a/crates/strategy-core/src/lib.rs
+++ b/crates/strategy-core/src/lib.rs
@@ -1,3 +1,13 @@
+use std::collections::BTreeMap;
+
+use protocol::{
+    RuntimeLane, RuntimeMode, RuntimeOnboardingState, RuntimeStrategyAssetConstraint,
+    RuntimeStrategyAssetRole, RuntimeStrategyCategory, RuntimeStrategyFeatureRequirement,
+    RuntimeStrategyParameterKind, RuntimeStrategyParameterSpec, RuntimeStrategyPromotionPolicy,
+    RuntimeStrategySpec, RuntimeStrategyVenueSupport, RUNTIME_PROTOCOL_SCHEMA_VERSION,
+};
+use thiserror::Error;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StrategyKind {
     Dca,
@@ -22,6 +32,262 @@ impl StrategyKind {
             Self::Breakout => "breakout",
             Self::MacroRotation => "macro_rotation",
             Self::VolatilityTarget => "volatility_target",
+        }
+    }
+
+    fn title(&self) -> &'static str {
+        match self {
+            Self::Dca => "Dollar-cost averaging",
+            Self::ThresholdRebalance => "Threshold rebalance",
+            Self::Twap => "Time-weighted average price",
+            Self::TrendFollowing => "Trend following",
+            Self::MeanReversion => "Mean reversion",
+            Self::Breakout => "Breakout",
+            Self::MacroRotation => "Macro rotation",
+            Self::VolatilityTarget => "Volatility target",
+        }
+    }
+
+    fn summary(&self) -> &'static str {
+        match self {
+            Self::Dca => {
+                "Accumulates a base sleeve with fixed notional slices under reserve budgets."
+            }
+            Self::ThresholdRebalance => {
+                "Rebalances toward a target sleeve split when drift exceeds tolerance."
+            }
+            Self::Twap => {
+                "Slices the deployment budget over multiple runs using maxConcurrentRuns."
+            }
+            Self::TrendFollowing => {
+                "Follows the short-window return direction from the feature cache."
+            }
+            Self::MeanReversion => {
+                "Fades the short-window return direction from the feature cache."
+            }
+            Self::Breakout => {
+                "Requires short-window momentum plus long-window confirmation before it moves risk."
+            }
+            Self::MacroRotation => {
+                "Uses long-window regime with short-window alignment to rotate exposure."
+            }
+            Self::VolatilityTarget => {
+                "Targets base exposure from realized volatility and rebalances toward that budget."
+            }
+        }
+    }
+
+    fn category(&self) -> RuntimeStrategyCategory {
+        match self {
+            Self::Dca | Self::ThresholdRebalance | Self::Twap => {
+                RuntimeStrategyCategory::Allocation
+            }
+            Self::TrendFollowing | Self::MeanReversion => RuntimeStrategyCategory::Signal,
+            Self::Breakout | Self::MacroRotation | Self::VolatilityTarget => {
+                RuntimeStrategyCategory::Advanced
+            }
+        }
+    }
+
+    fn lane_eligibility(&self) -> Vec<RuntimeLane> {
+        match self.category() {
+            RuntimeStrategyCategory::Allocation => {
+                vec![RuntimeLane::Safe, RuntimeLane::Protected, RuntimeLane::Fast]
+            }
+            RuntimeStrategyCategory::Signal | RuntimeStrategyCategory::Advanced => {
+                vec![RuntimeLane::Safe, RuntimeLane::Protected]
+            }
+        }
+    }
+
+    fn supported_modes(&self) -> Vec<RuntimeMode> {
+        vec![RuntimeMode::Shadow, RuntimeMode::Paper, RuntimeMode::Live]
+    }
+
+    fn supported_venues(&self) -> Vec<RuntimeStrategyVenueSupport> {
+        vec![RuntimeStrategyVenueSupport {
+            venue_key: "jupiter".to_string(),
+            onboarding_state: RuntimeOnboardingState::BroadLiveReady,
+            notes: Some(
+                "Current runtime execution and canary coverage is bounded to the Jupiter bridge."
+                    .to_string(),
+            ),
+        }]
+    }
+
+    fn asset_constraints(&self) -> Vec<RuntimeStrategyAssetConstraint> {
+        vec![
+            RuntimeStrategyAssetConstraint {
+                role: RuntimeStrategyAssetRole::Base,
+                asset_keys: Vec::new(),
+                required: true,
+                notes: Some(
+                    "The base asset is selected from the deployment pair at registration time."
+                        .to_string(),
+                ),
+            },
+            RuntimeStrategyAssetConstraint {
+                role: RuntimeStrategyAssetRole::Quote,
+                asset_keys: vec!["USDC".to_string()],
+                required: true,
+                notes: Some(
+                    "The quote leg must remain USD-denominated for current budgeting and canary controls."
+                        .to_string(),
+                ),
+            },
+        ]
+    }
+
+    fn feature_requirements(&self) -> Vec<RuntimeStrategyFeatureRequirement> {
+        match self {
+            Self::Dca | Self::ThresholdRebalance | Self::Twap => Vec::new(),
+            Self::TrendFollowing | Self::MeanReversion => vec![feature_requirement(
+                "short_return_bps",
+                20_000,
+                "Requires fresh short-window return inputs for every evaluation.",
+            )],
+            Self::Breakout | Self::MacroRotation => vec![
+                feature_requirement(
+                    "short_return_bps",
+                    20_000,
+                    "Short-window return drives trigger direction.",
+                ),
+                feature_requirement(
+                    "long_return_bps",
+                    20_000,
+                    "Long-window confirmation gates the advanced signal decision.",
+                ),
+            ],
+            Self::VolatilityTarget => vec![feature_requirement(
+                "realized_volatility_bps",
+                20_000,
+                "Realized volatility drives the target base-exposure budget.",
+            )],
+        }
+    }
+
+    fn parameter_specs(&self) -> Vec<RuntimeStrategyParameterSpec> {
+        let mut parameters = vec![
+            decimal_parameter(
+                "policy.max_notional_usd",
+                "Max notional USD",
+                true,
+                Some("25"),
+                Some("0.01"),
+                None,
+                "Upper bound for any single evaluation or slice.",
+            ),
+            bps_parameter(
+                "policy.max_slippage_bps",
+                "Max slippage bps",
+                true,
+                Some("50"),
+                Some("1"),
+                Some("250"),
+                "Execution slippage ceiling enforced by the runtime bridge.",
+            ),
+            decimal_parameter(
+                "policy.daily_loss_limit_usd",
+                "Daily loss limit USD",
+                true,
+                Some("10"),
+                Some("0"),
+                None,
+                "Daily stop-loss cap enforced by runtime risk controls.",
+            ),
+        ];
+
+        match self {
+            Self::ThresholdRebalance => parameters.push(bps_parameter(
+                "policy.rebalance_tolerance_bps",
+                "Rebalance tolerance bps",
+                true,
+                Some("125"),
+                Some("1"),
+                Some("2500"),
+                "Minimum drift required before the rebalance sleeve takes action.",
+            )),
+            Self::Twap => parameters.push(integer_parameter(
+                "policy.max_concurrent_runs",
+                "Max concurrent runs",
+                true,
+                Some("2"),
+                Some("1"),
+                Some("32"),
+                "Used to derive per-run TWAP slices from the deployment budget.",
+            )),
+            _ => {}
+        }
+
+        parameters
+    }
+
+    fn promotion_policy(&self) -> RuntimeStrategyPromotionPolicy {
+        match self.category() {
+            RuntimeStrategyCategory::Allocation => RuntimeStrategyPromotionPolicy {
+                requires_human_approval: true,
+                shadow_min_runs: 3,
+                paper_min_runs: 5,
+                live_lane_allowlist: vec![RuntimeLane::Safe, RuntimeLane::Protected],
+                requires_fresh_features: false,
+                limited_live_only: false,
+                notes: Some(
+                    "Allocation templates can progress to broader live use after bounded live validation."
+                        .to_string(),
+                ),
+            },
+            RuntimeStrategyCategory::Signal => RuntimeStrategyPromotionPolicy {
+                requires_human_approval: true,
+                shadow_min_runs: 5,
+                paper_min_runs: 7,
+                live_lane_allowlist: vec![RuntimeLane::Safe],
+                requires_fresh_features: true,
+                limited_live_only: true,
+                notes: Some(
+                    "Signal-driven templates require fresh features and remain bounded to safe-lane live rollout."
+                        .to_string(),
+                ),
+            },
+            RuntimeStrategyCategory::Advanced => RuntimeStrategyPromotionPolicy {
+                requires_human_approval: true,
+                shadow_min_runs: 5,
+                paper_min_runs: 7,
+                live_lane_allowlist: vec![RuntimeLane::Safe],
+                requires_fresh_features: true,
+                limited_live_only: true,
+                notes: Some(
+                    "Advanced templates stay in bounded live until they clear an explicit limited-live soak."
+                        .to_string(),
+                ),
+            },
+        }
+    }
+
+    #[must_use]
+    pub fn spec(&self) -> RuntimeStrategySpec {
+        RuntimeStrategySpec {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            strategy_key: self.as_key().to_string(),
+            title: self.title().to_string(),
+            summary: self.summary().to_string(),
+            category: self.category(),
+            plugin_key: format!("builtin::{}", self.as_key()),
+            default_lane: RuntimeLane::Safe,
+            supported_modes: self.supported_modes(),
+            lane_eligibility: self.lane_eligibility(),
+            supported_venues: self.supported_venues(),
+            asset_constraints: self.asset_constraints(),
+            feature_requirements: self.feature_requirements(),
+            parameter_specs: self.parameter_specs(),
+            promotion_policy: self.promotion_policy(),
+            tags: vec![
+                "builtin".to_string(),
+                match self.category() {
+                    RuntimeStrategyCategory::Allocation => "allocation".to_string(),
+                    RuntimeStrategyCategory::Signal => "signal".to_string(),
+                    RuntimeStrategyCategory::Advanced => "advanced".to_string(),
+                },
+            ],
         }
     }
 }
@@ -51,6 +317,230 @@ impl StrategyDeploymentDescriptor {
     }
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StrategyCatalog {
+    specs: BTreeMap<String, RuntimeStrategySpec>,
+}
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum StrategyCatalogError {
+    #[error("strategy {0} is already registered")]
+    DuplicateStrategy(String),
+    #[error("invalid strategy spec for {strategy_key}: {reason}")]
+    InvalidSpec {
+        strategy_key: String,
+        reason: String,
+    },
+}
+
+impl StrategyCatalog {
+    pub fn builtin() -> Result<Self, StrategyCatalogError> {
+        let mut catalog = Self::default();
+        for strategy in SUPPORTED_STRATEGIES {
+            catalog.register_spec(strategy.spec())?;
+        }
+        Ok(catalog)
+    }
+
+    pub fn register_spec(&mut self, spec: RuntimeStrategySpec) -> Result<(), StrategyCatalogError> {
+        validate_spec(&spec)?;
+        if self.specs.contains_key(&spec.strategy_key) {
+            return Err(StrategyCatalogError::DuplicateStrategy(spec.strategy_key));
+        }
+        self.specs.insert(spec.strategy_key.clone(), spec);
+        Ok(())
+    }
+
+    #[must_use]
+    pub fn get(&self, strategy_key: &str) -> Option<&RuntimeStrategySpec> {
+        self.specs.get(strategy_key)
+    }
+
+    pub fn require(
+        &self,
+        strategy_key: &str,
+    ) -> Result<&RuntimeStrategySpec, StrategyCatalogError> {
+        self.get(strategy_key)
+            .ok_or_else(|| StrategyCatalogError::InvalidSpec {
+                strategy_key: strategy_key.to_string(),
+                reason: "strategy is not registered".to_string(),
+            })
+    }
+
+    #[must_use]
+    pub fn keys(&self) -> Vec<String> {
+        self.specs.keys().cloned().collect()
+    }
+
+    #[must_use]
+    pub fn specs(&self) -> Vec<RuntimeStrategySpec> {
+        self.specs.values().cloned().collect()
+    }
+}
+
+fn validate_spec(spec: &RuntimeStrategySpec) -> Result<(), StrategyCatalogError> {
+    if spec.strategy_key.trim().is_empty() {
+        return Err(invalid_spec(spec, "strategyKey must not be empty"));
+    }
+    if spec.plugin_key.trim().is_empty() {
+        return Err(invalid_spec(spec, "pluginKey must not be empty"));
+    }
+    if spec.supported_modes.is_empty() {
+        return Err(invalid_spec(spec, "supportedModes must not be empty"));
+    }
+    if spec.lane_eligibility.is_empty() {
+        return Err(invalid_spec(spec, "laneEligibility must not be empty"));
+    }
+    if !spec.lane_eligibility.contains(&spec.default_lane) {
+        return Err(invalid_spec(
+            spec,
+            "defaultLane must be included in laneEligibility",
+        ));
+    }
+    if spec.supported_venues.is_empty() {
+        return Err(invalid_spec(spec, "supportedVenues must not be empty"));
+    }
+    if spec.asset_constraints.is_empty() {
+        return Err(invalid_spec(spec, "assetConstraints must not be empty"));
+    }
+    if spec
+        .promotion_policy
+        .live_lane_allowlist
+        .iter()
+        .any(|lane| !spec.lane_eligibility.contains(lane))
+    {
+        return Err(invalid_spec(
+            spec,
+            "promotionPolicy.liveLaneAllowlist must be a subset of laneEligibility",
+        ));
+    }
+    for parameter in &spec.parameter_specs {
+        if parameter.kind == RuntimeStrategyParameterKind::Enum
+            && parameter.allowed_values.is_empty()
+        {
+            return Err(invalid_spec(
+                spec,
+                "enum parameters must declare allowedValues",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn invalid_spec(spec: &RuntimeStrategySpec, reason: &str) -> StrategyCatalogError {
+    StrategyCatalogError::InvalidSpec {
+        strategy_key: spec.strategy_key.clone(),
+        reason: reason.to_string(),
+    }
+}
+
+fn feature_requirement(
+    feature_key: &str,
+    freshness_ms: u64,
+    notes: &str,
+) -> RuntimeStrategyFeatureRequirement {
+    RuntimeStrategyFeatureRequirement {
+        feature_key: feature_key.to_string(),
+        required: true,
+        freshness_ms: Some(freshness_ms),
+        notes: Some(notes.to_string()),
+    }
+}
+
+fn decimal_parameter(
+    key: &str,
+    label: &str,
+    required: bool,
+    default_value: Option<&str>,
+    min_value: Option<&str>,
+    max_value: Option<&str>,
+    notes: &str,
+) -> RuntimeStrategyParameterSpec {
+    parameter_spec(
+        key,
+        label,
+        RuntimeStrategyParameterKind::Decimal,
+        required,
+        default_value,
+        min_value,
+        max_value,
+        &[],
+        notes,
+    )
+}
+
+fn integer_parameter(
+    key: &str,
+    label: &str,
+    required: bool,
+    default_value: Option<&str>,
+    min_value: Option<&str>,
+    max_value: Option<&str>,
+    notes: &str,
+) -> RuntimeStrategyParameterSpec {
+    parameter_spec(
+        key,
+        label,
+        RuntimeStrategyParameterKind::Integer,
+        required,
+        default_value,
+        min_value,
+        max_value,
+        &[],
+        notes,
+    )
+}
+
+fn bps_parameter(
+    key: &str,
+    label: &str,
+    required: bool,
+    default_value: Option<&str>,
+    min_value: Option<&str>,
+    max_value: Option<&str>,
+    notes: &str,
+) -> RuntimeStrategyParameterSpec {
+    parameter_spec(
+        key,
+        label,
+        RuntimeStrategyParameterKind::Bps,
+        required,
+        default_value,
+        min_value,
+        max_value,
+        &[],
+        notes,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn parameter_spec(
+    key: &str,
+    label: &str,
+    kind: RuntimeStrategyParameterKind,
+    required: bool,
+    default_value: Option<&str>,
+    min_value: Option<&str>,
+    max_value: Option<&str>,
+    allowed_values: &[&str],
+    notes: &str,
+) -> RuntimeStrategyParameterSpec {
+    RuntimeStrategyParameterSpec {
+        key: key.to_string(),
+        label: label.to_string(),
+        kind,
+        required,
+        default_value: default_value.map(str::to_string),
+        min_value: min_value.map(str::to_string),
+        max_value: max_value.map(str::to_string),
+        allowed_values: allowed_values
+            .iter()
+            .map(|value| (*value).to_string())
+            .collect(),
+        notes: Some(notes.to_string()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -75,5 +565,32 @@ mod tests {
                 "volatility_target",
             ],
         );
+    }
+
+    #[test]
+    fn builds_builtin_catalog_with_strategy_specs() {
+        let catalog = StrategyCatalog::builtin().expect("builtin catalog");
+        let trend = catalog.get("trend_following").expect("trend spec");
+
+        assert_eq!(catalog.keys().len(), 8);
+        assert_eq!(trend.category, RuntimeStrategyCategory::Signal);
+        assert_eq!(trend.feature_requirements.len(), 1);
+        assert_eq!(
+            trend.promotion_policy.live_lane_allowlist,
+            vec![RuntimeLane::Safe]
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_specs() {
+        let mut catalog = StrategyCatalog::default();
+        let mut spec = StrategyKind::Dca.spec();
+        spec.lane_eligibility = vec![RuntimeLane::Protected];
+
+        let error = catalog
+            .register_spec(spec)
+            .expect_err("spec validation should fail");
+
+        assert!(matches!(error, StrategyCatalogError::InvalidSpec { .. }));
     }
 }

--- a/crates/strategy-registry/src/lib.rs
+++ b/crates/strategy-registry/src/lib.rs
@@ -12,7 +12,7 @@ use protocol::{
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use strategy_core::SUPPORTED_STRATEGIES;
+use strategy_core::{StrategyCatalog, StrategyCatalogError};
 use thiserror::Error;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
@@ -33,6 +33,7 @@ impl StrategyRegistryConfig {
 #[derive(Debug, Clone)]
 pub struct StrategyRegistry {
     database_path: PathBuf,
+    strategy_catalog: StrategyCatalog,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -93,6 +94,8 @@ pub enum StrategyRegistryError {
     DeploymentNotFound { deployment_id: String },
     #[error("unsupported strategy key: {0}")]
     UnsupportedStrategy(String),
+    #[error(transparent)]
+    StrategyCatalog(#[from] StrategyCatalogError),
     #[error("immutable deployment field changed for {deployment_id}: {field}")]
     ImmutableFieldChanged {
         deployment_id: String,
@@ -132,11 +135,18 @@ pub enum StrategyRegistryError {
 
 impl StrategyRegistry {
     pub fn new(config: StrategyRegistryConfig) -> Result<Self, StrategyRegistryError> {
+        Self::with_catalog(config, StrategyCatalog::builtin()?)
+    }
+
+    pub fn with_catalog(
+        config: StrategyRegistryConfig,
+        strategy_catalog: StrategyCatalog,
+    ) -> Result<Self, StrategyRegistryError> {
         let requested_path = normalize_database_path(&config.database_url);
-        match Self::initialize_at_path(requested_path.clone()) {
+        match Self::initialize_at_path(requested_path.clone(), strategy_catalog.clone()) {
             Ok(registry) => Ok(registry),
             Err(error) if should_fallback_to_tmp(&requested_path, &error) => {
-                Self::initialize_at_path(fallback_database_path())
+                Self::initialize_at_path(fallback_database_path(), strategy_catalog)
             }
             Err(error) => Err(error),
         }
@@ -147,11 +157,16 @@ impl StrategyRegistry {
         &self.database_path
     }
 
+    #[must_use]
+    pub fn supported_strategy_keys(&self) -> Vec<String> {
+        self.strategy_catalog.keys()
+    }
+
     pub fn upsert_deployment(
         &self,
         deployment: &RuntimeDeploymentRecord,
     ) -> Result<DeploymentWriteResult, StrategyRegistryError> {
-        ensure_supported_strategy(&deployment.strategy_key)?;
+        ensure_supported_strategy(&self.strategy_catalog, &deployment.strategy_key)?;
 
         let mut connection = self.open_connection()?;
         let transaction = connection.transaction()?;
@@ -630,7 +645,10 @@ impl StrategyRegistry {
         Ok(connection)
     }
 
-    fn initialize_at_path(database_path: PathBuf) -> Result<Self, StrategyRegistryError> {
+    fn initialize_at_path(
+        database_path: PathBuf,
+        strategy_catalog: StrategyCatalog,
+    ) -> Result<Self, StrategyRegistryError> {
         if database_path != Path::new(":memory:") {
             if let Some(parent) = database_path
                 .parent()
@@ -639,7 +657,10 @@ impl StrategyRegistry {
                 fs::create_dir_all(parent)?;
             }
         }
-        let registry = Self { database_path };
+        let registry = Self {
+            database_path,
+            strategy_catalog,
+        };
         let connection = registry.open_connection()?;
         initialize_schema(&connection)?;
         Ok(registry)
@@ -683,6 +704,7 @@ fn should_fallback_to_tmp(database_path: &Path, error: &StrategyRegistryError) -
         StrategyRegistryError::Serialization(_)
         | StrategyRegistryError::DeploymentNotFound { .. }
         | StrategyRegistryError::UnsupportedStrategy(_)
+        | StrategyRegistryError::StrategyCatalog(_)
         | StrategyRegistryError::ImmutableFieldChanged { .. }
         | StrategyRegistryError::InvalidStateTransition { .. }
         | StrategyRegistryError::DeploymentNotShadow { .. }
@@ -722,16 +744,14 @@ fn initialize_schema(connection: &Connection) -> Result<(), rusqlite::Error> {
     )
 }
 
-fn ensure_supported_strategy(strategy_key: &str) -> Result<(), StrategyRegistryError> {
-    if SUPPORTED_STRATEGIES
-        .iter()
-        .any(|strategy| strategy.as_key() == strategy_key)
-    {
-        return Ok(());
-    }
-    Err(StrategyRegistryError::UnsupportedStrategy(
-        strategy_key.to_string(),
-    ))
+fn ensure_supported_strategy(
+    strategy_catalog: &StrategyCatalog,
+    strategy_key: &str,
+) -> Result<(), StrategyRegistryError> {
+    strategy_catalog
+        .get(strategy_key)
+        .map(|_| ())
+        .ok_or_else(|| StrategyRegistryError::UnsupportedStrategy(strategy_key.to_string()))
 }
 
 fn deployment_is_runnable(state: &RuntimeDeploymentState) -> bool {
@@ -1115,6 +1135,7 @@ mod tests {
 
     use super::*;
     use protocol::{RuntimeCapital, RuntimeLane, RuntimePair, RuntimePolicy};
+    use strategy_core::{StrategyCatalog, StrategyKind};
 
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
@@ -1133,6 +1154,16 @@ mod tests {
     fn registry(test_name: &str) -> StrategyRegistry {
         StrategyRegistry::new(StrategyRegistryConfig::new(temp_database_url(test_name)))
             .expect("registry to initialize")
+    }
+
+    fn custom_catalog(strategy_key: &str) -> StrategyCatalog {
+        let mut catalog = StrategyCatalog::default();
+        let mut spec = StrategyKind::Dca.spec();
+        spec.strategy_key = strategy_key.to_string();
+        spec.plugin_key = format!("test::{strategy_key}");
+        spec.title = "Custom strategy".to_string();
+        catalog.register_spec(spec).expect("custom spec");
+        catalog
     }
 
     #[cfg(unix)]
@@ -1284,6 +1315,31 @@ mod tests {
                 .expect("deployment lookup")
                 .expect("deployment to exist"),
             deployment
+        );
+    }
+
+    #[test]
+    fn accepts_deployments_from_custom_catalog() {
+        let registry = StrategyRegistry::with_catalog(
+            StrategyRegistryConfig::new(temp_database_url("custom-catalog")),
+            custom_catalog("custom_signal"),
+        )
+        .expect("registry to initialize");
+        let mut deployment = deployment(
+            "deployment_custom",
+            RuntimeMode::Shadow,
+            RuntimeDeploymentState::Draft,
+        );
+        deployment.strategy_key = "custom_signal".to_string();
+
+        let result = registry
+            .upsert_deployment(&deployment)
+            .expect("custom deployment to store");
+
+        assert!(result.created);
+        assert_eq!(
+            registry.supported_strategy_keys(),
+            vec!["custom_signal".to_string()]
         );
     }
 

--- a/docs/runtime-contracts/README.md
+++ b/docs/runtime-contracts/README.md
@@ -16,19 +16,27 @@ autonomous runtime and strategy-lab research program.
 - Schema manifest: `docs/runtime-contracts/schema-manifest.v1.json`
 - Example fixtures: `docs/runtime-contracts/fixtures/*.json`
 
+The runtime contract set now also includes:
+
+- research lifecycle records for hypotheses, sources, experiments, and
+  evidence bundles,
+- the versioned `RuntimeStrategySpec` artifact used to describe strategy
+  parameters, feature requirements, venue support, asset constraints, and
+  promotion policy,
+- backward-compatible fixtures proving the Worker and Rust runtime can parse
+  the same strategy ABI.
+
 Generate or refresh the schemas with:
 
 ```bash
 bun run contracts:runtime:schemas
 ```
 
-## Intended Rust integration
+## Rust integration
 
-Runtime-rs does not exist in the repo yet. The agreed hook for later issues is:
-
-- `crates/protocol` or `services/runtime-rs` should consume the JSON Schemas and
-  manifest from this directory,
-- any Rust-side structs or serde codegen must derive from the same checked-in
-  schema set,
-- no private runtime route should ship before the Worker and runtime agree on
-  these artifacts.
+- `crates/protocol` mirrors these schemas directly for the runtime hot path.
+- `crates/strategy-core` consumes the shared `RuntimeStrategySpec` contract for
+  the built-in strategy catalog.
+- `services/runtime-rs` and `apps/worker` both consume the same checked-in
+  schema set; no private runtime route should ship before those surfaces agree
+  on these artifacts.

--- a/docs/runtime-contracts/fixtures/runtime.strategy_spec.valid.v1.json
+++ b/docs/runtime-contracts/fixtures/runtime.strategy_spec.valid.v1.json
@@ -1,0 +1,83 @@
+{
+  "schemaVersion": "v1",
+  "strategyKey": "trend_following",
+  "title": "Trend following",
+  "summary": "Follows the short-window return direction from the feature cache.",
+  "category": "signal",
+  "pluginKey": "builtin::trend_following",
+  "defaultLane": "safe",
+  "supportedModes": ["shadow", "paper", "live"],
+  "laneEligibility": ["safe", "protected"],
+  "supportedVenues": [
+    {
+      "venueKey": "jupiter",
+      "onboardingState": "broad_live_ready",
+      "notes": "Current runtime execution and canary coverage is bounded to the Jupiter bridge."
+    }
+  ],
+  "assetConstraints": [
+    {
+      "role": "base",
+      "assetKeys": [],
+      "required": true,
+      "notes": "The base asset is selected from the deployment pair at registration time."
+    },
+    {
+      "role": "quote",
+      "assetKeys": ["USDC"],
+      "required": true,
+      "notes": "The quote leg must remain USD-denominated for current budgeting and canary controls."
+    }
+  ],
+  "featureRequirements": [
+    {
+      "featureKey": "short_return_bps",
+      "required": true,
+      "freshnessMs": 20000,
+      "notes": "Requires fresh short-window return inputs for every evaluation."
+    }
+  ],
+  "parameterSpecs": [
+    {
+      "key": "policy.max_notional_usd",
+      "label": "Max notional USD",
+      "kind": "decimal",
+      "required": true,
+      "defaultValue": "25",
+      "minValue": "0.01",
+      "allowedValues": [],
+      "notes": "Upper bound for any single evaluation or slice."
+    },
+    {
+      "key": "policy.max_slippage_bps",
+      "label": "Max slippage bps",
+      "kind": "bps",
+      "required": true,
+      "defaultValue": "50",
+      "minValue": "1",
+      "maxValue": "250",
+      "allowedValues": [],
+      "notes": "Execution slippage ceiling enforced by the runtime bridge."
+    },
+    {
+      "key": "policy.daily_loss_limit_usd",
+      "label": "Daily loss limit USD",
+      "kind": "decimal",
+      "required": true,
+      "defaultValue": "10",
+      "minValue": "0",
+      "allowedValues": [],
+      "notes": "Daily stop-loss cap enforced by runtime risk controls."
+    }
+  ],
+  "promotionPolicy": {
+    "requiresHumanApproval": true,
+    "shadowMinRuns": 5,
+    "paperMinRuns": 7,
+    "liveLaneAllowlist": ["safe"],
+    "requiresFreshFeatures": true,
+    "limitedLiveOnly": true,
+    "notes": "Signal-driven templates require fresh features and remain bounded to safe-lane live rollout."
+  },
+  "tags": ["builtin", "signal"]
+}

--- a/docs/runtime-contracts/schema-manifest.v1.json
+++ b/docs/runtime-contracts/schema-manifest.v1.json
@@ -51,6 +51,11 @@
       "name": "researchEvidenceBundle",
       "schemaId": "https://trader-ralph.com/schemas/runtime/v1/research_evidence_bundle",
       "schemaFile": "docs/runtime-contracts/schemas/runtime.research_evidence_bundle.v1.schema.json"
+    },
+    {
+      "name": "strategySpec",
+      "schemaId": "https://trader-ralph.com/schemas/runtime/v1/strategy_spec",
+      "schemaFile": "docs/runtime-contracts/schemas/runtime.strategy_spec.v1.schema.json"
     }
   ],
   "rustCodegenHook": {

--- a/docs/runtime-contracts/schemas/runtime.strategy_spec.v1.schema.json
+++ b/docs/runtime-contracts/schemas/runtime.strategy_spec.v1.schema.json
@@ -1,0 +1,256 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://trader-ralph.com/schemas/runtime/v1/strategy_spec",
+  "type": "object",
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "v1"
+    },
+    "strategyKey": {
+      "type": "string",
+      "minLength": 1
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "category": {
+      "type": "string",
+      "enum": ["allocation", "signal", "advanced"]
+    },
+    "pluginKey": {
+      "type": "string",
+      "minLength": 1
+    },
+    "defaultLane": {
+      "type": "string",
+      "enum": ["safe", "protected", "fast"]
+    },
+    "supportedModes": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["shadow", "paper", "live"]
+      }
+    },
+    "laneEligibility": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["safe", "protected", "fast"]
+      }
+    },
+    "supportedVenues": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "venueKey": {
+            "type": "string",
+            "minLength": 1
+          },
+          "onboardingState": {
+            "type": "string",
+            "enum": [
+              "candidate",
+              "integrated",
+              "shadow_ready",
+              "paper_ready",
+              "limited_live_ready",
+              "broad_live_ready",
+              "paused",
+              "deprecated"
+            ]
+          },
+          "notes": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": ["venueKey", "onboardingState"],
+        "additionalProperties": false
+      }
+    },
+    "assetConstraints": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": ["base", "quote", "either"]
+          },
+          "assetKeys": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "notes": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": ["role", "assetKeys", "required"],
+        "additionalProperties": false
+      }
+    },
+    "featureRequirements": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "featureKey": {
+            "type": "string",
+            "minLength": 1
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "freshnessMs": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          },
+          "notes": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": ["featureKey", "required"],
+        "additionalProperties": false
+      }
+    },
+    "parameterSpecs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "minLength": 1
+          },
+          "label": {
+            "type": "string",
+            "minLength": 1
+          },
+          "kind": {
+            "type": "string",
+            "enum": ["decimal", "integer", "bps", "boolean", "enum"]
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "defaultValue": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minValue": {
+            "type": "string",
+            "minLength": 1
+          },
+          "maxValue": {
+            "type": "string",
+            "minLength": 1
+          },
+          "allowedValues": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "notes": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": ["key", "label", "kind", "required", "allowedValues"],
+        "additionalProperties": false
+      }
+    },
+    "promotionPolicy": {
+      "type": "object",
+      "properties": {
+        "requiresHumanApproval": {
+          "type": "boolean"
+        },
+        "shadowMinRuns": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "paperMinRuns": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "liveLaneAllowlist": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["safe", "protected", "fast"]
+          }
+        },
+        "requiresFreshFeatures": {
+          "type": "boolean"
+        },
+        "limitedLiveOnly": {
+          "type": "boolean"
+        },
+        "notes": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "requiresHumanApproval",
+        "shadowMinRuns",
+        "paperMinRuns",
+        "liveLaneAllowlist",
+        "requiresFreshFeatures",
+        "limitedLiveOnly"
+      ],
+      "additionalProperties": false
+    },
+    "tags": {
+      "maxItems": 16,
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "strategyKey",
+    "title",
+    "summary",
+    "category",
+    "pluginKey",
+    "defaultLane",
+    "supportedModes",
+    "laneEligibility",
+    "supportedVenues",
+    "assetConstraints",
+    "featureRequirements",
+    "parameterSpecs",
+    "promotionPolicy",
+    "tags"
+  ],
+  "additionalProperties": false
+}

--- a/services/runtime-rs/README.md
+++ b/services/runtime-rs/README.md
@@ -69,6 +69,15 @@ The bounded live bridge remains intentionally narrow in v1:
 - `runtime.shadowOnly` must be disabled explicitly through Worker ops controls
 - non-live runtime plans still coordinate synthetically through the Worker bridge
 
+Strategy selection is no longer hardcoded as a raw `strategy_key` allowlist:
+
+- `crates/strategy-core` owns the built-in `RuntimeStrategySpec` catalog
+- `crates/strategy-registry` validates deployments against that catalog
+- `crates/execution-planner` loads repo-owned strategy plugins from the same
+  contract surface
+- new strategies can be added by registering a new StrategySpec and planner
+  plugin without widening the public Worker API
+
 ## Local commands
 
 ```bash

--- a/services/runtime-rs/src/lib.rs
+++ b/services/runtime-rs/src/lib.rs
@@ -12,7 +12,7 @@ use exec_client::{
 };
 use execution_planner::{
     ExecutionPlanner, ExecutionPlannerConfig, ExecutionPlannerError, ExecutionPlannerInput,
-    ExecutionPlannerSnapshot,
+    ExecutionPlannerSnapshot, StrategyPluginRegistry,
 };
 use feature_cache::{FeatureCache, FeatureCacheConfig, FeatureCacheSnapshot};
 use market_adapters::{FeedGateway, FeedGatewayConfig, FeedGatewaySnapshot, FeedReplayFixture};
@@ -42,7 +42,7 @@ use runtime_scorecards::{
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::{json, Value};
-use strategy_core::SUPPORTED_STRATEGIES;
+use strategy_core::StrategyCatalog;
 use strategy_registry::{
     ShadowEvaluationTrigger, StrategyRegistry, StrategyRegistryConfig, StrategyRegistryError,
     StrategyRegistrySnapshot,
@@ -96,9 +96,14 @@ impl RuntimeAppState {
         if should_spawn_fixture_keepalive(&config) {
             spawn_fixture_keepalive(feed_gateway.clone(), feature_cache.clone());
         }
-        let strategy_registry =
-            StrategyRegistry::new(StrategyRegistryConfig::new(config.database_url.clone()))
-                .expect("strategy registry to initialize");
+        let strategy_plugins =
+            StrategyPluginRegistry::builtin().expect("strategy plugin registry to initialize");
+        let strategy_catalog: StrategyCatalog = strategy_plugins.catalog();
+        let strategy_registry = StrategyRegistry::with_catalog(
+            StrategyRegistryConfig::new(config.database_url.clone()),
+            strategy_catalog,
+        )
+        .expect("strategy registry to initialize");
         let research_registry =
             ResearchRegistry::new(ResearchRegistryConfig::new(config.database_url.clone()))
                 .expect("research registry to initialize");
@@ -113,9 +118,11 @@ impl RuntimeAppState {
             config.feature_stale_after_ms,
         ))
         .expect("risk engine to initialize");
-        let execution_planner =
-            ExecutionPlanner::new(ExecutionPlannerConfig::new(config.database_url.clone()))
-                .expect("execution planner to initialize");
+        let execution_planner = ExecutionPlanner::with_plugins(
+            ExecutionPlannerConfig::new(config.database_url.clone()),
+            strategy_plugins,
+        )
+        .expect("execution planner to initialize");
         let reconciler = Reconciler::new(ReconcilerConfig::new(config.database_url.clone()))
             .expect("reconciler to initialize");
         let exec_client = ExecClient::new(ExecClientConfig {
@@ -389,10 +396,7 @@ fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
         risk_engine,
         execution_planner,
         reconciler,
-        supported_strategies: SUPPORTED_STRATEGIES
-            .iter()
-            .map(|strategy| strategy.as_key().to_string())
-            .collect(),
+        supported_strategies: state.execution_planner.supported_strategy_keys(),
     }
 }
 
@@ -412,10 +416,7 @@ fn metrics_response(state: &RuntimeAppState) -> RuntimeMetricsResponse {
         risk_engine: state.risk_engine_snapshot(),
         execution_planner: state.execution_planner_snapshot(),
         reconciler: state.reconciler_snapshot(),
-        supported_strategies: SUPPORTED_STRATEGIES
-            .iter()
-            .map(|strategy| strategy.as_key().to_string())
-            .collect(),
+        supported_strategies: state.execution_planner.supported_strategy_keys(),
     }
 }
 
@@ -1459,6 +1460,11 @@ fn map_registry_error(error: StrategyRegistryError) -> JsonPayload {
             "unsupported-strategy",
             json!({ "strategyKey": strategy_key }),
         ),
+        StrategyRegistryError::StrategyCatalog(error) => error_json(
+            StatusCode::BAD_REQUEST,
+            "invalid-strategy-spec",
+            json!({ "reason": error.to_string() }),
+        ),
         StrategyRegistryError::ImmutableFieldChanged {
             deployment_id,
             field,
@@ -1604,6 +1610,16 @@ fn map_execution_planner_error(error: ExecutionPlannerError) -> JsonPayload {
             StatusCode::NOT_FOUND,
             "execution-plan-not-found",
             json!({ "planId": plan_id }),
+        ),
+        ExecutionPlannerError::UnsupportedStrategy(strategy_key) => error_json(
+            StatusCode::BAD_REQUEST,
+            "unsupported-strategy",
+            json!({ "strategyKey": strategy_key }),
+        ),
+        ExecutionPlannerError::StrategyCatalog(error) => error_json(
+            StatusCode::BAD_REQUEST,
+            "invalid-strategy-spec",
+            json!({ "reason": error.to_string() }),
         ),
         ExecutionPlannerError::Io(error) => error_json(
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/runtime/contracts/autonomous_runtime.ts
+++ b/src/runtime/contracts/autonomous_runtime.ts
@@ -379,6 +379,106 @@ export const RuntimeResearchEvidenceBundleRecordSchema = VersionedSchema.extend(
   },
 ).strict();
 
+export const RuntimeStrategyCategorySchema = z.enum([
+  "allocation",
+  "signal",
+  "advanced",
+]);
+
+export const RuntimeStrategyParameterKindSchema = z.enum([
+  "decimal",
+  "integer",
+  "bps",
+  "boolean",
+  "enum",
+]);
+
+export const RuntimeStrategyAssetRoleSchema = z.enum([
+  "base",
+  "quote",
+  "either",
+]);
+
+export const RuntimeOnboardingStateSchema = z.enum([
+  "candidate",
+  "integrated",
+  "shadow_ready",
+  "paper_ready",
+  "limited_live_ready",
+  "broad_live_ready",
+  "paused",
+  "deprecated",
+]);
+
+const RuntimeStrategyVenueSupportSchema = z
+  .object({
+    venueKey: NON_EMPTY_STRING_SCHEMA,
+    onboardingState: RuntimeOnboardingStateSchema,
+    notes: NON_EMPTY_STRING_SCHEMA.optional(),
+  })
+  .strict();
+
+const RuntimeStrategyAssetConstraintSchema = z
+  .object({
+    role: RuntimeStrategyAssetRoleSchema,
+    assetKeys: z.array(NON_EMPTY_STRING_SCHEMA),
+    required: z.boolean(),
+    notes: NON_EMPTY_STRING_SCHEMA.optional(),
+  })
+  .strict();
+
+const RuntimeStrategyFeatureRequirementSchema = z
+  .object({
+    featureKey: NON_EMPTY_STRING_SCHEMA,
+    required: z.boolean(),
+    freshnessMs: z.number().int().positive().optional(),
+    notes: NON_EMPTY_STRING_SCHEMA.optional(),
+  })
+  .strict();
+
+const RuntimeStrategyParameterSpecSchema = z
+  .object({
+    key: NON_EMPTY_STRING_SCHEMA,
+    label: NON_EMPTY_STRING_SCHEMA,
+    kind: RuntimeStrategyParameterKindSchema,
+    required: z.boolean(),
+    defaultValue: NON_EMPTY_STRING_SCHEMA.optional(),
+    minValue: NON_EMPTY_STRING_SCHEMA.optional(),
+    maxValue: NON_EMPTY_STRING_SCHEMA.optional(),
+    allowedValues: z.array(NON_EMPTY_STRING_SCHEMA),
+    notes: NON_EMPTY_STRING_SCHEMA.optional(),
+  })
+  .strict();
+
+const RuntimeStrategyPromotionPolicySchema = z
+  .object({
+    requiresHumanApproval: z.boolean(),
+    shadowMinRuns: z.number().int().nonnegative(),
+    paperMinRuns: z.number().int().nonnegative(),
+    liveLaneAllowlist: z.array(RuntimeLaneSchema),
+    requiresFreshFeatures: z.boolean(),
+    limitedLiveOnly: z.boolean(),
+    notes: NON_EMPTY_STRING_SCHEMA.optional(),
+  })
+  .strict();
+
+export const RuntimeStrategySpecSchema = VersionedSchema.extend({
+  strategyKey: NON_EMPTY_STRING_SCHEMA,
+  title: NON_EMPTY_STRING_SCHEMA,
+  summary: NON_EMPTY_STRING_SCHEMA,
+  category: RuntimeStrategyCategorySchema,
+  pluginKey: NON_EMPTY_STRING_SCHEMA,
+  defaultLane: RuntimeLaneSchema,
+  supportedModes: z.array(RuntimeModeSchema).min(1),
+  laneEligibility: z.array(RuntimeLaneSchema).min(1),
+  supportedVenues: z.array(RuntimeStrategyVenueSupportSchema).min(1),
+  assetConstraints: z.array(RuntimeStrategyAssetConstraintSchema).min(1),
+  featureRequirements: z.array(RuntimeStrategyFeatureRequirementSchema),
+  parameterSpecs: z.array(RuntimeStrategyParameterSpecSchema),
+  promotionPolicy: RuntimeStrategyPromotionPolicySchema,
+  tags: z.array(NON_EMPTY_STRING_SCHEMA).max(16),
+}).strict();
+
 export type RuntimeMode = z.infer<typeof RuntimeModeSchema>;
 export type RuntimeLane = z.infer<typeof RuntimeLaneSchema>;
 export type RuntimeDeploymentState = z.infer<
@@ -407,6 +507,7 @@ export type RuntimeResearchExperimentRecord = z.infer<
 export type RuntimeResearchEvidenceBundleRecord = z.infer<
   typeof RuntimeResearchEvidenceBundleRecordSchema
 >;
+export type RuntimeStrategySpec = z.infer<typeof RuntimeStrategySpecSchema>;
 
 export const RUNTIME_DEPLOYMENT_STATE_TRANSITIONS = {
   draft: ["shadow", "paper", "live", "archived"],
@@ -488,6 +589,11 @@ export const RUNTIME_PROTOCOL_SCHEMA_REGISTRY = {
       "https://trader-ralph.com/schemas/runtime/v1/research_evidence_bundle",
     outputFile: "runtime.research_evidence_bundle.v1.schema.json",
   },
+  strategySpec: {
+    schema: RuntimeStrategySpecSchema,
+    schemaId: "https://trader-ralph.com/schemas/runtime/v1/strategy_spec",
+    outputFile: "runtime.strategy_spec.v1.schema.json",
+  },
 } as const;
 
 export function canTransitionRuntimeDeploymentState(
@@ -566,6 +672,10 @@ export function parseRuntimeResearchEvidenceBundleRecord(
   return RuntimeResearchEvidenceBundleRecordSchema.parse(input);
 }
 
+export function parseRuntimeStrategySpec(input: unknown): RuntimeStrategySpec {
+  return RuntimeStrategySpecSchema.parse(input);
+}
+
 export function safeParseRuntimeDeploymentRecord(input: unknown) {
   return RuntimeDeploymentRecordSchema.safeParse(input);
 }
@@ -604,4 +714,8 @@ export function safeParseRuntimeResearchExperimentRecord(input: unknown) {
 
 export function safeParseRuntimeResearchEvidenceBundleRecord(input: unknown) {
   return RuntimeResearchEvidenceBundleRecordSchema.safeParse(input);
+}
+
+export function safeParseRuntimeStrategySpec(input: unknown) {
+  return RuntimeStrategySpecSchema.safeParse(input);
 }

--- a/tests/unit/runtime_protocol_contracts.test.ts
+++ b/tests/unit/runtime_protocol_contracts.test.ts
@@ -13,6 +13,7 @@ import {
   parseRuntimeResearchSourceRecord,
   parseRuntimeRiskVerdict,
   parseRuntimeRunRecord,
+  parseRuntimeStrategySpec,
   RUNTIME_DEPLOYMENT_STATE_TRANSITIONS,
   RUNTIME_PROTOCOL_SCHEMA_REGISTRY,
   RUNTIME_RUN_STATE_TRANSITIONS,
@@ -301,6 +302,62 @@ describe("runtime protocol contracts", () => {
       summary: "Evidence bundle for shadow-to-paper review.",
       tags: ["promotion"],
     });
+    const strategySpec = parseRuntimeStrategySpec({
+      schemaVersion: "v1",
+      strategyKey: "trend_following",
+      title: "Trend following",
+      summary:
+        "Follows the short-window return direction from the feature cache.",
+      category: "signal",
+      pluginKey: "builtin::trend_following",
+      defaultLane: "safe",
+      supportedModes: ["shadow", "paper", "live"],
+      laneEligibility: ["safe", "protected"],
+      supportedVenues: [
+        {
+          venueKey: "jupiter",
+          onboardingState: "broad_live_ready",
+        },
+      ],
+      assetConstraints: [
+        {
+          role: "base",
+          assetKeys: [],
+          required: true,
+        },
+        {
+          role: "quote",
+          assetKeys: ["USDC"],
+          required: true,
+        },
+      ],
+      featureRequirements: [
+        {
+          featureKey: "short_return_bps",
+          required: true,
+          freshnessMs: 20000,
+        },
+      ],
+      parameterSpecs: [
+        {
+          key: "policy.max_notional_usd",
+          label: "Max notional USD",
+          kind: "decimal",
+          required: true,
+          defaultValue: "25",
+          allowedValues: [],
+        },
+      ],
+      promotionPolicy: {
+        requiresHumanApproval: true,
+        shadowMinRuns: 5,
+        paperMinRuns: 7,
+        liveLaneAllowlist: ["safe"],
+        requiresFreshFeatures: true,
+        limitedLiveOnly: true,
+      },
+      tags: ["builtin", "signal"],
+    });
 
     expect(run.state).toBe("planned");
     expect(ledger.totals.availableUsd).toBe("95");
@@ -313,6 +370,7 @@ describe("runtime protocol contracts", () => {
     expect(sourceRecord.sourceKind).toBe("paper");
     expect(experiment.datasetSnapshots).toHaveLength(1);
     expect(evidenceBundle.promotionTarget).toBe("paper");
+    expect(strategySpec.pluginKey).toBe("builtin::trend_following");
   });
 
   test("rejects an execution plan without slices", () => {

--- a/tests/unit/runtime_protocol_schema_fixtures.test.ts
+++ b/tests/unit/runtime_protocol_schema_fixtures.test.ts
@@ -82,6 +82,12 @@ describe("runtime protocol schema fixtures", () => {
         "docs/runtime-contracts/fixtures/runtime.research_evidence_bundle.valid.v1.json",
       ),
     ).toBe(true);
+    expect(
+      validate(
+        "docs/runtime-contracts/schemas/runtime.strategy_spec.v1.schema.json",
+        "docs/runtime-contracts/fixtures/runtime.strategy_spec.valid.v1.json",
+      ),
+    ).toBe(true);
   });
 
   test("manifest lists every runtime schema file", () => {
@@ -102,6 +108,7 @@ describe("runtime protocol schema fixtures", () => {
       "docs/runtime-contracts/schemas/runtime.research_source.v1.schema.json",
       "docs/runtime-contracts/schemas/runtime.research_experiment.v1.schema.json",
       "docs/runtime-contracts/schemas/runtime.research_evidence_bundle.v1.schema.json",
+      "docs/runtime-contracts/schemas/runtime.strategy_spec.v1.schema.json",
     ]);
   });
 });

--- a/tests/unit/worker_runtime_contracts.test.ts
+++ b/tests/unit/worker_runtime_contracts.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import {
   parseRuntimeDeploymentRecord,
+  parseRuntimeStrategySpec,
   RUNTIME_PROTOCOL_SCHEMA_REGISTRY,
 } from "../../apps/worker/src/runtime_contracts.js";
 
@@ -24,6 +25,7 @@ describe("worker runtime contract bridge", () => {
       "researchSource",
       "researchExperiment",
       "researchEvidenceBundle",
+      "strategySpec",
     ]);
   });
 
@@ -36,5 +38,16 @@ describe("worker runtime contract bridge", () => {
 
     expect(deployment.deploymentId).toBe("dep_runtime_sol_usdc_shadow");
     expect(deployment.mode).toBe("shadow");
+  });
+
+  test("worker can parse the canonical strategy spec fixture", () => {
+    const strategySpec = parseRuntimeStrategySpec(
+      readJson(
+        "docs/runtime-contracts/fixtures/runtime.strategy_spec.valid.v1.json",
+      ),
+    );
+
+    expect(strategySpec.strategyKey).toBe("trend_following");
+    expect(strategySpec.pluginKey).toBe("builtin::trend_following");
   });
 });


### PR DESCRIPTION
## Summary
- add a versioned `RuntimeStrategySpec` contract, fixture, and schema generation output
- replace raw fixed-strategy validation with a repo-owned built-in strategy catalog in `strategy-core`
- route deployment validation and execution planning through shared strategy specs and an internal plugin registry

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun test tests/unit/runtime_protocol_contracts.test.ts tests/unit/runtime_protocol_schema_fixtures.test.ts tests/unit/worker_runtime_contracts.test.ts`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Risk Notes
- Worker public APIs stay unchanged; the new StrategySpec and plugin contract are internal/runtime-owned only.
- Existing built-in strategies are mapped into the new catalog first, and unsupported specs fail closed.

Closes #307