### PR TITLE
Fix runtime-rs Fly startup defaults

### DIFF
--- a/.github/workflows/deploy-runtime-rs.yml
+++ b/.github/workflows/deploy-runtime-rs.yml
@@ -32,11 +32,12 @@ jobs:
         env:
           ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          RUNTIME_DATABASE_URL: ${{ secrets.RUNTIME_DATABASE_URL }}
           RUNTIME_INTERNAL_SERVICE_TOKEN: ${{ secrets.RUNTIME_INTERNAL_SERVICE_TOKEN }}
         run: |
           set -euo pipefail
 
-          for secret_name in ADMIN_TOKEN FLY_API_TOKEN RUNTIME_INTERNAL_SERVICE_TOKEN; do
+          for secret_name in ADMIN_TOKEN FLY_API_TOKEN RUNTIME_DATABASE_URL RUNTIME_INTERNAL_SERVICE_TOKEN; do
             if [ -z "${!secret_name:-}" ]; then
               echo "::error::Missing required secret ${secret_name} for runtime-rs deploy."
               exit 1

--- a/.github/workflows/rollback-runtime-rs.yml
+++ b/.github/workflows/rollback-runtime-rs.yml
@@ -63,11 +63,12 @@ jobs:
       - name: Check runtime rollback credentials
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          RUNTIME_DATABASE_URL: ${{ secrets.RUNTIME_DATABASE_URL }}
           RUNTIME_INTERNAL_SERVICE_TOKEN: ${{ secrets.RUNTIME_INTERNAL_SERVICE_TOKEN }}
         run: |
           set -euo pipefail
 
-          for secret_name in FLY_API_TOKEN RUNTIME_INTERNAL_SERVICE_TOKEN; do
+          for secret_name in FLY_API_TOKEN RUNTIME_DATABASE_URL RUNTIME_INTERNAL_SERVICE_TOKEN; do
             if [ -z "${!secret_name:-}" ]; then
               echo "::error::Missing required secret ${secret_name} for runtime-rs rollback."
               exit 1

--- a/crates/historical-data-lake/src/lib.rs
+++ b/crates/historical-data-lake/src/lib.rs
@@ -371,8 +371,20 @@ fn fixture_digest() -> Result<String, HistoricalDataLakeError> {
 }
 
 fn fixture_path() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../../services/runtime-rs/fixtures/runtime-feed-replay.sol_usdc.v1.json")
+    fixture_path_candidates()
+        .into_iter()
+        .find(|candidate| candidate.exists())
+        .unwrap_or_else(|| {
+            Path::new(env!("CARGO_MANIFEST_DIR")).join(format!("../../{FIXTURE_RELATIVE_PATH}"))
+        })
+}
+
+fn fixture_path_candidates() -> Vec<PathBuf> {
+    vec![
+        Path::new(env!("CARGO_MANIFEST_DIR")).join(format!("../../{FIXTURE_RELATIVE_PATH}")),
+        PathBuf::from(format!("/app/{FIXTURE_RELATIVE_PATH}")),
+        PathBuf::from(format!("./{FIXTURE_RELATIVE_PATH}")),
+    ]
 }
 
 fn validate_dataset_snapshot(
@@ -796,5 +808,13 @@ mod tests {
             result.dataset_snapshots[0].dataset_id,
             "dataset_feed_replay_sol_usdc_market_events"
         );
+    }
+
+    #[test]
+    fn fixture_path_candidates_include_runtime_image_location() {
+        let candidates = fixture_path_candidates();
+        assert!(candidates
+            .iter()
+            .any(|candidate| candidate == &PathBuf::from(format!("/app/{FIXTURE_RELATIVE_PATH}"))));
     }
 }

