### PR TITLE
feat: add runtime asset registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "asset-registry"
+version = "0.1.0"
+dependencies = [
+ "protocol",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,6 +1002,7 @@ dependencies = [
 name = "runtime-rs"
 version = "0.1.0"
 dependencies = [
+ "asset-registry",
  "axum",
  "exec-client",
  "execution-planner",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+  "crates/asset-registry",
   "crates/execution-planner",
   "crates/exec-client",
   "crates/feature-cache",

--- a/apps/worker/src/runtime_contracts.ts
+++ b/apps/worker/src/runtime_contracts.ts
@@ -1,4 +1,6 @@
 export type {
+  RuntimeAssetListingState,
+  RuntimeAssetRecord,
   RuntimeDeploymentRecord,
   RuntimeDeploymentState,
   RuntimeExecutionPlan,
@@ -21,6 +23,7 @@ export type {
 export {
   canTransitionRuntimeDeploymentState,
   canTransitionRuntimeRunState,
+  parseRuntimeAssetRecord,
   parseRuntimeDeploymentRecord,
   parseRuntimeExecutionPlan,
   parseRuntimeLedgerSnapshot,
@@ -38,6 +41,7 @@ export {
   RUNTIME_PROTOCOL_SCHEMA_REGISTRY,
   RUNTIME_PROTOCOL_SCHEMA_VERSION,
   RUNTIME_RUN_STATE_TRANSITIONS,
+  safeParseRuntimeAssetRecord,
   safeParseRuntimeDeploymentRecord,
   safeParseRuntimeExecutionPlan,
   safeParseRuntimeLedgerSnapshot,

--- a/apps/worker/src/runtime_internal.ts
+++ b/apps/worker/src/runtime_internal.ts
@@ -4,6 +4,7 @@ import {
 } from "./execution/error_taxonomy";
 import { json } from "./response";
 import {
+  parseRuntimeAssetRecord,
   parseRuntimeDeploymentRecord,
   parseRuntimeExecutionPlan,
   parseRuntimeLedgerSnapshot,
@@ -13,6 +14,8 @@ import {
   parseRuntimeResearchSourceRecord,
   parseRuntimeRunRecord,
   RUNTIME_PROTOCOL_SCHEMA_VERSION,
+  type RuntimeAssetListingState,
+  type RuntimeAssetRecord,
   type RuntimeDeploymentRecord,
   type RuntimeExecutionPlan,
   type RuntimeLedgerSnapshot,
@@ -38,6 +41,8 @@ const INTERNAL_RUNTIME_RESEARCH_HYPOTHESES_PATH = `${INTERNAL_RUNTIME_RESEARCH_P
 const INTERNAL_RUNTIME_RESEARCH_SOURCES_PATH = `${INTERNAL_RUNTIME_RESEARCH_PATH}/sources`;
 const INTERNAL_RUNTIME_RESEARCH_EXPERIMENTS_PATH = `${INTERNAL_RUNTIME_RESEARCH_PATH}/experiments`;
 const INTERNAL_RUNTIME_RESEARCH_EVIDENCE_BUNDLES_PATH = `${INTERNAL_RUNTIME_RESEARCH_PATH}/evidence-bundles`;
+const INTERNAL_RUNTIME_ASSETS_PATH = `${INTERNAL_RUNTIME_PREFIX}/assets`;
+const INTERNAL_RUNTIME_ASSETS_PREFIX = `${INTERNAL_RUNTIME_ASSETS_PATH}/`;
 const FIXTURE_TIMESTAMP = "2026-03-07T00:00:00.000Z";
 const FIXTURE_BASE_MINT = "So11111111111111111111111111111111111111112";
 const FIXTURE_QUOTE_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
@@ -470,6 +475,12 @@ function createRuntimeHealthFixture() {
       latestExperimentCompletedAt: FIXTURE_TIMESTAMP,
       lastError: null,
     },
+    assetRegistry: {
+      status: "healthy",
+      assetCount: 2,
+      liveAssetCount: 2,
+      lastError: null,
+    },
     allocator: {
       status: "healthy",
       decisionCount: 1,
@@ -645,6 +656,74 @@ function createRuntimeResearchRegistryFixture() {
   };
 }
 
+function createRuntimeAssetFixture(
+  assetKey = "SOL",
+  listingState: RuntimeAssetListingState = "live",
+): RuntimeAssetRecord {
+  const isSol = assetKey === "SOL";
+  const nativeId = isSol
+    ? "So11111111111111111111111111111111111111112"
+    : "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+  return parseRuntimeAssetRecord({
+    schemaVersion: RUNTIME_PROTOCOL_SCHEMA_VERSION,
+    assetKey,
+    displayName: isSol ? "Solana" : "USD Coin",
+    symbol: assetKey,
+    chainKey: "solana-mainnet",
+    canonicalId: nativeId,
+    assetKind: isSol ? "native" : "stablecoin",
+    riskClass: "core",
+    listingState,
+    decimals: isSol ? 9 : 6,
+    aliases: isSol ? ["WSOL"] : ["USD Coin"],
+    quoteAssetKeys: ["USDC"],
+    venueMappings: [
+      {
+        venueKey: "jupiter",
+        nativeId,
+        venueSymbol: assetKey,
+        decimals: isSol ? 9 : 6,
+        listingState: "live",
+        quoteAssetKeys: ["USDC"],
+        priceDecimals: 6,
+        sizeDecimals: isSol ? 9 : 6,
+        minNotionalUsd: "0.01",
+        notes: "Primary live mapping.",
+      },
+      {
+        venueKey: "magicblock",
+        nativeId,
+        venueSymbol: assetKey,
+        decimals: isSol ? 9 : 6,
+        listingState: "paper",
+        quoteAssetKeys: ["USDC"],
+        priceDecimals: 6,
+        sizeDecimals: isSol ? 9 : 6,
+        minNotionalUsd: "0.01",
+        notes: "Paper-only mapping.",
+      },
+    ],
+    createdAt: FIXTURE_TIMESTAMP,
+    updatedAt: FIXTURE_TIMESTAMP,
+    ...(listingState === "live" ? { promotedAt: FIXTURE_TIMESTAMP } : {}),
+    ...(listingState === "paused" ? { pausedAt: FIXTURE_TIMESTAMP } : {}),
+    ...(listingState === "deprecated"
+      ? { deprecatedAt: FIXTURE_TIMESTAMP }
+      : {}),
+    tags: ["asset-registry", "fixture"],
+    notes: "Stubbed asset registry fixture.",
+  });
+}
+
+function createRuntimeAssetRegistryFixture() {
+  return {
+    assets: [
+      createRuntimeAssetFixture("SOL", "live"),
+      createRuntimeAssetFixture("USDC", "live"),
+    ],
+  };
+}
+
 async function readJsonBody(request: Request): Promise<unknown> {
   try {
     return await request.json();
@@ -683,6 +762,7 @@ function buildRuntimeHealthPayload(env: Env, service: string) {
       scorecards: INTERNAL_RUNTIME_SCORECARDS_PATH,
       allocator: INTERNAL_RUNTIME_ALLOCATOR_PATH,
       research: INTERNAL_RUNTIME_RESEARCH_PATH,
+      assets: INTERNAL_RUNTIME_ASSETS_PATH,
       executionPlans: INTERNAL_RUNTIME_EXECUTION_PLANS_PATH,
       health: `${INTERNAL_RUNTIME_PREFIX}/health`,
     },
@@ -723,6 +803,19 @@ function runtimeEvaluateDeploymentIdFromPath(pathname: string): string | null {
   }
   const deploymentId = suffix.slice(0, -evaluateSuffix.length);
   return deploymentId && !deploymentId.includes("/") ? deploymentId : null;
+}
+
+function runtimeAssetTransitionKeyFromPath(pathname: string): string | null {
+  if (!pathname.startsWith(INTERNAL_RUNTIME_ASSETS_PREFIX)) {
+    return null;
+  }
+  const suffix = pathname.slice(INTERNAL_RUNTIME_ASSETS_PREFIX.length);
+  const transitionSuffix = "/transition";
+  if (!suffix.endsWith(transitionSuffix)) {
+    return null;
+  }
+  const assetKey = suffix.slice(0, -transitionSuffix.length);
+  return assetKey && !assetKey.includes("/") ? assetKey : null;
 }
 
 async function dispatchRuntimeInternalJson(input: {
@@ -1067,6 +1160,56 @@ export async function writeRuntimeResearchEvidenceBundle(input: {
   });
 }
 
+export async function readRuntimeAssetRegistry(input: {
+  env: Env;
+  assetKey?: string;
+  venueKey?: string;
+  listingState?: RuntimeAssetListingState;
+}): Promise<RuntimeInternalJsonResult> {
+  const search = new URLSearchParams();
+  if (input.assetKey) search.set("assetKey", input.assetKey);
+  if (input.venueKey) search.set("venueKey", input.venueKey);
+  if (input.listingState) search.set("listingState", input.listingState);
+  return await dispatchRuntimeInternalJson({
+    env: input.env,
+    method: "GET",
+    pathname: search.size
+      ? `${INTERNAL_RUNTIME_ASSETS_PATH}?${search.toString()}`
+      : INTERNAL_RUNTIME_ASSETS_PATH,
+  });
+}
+
+export async function writeRuntimeAsset(input: {
+  env: Env;
+  asset: RuntimeAssetRecord;
+}): Promise<RuntimeInternalJsonResult> {
+  return await dispatchRuntimeInternalJson({
+    env: input.env,
+    method: "POST",
+    pathname: INTERNAL_RUNTIME_ASSETS_PATH,
+    body: input.asset,
+  });
+}
+
+export async function transitionRuntimeAssetListingState(input: {
+  env: Env;
+  assetKey: string;
+  listingState: RuntimeAssetListingState;
+  changedAt?: string;
+}): Promise<RuntimeInternalJsonResult> {
+  return await dispatchRuntimeInternalJson({
+    env: input.env,
+    method: "POST",
+    pathname: `${INTERNAL_RUNTIME_ASSETS_PATH}/${encodeURIComponent(
+      input.assetKey,
+    )}/transition`,
+    body: {
+      listingState: input.listingState,
+      ...(input.changedAt ? { changedAt: input.changedAt } : {}),
+    },
+  });
+}
+
 export async function readRuntimePositionSnapshot(
   env: Env,
   deploymentId: string,
@@ -1124,8 +1267,10 @@ export async function handleRuntimeInternalRoute(
     url.pathname === INTERNAL_RUNTIME_RESEARCH_SOURCES_PATH ||
     url.pathname === INTERNAL_RUNTIME_RESEARCH_EXPERIMENTS_PATH ||
     url.pathname === INTERNAL_RUNTIME_RESEARCH_EVIDENCE_BUNDLES_PATH ||
+    url.pathname === INTERNAL_RUNTIME_ASSETS_PATH ||
     url.pathname === INTERNAL_RUNTIME_EXECUTION_PLANS_PATH ||
     url.pathname.startsWith(INTERNAL_RUNTIME_DEPLOYMENTS_PREFIX) ||
+    url.pathname.startsWith(INTERNAL_RUNTIME_ASSETS_PREFIX) ||
     url.pathname.startsWith(INTERNAL_RUNTIME_RUNS_PREFIX);
   if (!isRuntimeRoute) return null;
 
@@ -1216,6 +1361,22 @@ export async function handleRuntimeInternalRoute(
         sourceId: url.searchParams.get("sourceId"),
       },
       registry: createRuntimeResearchRegistryFixture(),
+    });
+  }
+
+  if (
+    request.method === "GET" &&
+    url.pathname === INTERNAL_RUNTIME_ASSETS_PATH
+  ) {
+    return json({
+      ok: true,
+      source: "stub",
+      filters: {
+        assetKey: url.searchParams.get("assetKey"),
+        venueKey: url.searchParams.get("venueKey"),
+        listingState: url.searchParams.get("listingState"),
+      },
+      registry: createRuntimeAssetRegistryFixture(),
     });
   }
 
@@ -1495,6 +1656,70 @@ export async function handleRuntimeInternalRoute(
       },
       { status: 201 },
     );
+  }
+
+  if (
+    request.method === "POST" &&
+    url.pathname === INTERNAL_RUNTIME_ASSETS_PATH
+  ) {
+    let asset: RuntimeAssetRecord;
+    try {
+      const payload = await readJsonBody(request);
+      asset = parseRuntimeAssetRecord(payload);
+    } catch (error) {
+      return json(
+        {
+          ok: false,
+          error: "invalid-runtime-asset",
+          details: {
+            reason: error instanceof Error ? error.message : "unknown-error",
+          },
+        },
+        { status: 400 },
+      );
+    }
+    return json(
+      {
+        ok: true,
+        source: "stub",
+        created: true,
+        asset,
+      },
+      { status: 201 },
+    );
+  }
+
+  if (request.method === "POST") {
+    const transitionAssetKey = runtimeAssetTransitionKeyFromPath(url.pathname);
+    if (transitionAssetKey) {
+      let payload: Record<string, unknown>;
+      try {
+        const body = await readJsonBody(request);
+        payload =
+          body && typeof body === "object" && !Array.isArray(body)
+            ? (body as Record<string, unknown>)
+            : {};
+      } catch {
+        payload = {};
+      }
+      const listingState =
+        typeof payload.listingState === "string" &&
+        [
+          "candidate",
+          "shadow",
+          "paper",
+          "live",
+          "paused",
+          "deprecated",
+        ].includes(payload.listingState)
+          ? (payload.listingState as RuntimeAssetListingState)
+          : "live";
+      return json({
+        ok: true,
+        source: "stub",
+        asset: createRuntimeAssetFixture(transitionAssetKey, listingState),
+      });
+    }
   }
 
   if (

--- a/crates/asset-registry/Cargo.toml
+++ b/crates/asset-registry/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "asset-registry"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+protocol = { path = "../protocol" }
+rusqlite = { version = "0.37.0", features = ["bundled"] }
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true

--- a/crates/asset-registry/src/lib.rs
+++ b/crates/asset-registry/src/lib.rs
@@ -5,7 +5,8 @@ use std::{
 
 use protocol::{
     RuntimeAssetKind, RuntimeAssetListingState, RuntimeAssetRecord, RuntimeAssetRiskClass,
-    RuntimeAssetVenueMapping, RuntimeDeploymentRecord, RuntimeMode, RUNTIME_PROTOCOL_SCHEMA_VERSION,
+    RuntimeAssetVenueMapping, RuntimeDeploymentRecord, RuntimeMode,
+    RUNTIME_PROTOCOL_SCHEMA_VERSION,
 };
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
@@ -83,7 +84,10 @@ pub enum AssetRegistryError {
         mode: RuntimeMode,
     },
     #[error("asset {asset_key} does not support venue {venue_key}")]
-    VenueMappingMissing { asset_key: String, venue_key: String },
+    VenueMappingMissing {
+        asset_key: String,
+        venue_key: String,
+    },
     #[error("asset {asset_key} venue {venue_key} mapping is {listing_state:?} and does not support mode {mode:?}")]
     VenueMappingModeUnsupported {
         asset_key: String,
@@ -92,7 +96,10 @@ pub enum AssetRegistryError {
         mode: RuntimeMode,
     },
     #[error("asset mapping not found for venue {venue_key} native id {native_id}")]
-    VenueNativeIdNotFound { venue_key: String, native_id: String },
+    VenueNativeIdNotFound {
+        venue_key: String,
+        native_id: String,
+    },
 }
 
 impl AssetRegistry {
@@ -149,7 +156,7 @@ impl AssetRegistry {
         let rows = statement.query_map(
             params![
                 query.asset_key.as_deref(),
-                listing_state.as_deref(),
+                listing_state,
                 query.venue_key.as_deref(),
             ],
             |row| row.get::<_, String>(0),
@@ -209,18 +216,24 @@ impl AssetRegistry {
         deployment: &RuntimeDeploymentRecord,
     ) -> Result<SupportedPair, AssetRegistryError> {
         let connection = self.open_connection()?;
-        let base_asset =
-            load_asset_for_venue_native_id(&connection, &deployment.venue_key, &deployment.pair.base_mint)?
-                .ok_or_else(|| AssetRegistryError::VenueNativeIdNotFound {
-                    venue_key: deployment.venue_key.clone(),
-                    native_id: deployment.pair.base_mint.clone(),
-                })?;
-        let quote_asset =
-            load_asset_for_venue_native_id(&connection, &deployment.venue_key, &deployment.pair.quote_mint)?
-                .ok_or_else(|| AssetRegistryError::VenueNativeIdNotFound {
-                    venue_key: deployment.venue_key.clone(),
-                    native_id: deployment.pair.quote_mint.clone(),
-                })?;
+        let base_asset = load_asset_for_venue_native_id(
+            &connection,
+            &deployment.venue_key,
+            &deployment.pair.base_mint,
+        )?
+        .ok_or_else(|| AssetRegistryError::VenueNativeIdNotFound {
+            venue_key: deployment.venue_key.clone(),
+            native_id: deployment.pair.base_mint.clone(),
+        })?;
+        let quote_asset = load_asset_for_venue_native_id(
+            &connection,
+            &deployment.venue_key,
+            &deployment.pair.quote_mint,
+        )?
+        .ok_or_else(|| AssetRegistryError::VenueNativeIdNotFound {
+            venue_key: deployment.venue_key.clone(),
+            native_id: deployment.pair.quote_mint.clone(),
+        })?;
         ensure_asset_mode(&base_asset, &deployment.mode)?;
         ensure_asset_mode(&quote_asset, &deployment.mode)?;
         ensure_mapping_mode(&base_asset, &deployment.venue_key, &deployment.mode)?;
@@ -378,7 +391,11 @@ fn builtin_assets() -> Vec<RuntimeAssetRecord> {
             promoted_at: Some(timestamp.to_string()),
             paused_at: None,
             deprecated_at: None,
-            tags: vec!["core".to_string(), "stablecoin".to_string(), "usd".to_string()],
+            tags: vec![
+                "core".to_string(),
+                "stablecoin".to_string(),
+                "usd".to_string(),
+            ],
             notes: Some("Seeded runtime asset registry record.".to_string()),
         },
     ]
@@ -405,10 +422,7 @@ fn venue_mapping(
     }
 }
 
-fn listing_state_supports_mode(
-    state: &RuntimeAssetListingState,
-    mode: &RuntimeMode,
-) -> bool {
+fn listing_state_supports_mode(state: &RuntimeAssetListingState, mode: &RuntimeMode) -> bool {
     match state {
         RuntimeAssetListingState::Candidate => false,
         RuntimeAssetListingState::Shadow => matches!(mode, RuntimeMode::Shadow),
@@ -426,24 +440,61 @@ fn can_transition_listing_state(
 ) -> bool {
     matches!(
         (from, to),
-        (RuntimeAssetListingState::Candidate, RuntimeAssetListingState::Shadow)
-            | (RuntimeAssetListingState::Candidate, RuntimeAssetListingState::Paper)
-            | (RuntimeAssetListingState::Candidate, RuntimeAssetListingState::Live)
-            | (RuntimeAssetListingState::Candidate, RuntimeAssetListingState::Paused)
-            | (RuntimeAssetListingState::Candidate, RuntimeAssetListingState::Deprecated)
-            | (RuntimeAssetListingState::Shadow, RuntimeAssetListingState::Paper)
-            | (RuntimeAssetListingState::Shadow, RuntimeAssetListingState::Live)
-            | (RuntimeAssetListingState::Shadow, RuntimeAssetListingState::Paused)
-            | (RuntimeAssetListingState::Shadow, RuntimeAssetListingState::Deprecated)
-            | (RuntimeAssetListingState::Paper, RuntimeAssetListingState::Live)
-            | (RuntimeAssetListingState::Paper, RuntimeAssetListingState::Paused)
-            | (RuntimeAssetListingState::Paper, RuntimeAssetListingState::Deprecated)
-            | (RuntimeAssetListingState::Live, RuntimeAssetListingState::Paused)
-            | (RuntimeAssetListingState::Live, RuntimeAssetListingState::Deprecated)
-            | (RuntimeAssetListingState::Paused, RuntimeAssetListingState::Shadow)
-            | (RuntimeAssetListingState::Paused, RuntimeAssetListingState::Paper)
-            | (RuntimeAssetListingState::Paused, RuntimeAssetListingState::Live)
-            | (RuntimeAssetListingState::Paused, RuntimeAssetListingState::Deprecated)
+        (
+            RuntimeAssetListingState::Candidate,
+            RuntimeAssetListingState::Shadow
+        ) | (
+            RuntimeAssetListingState::Candidate,
+            RuntimeAssetListingState::Paper
+        ) | (
+            RuntimeAssetListingState::Candidate,
+            RuntimeAssetListingState::Live
+        ) | (
+            RuntimeAssetListingState::Candidate,
+            RuntimeAssetListingState::Paused
+        ) | (
+            RuntimeAssetListingState::Candidate,
+            RuntimeAssetListingState::Deprecated
+        ) | (
+            RuntimeAssetListingState::Shadow,
+            RuntimeAssetListingState::Paper
+        ) | (
+            RuntimeAssetListingState::Shadow,
+            RuntimeAssetListingState::Live
+        ) | (
+            RuntimeAssetListingState::Shadow,
+            RuntimeAssetListingState::Paused
+        ) | (
+            RuntimeAssetListingState::Shadow,
+            RuntimeAssetListingState::Deprecated
+        ) | (
+            RuntimeAssetListingState::Paper,
+            RuntimeAssetListingState::Live
+        ) | (
+            RuntimeAssetListingState::Paper,
+            RuntimeAssetListingState::Paused
+        ) | (
+            RuntimeAssetListingState::Paper,
+            RuntimeAssetListingState::Deprecated
+        ) | (
+            RuntimeAssetListingState::Live,
+            RuntimeAssetListingState::Paused
+        ) | (
+            RuntimeAssetListingState::Live,
+            RuntimeAssetListingState::Deprecated
+        ) | (
+            RuntimeAssetListingState::Paused,
+            RuntimeAssetListingState::Shadow
+        ) | (
+            RuntimeAssetListingState::Paused,
+            RuntimeAssetListingState::Paper
+        ) | (
+            RuntimeAssetListingState::Paused,
+            RuntimeAssetListingState::Live
+        ) | (
+            RuntimeAssetListingState::Paused,
+            RuntimeAssetListingState::Deprecated
+        )
     )
 }
 
@@ -501,7 +552,10 @@ fn validate_asset_record(record: &RuntimeAssetRecord) -> Result<(), AssetRegistr
     Ok(())
 }
 
-fn persist_asset(connection: &Connection, record: &RuntimeAssetRecord) -> Result<(), AssetRegistryError> {
+fn persist_asset(
+    connection: &Connection,
+    record: &RuntimeAssetRecord,
+) -> Result<(), AssetRegistryError> {
     connection.execute(
         "INSERT INTO asset_records (
             asset_key,
@@ -712,7 +766,9 @@ mod tests {
             tags: vec!["test".to_string()],
         };
 
-        let supported = registry.ensure_pair_supported(&deployment).expect("pair supported");
+        let supported = registry
+            .ensure_pair_supported(&deployment)
+            .expect("pair supported");
         assert_eq!(supported.base_asset.asset_key, "SOL");
         assert_eq!(supported.quote_asset.asset_key, "USDC");
     }
@@ -755,7 +811,9 @@ mod tests {
             tags: vec!["test".to_string()],
         };
 
-        let error = registry.ensure_pair_supported(&deployment).expect_err("blocked");
+        let error = registry
+            .ensure_pair_supported(&deployment)
+            .expect_err("blocked");
         assert!(matches!(
             error,
             AssetRegistryError::VenueMappingModeUnsupported { .. }

--- a/crates/asset-registry/src/lib.rs
+++ b/crates/asset-registry/src/lib.rs
@@ -88,12 +88,23 @@ pub enum AssetRegistryError {
         asset_key: String,
         venue_key: String,
     },
+    #[error("asset {base_asset_key} does not support quote asset {quote_asset_key}")]
+    QuoteAssetUnsupported {
+        base_asset_key: String,
+        quote_asset_key: String,
+    },
     #[error("asset {asset_key} venue {venue_key} mapping is {listing_state:?} and does not support mode {mode:?}")]
     VenueMappingModeUnsupported {
         asset_key: String,
         venue_key: String,
         listing_state: RuntimeAssetListingState,
         mode: RuntimeMode,
+    },
+    #[error("asset {base_asset_key} venue {venue_key} mapping does not support quote asset {quote_asset_key}")]
+    VenueMappingQuoteUnsupported {
+        base_asset_key: String,
+        quote_asset_key: String,
+        venue_key: String,
     },
     #[error("asset mapping not found for venue {venue_key} native id {native_id}")]
     VenueNativeIdNotFound {
@@ -238,6 +249,8 @@ impl AssetRegistry {
         ensure_asset_mode(&quote_asset, &deployment.mode)?;
         ensure_mapping_mode(&base_asset, &deployment.venue_key, &deployment.mode)?;
         ensure_mapping_mode(&quote_asset, &deployment.venue_key, &deployment.mode)?;
+        ensure_quote_pair_supported(&base_asset, &quote_asset)?;
+        ensure_mapping_quote_supported(&base_asset, &quote_asset, &deployment.venue_key)?;
         Ok(SupportedPair {
             base_asset,
             quote_asset,
@@ -536,6 +549,50 @@ fn ensure_mapping_mode(
     })
 }
 
+fn ensure_quote_pair_supported(
+    base_asset: &RuntimeAssetRecord,
+    quote_asset: &RuntimeAssetRecord,
+) -> Result<(), AssetRegistryError> {
+    if base_asset
+        .quote_asset_keys
+        .iter()
+        .any(|asset_key| asset_key == &quote_asset.asset_key)
+    {
+        return Ok(());
+    }
+    Err(AssetRegistryError::QuoteAssetUnsupported {
+        base_asset_key: base_asset.asset_key.clone(),
+        quote_asset_key: quote_asset.asset_key.clone(),
+    })
+}
+
+fn ensure_mapping_quote_supported(
+    base_asset: &RuntimeAssetRecord,
+    quote_asset: &RuntimeAssetRecord,
+    venue_key: &str,
+) -> Result<(), AssetRegistryError> {
+    let mapping = base_asset
+        .venue_mappings
+        .iter()
+        .find(|mapping| mapping.venue_key == venue_key)
+        .ok_or_else(|| AssetRegistryError::VenueMappingMissing {
+            asset_key: base_asset.asset_key.clone(),
+            venue_key: venue_key.to_string(),
+        })?;
+    if mapping
+        .quote_asset_keys
+        .iter()
+        .any(|asset_key| asset_key == &quote_asset.asset_key)
+    {
+        return Ok(());
+    }
+    Err(AssetRegistryError::VenueMappingQuoteUnsupported {
+        base_asset_key: base_asset.asset_key.clone(),
+        quote_asset_key: quote_asset.asset_key.clone(),
+        venue_key: venue_key.to_string(),
+    })
+}
+
 fn validate_asset_record(record: &RuntimeAssetRecord) -> Result<(), AssetRegistryError> {
     if record.asset_key.trim().is_empty() {
         return Err(AssetRegistryError::InvalidRecord {
@@ -817,6 +874,119 @@ mod tests {
         assert!(matches!(
             error,
             AssetRegistryError::VenueMappingModeUnsupported { .. }
+        ));
+    }
+
+    #[test]
+    fn blocks_pairs_when_base_asset_disallows_the_quote_asset() {
+        let registry = registry("quote-allowlist");
+        let mut sol_asset = registry
+            .get_asset("SOL")
+            .expect("asset lookup")
+            .expect("sol asset");
+        sol_asset.quote_asset_keys = vec!["USDT".to_string()];
+        registry.upsert_asset(&sol_asset).expect("asset update");
+
+        let deployment = RuntimeDeploymentRecord {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            deployment_id: "deployment_live_sol_wrong_quote".to_string(),
+            strategy_key: "dca".to_string(),
+            sleeve_id: "sleeve_alpha".to_string(),
+            owner_user_id: "user_123".to_string(),
+            venue_key: "jupiter".to_string(),
+            pair: protocol::RuntimePair {
+                symbol: "SOL/USDC".to_string(),
+                base_mint: "So11111111111111111111111111111111111111112".to_string(),
+                quote_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+            },
+            mode: RuntimeMode::Live,
+            state: protocol::RuntimeDeploymentState::Live,
+            lane: protocol::RuntimeLane::Safe,
+            created_at: "2026-03-10T00:00:00.000Z".to_string(),
+            updated_at: "2026-03-10T00:00:00.000Z".to_string(),
+            promoted_at: Some("2026-03-10T00:00:00.000Z".to_string()),
+            paused_at: None,
+            killed_at: None,
+            policy: protocol::RuntimePolicy {
+                max_notional_usd: "5.00".to_string(),
+                daily_loss_limit_usd: "25.00".to_string(),
+                max_slippage_bps: 50,
+                max_concurrent_runs: 1,
+                rebalance_tolerance_bps: 100,
+            },
+            capital: protocol::RuntimeCapital {
+                allocated_usd: "25.00".to_string(),
+                reserved_usd: "5.00".to_string(),
+                available_usd: "20.00".to_string(),
+            },
+            tags: vec!["test".to_string()],
+        };
+
+        let error = registry
+            .ensure_pair_supported(&deployment)
+            .expect_err("quote allowlist mismatch");
+        assert!(matches!(
+            error,
+            AssetRegistryError::QuoteAssetUnsupported { .. }
+        ));
+    }
+
+    #[test]
+    fn blocks_pairs_when_venue_mapping_disallows_the_quote_asset() {
+        let registry = registry("mapping-quote-allowlist");
+        let mut sol_asset = registry
+            .get_asset("SOL")
+            .expect("asset lookup")
+            .expect("sol asset");
+        let mapping = sol_asset
+            .venue_mappings
+            .iter_mut()
+            .find(|mapping| mapping.venue_key == "jupiter")
+            .expect("jupiter mapping");
+        mapping.quote_asset_keys = vec!["USDT".to_string()];
+        registry.upsert_asset(&sol_asset).expect("asset update");
+
+        let deployment = RuntimeDeploymentRecord {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            deployment_id: "deployment_live_sol_mapping_quote".to_string(),
+            strategy_key: "dca".to_string(),
+            sleeve_id: "sleeve_alpha".to_string(),
+            owner_user_id: "user_123".to_string(),
+            venue_key: "jupiter".to_string(),
+            pair: protocol::RuntimePair {
+                symbol: "SOL/USDC".to_string(),
+                base_mint: "So11111111111111111111111111111111111111112".to_string(),
+                quote_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+            },
+            mode: RuntimeMode::Live,
+            state: protocol::RuntimeDeploymentState::Live,
+            lane: protocol::RuntimeLane::Safe,
+            created_at: "2026-03-10T00:00:00.000Z".to_string(),
+            updated_at: "2026-03-10T00:00:00.000Z".to_string(),
+            promoted_at: Some("2026-03-10T00:00:00.000Z".to_string()),
+            paused_at: None,
+            killed_at: None,
+            policy: protocol::RuntimePolicy {
+                max_notional_usd: "5.00".to_string(),
+                daily_loss_limit_usd: "25.00".to_string(),
+                max_slippage_bps: 50,
+                max_concurrent_runs: 1,
+                rebalance_tolerance_bps: 100,
+            },
+            capital: protocol::RuntimeCapital {
+                allocated_usd: "25.00".to_string(),
+                reserved_usd: "5.00".to_string(),
+                available_usd: "20.00".to_string(),
+            },
+            tags: vec!["test".to_string()],
+        };
+
+        let error = registry
+            .ensure_pair_supported(&deployment)
+            .expect_err("mapping quote allowlist mismatch");
+        assert!(matches!(
+            error,
+            AssetRegistryError::VenueMappingQuoteUnsupported { .. }
         ));
     }
 }

--- a/crates/asset-registry/src/lib.rs
+++ b/crates/asset-registry/src/lib.rs
@@ -1,0 +1,764 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use protocol::{
+    RuntimeAssetKind, RuntimeAssetListingState, RuntimeAssetRecord, RuntimeAssetRiskClass,
+    RuntimeAssetVenueMapping, RuntimeDeploymentRecord, RuntimeMode, RUNTIME_PROTOCOL_SCHEMA_VERSION,
+};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssetRegistryConfig {
+    pub database_url: String,
+}
+
+impl AssetRegistryConfig {
+    #[must_use]
+    pub fn new(database_url: impl Into<String>) -> Self {
+        Self {
+            database_url: database_url.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AssetRegistry {
+    database_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssetRegistrySnapshot {
+    pub status: String,
+    pub asset_count: u64,
+    pub live_asset_count: u64,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AssetRegistryQuery {
+    pub asset_key: Option<String>,
+    pub venue_key: Option<String>,
+    pub listing_state: Option<RuntimeAssetListingState>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssetWriteResult<T> {
+    pub record: T,
+    pub created: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SupportedPair {
+    pub base_asset: RuntimeAssetRecord,
+    pub quote_asset: RuntimeAssetRecord,
+}
+
+#[derive(Debug, Error)]
+pub enum AssetRegistryError {
+    #[error("storage io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("storage error: {0}")]
+    Storage(#[from] rusqlite::Error),
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("asset {asset_key} not found")]
+    AssetNotFound { asset_key: String },
+    #[error("invalid asset record for {asset_key}: {reason}")]
+    InvalidRecord { asset_key: String, reason: String },
+    #[error("invalid asset transition for {asset_key}: {from_state:?} -> {to_state:?}")]
+    InvalidStateTransition {
+        asset_key: String,
+        from_state: RuntimeAssetListingState,
+        to_state: RuntimeAssetListingState,
+    },
+    #[error("asset {asset_key} does not support mode {mode:?} while in state {listing_state:?}")]
+    AssetModeUnsupported {
+        asset_key: String,
+        listing_state: RuntimeAssetListingState,
+        mode: RuntimeMode,
+    },
+    #[error("asset {asset_key} does not support venue {venue_key}")]
+    VenueMappingMissing { asset_key: String, venue_key: String },
+    #[error("asset {asset_key} venue {venue_key} mapping is {listing_state:?} and does not support mode {mode:?}")]
+    VenueMappingModeUnsupported {
+        asset_key: String,
+        venue_key: String,
+        listing_state: RuntimeAssetListingState,
+        mode: RuntimeMode,
+    },
+    #[error("asset mapping not found for venue {venue_key} native id {native_id}")]
+    VenueNativeIdNotFound { venue_key: String, native_id: String },
+}
+
+impl AssetRegistry {
+    pub fn new(config: AssetRegistryConfig) -> Result<Self, AssetRegistryError> {
+        let requested_path = normalize_database_path(&config.database_url);
+        match Self::initialize_at_path(requested_path.clone()) {
+            Ok(registry) => Ok(registry),
+            Err(error) if should_fallback_to_tmp(&requested_path, &error) => {
+                Self::initialize_at_path(fallback_database_path())
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    pub fn upsert_asset(
+        &self,
+        record: &RuntimeAssetRecord,
+    ) -> Result<AssetWriteResult<RuntimeAssetRecord>, AssetRegistryError> {
+        validate_asset_record(record)?;
+        let mut connection = self.open_connection()?;
+        let transaction = connection.transaction()?;
+        let existing = load_asset(&transaction, &record.asset_key)?;
+        persist_asset(&transaction, record)?;
+        transaction.commit()?;
+        Ok(AssetWriteResult {
+            record: record.clone(),
+            created: existing.is_none(),
+        })
+    }
+
+    pub fn get_asset(
+        &self,
+        asset_key: &str,
+    ) -> Result<Option<RuntimeAssetRecord>, AssetRegistryError> {
+        let connection = self.open_connection()?;
+        load_asset(&connection, asset_key)
+    }
+
+    pub fn list_assets(
+        &self,
+        query: &AssetRegistryQuery,
+    ) -> Result<Vec<RuntimeAssetRecord>, AssetRegistryError> {
+        let connection = self.open_connection()?;
+        let mut statement = connection.prepare(
+            "SELECT DISTINCT a.record_json
+             FROM asset_records a
+             LEFT JOIN asset_venue_mappings m ON m.asset_key = a.asset_key
+             WHERE (?1 IS NULL OR a.asset_key = ?1)
+               AND (?2 IS NULL OR a.listing_state = ?2)
+               AND (?3 IS NULL OR m.venue_key = ?3)
+             ORDER BY a.updated_at DESC, a.asset_key DESC",
+        )?;
+        let listing_state = query.listing_state.as_ref().map(listing_state_key);
+        let rows = statement.query_map(
+            params![
+                query.asset_key.as_deref(),
+                listing_state.as_deref(),
+                query.venue_key.as_deref(),
+            ],
+            |row| row.get::<_, String>(0),
+        )?;
+        let mut assets = Vec::new();
+        for row in rows {
+            assets.push(deserialize_json(&row?)?);
+        }
+        Ok(assets)
+    }
+
+    pub fn transition_asset(
+        &self,
+        asset_key: &str,
+        next_state: RuntimeAssetListingState,
+        changed_at: &str,
+    ) -> Result<RuntimeAssetRecord, AssetRegistryError> {
+        let mut connection = self.open_connection()?;
+        let transaction = connection.transaction()?;
+        let mut record = load_asset(&transaction, asset_key)?.ok_or_else(|| {
+            AssetRegistryError::AssetNotFound {
+                asset_key: asset_key.to_string(),
+            }
+        })?;
+        if record.listing_state != next_state
+            && !can_transition_listing_state(&record.listing_state, &next_state)
+        {
+            return Err(AssetRegistryError::InvalidStateTransition {
+                asset_key: asset_key.to_string(),
+                from_state: record.listing_state.clone(),
+                to_state: next_state,
+            });
+        }
+        record.listing_state = next_state;
+        record.updated_at = changed_at.to_string();
+        match record.listing_state {
+            RuntimeAssetListingState::Live => {
+                record.promoted_at = Some(changed_at.to_string());
+                record.paused_at = None;
+                record.deprecated_at = None;
+            }
+            RuntimeAssetListingState::Paused => {
+                record.paused_at = Some(changed_at.to_string());
+            }
+            RuntimeAssetListingState::Deprecated => {
+                record.deprecated_at = Some(changed_at.to_string());
+            }
+            _ => {}
+        }
+        persist_asset(&transaction, &record)?;
+        transaction.commit()?;
+        Ok(record)
+    }
+
+    pub fn ensure_pair_supported(
+        &self,
+        deployment: &RuntimeDeploymentRecord,
+    ) -> Result<SupportedPair, AssetRegistryError> {
+        let connection = self.open_connection()?;
+        let base_asset =
+            load_asset_for_venue_native_id(&connection, &deployment.venue_key, &deployment.pair.base_mint)?
+                .ok_or_else(|| AssetRegistryError::VenueNativeIdNotFound {
+                    venue_key: deployment.venue_key.clone(),
+                    native_id: deployment.pair.base_mint.clone(),
+                })?;
+        let quote_asset =
+            load_asset_for_venue_native_id(&connection, &deployment.venue_key, &deployment.pair.quote_mint)?
+                .ok_or_else(|| AssetRegistryError::VenueNativeIdNotFound {
+                    venue_key: deployment.venue_key.clone(),
+                    native_id: deployment.pair.quote_mint.clone(),
+                })?;
+        ensure_asset_mode(&base_asset, &deployment.mode)?;
+        ensure_asset_mode(&quote_asset, &deployment.mode)?;
+        ensure_mapping_mode(&base_asset, &deployment.venue_key, &deployment.mode)?;
+        ensure_mapping_mode(&quote_asset, &deployment.venue_key, &deployment.mode)?;
+        Ok(SupportedPair {
+            base_asset,
+            quote_asset,
+        })
+    }
+
+    #[must_use]
+    pub fn snapshot_now(&self) -> AssetRegistrySnapshot {
+        match self.snapshot_counts() {
+            Ok((asset_count, live_asset_count)) => AssetRegistrySnapshot {
+                status: "healthy".to_string(),
+                asset_count,
+                live_asset_count,
+                last_error: None,
+            },
+            Err(error) => AssetRegistrySnapshot {
+                status: "degraded".to_string(),
+                asset_count: 0,
+                live_asset_count: 0,
+                last_error: Some(error.to_string()),
+            },
+        }
+    }
+
+    fn snapshot_counts(&self) -> Result<(u64, u64), AssetRegistryError> {
+        let connection = self.open_connection()?;
+        let asset_count =
+            connection.query_row("SELECT COUNT(*) FROM asset_records", [], |row| {
+                row.get::<_, u64>(0)
+            })?;
+        let live_asset_count = connection.query_row(
+            "SELECT COUNT(*) FROM asset_records WHERE listing_state = 'live'",
+            [],
+            |row| row.get::<_, u64>(0),
+        )?;
+        Ok((asset_count, live_asset_count))
+    }
+
+    fn initialize_at_path(path: PathBuf) -> Result<Self, AssetRegistryError> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let registry = Self {
+            database_path: path.clone(),
+        };
+        let connection = registry.open_connection()?;
+        initialize_schema(&connection)?;
+        registry.seed_builtin_assets()?;
+        Ok(registry)
+    }
+
+    fn seed_builtin_assets(&self) -> Result<(), AssetRegistryError> {
+        for asset in builtin_assets() {
+            let _ = self.upsert_asset(&asset)?;
+        }
+        Ok(())
+    }
+
+    fn open_connection(&self) -> Result<Connection, AssetRegistryError> {
+        let connection = Connection::open(&self.database_path)?;
+        connection.execute_batch("PRAGMA foreign_keys = ON;")?;
+        Ok(connection)
+    }
+}
+
+fn builtin_assets() -> Vec<RuntimeAssetRecord> {
+    let timestamp = "2026-03-10T00:00:00.000Z";
+    vec![
+        RuntimeAssetRecord {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            asset_key: "SOL".to_string(),
+            display_name: "Solana".to_string(),
+            symbol: "SOL".to_string(),
+            chain_key: "solana-mainnet".to_string(),
+            canonical_id: "So11111111111111111111111111111111111111112".to_string(),
+            asset_kind: RuntimeAssetKind::Native,
+            risk_class: RuntimeAssetRiskClass::Core,
+            listing_state: RuntimeAssetListingState::Live,
+            decimals: 9,
+            aliases: vec!["WSOL".to_string()],
+            quote_asset_keys: vec!["USDC".to_string()],
+            venue_mappings: vec![
+                venue_mapping(
+                    "jupiter",
+                    "So11111111111111111111111111111111111111112",
+                    "SOL",
+                    RuntimeAssetListingState::Live,
+                    9,
+                ),
+                venue_mapping(
+                    "magicblock",
+                    "So11111111111111111111111111111111111111112",
+                    "SOL",
+                    RuntimeAssetListingState::Paper,
+                    9,
+                ),
+                venue_mapping(
+                    "phoenix",
+                    "So11111111111111111111111111111111111111112",
+                    "SOL",
+                    RuntimeAssetListingState::Candidate,
+                    9,
+                ),
+            ],
+            created_at: timestamp.to_string(),
+            updated_at: timestamp.to_string(),
+            promoted_at: Some(timestamp.to_string()),
+            paused_at: None,
+            deprecated_at: None,
+            tags: vec!["core".to_string(), "spot".to_string(), "solana".to_string()],
+            notes: Some("Seeded runtime asset registry record.".to_string()),
+        },
+        RuntimeAssetRecord {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            asset_key: "USDC".to_string(),
+            display_name: "USD Coin".to_string(),
+            symbol: "USDC".to_string(),
+            chain_key: "solana-mainnet".to_string(),
+            canonical_id: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+            asset_kind: RuntimeAssetKind::Stablecoin,
+            risk_class: RuntimeAssetRiskClass::Core,
+            listing_state: RuntimeAssetListingState::Live,
+            decimals: 6,
+            aliases: vec!["USD Coin".to_string()],
+            quote_asset_keys: vec!["USDC".to_string()],
+            venue_mappings: vec![
+                venue_mapping(
+                    "jupiter",
+                    "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                    "USDC",
+                    RuntimeAssetListingState::Live,
+                    6,
+                ),
+                venue_mapping(
+                    "magicblock",
+                    "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                    "USDC",
+                    RuntimeAssetListingState::Paper,
+                    6,
+                ),
+                venue_mapping(
+                    "phoenix",
+                    "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                    "USDC",
+                    RuntimeAssetListingState::Candidate,
+                    6,
+                ),
+            ],
+            created_at: timestamp.to_string(),
+            updated_at: timestamp.to_string(),
+            promoted_at: Some(timestamp.to_string()),
+            paused_at: None,
+            deprecated_at: None,
+            tags: vec!["core".to_string(), "stablecoin".to_string(), "usd".to_string()],
+            notes: Some("Seeded runtime asset registry record.".to_string()),
+        },
+    ]
+}
+
+fn venue_mapping(
+    venue_key: &str,
+    native_id: &str,
+    venue_symbol: &str,
+    listing_state: RuntimeAssetListingState,
+    decimals: u32,
+) -> RuntimeAssetVenueMapping {
+    RuntimeAssetVenueMapping {
+        venue_key: venue_key.to_string(),
+        native_id: native_id.to_string(),
+        venue_symbol: venue_symbol.to_string(),
+        decimals,
+        listing_state,
+        quote_asset_keys: vec!["USDC".to_string()],
+        price_decimals: Some(6),
+        size_decimals: Some(decimals),
+        min_notional_usd: Some("0.01".to_string()),
+        notes: Some("Seeded venue mapping.".to_string()),
+    }
+}
+
+fn listing_state_supports_mode(
+    state: &RuntimeAssetListingState,
+    mode: &RuntimeMode,
+) -> bool {
+    match state {
+        RuntimeAssetListingState::Candidate => false,
+        RuntimeAssetListingState::Shadow => matches!(mode, RuntimeMode::Shadow),
+        RuntimeAssetListingState::Paper => {
+            matches!(mode, RuntimeMode::Shadow | RuntimeMode::Paper)
+        }
+        RuntimeAssetListingState::Live => true,
+        RuntimeAssetListingState::Paused | RuntimeAssetListingState::Deprecated => false,
+    }
+}
+
+fn can_transition_listing_state(
+    from: &RuntimeAssetListingState,
+    to: &RuntimeAssetListingState,
+) -> bool {
+    matches!(
+        (from, to),
+        (RuntimeAssetListingState::Candidate, RuntimeAssetListingState::Shadow)
+            | (RuntimeAssetListingState::Candidate, RuntimeAssetListingState::Paper)
+            | (RuntimeAssetListingState::Candidate, RuntimeAssetListingState::Live)
+            | (RuntimeAssetListingState::Candidate, RuntimeAssetListingState::Paused)
+            | (RuntimeAssetListingState::Candidate, RuntimeAssetListingState::Deprecated)
+            | (RuntimeAssetListingState::Shadow, RuntimeAssetListingState::Paper)
+            | (RuntimeAssetListingState::Shadow, RuntimeAssetListingState::Live)
+            | (RuntimeAssetListingState::Shadow, RuntimeAssetListingState::Paused)
+            | (RuntimeAssetListingState::Shadow, RuntimeAssetListingState::Deprecated)
+            | (RuntimeAssetListingState::Paper, RuntimeAssetListingState::Live)
+            | (RuntimeAssetListingState::Paper, RuntimeAssetListingState::Paused)
+            | (RuntimeAssetListingState::Paper, RuntimeAssetListingState::Deprecated)
+            | (RuntimeAssetListingState::Live, RuntimeAssetListingState::Paused)
+            | (RuntimeAssetListingState::Live, RuntimeAssetListingState::Deprecated)
+            | (RuntimeAssetListingState::Paused, RuntimeAssetListingState::Shadow)
+            | (RuntimeAssetListingState::Paused, RuntimeAssetListingState::Paper)
+            | (RuntimeAssetListingState::Paused, RuntimeAssetListingState::Live)
+            | (RuntimeAssetListingState::Paused, RuntimeAssetListingState::Deprecated)
+    )
+}
+
+fn ensure_asset_mode(
+    asset: &RuntimeAssetRecord,
+    mode: &RuntimeMode,
+) -> Result<(), AssetRegistryError> {
+    if listing_state_supports_mode(&asset.listing_state, mode) {
+        return Ok(());
+    }
+    Err(AssetRegistryError::AssetModeUnsupported {
+        asset_key: asset.asset_key.clone(),
+        listing_state: asset.listing_state.clone(),
+        mode: mode.clone(),
+    })
+}
+
+fn ensure_mapping_mode(
+    asset: &RuntimeAssetRecord,
+    venue_key: &str,
+    mode: &RuntimeMode,
+) -> Result<(), AssetRegistryError> {
+    let mapping = asset
+        .venue_mappings
+        .iter()
+        .find(|mapping| mapping.venue_key == venue_key)
+        .ok_or_else(|| AssetRegistryError::VenueMappingMissing {
+            asset_key: asset.asset_key.clone(),
+            venue_key: venue_key.to_string(),
+        })?;
+    if listing_state_supports_mode(&mapping.listing_state, mode) {
+        return Ok(());
+    }
+    Err(AssetRegistryError::VenueMappingModeUnsupported {
+        asset_key: asset.asset_key.clone(),
+        venue_key: venue_key.to_string(),
+        listing_state: mapping.listing_state.clone(),
+        mode: mode.clone(),
+    })
+}
+
+fn validate_asset_record(record: &RuntimeAssetRecord) -> Result<(), AssetRegistryError> {
+    if record.asset_key.trim().is_empty() {
+        return Err(AssetRegistryError::InvalidRecord {
+            asset_key: record.asset_key.clone(),
+            reason: "assetKey must not be empty".to_string(),
+        });
+    }
+    if record.venue_mappings.is_empty() {
+        return Err(AssetRegistryError::InvalidRecord {
+            asset_key: record.asset_key.clone(),
+            reason: "venueMappings must not be empty".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn persist_asset(connection: &Connection, record: &RuntimeAssetRecord) -> Result<(), AssetRegistryError> {
+    connection.execute(
+        "INSERT INTO asset_records (
+            asset_key,
+            listing_state,
+            updated_at,
+            record_json
+         ) VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT(asset_key) DO UPDATE SET
+            listing_state = excluded.listing_state,
+            updated_at = excluded.updated_at,
+            record_json = excluded.record_json",
+        params![
+            record.asset_key,
+            listing_state_key(&record.listing_state),
+            record.updated_at,
+            serialize_json(record)?,
+        ],
+    )?;
+    connection.execute(
+        "DELETE FROM asset_venue_mappings WHERE asset_key = ?1",
+        params![record.asset_key],
+    )?;
+    for mapping in &record.venue_mappings {
+        connection.execute(
+            "INSERT INTO asset_venue_mappings (
+                asset_key,
+                venue_key,
+                native_id,
+                listing_state
+             ) VALUES (?1, ?2, ?3, ?4)",
+            params![
+                record.asset_key,
+                mapping.venue_key,
+                mapping.native_id,
+                listing_state_key(&mapping.listing_state),
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+fn load_asset(
+    connection: &Connection,
+    asset_key: &str,
+) -> Result<Option<RuntimeAssetRecord>, AssetRegistryError> {
+    connection
+        .query_row(
+            "SELECT record_json FROM asset_records WHERE asset_key = ?1",
+            params![asset_key],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|json| deserialize_json(&json))
+        .transpose()
+}
+
+fn load_asset_for_venue_native_id(
+    connection: &Connection,
+    venue_key: &str,
+    native_id: &str,
+) -> Result<Option<RuntimeAssetRecord>, AssetRegistryError> {
+    connection
+        .query_row(
+            "SELECT a.record_json
+             FROM asset_records a
+             INNER JOIN asset_venue_mappings m
+               ON m.asset_key = a.asset_key
+             WHERE m.venue_key = ?1
+               AND m.native_id = ?2",
+            params![venue_key, native_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|json| deserialize_json(&json))
+        .transpose()
+}
+
+fn initialize_schema(connection: &Connection) -> Result<(), AssetRegistryError> {
+    connection.execute_batch(
+        "CREATE TABLE IF NOT EXISTS asset_records (
+            asset_key TEXT PRIMARY KEY,
+            listing_state TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            record_json TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS asset_venue_mappings (
+            asset_key TEXT NOT NULL,
+            venue_key TEXT NOT NULL,
+            native_id TEXT NOT NULL,
+            listing_state TEXT NOT NULL,
+            PRIMARY KEY (asset_key, venue_key, native_id),
+            FOREIGN KEY (asset_key) REFERENCES asset_records(asset_key) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_asset_records_listing_state
+            ON asset_records (listing_state, updated_at DESC, asset_key DESC);
+        CREATE INDEX IF NOT EXISTS idx_asset_venue_mappings_lookup
+            ON asset_venue_mappings (venue_key, native_id);
+        CREATE INDEX IF NOT EXISTS idx_asset_venue_mappings_venue
+            ON asset_venue_mappings (venue_key, listing_state, asset_key);",
+    )?;
+    Ok(())
+}
+
+fn listing_state_key(state: &RuntimeAssetListingState) -> &'static str {
+    match state {
+        RuntimeAssetListingState::Candidate => "candidate",
+        RuntimeAssetListingState::Shadow => "shadow",
+        RuntimeAssetListingState::Paper => "paper",
+        RuntimeAssetListingState::Live => "live",
+        RuntimeAssetListingState::Paused => "paused",
+        RuntimeAssetListingState::Deprecated => "deprecated",
+    }
+}
+
+fn normalize_database_path(database_url: &str) -> PathBuf {
+    let trimmed = database_url.trim();
+    let without_scheme = trimmed
+        .strip_prefix("sqlite://")
+        .or_else(|| trimmed.strip_prefix("file:"))
+        .unwrap_or(trimmed);
+    let candidate = PathBuf::from(without_scheme);
+    if candidate.is_absolute() {
+        candidate
+    } else {
+        PathBuf::from(".").join(candidate)
+    }
+}
+
+fn fallback_database_path() -> PathBuf {
+    std::env::temp_dir().join("runtime-rs/asset-registry.sqlite3")
+}
+
+fn should_fallback_to_tmp(path: &Path, error: &AssetRegistryError) -> bool {
+    !path.starts_with(std::env::temp_dir()) && matches!(error, AssetRegistryError::Io(_))
+}
+
+fn serialize_json<T>(value: &T) -> Result<String, AssetRegistryError>
+where
+    T: Serialize,
+{
+    Ok(serde_json::to_string(value)?)
+}
+
+fn deserialize_json<T>(value: &str) -> Result<T, AssetRegistryError>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    Ok(serde_json::from_str(value)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn registry(name: &str) -> AssetRegistry {
+        let database_url = format!(".tmp/tests/asset-registry/{name}.sqlite3");
+        AssetRegistry::new(AssetRegistryConfig::new(database_url)).expect("registry")
+    }
+
+    #[test]
+    fn seeds_builtin_assets_and_queries_by_venue() {
+        let registry = registry("seed");
+        let jupiter_assets = registry
+            .list_assets(&AssetRegistryQuery {
+                venue_key: Some("jupiter".to_string()),
+                ..AssetRegistryQuery::default()
+            })
+            .expect("jupiter assets");
+        assert!(jupiter_assets.iter().any(|asset| asset.asset_key == "SOL"));
+        assert!(jupiter_assets.iter().any(|asset| asset.asset_key == "USDC"));
+    }
+
+    #[test]
+    fn ensures_pair_support_for_live_jupiter_deployments() {
+        let registry = registry("pair");
+        let deployment = RuntimeDeploymentRecord {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            deployment_id: "deployment_live_sol".to_string(),
+            strategy_key: "dca".to_string(),
+            sleeve_id: "sleeve_alpha".to_string(),
+            owner_user_id: "user_123".to_string(),
+            venue_key: "jupiter".to_string(),
+            pair: protocol::RuntimePair {
+                symbol: "SOL/USDC".to_string(),
+                base_mint: "So11111111111111111111111111111111111111112".to_string(),
+                quote_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+            },
+            mode: RuntimeMode::Live,
+            state: protocol::RuntimeDeploymentState::Live,
+            lane: protocol::RuntimeLane::Safe,
+            created_at: "2026-03-10T00:00:00.000Z".to_string(),
+            updated_at: "2026-03-10T00:00:00.000Z".to_string(),
+            promoted_at: Some("2026-03-10T00:00:00.000Z".to_string()),
+            paused_at: None,
+            killed_at: None,
+            policy: protocol::RuntimePolicy {
+                max_notional_usd: "5.00".to_string(),
+                daily_loss_limit_usd: "25.00".to_string(),
+                max_slippage_bps: 50,
+                max_concurrent_runs: 1,
+                rebalance_tolerance_bps: 100,
+            },
+            capital: protocol::RuntimeCapital {
+                allocated_usd: "25.00".to_string(),
+                reserved_usd: "5.00".to_string(),
+                available_usd: "20.00".to_string(),
+            },
+            tags: vec!["test".to_string()],
+        };
+
+        let supported = registry.ensure_pair_supported(&deployment).expect("pair supported");
+        assert_eq!(supported.base_asset.asset_key, "SOL");
+        assert_eq!(supported.quote_asset.asset_key, "USDC");
+    }
+
+    #[test]
+    fn blocks_live_when_venue_mapping_is_not_live_ready() {
+        let registry = registry("venue-mode");
+        let deployment = RuntimeDeploymentRecord {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            deployment_id: "deployment_live_sol_magicblock".to_string(),
+            strategy_key: "dca".to_string(),
+            sleeve_id: "sleeve_alpha".to_string(),
+            owner_user_id: "user_123".to_string(),
+            venue_key: "magicblock".to_string(),
+            pair: protocol::RuntimePair {
+                symbol: "SOL/USDC".to_string(),
+                base_mint: "So11111111111111111111111111111111111111112".to_string(),
+                quote_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+            },
+            mode: RuntimeMode::Live,
+            state: protocol::RuntimeDeploymentState::Live,
+            lane: protocol::RuntimeLane::Safe,
+            created_at: "2026-03-10T00:00:00.000Z".to_string(),
+            updated_at: "2026-03-10T00:00:00.000Z".to_string(),
+            promoted_at: Some("2026-03-10T00:00:00.000Z".to_string()),
+            paused_at: None,
+            killed_at: None,
+            policy: protocol::RuntimePolicy {
+                max_notional_usd: "5.00".to_string(),
+                daily_loss_limit_usd: "25.00".to_string(),
+                max_slippage_bps: 50,
+                max_concurrent_runs: 1,
+                rebalance_tolerance_bps: 100,
+            },
+            capital: protocol::RuntimeCapital {
+                allocated_usd: "25.00".to_string(),
+                reserved_usd: "5.00".to_string(),
+                available_usd: "20.00".to_string(),
+            },
+            tags: vec!["test".to_string()],
+        };
+
+        let error = registry.ensure_pair_supported(&deployment).expect_err("blocked");
+        assert!(matches!(
+            error,
+            AssetRegistryError::VenueMappingModeUnsupported { .. }
+        ));
+    }
+}

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -763,6 +763,37 @@ pub enum RuntimeOnboardingState {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+pub enum RuntimeAssetListingState {
+    Candidate,
+    Shadow,
+    Paper,
+    Live,
+    Paused,
+    Deprecated,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeAssetKind {
+    Native,
+    Token,
+    Stablecoin,
+    Wrapped,
+    Synthetic,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeAssetRiskClass {
+    Core,
+    Standard,
+    Volatile,
+    Experimental,
+    Restricted,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum RuntimeVenueMarketType {
     Spot,
     Perp,
@@ -842,6 +873,46 @@ pub struct RuntimeVenueCapability {
     pub settlement_behavior: RuntimeVenueSettlementBehavior,
     pub supported_modes: Vec<RuntimeMode>,
     pub onboarding_state: RuntimeOnboardingState,
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeAssetVenueMapping {
+    pub venue_key: String,
+    pub native_id: String,
+    pub venue_symbol: String,
+    pub decimals: u32,
+    pub listing_state: RuntimeAssetListingState,
+    pub quote_asset_keys: Vec<String>,
+    pub price_decimals: Option<u32>,
+    pub size_decimals: Option<u32>,
+    pub min_notional_usd: Option<String>,
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeAssetRecord {
+    pub schema_version: String,
+    pub asset_key: String,
+    pub display_name: String,
+    pub symbol: String,
+    pub chain_key: String,
+    pub canonical_id: String,
+    pub asset_kind: RuntimeAssetKind,
+    pub risk_class: RuntimeAssetRiskClass,
+    pub listing_state: RuntimeAssetListingState,
+    pub decimals: u32,
+    pub aliases: Vec<String>,
+    pub quote_asset_keys: Vec<String>,
+    pub venue_mappings: Vec<RuntimeAssetVenueMapping>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub promoted_at: Option<String>,
+    pub paused_at: Option<String>,
+    pub deprecated_at: Option<String>,
+    pub tags: Vec<String>,
     pub notes: Option<String>,
 }
 
@@ -969,6 +1040,9 @@ mod tests {
         let venue_capability: RuntimeVenueCapability =
             serde_json::from_str(&read_fixture("runtime.venue_capability.valid.v1.json"))
                 .expect("venue capability fixture to deserialize");
+        let asset_record: RuntimeAssetRecord =
+            serde_json::from_str(&read_fixture("runtime.asset_record.valid.v1.json"))
+                .expect("asset record fixture to deserialize");
         let strategy_spec: RuntimeStrategySpec =
             serde_json::from_str(&read_fixture("runtime.strategy_spec.valid.v1.json"))
                 .expect("strategy spec fixture to deserialize");
@@ -990,6 +1064,7 @@ mod tests {
             venue_capability.schema_version,
             RUNTIME_PROTOCOL_SCHEMA_VERSION
         );
+        assert_eq!(asset_record.schema_version, RUNTIME_PROTOCOL_SCHEMA_VERSION);
         assert_eq!(
             strategy_spec.schema_version,
             RUNTIME_PROTOCOL_SCHEMA_VERSION
@@ -998,6 +1073,7 @@ mod tests {
         assert_eq!(experiment.dataset_snapshots.len(), 1);
         assert_eq!(evidence.artifacts.len(), 2);
         assert_eq!(venue_capability.venue_key, "jupiter");
+        assert_eq!(asset_record.asset_key, "SOL");
         assert_eq!(strategy_spec.strategy_key, "trend_following");
     }
 

--- a/docs/runtime-contracts/fixtures/runtime.asset_record.valid.v1.json
+++ b/docs/runtime-contracts/fixtures/runtime.asset_record.valid.v1.json
@@ -1,0 +1,57 @@
+{
+  "schemaVersion": "v1",
+  "assetKey": "SOL",
+  "displayName": "Solana",
+  "symbol": "SOL",
+  "chainKey": "solana-mainnet",
+  "canonicalId": "So11111111111111111111111111111111111111112",
+  "assetKind": "native",
+  "riskClass": "core",
+  "listingState": "live",
+  "decimals": 9,
+  "aliases": ["WSOL"],
+  "quoteAssetKeys": ["USDC"],
+  "venueMappings": [
+    {
+      "venueKey": "jupiter",
+      "nativeId": "So11111111111111111111111111111111111111112",
+      "venueSymbol": "SOL",
+      "decimals": 9,
+      "listingState": "live",
+      "quoteAssetKeys": ["USDC"],
+      "priceDecimals": 6,
+      "sizeDecimals": 9,
+      "minNotionalUsd": "0.01",
+      "notes": "Primary live asset mapping."
+    },
+    {
+      "venueKey": "magicblock",
+      "nativeId": "So11111111111111111111111111111111111111112",
+      "venueSymbol": "SOL",
+      "decimals": 9,
+      "listingState": "paper",
+      "quoteAssetKeys": ["USDC"],
+      "priceDecimals": 6,
+      "sizeDecimals": 9,
+      "minNotionalUsd": "0.01",
+      "notes": "Bounded to paper until venue onboarding advances."
+    },
+    {
+      "venueKey": "phoenix",
+      "nativeId": "So11111111111111111111111111111111111111112",
+      "venueSymbol": "SOL",
+      "decimals": 9,
+      "listingState": "candidate",
+      "quoteAssetKeys": ["USDC"],
+      "priceDecimals": 6,
+      "sizeDecimals": 9,
+      "minNotionalUsd": "0.01",
+      "notes": "Candidate mapping for venue onboarding."
+    }
+  ],
+  "createdAt": "2026-03-10T00:00:00.000Z",
+  "updatedAt": "2026-03-10T00:00:00.000Z",
+  "promotedAt": "2026-03-10T00:00:00.000Z",
+  "tags": ["core", "solana", "spot"],
+  "notes": "Canonical base asset fixture used by the runtime asset registry."
+}

--- a/docs/runtime-contracts/schema-manifest.v1.json
+++ b/docs/runtime-contracts/schema-manifest.v1.json
@@ -58,6 +58,11 @@
       "schemaFile": "docs/runtime-contracts/schemas/runtime.venue_capability.v1.schema.json"
     },
     {
+      "name": "assetRecord",
+      "schemaId": "https://trader-ralph.com/schemas/runtime/v1/asset_record",
+      "schemaFile": "docs/runtime-contracts/schemas/runtime.asset_record.v1.schema.json"
+    },
+    {
       "name": "strategySpec",
       "schemaId": "https://trader-ralph.com/schemas/runtime/v1/strategy_spec",
       "schemaFile": "docs/runtime-contracts/schemas/runtime.strategy_spec.v1.schema.json"

--- a/docs/runtime-contracts/schemas/runtime.asset_record.v1.schema.json
+++ b/docs/runtime-contracts/schemas/runtime.asset_record.v1.schema.json
@@ -1,0 +1,191 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://trader-ralph.com/schemas/runtime/v1/asset_record",
+  "type": "object",
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "v1"
+    },
+    "assetKey": {
+      "type": "string",
+      "minLength": 1
+    },
+    "displayName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "symbol": {
+      "type": "string",
+      "minLength": 1
+    },
+    "chainKey": {
+      "type": "string",
+      "minLength": 1
+    },
+    "canonicalId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "assetKind": {
+      "type": "string",
+      "enum": ["native", "token", "stablecoin", "wrapped", "synthetic"]
+    },
+    "riskClass": {
+      "type": "string",
+      "enum": ["core", "standard", "volatile", "experimental", "restricted"]
+    },
+    "listingState": {
+      "type": "string",
+      "enum": ["candidate", "shadow", "paper", "live", "paused", "deprecated"]
+    },
+    "decimals": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "aliases": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "quoteAssetKeys": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "venueMappings": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "venueKey": {
+            "type": "string",
+            "minLength": 1
+          },
+          "nativeId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "venueSymbol": {
+            "type": "string",
+            "minLength": 1
+          },
+          "decimals": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "listingState": {
+            "type": "string",
+            "enum": [
+              "candidate",
+              "shadow",
+              "paper",
+              "live",
+              "paused",
+              "deprecated"
+            ]
+          },
+          "quoteAssetKeys": {
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "priceDecimals": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "sizeDecimals": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "minNotionalUsd": {
+            "type": "string",
+            "pattern": "^\\d+(?:\\.\\d+)?$"
+          },
+          "notes": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "venueKey",
+          "nativeId",
+          "venueSymbol",
+          "decimals",
+          "listingState",
+          "quoteAssetKeys"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+    },
+    "promotedAt": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+    },
+    "pausedAt": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+    },
+    "deprecatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+    },
+    "tags": {
+      "maxItems": 16,
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "notes": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "assetKey",
+    "displayName",
+    "symbol",
+    "chainKey",
+    "canonicalId",
+    "assetKind",
+    "riskClass",
+    "listingState",
+    "decimals",
+    "aliases",
+    "quoteAssetKeys",
+    "venueMappings",
+    "createdAt",
+    "updatedAt",
+    "tags"
+  ],
+  "additionalProperties": false
+}

--- a/services/runtime-rs/Cargo.toml
+++ b/services/runtime-rs/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 axum.workspace = true
+asset-registry = { path = "../../crates/asset-registry" }
 execution-planner = { path = "../../crates/execution-planner" }
 exec-client = { path = "../../crates/exec-client" }
 feature-cache = { path = "../../crates/feature-cache" }

--- a/services/runtime-rs/src/lib.rs
+++ b/services/runtime-rs/src/lib.rs
@@ -1,5 +1,9 @@
 use std::sync::{Arc, RwLock};
 
+use asset_registry::{
+    AssetRegistry, AssetRegistryConfig, AssetRegistryError, AssetRegistryQuery,
+    AssetRegistrySnapshot,
+};
 use axum::{
     body::Bytes,
     extract::{Path, Query, State},
@@ -20,9 +24,9 @@ use portfolio_ledger::{
     PortfolioLedger, PortfolioLedgerConfig, PortfolioLedgerError, PortfolioLedgerSnapshot,
 };
 use protocol::{
-    RuntimeDeploymentRecord, RuntimeDeploymentState, RuntimeResearchEvidenceBundleRecord,
-    RuntimeResearchExperimentRecord, RuntimeResearchHypothesisRecord, RuntimeResearchSourceRecord,
-    RuntimeRunRecord,
+    RuntimeAssetListingState, RuntimeAssetRecord, RuntimeDeploymentRecord, RuntimeDeploymentState,
+    RuntimeResearchEvidenceBundleRecord, RuntimeResearchExperimentRecord,
+    RuntimeResearchHypothesisRecord, RuntimeResearchSourceRecord, RuntimeRunRecord,
 };
 use reconciler::{Reconciler, ReconcilerConfig, ReconcilerError, ReconcilerSnapshot};
 use research_registry::{
@@ -77,6 +81,7 @@ pub struct RuntimeAppState {
     feature_cache: Arc<RwLock<FeatureCache>>,
     strategy_registry: StrategyRegistry,
     research_registry: ResearchRegistry,
+    asset_registry: AssetRegistry,
     portfolio_ledger: PortfolioLedger,
     runtime_allocator: RuntimeAllocator,
     risk_engine: RiskEngine,
@@ -107,6 +112,8 @@ impl RuntimeAppState {
         let research_registry =
             ResearchRegistry::new(ResearchRegistryConfig::new(config.database_url.clone()))
                 .expect("research registry to initialize");
+        let asset_registry = AssetRegistry::new(AssetRegistryConfig::new(config.database_url.clone()))
+            .expect("asset registry to initialize");
         let portfolio_ledger =
             PortfolioLedger::new(PortfolioLedgerConfig::new(config.database_url.clone()))
                 .expect("portfolio ledger to initialize");
@@ -140,6 +147,7 @@ impl RuntimeAppState {
             feature_cache,
             strategy_registry,
             research_registry,
+            asset_registry,
             portfolio_ledger,
             runtime_allocator,
             risk_engine,
@@ -168,6 +176,10 @@ impl RuntimeAppState {
 
     fn research_registry_snapshot(&self) -> ResearchRegistrySnapshot {
         self.research_registry.snapshot_now()
+    }
+
+    fn asset_registry_snapshot(&self) -> AssetRegistrySnapshot {
+        self.asset_registry.snapshot_now()
     }
 
     fn portfolio_ledger_snapshot(&self) -> PortfolioLedgerSnapshot {
@@ -209,6 +221,7 @@ pub struct RuntimeHealthResponse {
     pub feature_cache: FeatureCacheSnapshot,
     pub strategy_registry: StrategyRegistrySnapshot,
     pub research_registry: ResearchRegistrySnapshot,
+    pub asset_registry: AssetRegistrySnapshot,
     pub portfolio_ledger: PortfolioLedgerSnapshot,
     pub allocator: RuntimeAllocatorSnapshot,
     pub risk_engine: RiskEngineSnapshot,
@@ -229,6 +242,7 @@ pub struct RuntimeMetricsResponse {
     pub feature_cache: FeatureCacheSnapshot,
     pub strategy_registry: StrategyRegistrySnapshot,
     pub research_registry: ResearchRegistrySnapshot,
+    pub asset_registry: AssetRegistrySnapshot,
     pub portfolio_ledger: PortfolioLedgerSnapshot,
     pub allocator: RuntimeAllocatorSnapshot,
     pub risk_engine: RiskEngineSnapshot,
@@ -264,6 +278,21 @@ struct RuntimeResearchQueryParams {
     pub venue_key: Option<String>,
     pub asset_key: Option<String>,
     pub source_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct RuntimeAssetQueryParams {
+    pub asset_key: Option<String>,
+    pub venue_key: Option<String>,
+    pub listing_state: Option<RuntimeAssetListingState>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct RuntimeAssetTransitionRequest {
+    pub listing_state: RuntimeAssetListingState,
+    pub changed_at: Option<String>,
 }
 
 pub fn app(config: RuntimeConfig) -> Router {
@@ -339,6 +368,14 @@ pub fn app(config: RuntimeConfig) -> Router {
             post(create_research_evidence_bundle_handler),
         )
         .route(
+            &format!("{INTERNAL_RUNTIME_PREFIX}/assets"),
+            get(asset_query_handler).post(create_asset_handler),
+        )
+        .route(
+            &format!("{INTERNAL_RUNTIME_PREFIX}/assets/{{asset_key}}/transition"),
+            post(transition_asset_handler),
+        )
+        .route(
             &format!("{INTERNAL_RUNTIME_PREFIX}/risk"),
             get(risk_handler),
         )
@@ -356,6 +393,7 @@ fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
     let feature_cache = state.feature_cache_snapshot();
     let strategy_registry = state.strategy_registry_snapshot();
     let research_registry = state.research_registry_snapshot();
+    let asset_registry = state.asset_registry_snapshot();
     let portfolio_ledger = state.portfolio_ledger_snapshot();
     let allocator = state.runtime_allocator_snapshot();
     let risk_engine = state.risk_engine_snapshot();
@@ -365,6 +403,7 @@ fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
         && feature_cache.status == "healthy"
         && strategy_registry.status == "healthy"
         && research_registry.status == "healthy"
+        && asset_registry.status == "healthy"
         && portfolio_ledger.status == "healthy"
         && allocator.status == "healthy"
         && risk_engine.status == "healthy"
@@ -391,6 +430,7 @@ fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
         feature_cache,
         strategy_registry,
         research_registry,
+        asset_registry,
         portfolio_ledger,
         allocator,
         risk_engine,
@@ -411,6 +451,7 @@ fn metrics_response(state: &RuntimeAppState) -> RuntimeMetricsResponse {
         feature_cache: state.feature_cache_snapshot(),
         strategy_registry: state.strategy_registry_snapshot(),
         research_registry: state.research_registry_snapshot(),
+        asset_registry: state.asset_registry_snapshot(),
         portfolio_ledger: state.portfolio_ledger_snapshot(),
         allocator: state.runtime_allocator_snapshot(),
         risk_engine: state.risk_engine_snapshot(),
@@ -450,6 +491,10 @@ async fn create_deployment_handler(
 ) -> HandlerResult {
     authorize_internal_request(&headers, &state)?;
     let deployment: RuntimeDeploymentRecord = parse_json_body(&body, "invalid-runtime-deployment")?;
+    state
+        .asset_registry
+        .ensure_pair_supported(&deployment)
+        .map_err(map_asset_registry_error)?;
     let previous = state
         .strategy_registry
         .get_deployment(&deployment.deployment_id)
@@ -631,6 +676,10 @@ async fn evaluate_deployment_handler(
             request.trigger,
         )
         .map_err(map_registry_error)?;
+    state
+        .asset_registry
+        .ensure_pair_supported(&result.deployment)
+        .map_err(map_asset_registry_error)?;
     let ledger_snapshot = state
         .portfolio_ledger
         .snapshot_for_deployment(&deployment_id)
@@ -1282,6 +1331,86 @@ async fn create_research_evidence_bundle_handler(
     ))
 }
 
+async fn asset_query_handler(
+    headers: HeaderMap,
+    Query(query): Query<RuntimeAssetQueryParams>,
+    State(state): State<RuntimeAppState>,
+) -> HandlerResult {
+    authorize_internal_request(&headers, &state)?;
+    let filters = query.clone();
+    let assets = state
+        .asset_registry
+        .list_assets(&AssetRegistryQuery {
+            asset_key: query.asset_key.filter(|value| !value.trim().is_empty()),
+            venue_key: query.venue_key.filter(|value| !value.trim().is_empty()),
+            listing_state: query.listing_state,
+        })
+        .map_err(map_asset_registry_error)?;
+    Ok(OkJson::with_status(
+        StatusCode::OK,
+        json!({
+            "ok": true,
+            "source": "runtime-rs",
+            "filters": filters,
+            "registry": {
+                "assets": assets,
+            },
+        }),
+    ))
+}
+
+async fn create_asset_handler(
+    headers: HeaderMap,
+    State(state): State<RuntimeAppState>,
+    body: Bytes,
+) -> HandlerResult {
+    authorize_internal_request(&headers, &state)?;
+    let record: RuntimeAssetRecord = parse_json_body(&body, "invalid-runtime-asset")?;
+    let result = state
+        .asset_registry
+        .upsert_asset(&record)
+        .map_err(map_asset_registry_error)?;
+    Ok(OkJson::with_status(
+        if result.created {
+            StatusCode::CREATED
+        } else {
+            StatusCode::OK
+        },
+        json!({
+            "ok": true,
+            "source": "runtime-rs",
+            "created": result.created,
+            "asset": result.record,
+        }),
+    ))
+}
+
+async fn transition_asset_handler(
+    headers: HeaderMap,
+    Path(asset_key): Path<String>,
+    State(state): State<RuntimeAppState>,
+    body: Bytes,
+) -> HandlerResult {
+    authorize_internal_request(&headers, &state)?;
+    let request: RuntimeAssetTransitionRequest =
+        parse_json_body(&body, "invalid-runtime-asset-transition")?;
+    let changed_at = request
+        .changed_at
+        .unwrap_or_else(|| OffsetDateTime::now_utc().format(&time::format_description::well_known::Rfc3339).expect("timestamp"));
+    let asset = state
+        .asset_registry
+        .transition_asset(&asset_key, request.listing_state, &changed_at)
+        .map_err(map_asset_registry_error)?;
+    Ok(OkJson::with_status(
+        StatusCode::OK,
+        json!({
+            "ok": true,
+            "source": "runtime-rs",
+            "asset": asset,
+        }),
+    ))
+}
+
 struct ShadowEvaluationResponse {
     created: bool,
     deployment: RuntimeDeploymentRecord,
@@ -1786,6 +1915,87 @@ fn map_research_registry_error(error: ResearchRegistryError) -> JsonPayload {
         ResearchRegistryError::Serialization(error) => error_json(
             StatusCode::INTERNAL_SERVER_ERROR,
             "runtime-research-registry-error",
+            json!({ "reason": error.to_string() }),
+        ),
+    }
+}
+
+fn map_asset_registry_error(error: AssetRegistryError) -> JsonPayload {
+    match error {
+        AssetRegistryError::AssetNotFound { asset_key } => error_json(
+            StatusCode::NOT_FOUND,
+            "asset-not-found",
+            json!({ "assetKey": asset_key }),
+        ),
+        AssetRegistryError::InvalidStateTransition {
+            asset_key,
+            from_state,
+            to_state,
+        } => error_json(
+            StatusCode::CONFLICT,
+            "invalid-asset-state-transition",
+            json!({
+                "assetKey": asset_key,
+                "fromState": from_state,
+                "toState": to_state,
+            }),
+        ),
+        AssetRegistryError::AssetModeUnsupported {
+            asset_key,
+            listing_state,
+            mode,
+        } => error_json(
+            StatusCode::CONFLICT,
+            "asset-mode-not-supported",
+            json!({
+                "assetKey": asset_key,
+                "listingState": listing_state,
+                "mode": mode,
+            }),
+        ),
+        AssetRegistryError::VenueMappingMissing { asset_key, venue_key } => error_json(
+            StatusCode::BAD_REQUEST,
+            "asset-venue-mapping-missing",
+            json!({ "assetKey": asset_key, "venueKey": venue_key }),
+        ),
+        AssetRegistryError::VenueMappingModeUnsupported {
+            asset_key,
+            venue_key,
+            listing_state,
+            mode,
+        } => error_json(
+            StatusCode::CONFLICT,
+            "asset-venue-mode-not-supported",
+            json!({
+                "assetKey": asset_key,
+                "venueKey": venue_key,
+                "listingState": listing_state,
+                "mode": mode,
+            }),
+        ),
+        AssetRegistryError::VenueNativeIdNotFound { venue_key, native_id } => error_json(
+            StatusCode::BAD_REQUEST,
+            "asset-venue-native-id-not-found",
+            json!({ "venueKey": venue_key, "nativeId": native_id }),
+        ),
+        AssetRegistryError::InvalidRecord { asset_key, reason } => error_json(
+            StatusCode::BAD_REQUEST,
+            "invalid-runtime-asset",
+            json!({ "assetKey": asset_key, "reason": reason }),
+        ),
+        AssetRegistryError::Io(error) => error_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "runtime-asset-registry-error",
+            json!({ "reason": error.to_string() }),
+        ),
+        AssetRegistryError::Storage(error) => error_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "runtime-asset-registry-error",
+            json!({ "reason": error.to_string() }),
+        ),
+        AssetRegistryError::Serialization(error) => error_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "runtime-asset-registry-error",
             json!({ "reason": error.to_string() }),
         ),
     }
@@ -2301,6 +2511,9 @@ mod tests {
         assert_eq!(payload.strategy_registry.deployment_count, 0);
         assert_eq!(payload.research_registry.status, "healthy");
         assert_eq!(payload.research_registry.hypothesis_count, 0);
+        assert_eq!(payload.asset_registry.status, "healthy");
+        assert_eq!(payload.asset_registry.asset_count, 2);
+        assert_eq!(payload.asset_registry.live_asset_count, 2);
         assert_eq!(payload.portfolio_ledger.status, "healthy");
         assert_eq!(payload.portfolio_ledger.deployment_count, 0);
         assert_eq!(payload.allocator.status, "healthy");
@@ -2340,6 +2553,8 @@ mod tests {
         assert_eq!(payload.feature_cache.total_market_samples, 1);
         assert_eq!(payload.strategy_registry.status, "healthy");
         assert_eq!(payload.research_registry.status, "healthy");
+        assert_eq!(payload.asset_registry.status, "healthy");
+        assert_eq!(payload.asset_registry.asset_count, 2);
         assert_eq!(payload.portfolio_ledger.status, "healthy");
         assert_eq!(payload.allocator.status, "healthy");
         assert_eq!(payload.risk_engine.status, "healthy");
@@ -3790,5 +4005,135 @@ mod tests {
             .await
             .expect("response");
         assert_eq!(missing_response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn serves_asset_registry_and_transitions_assets() {
+        let router = app(test_config());
+        let asset = json!({
+            "schemaVersion": "v1",
+            "assetKey": "BONK",
+            "displayName": "Bonk",
+            "symbol": "BONK",
+            "chainKey": "solana-mainnet",
+            "canonicalId": "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
+            "assetKind": "token",
+            "riskClass": "volatile",
+            "listingState": "candidate",
+            "decimals": 5,
+            "aliases": ["Bonk Inu"],
+            "quoteAssetKeys": ["USDC"],
+            "venueMappings": [
+                {
+                    "venueKey": "jupiter",
+                    "nativeId": "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
+                    "venueSymbol": "BONK",
+                    "decimals": 5,
+                    "listingState": "candidate",
+                    "quoteAssetKeys": ["USDC"],
+                    "priceDecimals": 8,
+                    "sizeDecimals": 5,
+                    "minNotionalUsd": "0.10"
+                }
+            ],
+            "createdAt": "2026-03-10T14:25:00.000Z",
+            "updatedAt": "2026-03-10T14:25:00.000Z",
+            "tags": ["candidate", "meme"]
+        });
+
+        let write_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/assets")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(asset.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(write_response.status(), StatusCode::CREATED);
+        let write_payload = read_json(write_response).await;
+        assert_eq!(write_payload["asset"]["assetKey"], json!("BONK"));
+        assert_eq!(write_payload["asset"]["listingState"], json!("candidate"));
+
+        let list_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/internal/runtime/assets?assetKey=BONK&venueKey=jupiter")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(list_response.status(), StatusCode::OK);
+        let list_payload = read_json(list_response).await;
+        assert_eq!(list_payload["registry"]["assets"].as_array().expect("array").len(), 1);
+        assert_eq!(list_payload["registry"]["assets"][0]["assetKey"], json!("BONK"));
+
+        let transition_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/assets/BONK/transition")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "listingState": "paper",
+                            "changedAt": "2026-03-10T14:30:00.000Z"
+                        })
+                        .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(transition_response.status(), StatusCode::OK);
+        let transition_payload = read_json(transition_response).await;
+        assert_eq!(transition_payload["asset"]["assetKey"], json!("BONK"));
+        assert_eq!(transition_payload["asset"]["listingState"], json!("paper"));
+        assert_eq!(
+            transition_payload["asset"]["updatedAt"],
+            json!("2026-03-10T14:30:00.000Z")
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_deployments_for_unlisted_assets() {
+        let router = app(test_config());
+        let mut deployment = runtime_deployment(
+            "deployment_unknown_asset",
+            "sleeve_alpha",
+            "1000.00",
+            "125.00",
+        );
+        deployment["pair"] = json!({
+            "symbol": "BONK/USDC",
+            "baseMint": "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
+            "quoteMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        });
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/deployments")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(deployment.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let payload = read_json(response).await;
+        assert_eq!(payload["error"], json!("asset-venue-native-id-not-found"));
+        assert_eq!(payload["details"]["nativeId"], deployment["pair"]["baseMint"]);
     }
 }

--- a/services/runtime-rs/src/lib.rs
+++ b/services/runtime-rs/src/lib.rs
@@ -112,8 +112,9 @@ impl RuntimeAppState {
         let research_registry =
             ResearchRegistry::new(ResearchRegistryConfig::new(config.database_url.clone()))
                 .expect("research registry to initialize");
-        let asset_registry = AssetRegistry::new(AssetRegistryConfig::new(config.database_url.clone()))
-            .expect("asset registry to initialize");
+        let asset_registry =
+            AssetRegistry::new(AssetRegistryConfig::new(config.database_url.clone()))
+                .expect("asset registry to initialize");
         let portfolio_ledger =
             PortfolioLedger::new(PortfolioLedgerConfig::new(config.database_url.clone()))
                 .expect("portfolio ledger to initialize");
@@ -1394,9 +1395,11 @@ async fn transition_asset_handler(
     authorize_internal_request(&headers, &state)?;
     let request: RuntimeAssetTransitionRequest =
         parse_json_body(&body, "invalid-runtime-asset-transition")?;
-    let changed_at = request
-        .changed_at
-        .unwrap_or_else(|| OffsetDateTime::now_utc().format(&time::format_description::well_known::Rfc3339).expect("timestamp"));
+    let changed_at = request.changed_at.unwrap_or_else(|| {
+        OffsetDateTime::now_utc()
+            .format(&time::format_description::well_known::Rfc3339)
+            .expect("timestamp")
+    });
     let asset = state
         .asset_registry
         .transition_asset(&asset_key, request.listing_state, &changed_at)
@@ -1953,7 +1956,10 @@ fn map_asset_registry_error(error: AssetRegistryError) -> JsonPayload {
                 "mode": mode,
             }),
         ),
-        AssetRegistryError::VenueMappingMissing { asset_key, venue_key } => error_json(
+        AssetRegistryError::VenueMappingMissing {
+            asset_key,
+            venue_key,
+        } => error_json(
             StatusCode::BAD_REQUEST,
             "asset-venue-mapping-missing",
             json!({ "assetKey": asset_key, "venueKey": venue_key }),
@@ -1973,7 +1979,10 @@ fn map_asset_registry_error(error: AssetRegistryError) -> JsonPayload {
                 "mode": mode,
             }),
         ),
-        AssetRegistryError::VenueNativeIdNotFound { venue_key, native_id } => error_json(
+        AssetRegistryError::VenueNativeIdNotFound {
+            venue_key,
+            native_id,
+        } => error_json(
             StatusCode::BAD_REQUEST,
             "asset-venue-native-id-not-found",
             json!({ "venueKey": venue_key, "nativeId": native_id }),
@@ -4072,8 +4081,17 @@ mod tests {
             .expect("response");
         assert_eq!(list_response.status(), StatusCode::OK);
         let list_payload = read_json(list_response).await;
-        assert_eq!(list_payload["registry"]["assets"].as_array().expect("array").len(), 1);
-        assert_eq!(list_payload["registry"]["assets"][0]["assetKey"], json!("BONK"));
+        assert_eq!(
+            list_payload["registry"]["assets"]
+                .as_array()
+                .expect("array")
+                .len(),
+            1
+        );
+        assert_eq!(
+            list_payload["registry"]["assets"][0]["assetKey"],
+            json!("BONK")
+        );
 
         let transition_response = router
             .clone()
@@ -4134,6 +4152,9 @@ mod tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let payload = read_json(response).await;
         assert_eq!(payload["error"], json!("asset-venue-native-id-not-found"));
-        assert_eq!(payload["details"]["nativeId"], deployment["pair"]["baseMint"]);
+        assert_eq!(
+            payload["details"]["nativeId"],
+            deployment["pair"]["baseMint"]
+        );
     }
 }

--- a/services/runtime-rs/src/lib.rs
+++ b/services/runtime-rs/src/lib.rs
@@ -1975,6 +1975,17 @@ fn map_asset_registry_error(error: AssetRegistryError) -> JsonPayload {
             "asset-venue-mapping-missing",
             json!({ "assetKey": asset_key, "venueKey": venue_key }),
         ),
+        AssetRegistryError::QuoteAssetUnsupported {
+            base_asset_key,
+            quote_asset_key,
+        } => error_json(
+            StatusCode::BAD_REQUEST,
+            "asset-quote-not-supported",
+            json!({
+                "baseAssetKey": base_asset_key,
+                "quoteAssetKey": quote_asset_key,
+            }),
+        ),
         AssetRegistryError::VenueMappingModeUnsupported {
             asset_key,
             venue_key,
@@ -1988,6 +1999,19 @@ fn map_asset_registry_error(error: AssetRegistryError) -> JsonPayload {
                 "venueKey": venue_key,
                 "listingState": listing_state,
                 "mode": mode,
+            }),
+        ),
+        AssetRegistryError::VenueMappingQuoteUnsupported {
+            base_asset_key,
+            quote_asset_key,
+            venue_key,
+        } => error_json(
+            StatusCode::BAD_REQUEST,
+            "asset-venue-quote-not-supported",
+            json!({
+                "baseAssetKey": base_asset_key,
+                "quoteAssetKey": quote_asset_key,
+                "venueKey": venue_key,
             }),
         ),
         AssetRegistryError::VenueNativeIdNotFound {

--- a/services/runtime-rs/src/lib.rs
+++ b/services/runtime-rs/src/lib.rs
@@ -669,6 +669,21 @@ async fn evaluate_deployment_handler(
     };
     let is_runtime_canary = is_worker_runtime_canary_trigger(request.trigger.as_ref());
     let observed_ledger_override = request.observed_ledger_snapshot.clone();
+    let deployment = state
+        .strategy_registry
+        .get_deployment(&deployment_id)
+        .map_err(map_registry_error)?
+        .ok_or_else(|| {
+            error_json(
+                StatusCode::NOT_FOUND,
+                "deployment-not-found",
+                json!({ "deploymentId": deployment_id }),
+            )
+        })?;
+    state
+        .asset_registry
+        .ensure_pair_supported(&deployment)
+        .map_err(map_asset_registry_error)?;
     let result = state
         .strategy_registry
         .evaluate_deployment_trigger(
@@ -677,10 +692,6 @@ async fn evaluate_deployment_handler(
             request.trigger,
         )
         .map_err(map_registry_error)?;
-    state
-        .asset_registry
-        .ensure_pair_supported(&result.deployment)
-        .map_err(map_asset_registry_error)?;
     let ledger_snapshot = state
         .portfolio_ledger
         .snapshot_for_deployment(&deployment_id)
@@ -4120,6 +4131,48 @@ mod tests {
             transition_payload["asset"]["updatedAt"],
             json!("2026-03-10T14:30:00.000Z")
         );
+    }
+
+    #[tokio::test]
+    async fn unsupported_asset_evaluation_does_not_persist_runs() {
+        let state = RuntimeAppState::new(test_config());
+        let mut deployment: RuntimeDeploymentRecord = serde_json::from_value(runtime_deployment(
+            "deployment_unknown_asset_eval",
+            "sleeve_alpha",
+            "1000.00",
+            "125.00",
+        ))
+        .expect("deployment");
+        deployment.pair = protocol::RuntimePair {
+            symbol: "BONK/USDC".to_string(),
+            base_mint: "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263".to_string(),
+            quote_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+        };
+        state
+            .strategy_registry
+            .upsert_deployment(&deployment)
+            .expect("deployment to store");
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "authorization",
+            HeaderValue::from_static("Bearer runtime-service-secret"),
+        );
+        let error = evaluate_deployment_handler(
+            headers,
+            Path("deployment_unknown_asset_eval".to_string()),
+            State(state.clone()),
+            Bytes::from("{}"),
+        )
+        .await
+        .expect_err("unsupported pair to fail before run creation");
+
+        assert_eq!(error.0, StatusCode::BAD_REQUEST);
+        let runs = state
+            .strategy_registry
+            .list_runs("deployment_unknown_asset_eval")
+            .expect("runs to list");
+        assert!(runs.is_empty());
     }
 
     #[tokio::test]

--- a/src/runtime/contracts/autonomous_runtime.ts
+++ b/src/runtime/contracts/autonomous_runtime.ts
@@ -432,6 +432,31 @@ export const RuntimeOnboardingStateSchema = z.enum([
   "deprecated",
 ]);
 
+export const RuntimeAssetListingStateSchema = z.enum([
+  "candidate",
+  "shadow",
+  "paper",
+  "live",
+  "paused",
+  "deprecated",
+]);
+
+export const RuntimeAssetKindSchema = z.enum([
+  "native",
+  "token",
+  "stablecoin",
+  "wrapped",
+  "synthetic",
+]);
+
+export const RuntimeAssetRiskClassSchema = z.enum([
+  "core",
+  "standard",
+  "volatile",
+  "experimental",
+  "restricted",
+]);
+
 export const RuntimeVenueMarketTypeSchema = z.enum(["spot", "perp", "options"]);
 
 export const RuntimeVenueOrderTypeSchema = z.enum([
@@ -496,6 +521,43 @@ export const RuntimeVenueCapabilitySchema = VersionedSchema.extend({
   settlementBehavior: RuntimeVenueSettlementBehaviorSchema,
   supportedModes: z.array(RuntimeModeSchema).min(1),
   onboardingState: RuntimeOnboardingStateSchema,
+  notes: NON_EMPTY_STRING_SCHEMA.optional(),
+}).strict();
+
+const RuntimeAssetVenueMappingSchema = z
+  .object({
+    venueKey: NON_EMPTY_STRING_SCHEMA,
+    nativeId: NON_EMPTY_STRING_SCHEMA,
+    venueSymbol: NON_EMPTY_STRING_SCHEMA,
+    decimals: z.number().int().nonnegative(),
+    listingState: RuntimeAssetListingStateSchema,
+    quoteAssetKeys: z.array(NON_EMPTY_STRING_SCHEMA).min(1),
+    priceDecimals: z.number().int().nonnegative().optional(),
+    sizeDecimals: z.number().int().nonnegative().optional(),
+    minNotionalUsd: DECIMAL_STRING_SCHEMA.optional(),
+    notes: NON_EMPTY_STRING_SCHEMA.optional(),
+  })
+  .strict();
+
+export const RuntimeAssetRecordSchema = VersionedSchema.extend({
+  assetKey: NON_EMPTY_STRING_SCHEMA,
+  displayName: NON_EMPTY_STRING_SCHEMA,
+  symbol: NON_EMPTY_STRING_SCHEMA,
+  chainKey: NON_EMPTY_STRING_SCHEMA,
+  canonicalId: NON_EMPTY_STRING_SCHEMA,
+  assetKind: RuntimeAssetKindSchema,
+  riskClass: RuntimeAssetRiskClassSchema,
+  listingState: RuntimeAssetListingStateSchema,
+  decimals: z.number().int().nonnegative(),
+  aliases: z.array(NON_EMPTY_STRING_SCHEMA),
+  quoteAssetKeys: z.array(NON_EMPTY_STRING_SCHEMA).min(1),
+  venueMappings: z.array(RuntimeAssetVenueMappingSchema).min(1),
+  createdAt: ISO_DATETIME_SCHEMA,
+  updatedAt: ISO_DATETIME_SCHEMA,
+  promotedAt: ISO_DATETIME_SCHEMA.optional(),
+  pausedAt: ISO_DATETIME_SCHEMA.optional(),
+  deprecatedAt: ISO_DATETIME_SCHEMA.optional(),
+  tags: z.array(NON_EMPTY_STRING_SCHEMA).max(16),
   notes: NON_EMPTY_STRING_SCHEMA.optional(),
 }).strict();
 
@@ -608,6 +670,11 @@ export type RuntimeResearchEvidenceBundleRecord = z.infer<
 export type RuntimeOnboardingState = z.infer<
   typeof RuntimeOnboardingStateSchema
 >;
+export type RuntimeAssetListingState = z.infer<
+  typeof RuntimeAssetListingStateSchema
+>;
+export type RuntimeAssetKind = z.infer<typeof RuntimeAssetKindSchema>;
+export type RuntimeAssetRiskClass = z.infer<typeof RuntimeAssetRiskClassSchema>;
 export type RuntimeVenueMarketType = z.infer<
   typeof RuntimeVenueMarketTypeSchema
 >;
@@ -620,6 +687,7 @@ export type RuntimeVenueSettlementBehavior = z.infer<
 export type RuntimeVenueCapability = z.infer<
   typeof RuntimeVenueCapabilitySchema
 >;
+export type RuntimeAssetRecord = z.infer<typeof RuntimeAssetRecordSchema>;
 export type RuntimeStrategySpec = z.infer<typeof RuntimeStrategySpecSchema>;
 
 export const RUNTIME_DEPLOYMENT_STATE_TRANSITIONS = {
@@ -706,6 +774,11 @@ export const RUNTIME_PROTOCOL_SCHEMA_REGISTRY = {
     schema: RuntimeVenueCapabilitySchema,
     schemaId: "https://trader-ralph.com/schemas/runtime/v1/venue_capability",
     outputFile: "runtime.venue_capability.v1.schema.json",
+  },
+  assetRecord: {
+    schema: RuntimeAssetRecordSchema,
+    schemaId: "https://trader-ralph.com/schemas/runtime/v1/asset_record",
+    outputFile: "runtime.asset_record.v1.schema.json",
   },
   strategySpec: {
     schema: RuntimeStrategySpecSchema,
@@ -796,6 +869,10 @@ export function parseRuntimeVenueCapability(
   return RuntimeVenueCapabilitySchema.parse(input);
 }
 
+export function parseRuntimeAssetRecord(input: unknown): RuntimeAssetRecord {
+  return RuntimeAssetRecordSchema.parse(input);
+}
+
 export function parseRuntimeStrategySpec(input: unknown): RuntimeStrategySpec {
   return RuntimeStrategySpecSchema.parse(input);
 }
@@ -842,6 +919,10 @@ export function safeParseRuntimeResearchEvidenceBundleRecord(input: unknown) {
 
 export function safeParseRuntimeVenueCapability(input: unknown) {
   return RuntimeVenueCapabilitySchema.safeParse(input);
+}
+
+export function safeParseRuntimeAssetRecord(input: unknown) {
+  return RuntimeAssetRecordSchema.safeParse(input);
 }
 
 export function safeParseRuntimeStrategySpec(input: unknown) {

--- a/tests/unit/runtime_protocol_contracts.test.ts
+++ b/tests/unit/runtime_protocol_contracts.test.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import {
   canTransitionRuntimeDeploymentState,
   canTransitionRuntimeRunState,
+  parseRuntimeAssetRecord,
   parseRuntimeDeploymentRecord,
   parseRuntimeExecutionPlan,
   parseRuntimeLedgerSnapshot,
@@ -397,6 +398,37 @@ describe("runtime protocol contracts", () => {
       supportedModes: ["shadow", "paper", "live"],
       onboardingState: "broad_live_ready",
     });
+    const assetRecord = parseRuntimeAssetRecord({
+      schemaVersion: "v1",
+      assetKey: "SOL",
+      displayName: "Solana",
+      symbol: "SOL",
+      chainKey: "solana-mainnet",
+      canonicalId: SOL_MINT,
+      assetKind: "native",
+      riskClass: "core",
+      listingState: "live",
+      decimals: 9,
+      aliases: ["WSOL"],
+      quoteAssetKeys: ["USDC"],
+      venueMappings: [
+        {
+          venueKey: "jupiter",
+          nativeId: SOL_MINT,
+          venueSymbol: "SOL",
+          decimals: 9,
+          listingState: "live",
+          quoteAssetKeys: ["USDC"],
+          priceDecimals: 6,
+          sizeDecimals: 9,
+          minNotionalUsd: "0.01",
+        },
+      ],
+      createdAt: "2026-03-10T14:00:00Z",
+      updatedAt: "2026-03-10T14:00:00Z",
+      promotedAt: "2026-03-10T14:00:00Z",
+      tags: ["core"],
+    });
 
     expect(run.state).toBe("planned");
     expect(ledger.totals.availableUsd).toBe("95");
@@ -410,6 +442,7 @@ describe("runtime protocol contracts", () => {
     expect(experiment.datasetSnapshots).toHaveLength(1);
     expect(evidenceBundle.promotionTarget).toBe("paper");
     expect(venueCapability.adapterKeys).toContain("jupiter");
+    expect(assetRecord.venueMappings[0]?.venueKey).toBe("jupiter");
     expect(strategySpec.pluginKey).toBe("builtin::trend_following");
   });
 

--- a/tests/unit/runtime_protocol_schema_fixtures.test.ts
+++ b/tests/unit/runtime_protocol_schema_fixtures.test.ts
@@ -84,6 +84,18 @@ describe("runtime protocol schema fixtures", () => {
     ).toBe(true);
     expect(
       validate(
+        "docs/runtime-contracts/schemas/runtime.venue_capability.v1.schema.json",
+        "docs/runtime-contracts/fixtures/runtime.venue_capability.valid.v1.json",
+      ),
+    ).toBe(true);
+    expect(
+      validate(
+        "docs/runtime-contracts/schemas/runtime.asset_record.v1.schema.json",
+        "docs/runtime-contracts/fixtures/runtime.asset_record.valid.v1.json",
+      ),
+    ).toBe(true);
+    expect(
+      validate(
         "docs/runtime-contracts/schemas/runtime.strategy_spec.v1.schema.json",
         "docs/runtime-contracts/fixtures/runtime.strategy_spec.valid.v1.json",
       ),
@@ -109,6 +121,7 @@ describe("runtime protocol schema fixtures", () => {
       "docs/runtime-contracts/schemas/runtime.research_experiment.v1.schema.json",
       "docs/runtime-contracts/schemas/runtime.research_evidence_bundle.v1.schema.json",
       "docs/runtime-contracts/schemas/runtime.venue_capability.v1.schema.json",
+      "docs/runtime-contracts/schemas/runtime.asset_record.v1.schema.json",
       "docs/runtime-contracts/schemas/runtime.strategy_spec.v1.schema.json",
     ]);
   });

--- a/tests/unit/worker_runtime_contracts.test.ts
+++ b/tests/unit/worker_runtime_contracts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import {
+  parseRuntimeAssetRecord,
   parseRuntimeDeploymentRecord,
   parseRuntimeStrategySpec,
   parseRuntimeVenueCapability,
@@ -27,6 +28,7 @@ describe("worker runtime contract bridge", () => {
       "researchExperiment",
       "researchEvidenceBundle",
       "venueCapability",
+      "assetRecord",
       "strategySpec",
     ]);
   });
@@ -62,5 +64,16 @@ describe("worker runtime contract bridge", () => {
 
     expect(venueCapability.venueKey).toBe("jupiter");
     expect(venueCapability.adapterKeys).toContain("jupiter");
+  });
+
+  test("worker can parse the canonical asset record fixture", () => {
+    const assetRecord = parseRuntimeAssetRecord(
+      readJson(
+        "docs/runtime-contracts/fixtures/runtime.asset_record.valid.v1.json",
+      ),
+    );
+
+    expect(assetRecord.assetKey).toBe("SOL");
+    expect(assetRecord.venueMappings[0]?.venueKey).toBe("jupiter");
   });
 });

--- a/tests/unit/worker_runtime_internal_routes.test.ts
+++ b/tests/unit/worker_runtime_internal_routes.test.ts
@@ -308,6 +308,37 @@ const VALID_RUNTIME_RESEARCH_EVIDENCE_BUNDLE = {
   tags: ["promotion"],
 };
 
+const VALID_RUNTIME_ASSET = {
+  schemaVersion: "v1",
+  assetKey: "BONK",
+  displayName: "Bonk",
+  symbol: "BONK",
+  chainKey: "solana-mainnet",
+  canonicalId: "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
+  assetKind: "token",
+  riskClass: "volatile",
+  listingState: "candidate",
+  decimals: 5,
+  aliases: ["Bonk Inu"],
+  quoteAssetKeys: ["USDC"],
+  venueMappings: [
+    {
+      venueKey: "jupiter",
+      nativeId: "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
+      venueSymbol: "BONK",
+      decimals: 5,
+      listingState: "candidate",
+      quoteAssetKeys: ["USDC"],
+      priceDecimals: 8,
+      sizeDecimals: 5,
+      minNotionalUsd: "0.10",
+    },
+  ],
+  createdAt: "2026-03-10T14:25:00.000Z",
+  updatedAt: "2026-03-10T14:25:00.000Z",
+  tags: ["candidate", "meme"],
+};
+
 describe("worker runtime internal routes", () => {
   test("requires runtime service auth", async () => {
     const env = createWorkerLiveEnv();
@@ -961,6 +992,101 @@ describe("worker runtime internal routes", () => {
       created: true,
       evidenceBundle: {
         evidenceBundleId: "evidence_signal_trend_shadow",
+      },
+    });
+  });
+
+  test("returns stubbed runtime asset registry", async () => {
+    const env = createWorkerLiveEnv();
+
+    const response = await worker.fetch(
+      new Request(
+        "http://localhost/api/internal/runtime/assets?assetKey=SOL&venueKey=jupiter&listingState=live",
+        {
+          headers: {
+            authorization: "Bearer runtime-service-secret",
+          },
+        },
+      ),
+      env,
+      createExecutionContextStub(),
+    );
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload).toMatchObject({
+      ok: true,
+      source: "stub",
+      filters: {
+        assetKey: "SOL",
+        venueKey: "jupiter",
+        listingState: "live",
+      },
+    });
+    expect(payload.registry.assets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          assetKey: "SOL",
+          venueMappings: expect.arrayContaining([
+            expect.objectContaining({ venueKey: "jupiter" }),
+          ]),
+        }),
+      ]),
+    );
+  });
+
+  test("accepts stubbed runtime asset writes and transitions", async () => {
+    const env = createWorkerLiveEnv();
+
+    const writeResponse = await worker.fetch(
+      new Request("http://localhost/api/internal/runtime/assets", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer runtime-service-secret",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(VALID_RUNTIME_ASSET),
+      }),
+      env,
+      createExecutionContextStub(),
+    );
+    expect(writeResponse.status).toBe(201);
+    expect(await writeResponse.json()).toMatchObject({
+      ok: true,
+      source: "stub",
+      created: true,
+      asset: {
+        assetKey: "BONK",
+        listingState: "candidate",
+      },
+    });
+
+    const transitionResponse = await worker.fetch(
+      new Request(
+        "http://localhost/api/internal/runtime/assets/BONK/transition",
+        {
+          method: "POST",
+          headers: {
+            authorization: "Bearer runtime-service-secret",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            listingState: "paper",
+            changedAt: "2026-03-10T14:30:00.000Z",
+          }),
+        },
+      ),
+      env,
+      createExecutionContextStub(),
+    );
+
+    expect(transitionResponse.status).toBe(200);
+    expect(await transitionResponse.json()).toMatchObject({
+      ok: true,
+      source: "stub",
+      asset: {
+        assetKey: "BONK",
+        listingState: "paper",
       },
     });
   });


### PR DESCRIPTION
## Summary
- add a versioned runtime asset registry contract and canonical SOL fixture/schema
- add a new Rust asset-registry crate plus runtime-rs asset query/write/transition routes
- make deployment creation and evaluation fail closed when pairs are not listed or venue mappings are not ready

## Validation
- bun run contracts:runtime:schemas
- bun run lint
- bun run typecheck
- bun test tests/unit/runtime_protocol_contracts.test.ts tests/unit/runtime_protocol_schema_fixtures.test.ts tests/unit/worker_runtime_contracts.test.ts tests/unit/worker_runtime_internal_routes.test.ts
- cargo test --workspace

Fixes #310
