### PR TITLE
Destroy Fly standby machines before deploy

### DIFF
--- a/scripts/runtime_rs/fly_deploy.mjs
+++ b/scripts/runtime_rs/fly_deploy.mjs
@@ -223,7 +223,19 @@ async function main() {
   ensureApp(config);
   stageSecrets(config);
   destroyStandbyRegionMachines(config, listMachines(config.appName));
-  deployRuntime(config);
+  try {
+    deployRuntime(config);
+  } catch (error) {
+    const rollbackMachines = listMachines(config.appName);
+    const rollbackPrimary =
+      listPrimaryMachines(config, rollbackMachines)[0] ?? null;
+
+    if (rollbackPrimary) {
+      await ensureStandby(config, rollbackPrimary.id);
+    }
+
+    throw error;
+  }
 
   let machines = listMachines(config.appName);
   const primary = selectPrimaryMachine(config, machines);

--- a/scripts/runtime_rs/fly_deploy.mjs
+++ b/scripts/runtime_rs/fly_deploy.mjs
@@ -2,6 +2,7 @@
 
 import {
   findStandbyFor,
+  isDestroyedMachine,
   readRuntimeFlyConfig,
   runFly,
   runFlyJson,
@@ -83,10 +84,24 @@ function destroyMismatchedStandbys(config, machines, primaryMachineId) {
     (machine) =>
       machine?.region === config.standbyRegion &&
       findStandbyFor(machine) !== primaryMachineId &&
-      machine?.state !== "destroyed",
+      !isDestroyedMachine(machine),
   );
 
   for (const machine of mismatched) {
+    runFly(
+      ["machine", "destroy", machine.id, "--app", config.appName, "--force"],
+      { stdio: "inherit" },
+    );
+  }
+}
+
+function destroyStandbyRegionMachines(config, machines) {
+  const standbyMachines = machines.filter(
+    (machine) =>
+      machine?.region === config.standbyRegion && !isDestroyedMachine(machine),
+  );
+
+  for (const machine of standbyMachines) {
     runFly(
       ["machine", "destroy", machine.id, "--app", config.appName, "--force"],
       { stdio: "inherit" },
@@ -207,6 +222,7 @@ async function main() {
 
   ensureApp(config);
   stageSecrets(config);
+  destroyStandbyRegionMachines(config, listMachines(config.appName));
   deployRuntime(config);
 
   let machines = listMachines(config.appName);


### PR DESCRIPTION
## Summary
- destroy standby-region runtime machines before running `fly deploy`
- let `fly deploy` converge only on the primary machine for the new release
- recreate the standby machine after the primary release is healthy

## Validation
- node --check scripts/runtime_rs/fly_deploy.mjs
- bunx biome check scripts/runtime_rs/fly_deploy.mjs

## Notes
- This fixes the runtime deploy lane hanging after a healthy release because a deliberately stopped standby machine kept the Fly deploy step open.