--- a/crates/runtime-ops/src/lib.rs
+++ b/crates/runtime-ops/src/lib.rs
@@ -95,7 +95,7 @@ impl RuntimeConfig {
             database_url: lookup("RUNTIME_DATABASE_URL")
                 .map(|value| value.trim().to_string())
                 .filter(|value| !value.is_empty())
-                .unwrap_or_else(|| ".tmp/runtime-rs/strategy-registry.sqlite3".to_string()),
+                .unwrap_or_else(|| "/tmp/runtime-rs/runtime-state.sqlite3".to_string()),
             feed_provider: lookup("RUNTIME_FEED_PROVIDER").unwrap_or_else(|| "fixture".to_string()),
             feed_websocket_url: lookup("RUNTIME_FEED_WS_URL")
                 .unwrap_or_else(|| "wss://price-feed.example/runtime".to_string()),
@@ -189,7 +189,7 @@ mod tests {
         assert_eq!(config.worker_health_path, "/api/internal/runtime/health");
         assert_eq!(
             config.database_url,
-            ".tmp/runtime-rs/strategy-registry.sqlite3"
+            "/tmp/runtime-rs/runtime-state.sqlite3"
         );
         assert_eq!(config.feed_provider, "fixture");
         assert_eq!(config.feed_market_stale_after_ms, 30_000);
@@ -215,7 +215,7 @@ mod tests {
                 Some("/api/internal/runtime/execution-plans".to_string())
             }
             "RUNTIME_WORKER_HEALTH_PATH" => Some("/api/internal/runtime/health".to_string()),
-            "RUNTIME_DATABASE_URL" => Some("/tmp/runtime-state.sqlite3".to_string()),
+            "RUNTIME_DATABASE_URL" => Some("/tmp/runtime-rs/runtime-state.sqlite3".to_string()),
             "RUNTIME_FEED_PROVIDER" => Some("jupiter".to_string()),
             "RUNTIME_FEED_WS_URL" => Some("wss://feeds.jupiter.example/runtime".to_string()),
             "RUNTIME_FEED_HTTP_URL" => Some("https://rpc.jupiter.example/runtime".to_string()),
@@ -245,7 +245,7 @@ mod tests {
             "/api/internal/runtime/execution-plans"
         );
         assert_eq!(config.worker_health_path, "/api/internal/runtime/health");
-        assert_eq!(config.database_url, "/tmp/runtime-state.sqlite3");
+        assert_eq!(config.database_url, "/tmp/runtime-rs/runtime-state.sqlite3");
         assert_eq!(config.feed_provider, "jupiter");
         assert_eq!(
             config.feed_websocket_url,

--- a/crates/runtime-ops/src/lib.rs
+++ b/crates/runtime-ops/src/lib.rs
@@ -187,10 +187,7 @@ mod tests {
             "/api/internal/runtime/execution-plans"
         );
         assert_eq!(config.worker_health_path, "/api/internal/runtime/health");
-        assert_eq!(
-            config.database_url,
-            "/tmp/runtime-rs/runtime-state.sqlite3"
-        );
+        assert_eq!(config.database_url, "/tmp/runtime-rs/runtime-state.sqlite3");
         assert_eq!(config.feed_provider, "fixture");
         assert_eq!(config.feed_market_stale_after_ms, 30_000);
         assert_eq!(config.feed_slot_stale_after_ms, 15_000);

--- a/services/runtime-rs/Dockerfile
+++ b/services/runtime-rs/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
 WORKDIR /app
 
 COPY --from=builder /app/target/release/runtime-rs /usr/local/bin/runtime-rs
+COPY --from=builder /app/services/runtime-rs/fixtures /app/services/runtime-rs/fixtures
 
 USER runtime
 

--- a/services/runtime-rs/README.md
+++ b/services/runtime-rs/README.md
@@ -129,9 +129,9 @@ bun run runtime:fly:smoke
   Default: `64`
 - `RUNTIME_DATABASE_URL`
   SQLite database path or `sqlite://` URL for the runtime-owned registry.
-  Default: `.tmp/runtime-rs/strategy-registry.sqlite3`
-  If the configured path is not writable, runtime-rs falls back to
-  `/tmp/runtime-rs/strategy-registry.sqlite3`.
+  Default: `/tmp/runtime-rs/runtime-state.sqlite3`
+  If the configured path is not writable, individual runtime components fall
+  back to their own `/tmp/runtime-rs/*.sqlite3` state files.
 
 ## Health check
 


### PR DESCRIPTION
Closes #313

## Summary
- switch the runtime default database path to `/tmp/runtime-rs/runtime-state.sqlite3` so production has a writable default even when `RUNTIME_DATABASE_URL` is absent
- require `RUNTIME_DATABASE_URL` in the Fly deploy and rollback workflows instead of silently deploying with an empty runtime DB path
- copy `services/runtime-rs/fixtures` into the final Fly image so historical-data-lake seed fixtures exist at runtime

## Validation
- `bun run lint`
- `bun run typecheck`
- `cargo test -p runtime-ops -p runtime-rs --lib`
- `cargo clippy -p runtime-ops -p runtime-rs --all-targets -- -D warnings`

## Notes
- production GitHub and Fly secrets were updated to set `RUNTIME_DATABASE_URL=/tmp/runtime-rs/runtime-state.sqlite3` so the current merged release can recover immediately once a healthy image is deployed
- local Docker image build verification was attempted, but Docker Desktop is not running on this machine (`Cannot connect to the Docker daemon`)
- no portal/UI changes; `harness:proof` is unchanged and CI browser-proof remains the repo-owned browser gate

## Risk Notes
- this is a deployment-safety follow-up to #313, not a contract expansion
- rollback remains safe because the workflow now fails fast when the runtime DB secret is missing