### PR TITLE
Build runtime backtesting engine with walk-forward validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtesting-engine"
+version = "0.1.0"
+dependencies = [
+ "feature-cache",
+ "market-adapters",
+ "protocol",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2",
+ "strategy-core",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,6 +1055,7 @@ version = "0.1.0"
 dependencies = [
  "asset-registry",
  "axum",
+ "backtesting-engine",
  "cost-model-registry",
  "exec-client",
  "execution-planner",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "crates/asset-registry",
+  "crates/backtesting-engine",
   "crates/cost-model-registry",
   "crates/execution-planner",
   "crates/exec-client",

--- a/apps/worker/src/runtime_contracts.ts
+++ b/apps/worker/src/runtime_contracts.ts
@@ -1,6 +1,7 @@
 export type {
   RuntimeAssetListingState,
   RuntimeAssetRecord,
+  RuntimeBacktestReport,
   RuntimeDeploymentRecord,
   RuntimeDeploymentState,
   RuntimeExecutionCostModelRecord,
@@ -29,6 +30,7 @@ export {
   canTransitionRuntimeDeploymentState,
   canTransitionRuntimeRunState,
   parseRuntimeAssetRecord,
+  parseRuntimeBacktestReport,
   parseRuntimeDeploymentRecord,
   parseRuntimeExecutionCostModelRecord,
   parseRuntimeExecutionPlan,
@@ -52,6 +54,7 @@ export {
   RUNTIME_PROTOCOL_SCHEMA_VERSION,
   RUNTIME_RUN_STATE_TRANSITIONS,
   safeParseRuntimeAssetRecord,
+  safeParseRuntimeBacktestReport,
   safeParseRuntimeDeploymentRecord,
   safeParseRuntimeExecutionCostModelRecord,
   safeParseRuntimeExecutionPlan,

--- a/apps/worker/src/runtime_internal.ts
+++ b/apps/worker/src/runtime_internal.ts
@@ -5,6 +5,7 @@ import {
 import { json } from "./response";
 import {
   parseRuntimeAssetRecord,
+  parseRuntimeBacktestReport,
   parseRuntimeDeploymentRecord,
   parseRuntimeExecutionCostModelRecord,
   parseRuntimeExecutionPlan,
@@ -21,6 +22,7 @@ import {
   RUNTIME_PROTOCOL_SCHEMA_VERSION,
   type RuntimeAssetListingState,
   type RuntimeAssetRecord,
+  type RuntimeBacktestReport,
   type RuntimeDeploymentRecord,
   type RuntimeExecutionCostModelRecord,
   type RuntimeExecutionPlan,
@@ -54,6 +56,7 @@ const INTERNAL_RUNTIME_RESEARCH_EVIDENCE_BUNDLES_PATH = `${INTERNAL_RUNTIME_RESE
 const INTERNAL_RUNTIME_ASSETS_PATH = `${INTERNAL_RUNTIME_PREFIX}/assets`;
 const INTERNAL_RUNTIME_ASSETS_PREFIX = `${INTERNAL_RUNTIME_ASSETS_PATH}/`;
 const INTERNAL_RUNTIME_DATASETS_PATH = `${INTERNAL_RUNTIME_PREFIX}/datasets`;
+const INTERNAL_RUNTIME_BACKTESTS_PATH = `${INTERNAL_RUNTIME_PREFIX}/backtests`;
 const INTERNAL_RUNTIME_DATASET_SNAPSHOTS_PATH = `${INTERNAL_RUNTIME_DATASETS_PATH}/snapshots`;
 const INTERNAL_RUNTIME_REPLAY_CORPORA_PATH = `${INTERNAL_RUNTIME_DATASETS_PATH}/replay-corpora`;
 const INTERNAL_RUNTIME_FEATURES_PATH = `${INTERNAL_RUNTIME_PREFIX}/features`;
@@ -724,6 +727,120 @@ function createRuntimeResearchRegistryFixture() {
   };
 }
 
+function createRuntimeBacktestFixture(
+  reportId = "backtest_alloc_dca_report",
+): RuntimeBacktestReport {
+  return parseRuntimeBacktestReport({
+    schemaVersion: RUNTIME_PROTOCOL_SCHEMA_VERSION,
+    reportId,
+    experimentId: "experiment_alloc_dca_backtest",
+    strategyKey: "dca",
+    status: "completed",
+    generatedAt: FIXTURE_TIMESTAMP,
+    venueKeys: ["jupiter"],
+    assetKeys: ["SOL", "USDC"],
+    codeRevision: {
+      vcs: "git",
+      repository: "github.com/GuiBibeau/serious-trader-ralph",
+      revision: "356b539e3ec730663c4025b8f00cd6b47b823d1a",
+      treeDirty: false,
+    },
+    datasetSnapshots: [
+      {
+        datasetId: "dataset_feature_cache_sol_usdc_market_events",
+        snapshotId: "snapshot_2026_03_07_backtest",
+        capturedAt: FIXTURE_TIMESTAMP,
+        uri: "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json#marketEvents",
+        contentDigest: "sha256:feature-cache",
+      },
+    ],
+    strategySpecDigest:
+      "sha256:1992048eb2efcd762981bd78d6ae7685c39873c4ccb8189681e2003ca8d84bff",
+    config: {
+      replayCorpusId: "replay_corpus_sol_usdc_feature_cache",
+      venueKey: "jupiter",
+      pairSymbol: "SOL/USDC",
+      marketType: "spot",
+      windowMode: "rolling",
+      trainingWindowObservations: 2,
+      testingWindowObservations: 1,
+      stepObservations: 1,
+      purgeObservations: 0,
+      baselineStrategies: ["flat_cash", "buy_and_hold"],
+    },
+    foldReports: [
+      {
+        foldId: "fold_0",
+        foldIndex: 0,
+        trainingStartAt: "2026-03-07T00:00:00Z",
+        trainingEndAt: "2026-03-07T00:00:10Z",
+        testStartAt: "2026-03-07T00:00:10Z",
+        testEndAt: "2026-03-07T00:00:15Z",
+        trainObservationCount: 2,
+        purgedObservationCount: 0,
+        testObservationCount: 1,
+        metrics: {
+          observationCount: 1,
+          tradeCount: 1,
+          grossReturnBps: "22.5384",
+          netReturnBps: "22.5384",
+          totalCostBps: "0.0000",
+          winRateBps: 10000,
+          maxDrawdownBps: "0.0000",
+        },
+        baselineComparisons: [
+          {
+            baseline: "flat_cash",
+            baselineReturnBps: "0.0000",
+            excessReturnBps: "22.5384",
+          },
+        ],
+        regimeMetrics: [
+          {
+            regimeKey: "short_trend",
+            regimeValue: "flat",
+            observationCount: 1,
+            tradeCount: 1,
+            netReturnBps: "22.5384",
+            winRateBps: 10000,
+          },
+        ],
+      },
+    ],
+    aggregateMetrics: {
+      observationCount: 1,
+      tradeCount: 1,
+      grossReturnBps: "22.5384",
+      netReturnBps: "22.5384",
+      totalCostBps: "0.0000",
+      winRateBps: 10000,
+      maxDrawdownBps: "0.0000",
+    },
+    aggregateBaselineComparisons: [
+      {
+        baseline: "flat_cash",
+        baselineReturnBps: "0.0000",
+        excessReturnBps: "22.5384",
+      },
+    ],
+    aggregateRegimeMetrics: [
+      {
+        regimeKey: "short_trend",
+        regimeValue: "flat",
+        observationCount: 1,
+        tradeCount: 1,
+        netReturnBps: "22.5384",
+        winRateBps: 10000,
+      },
+    ],
+    promotionEligible: true,
+    blockingReasons: [],
+    summary:
+      "Backtest cleared two walk-forward folds for dca with positive aggregate net return.",
+    tags: ["backtest", "paper"],
+  });
+}
+
 function createRuntimeAssetFixture(
   assetKey = "SOL",
   listingState: RuntimeAssetListingState = "live",
@@ -1154,6 +1271,7 @@ function buildRuntimeHealthPayload(env: Env, service: string) {
       research: INTERNAL_RUNTIME_RESEARCH_PATH,
       assets: INTERNAL_RUNTIME_ASSETS_PATH,
       datasets: INTERNAL_RUNTIME_DATASETS_PATH,
+      backtests: INTERNAL_RUNTIME_BACKTESTS_PATH,
       features: INTERNAL_RUNTIME_FEATURES_PATH,
       costModels: INTERNAL_RUNTIME_COST_MODELS_PATH,
       executionPlans: INTERNAL_RUNTIME_EXECUTION_PLANS_PATH,
@@ -1628,6 +1746,49 @@ export async function readRuntimeHistoricalDataLake(input: {
   });
 }
 
+export async function readRuntimeBacktests(input: {
+  env: Env;
+  reportId?: string;
+  experimentId?: string;
+  strategyKey?: string;
+  venueKey?: string;
+  assetKey?: string;
+  marketType?: string;
+  status?: string;
+  promotionEligible?: boolean;
+}): Promise<RuntimeInternalJsonResult> {
+  const search = new URLSearchParams();
+  if (input.reportId) search.set("reportId", input.reportId);
+  if (input.experimentId) search.set("experimentId", input.experimentId);
+  if (input.strategyKey) search.set("strategyKey", input.strategyKey);
+  if (input.venueKey) search.set("venueKey", input.venueKey);
+  if (input.assetKey) search.set("assetKey", input.assetKey);
+  if (input.marketType) search.set("marketType", input.marketType);
+  if (input.status) search.set("status", input.status);
+  if (typeof input.promotionEligible === "boolean") {
+    search.set("promotionEligible", String(input.promotionEligible));
+  }
+  return await dispatchRuntimeInternalJson({
+    env: input.env,
+    method: "GET",
+    pathname: search.size
+      ? `${INTERNAL_RUNTIME_BACKTESTS_PATH}?${search.toString()}`
+      : INTERNAL_RUNTIME_BACKTESTS_PATH,
+  });
+}
+
+export async function runRuntimeBacktest(input: {
+  env: Env;
+  payload: RuntimeBacktestReport | Record<string, unknown>;
+}): Promise<RuntimeInternalJsonResult> {
+  return await dispatchRuntimeInternalJson({
+    env: input.env,
+    method: "POST",
+    pathname: INTERNAL_RUNTIME_BACKTESTS_PATH,
+    body: input.payload,
+  });
+}
+
 export async function writeRuntimeHistoricalDatasetSnapshot(input: {
   env: Env;
   datasetSnapshot: RuntimeHistoricalDatasetSnapshotRecord;
@@ -1803,6 +1964,7 @@ export async function handleRuntimeInternalRoute(
     url.pathname === INTERNAL_RUNTIME_RESEARCH_EVIDENCE_BUNDLES_PATH ||
     url.pathname === INTERNAL_RUNTIME_ASSETS_PATH ||
     url.pathname === INTERNAL_RUNTIME_DATASETS_PATH ||
+    url.pathname === INTERNAL_RUNTIME_BACKTESTS_PATH ||
     url.pathname === INTERNAL_RUNTIME_DATASET_SNAPSHOTS_PATH ||
     url.pathname === INTERNAL_RUNTIME_REPLAY_CORPORA_PATH ||
     url.pathname === INTERNAL_RUNTIME_COST_MODELS_PATH ||
@@ -1934,6 +2096,27 @@ export async function handleRuntimeInternalRoute(
         datasetKind: url.searchParams.get("datasetKind"),
       },
       registry: createRuntimeHistoricalDataLakeFixture(),
+    });
+  }
+
+  if (
+    request.method === "GET" &&
+    url.pathname === INTERNAL_RUNTIME_BACKTESTS_PATH
+  ) {
+    return json({
+      ok: true,
+      source: "stub",
+      filters: {
+        reportId: url.searchParams.get("reportId"),
+        experimentId: url.searchParams.get("experimentId"),
+        strategyKey: url.searchParams.get("strategyKey"),
+        venueKey: url.searchParams.get("venueKey"),
+        assetKey: url.searchParams.get("assetKey"),
+        marketType: url.searchParams.get("marketType"),
+        status: url.searchParams.get("status"),
+        promotionEligible: url.searchParams.get("promotionEligible"),
+      },
+      reports: [createRuntimeBacktestFixture()],
     });
   }
 
@@ -2344,6 +2527,37 @@ export async function handleRuntimeInternalRoute(
         source: "stub",
         created: true,
         replayCorpus,
+      },
+      { status: 201 },
+    );
+  }
+
+  if (
+    request.method === "POST" &&
+    url.pathname === INTERNAL_RUNTIME_BACKTESTS_PATH
+  ) {
+    let report: RuntimeBacktestReport;
+    try {
+      const payload = await readJsonBody(request);
+      report = parseRuntimeBacktestReport(payload);
+    } catch (error) {
+      return json(
+        {
+          ok: false,
+          error: "invalid-runtime-backtest-report",
+          details: {
+            reason: error instanceof Error ? error.message : "unknown-error",
+          },
+        },
+        { status: 400 },
+      );
+    }
+    return json(
+      {
+        ok: true,
+        source: "stub",
+        created: true,
+        report,
       },
       { status: 201 },
     );

--- a/crates/backtesting-engine/Cargo.toml
+++ b/crates/backtesting-engine/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "backtesting-engine"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+feature-cache = { path = "../feature-cache" }
+market-adapters = { path = "../market-adapters" }
+protocol = { path = "../protocol" }
+rusqlite = { version = "0.37.0", features = ["bundled"] }
+serde.workspace = true
+serde_json.workspace = true
+sha2 = "0.10.9"
+thiserror.workspace = true
+time = { version = "=0.3.44", features = ["formatting", "parsing"] }
+
+[dev-dependencies]
+strategy-core = { path = "../strategy-core" }

--- a/crates/backtesting-engine/src/lib.rs
+++ b/crates/backtesting-engine/src/lib.rs
@@ -1,0 +1,1454 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::{Path, PathBuf},
+};
+
+use feature_cache::{DerivedMarketFeatureSnapshot, FeatureCache, FeatureCacheConfig, FeatureCacheError};
+use market_adapters::{FeedGatewayError, FeedReplayFixture};
+use protocol::{
+    RuntimeBacktestBaseline, RuntimeBacktestBaselineComparison, RuntimeBacktestConfig,
+    RuntimeBacktestFoldReport, RuntimeBacktestMetrics, RuntimeBacktestRegimeMetrics,
+    RuntimeBacktestReport, RuntimeBacktestStatus, RuntimeBacktestWindowMode,
+    RuntimeExecutionCostModelRecord, RuntimeFeatureDefinitionRecord, RuntimeRegimeTagRecord,
+    RuntimeResearchExperimentRecord, RuntimeReplayCorpusRecord, RuntimeStrategySpec,
+    RUNTIME_PROTOCOL_SCHEMA_VERSION,
+};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+const FEATURE_STALE_AFTER_MS: u64 = 20_000;
+const SLOT_STALE_AFTER_MS: u64 = 15_000;
+const MAX_SLOT_GAP: u64 = 2;
+const SHORT_WINDOW_MS: u64 = 10_000;
+const LONG_WINDOW_MS: u64 = 25_000;
+const VOLATILITY_WINDOW_SIZE: usize = 4;
+const MAX_SAMPLES_PER_STREAM: usize = 64;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BacktestingEngineConfig {
+    pub database_url: String,
+}
+
+impl BacktestingEngineConfig {
+    #[must_use]
+    pub fn new(database_url: impl Into<String>) -> Self {
+        Self {
+            database_url: database_url.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BacktestingEngine {
+    database_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BacktestingEngineSnapshot {
+    pub status: String,
+    pub report_count: u64,
+    pub latest_report_generated_at: Option<String>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BacktestingQuery {
+    pub report_id: Option<String>,
+    pub experiment_id: Option<String>,
+    pub strategy_key: Option<String>,
+    pub promotion_eligible: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BacktestRunRequest {
+    pub report_id: Option<String>,
+    pub experiment: RuntimeResearchExperimentRecord,
+    pub strategy_spec: RuntimeStrategySpec,
+    pub cost_model: Option<RuntimeExecutionCostModelRecord>,
+    pub feature_definitions: Vec<RuntimeFeatureDefinitionRecord>,
+    pub regime_tags: Vec<RuntimeRegimeTagRecord>,
+    pub replay_corpus: RuntimeReplayCorpusRecord,
+    pub config: RuntimeBacktestConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BacktestRunResult {
+    pub report: RuntimeBacktestReport,
+    pub created: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum BacktestingEngineError {
+    #[error("storage io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("storage error: {0}")]
+    Storage(#[from] rusqlite::Error),
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("feed fixture error: {0}")]
+    FeedFixture(#[from] FeedGatewayError),
+    #[error("feature cache error: {0}")]
+    FeatureCache(#[from] FeatureCacheError),
+    #[error("invalid timestamp for {field}: {value}")]
+    InvalidTimestamp { field: &'static str, value: String },
+    #[error("invalid numeric value for {field}: {value}")]
+    InvalidNumber { field: &'static str, value: String },
+    #[error("unsupported fixture uri: {uri}")]
+    UnsupportedFixtureUri { uri: String },
+    #[error("replay corpus {corpus_id} does not include a fixture uri")]
+    MissingFixtureUri { corpus_id: String },
+    #[error("invalid backtest config: {reason}")]
+    InvalidConfig { reason: String },
+    #[error("insufficient observations for backtest: required at least {required}, got {available}")]
+    InsufficientObservations { required: usize, available: usize },
+    #[error("backtest report {report_id} not found")]
+    ReportNotFound { report_id: String },
+}
+
+impl BacktestingEngine {
+    pub fn new(config: BacktestingEngineConfig) -> Result<Self, BacktestingEngineError> {
+        let requested_path = normalize_database_path(&config.database_url);
+        match Self::initialize_at_path(requested_path.clone()) {
+            Ok(engine) => Ok(engine),
+            Err(error) if should_fallback_to_tmp(&requested_path, &error) => {
+                Self::initialize_at_path(fallback_database_path())
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    pub fn run(&self, input: &BacktestRunRequest) -> Result<BacktestRunResult, BacktestingEngineError> {
+        validate_config(&input.config)?;
+        let fixture = load_replay_fixture(&input.replay_corpus)?;
+        let observations = build_observations(&fixture, &input.regime_tags)?;
+        let required_observations = input.config.training_window_observations as usize
+            + input.config.purge_observations as usize
+            + input.config.testing_window_observations as usize;
+        if observations.len() < required_observations + 1 {
+            return Err(BacktestingEngineError::InsufficientObservations {
+                required: required_observations + 1,
+                available: observations.len(),
+            });
+        }
+
+        let strategy_digest = strategy_spec_digest(&input.strategy_spec)?;
+        let generated_at = now_rfc3339();
+        let report_id = input
+            .report_id
+            .clone()
+            .unwrap_or_else(|| default_report_id(&input.experiment.experiment_id, &strategy_digest, &input.config));
+        let missing_feature_keys = missing_required_feature_keys(
+            &input.strategy_spec,
+            &input.feature_definitions,
+        );
+        let missing_regime_keys = missing_required_regime_keys(&input.strategy_spec, &input.regime_tags);
+        let evaluations = evaluate_walk_forward_folds(
+            &observations,
+            &input.strategy_spec,
+            input.cost_model.as_ref(),
+            &input.config,
+        )?;
+        let mut blocking_reasons = Vec::new();
+        if !missing_feature_keys.is_empty() {
+            blocking_reasons.push(format!(
+                "missing required feature definitions: {}",
+                missing_feature_keys.join(", ")
+            ));
+        }
+        if !missing_regime_keys.is_empty() {
+            blocking_reasons.push(format!(
+                "missing required regime tags: {}",
+                missing_regime_keys.join(", ")
+            ));
+        }
+        if evaluations.len() < 2 {
+            blocking_reasons.push("walk-forward evaluation requires at least two folds".to_string());
+        }
+
+        let fold_reports = evaluations
+            .iter()
+            .map(|evaluation| evaluation.fold_report.clone())
+            .collect::<Vec<_>>();
+        let aggregate = aggregate_evaluations(
+            &evaluations,
+            &input.config.baseline_strategies,
+            &input.strategy_spec,
+            &mut blocking_reasons,
+        );
+        let promotion_eligible = blocking_reasons.is_empty();
+        let status = if promotion_eligible {
+            RuntimeBacktestStatus::Completed
+        } else {
+            RuntimeBacktestStatus::Blocked
+        };
+        let summary = if promotion_eligible {
+            format!(
+                "Backtest cleared {} walk-forward folds for {} with net return {} bps.",
+                fold_reports.len(),
+                input.strategy_spec.strategy_key,
+                aggregate.metrics.net_return_bps
+            )
+        } else {
+            format!(
+                "Backtest blocked for {}: {}.",
+                input.strategy_spec.strategy_key,
+                blocking_reasons.join("; ")
+            )
+        };
+        let mut tags = input.experiment.tags.clone();
+        if !tags.iter().any(|tag| tag == "backtest") {
+            tags.push("backtest".to_string());
+        }
+        let report = RuntimeBacktestReport {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            report_id: report_id.clone(),
+            experiment_id: input.experiment.experiment_id.clone(),
+            strategy_key: input.strategy_spec.strategy_key.clone(),
+            status,
+            generated_at: generated_at.clone(),
+            venue_keys: input.experiment.venue_keys.clone(),
+            asset_keys: input.experiment.asset_keys.clone(),
+            code_revision: input.experiment.code_revision.clone(),
+            dataset_snapshots: input.experiment.dataset_snapshots.clone(),
+            strategy_spec_digest: strategy_digest,
+            config: input.config.clone(),
+            fold_reports,
+            aggregate_metrics: aggregate.metrics,
+            aggregate_baseline_comparisons: aggregate.baselines,
+            aggregate_regime_metrics: aggregate.regimes,
+            promotion_eligible,
+            blocking_reasons,
+            summary,
+            tags,
+        };
+
+        let mut connection = self.open_connection()?;
+        let transaction = connection.transaction()?;
+        let existing = load_report(&transaction, &report_id)?;
+        persist_report(&transaction, &report)?;
+        transaction.commit()?;
+        Ok(BacktestRunResult {
+            report,
+            created: existing.is_none(),
+        })
+    }
+
+    pub fn query(
+        &self,
+        query: &BacktestingQuery,
+    ) -> Result<Vec<RuntimeBacktestReport>, BacktestingEngineError> {
+        let connection = self.open_connection()?;
+        list_reports(&connection, query)
+    }
+
+    pub fn get_report(
+        &self,
+        report_id: &str,
+    ) -> Result<Option<RuntimeBacktestReport>, BacktestingEngineError> {
+        let connection = self.open_connection()?;
+        load_report(&connection, report_id)
+    }
+
+    #[must_use]
+    pub fn snapshot_now(&self) -> BacktestingEngineSnapshot {
+        match self.snapshot_counts() {
+            Ok(snapshot) => snapshot,
+            Err(error) => BacktestingEngineSnapshot {
+                status: "degraded".to_string(),
+                report_count: 0,
+                latest_report_generated_at: None,
+                last_error: Some(error.to_string()),
+            },
+        }
+    }
+
+    fn snapshot_counts(&self) -> Result<BacktestingEngineSnapshot, BacktestingEngineError> {
+        let connection = self.open_connection()?;
+        let report_count =
+            connection.query_row("SELECT COUNT(*) FROM backtest_reports", [], |row| {
+                row.get::<_, u64>(0)
+            })?;
+        let latest_report_generated_at = connection
+            .query_row(
+                "SELECT generated_at
+                 FROM backtest_reports
+                 ORDER BY generated_at DESC, report_id DESC
+                 LIMIT 1",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        Ok(BacktestingEngineSnapshot {
+            status: "healthy".to_string(),
+            report_count,
+            latest_report_generated_at,
+            last_error: None,
+        })
+    }
+
+    fn initialize_at_path(path: PathBuf) -> Result<Self, BacktestingEngineError> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let engine = Self {
+            database_path: path.clone(),
+        };
+        let connection = engine.open_connection()?;
+        initialize_schema(&connection)?;
+        Ok(engine)
+    }
+
+    fn open_connection(&self) -> Result<Connection, BacktestingEngineError> {
+        let connection = Connection::open(&self.database_path)?;
+        connection.execute_batch("PRAGMA foreign_keys = ON;")?;
+        Ok(connection)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Observation {
+    observed_at: String,
+    observed_at_ts: OffsetDateTime,
+    next_observed_at: String,
+    next_observed_at_ts: OffsetDateTime,
+    next_return_bps: f64,
+    feature: DerivedMarketFeatureSnapshot,
+    regimes: Vec<(String, String)>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct Calibration {
+    primary_threshold_bps: f64,
+    confirmation_threshold_bps: f64,
+    low_vol_threshold_bps: f64,
+    high_vol_threshold_bps: f64,
+}
+
+#[derive(Debug, Clone, Default)]
+struct RawMetrics {
+    observation_count: u32,
+    trade_count: u32,
+    gross_return_bps: f64,
+    net_return_bps: f64,
+    total_cost_bps: f64,
+    win_count: u32,
+    max_drawdown_bps: f64,
+}
+
+#[derive(Debug, Clone, Default)]
+struct RegimeAccumulator {
+    observation_count: u32,
+    trade_count: u32,
+    net_return_bps: f64,
+    win_count: u32,
+}
+
+#[derive(Debug, Clone)]
+struct FoldEvaluation {
+    fold_report: RuntimeBacktestFoldReport,
+    raw_metrics: RawMetrics,
+    baseline_totals: BTreeMap<RuntimeBacktestBaseline, f64>,
+    regime_totals: BTreeMap<(String, String), RegimeAccumulator>,
+}
+
+#[derive(Debug, Clone)]
+struct AggregateEvaluation {
+    metrics: RuntimeBacktestMetrics,
+    baselines: Vec<RuntimeBacktestBaselineComparison>,
+    regimes: Vec<RuntimeBacktestRegimeMetrics>,
+}
+
+fn evaluate_walk_forward_folds(
+    observations: &[Observation],
+    strategy_spec: &RuntimeStrategySpec,
+    cost_model: Option<&RuntimeExecutionCostModelRecord>,
+    config: &RuntimeBacktestConfig,
+) -> Result<Vec<FoldEvaluation>, BacktestingEngineError> {
+    let effective = observations.len() - 1;
+    let train_size = config.training_window_observations as usize;
+    let test_size = config.testing_window_observations as usize;
+    let step_size = config.step_observations as usize;
+    let purge_size = config.purge_observations as usize;
+    let mut evaluations = Vec::new();
+    let mut test_start = train_size + purge_size;
+    let mut fold_index = 0_u32;
+
+    while test_start + test_size <= effective {
+        let train_end = test_start.saturating_sub(purge_size);
+        let train_start = match config.window_mode {
+            RuntimeBacktestWindowMode::Rolling => train_end.saturating_sub(train_size),
+            RuntimeBacktestWindowMode::Expanding => 0,
+        };
+        if train_end <= train_start {
+            break;
+        }
+        let training = &observations[train_start..train_end];
+        let testing = &observations[test_start..test_start + test_size];
+        let calibration = calibrate_strategy(strategy_spec, training);
+        evaluations.push(evaluate_fold(
+            fold_index,
+            training,
+            testing,
+            purge_size as u32,
+            strategy_spec,
+            &calibration,
+            cost_model,
+            &config.baseline_strategies,
+        )?);
+        fold_index += 1;
+        test_start += step_size.max(1);
+    }
+
+    Ok(evaluations)
+}
+
+fn evaluate_fold(
+    fold_index: u32,
+    training: &[Observation],
+    testing: &[Observation],
+    purged_observation_count: u32,
+    strategy_spec: &RuntimeStrategySpec,
+    calibration: &Calibration,
+    cost_model: Option<&RuntimeExecutionCostModelRecord>,
+    baselines: &[RuntimeBacktestBaseline],
+) -> Result<FoldEvaluation, BacktestingEngineError> {
+    let mut previous_exposure = 0.0_f64;
+    let mut cumulative_net = 0.0_f64;
+    let mut peak_net = 0.0_f64;
+    let mut raw_metrics = RawMetrics::default();
+    let mut baseline_totals = BTreeMap::new();
+    let mut regime_totals: BTreeMap<(String, String), RegimeAccumulator> = BTreeMap::new();
+    for baseline in baselines {
+        baseline_totals.insert(baseline.clone(), 0.0);
+    }
+
+    for observation in testing {
+        let exposure = target_exposure(strategy_spec, observation, calibration);
+        let turnover = (exposure - previous_exposure).abs();
+        let cost_bps = modeled_cost_bps(cost_model, turnover, observation)?;
+        let gross_return_bps = exposure * observation.next_return_bps;
+        let net_return_bps = gross_return_bps - cost_bps;
+
+        raw_metrics.observation_count += 1;
+        raw_metrics.gross_return_bps += gross_return_bps;
+        raw_metrics.net_return_bps += net_return_bps;
+        raw_metrics.total_cost_bps += cost_bps;
+        if turnover > 0.0001 {
+            raw_metrics.trade_count += 1;
+        }
+        if net_return_bps > 0.0 {
+            raw_metrics.win_count += 1;
+        }
+        cumulative_net += net_return_bps;
+        peak_net = peak_net.max(cumulative_net);
+        raw_metrics.max_drawdown_bps = raw_metrics
+            .max_drawdown_bps
+            .max((peak_net - cumulative_net).max(0.0));
+
+        for baseline in baselines {
+            let entry = baseline_totals.entry(baseline.clone()).or_insert(0.0);
+            *entry += baseline_return_bps(baseline, observation.next_return_bps);
+        }
+        for (regime_key, regime_value) in &observation.regimes {
+            let entry = regime_totals
+                .entry((regime_key.clone(), regime_value.clone()))
+                .or_default();
+            entry.observation_count += 1;
+            if turnover > 0.0001 {
+                entry.trade_count += 1;
+            }
+            entry.net_return_bps += net_return_bps;
+            if net_return_bps > 0.0 {
+                entry.win_count += 1;
+            }
+        }
+        previous_exposure = exposure;
+    }
+
+    let fold_metrics = runtime_backtest_metrics(&raw_metrics);
+    let baseline_comparisons = baseline_totals
+        .iter()
+        .map(|(baseline, baseline_return)| RuntimeBacktestBaselineComparison {
+            baseline: baseline.clone(),
+            baseline_return_bps: format_bps(*baseline_return),
+            excess_return_bps: format_bps(raw_metrics.net_return_bps - *baseline_return),
+        })
+        .collect::<Vec<_>>();
+    let regime_metrics = regime_totals
+        .iter()
+        .map(|((regime_key, regime_value), accumulator)| RuntimeBacktestRegimeMetrics {
+            regime_key: regime_key.clone(),
+            regime_value: regime_value.clone(),
+            observation_count: accumulator.observation_count,
+            trade_count: accumulator.trade_count,
+            net_return_bps: format_bps(accumulator.net_return_bps),
+            win_rate_bps: rate_bps(accumulator.win_count, accumulator.observation_count),
+        })
+        .collect::<Vec<_>>();
+
+    Ok(FoldEvaluation {
+        fold_report: RuntimeBacktestFoldReport {
+            fold_id: format!("fold_{fold_index}"),
+            fold_index,
+            training_start_at: training
+                .first()
+                .map(|record| record.observed_at.clone())
+                .unwrap_or_else(now_rfc3339),
+            training_end_at: training
+                .last()
+                .map(|record| record.next_observed_at.clone())
+                .unwrap_or_else(now_rfc3339),
+            test_start_at: testing
+                .first()
+                .map(|record| record.observed_at.clone())
+                .unwrap_or_else(now_rfc3339),
+            test_end_at: testing
+                .last()
+                .map(|record| record.next_observed_at.clone())
+                .unwrap_or_else(now_rfc3339),
+            train_observation_count: training.len() as u32,
+            purged_observation_count,
+            test_observation_count: testing.len() as u32,
+            metrics: fold_metrics,
+            baseline_comparisons,
+            regime_metrics,
+        },
+        raw_metrics,
+        baseline_totals,
+        regime_totals,
+    })
+}
+
+fn aggregate_evaluations(
+    evaluations: &[FoldEvaluation],
+    baselines: &[RuntimeBacktestBaseline],
+    strategy_spec: &RuntimeStrategySpec,
+    blocking_reasons: &mut Vec<String>,
+) -> AggregateEvaluation {
+    let mut aggregate_raw = RawMetrics::default();
+    let mut baseline_totals: BTreeMap<RuntimeBacktestBaseline, f64> = BTreeMap::new();
+    let mut regime_totals: BTreeMap<(String, String), RegimeAccumulator> = BTreeMap::new();
+    for baseline in baselines {
+        baseline_totals.insert(baseline.clone(), 0.0);
+    }
+
+    for evaluation in evaluations {
+        aggregate_raw.observation_count += evaluation.raw_metrics.observation_count;
+        aggregate_raw.trade_count += evaluation.raw_metrics.trade_count;
+        aggregate_raw.gross_return_bps += evaluation.raw_metrics.gross_return_bps;
+        aggregate_raw.net_return_bps += evaluation.raw_metrics.net_return_bps;
+        aggregate_raw.total_cost_bps += evaluation.raw_metrics.total_cost_bps;
+        aggregate_raw.win_count += evaluation.raw_metrics.win_count;
+        aggregate_raw.max_drawdown_bps =
+            aggregate_raw.max_drawdown_bps.max(evaluation.raw_metrics.max_drawdown_bps);
+        for (baseline, total) in &evaluation.baseline_totals {
+            *baseline_totals.entry(baseline.clone()).or_insert(0.0) += total;
+        }
+        for (key, accumulator) in &evaluation.regime_totals {
+            let entry = regime_totals.entry(key.clone()).or_default();
+            entry.observation_count += accumulator.observation_count;
+            entry.trade_count += accumulator.trade_count;
+            entry.net_return_bps += accumulator.net_return_bps;
+            entry.win_count += accumulator.win_count;
+        }
+    }
+
+    if aggregate_raw.net_return_bps <= 0.0 {
+        blocking_reasons.push("aggregate out-of-sample net return must be positive".to_string());
+    }
+    let flat_cash_total = baseline_totals
+        .get(&RuntimeBacktestBaseline::FlatCash)
+        .copied()
+        .unwrap_or_default();
+    if aggregate_raw.net_return_bps <= flat_cash_total {
+        blocking_reasons.push("aggregate return must exceed flat-cash baseline".to_string());
+    }
+    if strategy_spec
+        .regime_requirements
+        .iter()
+        .any(|required| !regime_totals.keys().any(|(key, _)| key == required))
+    {
+        blocking_reasons.push(
+            "aggregate regime metrics did not cover every required strategy regime".to_string(),
+        );
+    }
+
+    AggregateEvaluation {
+        metrics: runtime_backtest_metrics(&aggregate_raw),
+        baselines: baseline_totals
+            .iter()
+            .map(|(baseline, total)| RuntimeBacktestBaselineComparison {
+                baseline: baseline.clone(),
+                baseline_return_bps: format_bps(*total),
+                excess_return_bps: format_bps(aggregate_raw.net_return_bps - *total),
+            })
+            .collect(),
+        regimes: regime_totals
+            .iter()
+            .map(|((regime_key, regime_value), accumulator)| RuntimeBacktestRegimeMetrics {
+                regime_key: regime_key.clone(),
+                regime_value: regime_value.clone(),
+                observation_count: accumulator.observation_count,
+                trade_count: accumulator.trade_count,
+                net_return_bps: format_bps(accumulator.net_return_bps),
+                win_rate_bps: rate_bps(accumulator.win_count, accumulator.observation_count),
+            })
+            .collect(),
+    }
+}
+
+fn runtime_backtest_metrics(raw: &RawMetrics) -> RuntimeBacktestMetrics {
+    RuntimeBacktestMetrics {
+        observation_count: raw.observation_count,
+        trade_count: raw.trade_count,
+        gross_return_bps: format_bps(raw.gross_return_bps),
+        net_return_bps: format_bps(raw.net_return_bps),
+        total_cost_bps: format_bps(raw.total_cost_bps),
+        win_rate_bps: rate_bps(raw.win_count, raw.observation_count),
+        max_drawdown_bps: format_bps(raw.max_drawdown_bps),
+    }
+}
+
+fn missing_required_feature_keys(
+    strategy_spec: &RuntimeStrategySpec,
+    feature_definitions: &[RuntimeFeatureDefinitionRecord],
+) -> Vec<String> {
+    let available = feature_definitions
+        .iter()
+        .map(|record| record.feature_key.clone())
+        .collect::<BTreeSet<_>>();
+    strategy_spec
+        .feature_requirements
+        .iter()
+        .filter(|requirement| requirement.required && !available.contains(&requirement.feature_key))
+        .map(|requirement| requirement.feature_key.clone())
+        .collect()
+}
+
+fn missing_required_regime_keys(
+    strategy_spec: &RuntimeStrategySpec,
+    regime_tags: &[RuntimeRegimeTagRecord],
+) -> Vec<String> {
+    let available = regime_tags
+        .iter()
+        .map(|record| record.regime_key.clone())
+        .collect::<BTreeSet<_>>();
+    strategy_spec
+        .regime_requirements
+        .iter()
+        .filter(|key| !available.contains(*key))
+        .cloned()
+        .collect()
+}
+
+fn build_observations(
+    fixture: &FeedReplayFixture,
+    regime_tags: &[RuntimeRegimeTagRecord],
+) -> Result<Vec<Observation>, BacktestingEngineError> {
+    let mut market_events = fixture.market_events.clone();
+    market_events.sort_by(|left, right| {
+        left.observed_at
+            .cmp(&right.observed_at)
+            .then(left.sequence.cmp(&right.sequence))
+    });
+    let mut slot_events = fixture.slot_events.clone();
+    slot_events.sort_by(|left, right| {
+        left.observed_at
+            .cmp(&right.observed_at)
+            .then(left.sequence.cmp(&right.sequence))
+    });
+
+    let mut feature_cache = FeatureCache::new(default_feature_cache_config());
+    let mut slot_index = 0_usize;
+    let mut snapshots = Vec::new();
+    for event in &market_events {
+        let observed_at_ts = parse_timestamp("marketEvent.observedAt", &event.observed_at)?;
+        while slot_index < slot_events.len()
+            && parse_timestamp("slotEvent.observedAt", &slot_events[slot_index].observed_at)?
+                <= observed_at_ts
+        {
+            feature_cache.ingest_slot_event(slot_events[slot_index].clone())?;
+            slot_index += 1;
+        }
+        feature_cache.ingest_market_event(event.clone())?;
+        let snapshot = feature_cache.snapshot_at(observed_at_ts);
+        let stream = snapshot
+            .feature_streams
+            .into_iter()
+            .find(|stream| stream.symbol == event.symbol && stream.source == event.source)
+            .ok_or_else(|| BacktestingEngineError::InvalidConfig {
+                reason: format!(
+                    "feature cache did not emit a stream for {} at {}",
+                    event.symbol, event.observed_at
+                ),
+            })?;
+        snapshots.push((event.price_usd.clone(), observed_at_ts, stream));
+    }
+
+    let regime_keys = regime_tags
+        .iter()
+        .map(|record| record.regime_key.clone())
+        .collect::<BTreeSet<_>>();
+    let mut observations = Vec::new();
+    for (index, (_price, observed_at_ts, snapshot)) in snapshots.iter().enumerate() {
+        if index + 1 >= snapshots.len() {
+            break;
+        }
+        let current_price = parse_number("feature.midPriceUsd", &snapshot.mid_price_usd)?;
+        let next_price = parse_number("feature.midPriceUsd", &snapshots[index + 1].2.mid_price_usd)?;
+        let next_return_bps = if current_price <= 0.0 {
+            0.0
+        } else {
+            ((next_price / current_price) - 1.0) * 10_000.0
+        };
+        let regimes = regime_keys
+            .iter()
+            .map(|key| (key.clone(), classify_regime(key, snapshot)))
+            .collect::<Vec<_>>();
+        observations.push(Observation {
+            observed_at: snapshot.observed_at.clone(),
+            observed_at_ts: *observed_at_ts,
+            next_observed_at: snapshots[index + 1].2.observed_at.clone(),
+            next_observed_at_ts: snapshots[index + 1].1,
+            next_return_bps,
+            feature: snapshot.clone(),
+            regimes,
+        });
+    }
+    Ok(observations)
+}
+
+fn classify_regime(regime_key: &str, snapshot: &DerivedMarketFeatureSnapshot) -> String {
+    match regime_key {
+        "short_trend" => classify_trend(snapshot.short_return_bps.as_deref(), 5.0),
+        "long_trend" => classify_trend(snapshot.long_return_bps.as_deref(), 10.0),
+        "volatility_band" => {
+            let value = parse_optional_metric(snapshot.realized_volatility_bps.as_deref());
+            match value {
+                Some(value) if value < 12.0 => "low".to_string(),
+                Some(value) if value < 20.0 => "medium".to_string(),
+                Some(_) => "high".to_string(),
+                None => "unknown".to_string(),
+            }
+        }
+        "liquidity_state" => {
+            let value = parse_optional_metric(snapshot.spread_bps.as_deref());
+            match value {
+                Some(value) if value < 10.0 => "tight".to_string(),
+                Some(value) if value < 18.0 => "normal".to_string(),
+                Some(_) => "wide".to_string(),
+                None => "unknown".to_string(),
+            }
+        }
+        _ => "unclassified".to_string(),
+    }
+}
+
+fn classify_trend(value: Option<&str>, flat_threshold_bps: f64) -> String {
+    match parse_optional_metric(value) {
+        Some(value) if value > flat_threshold_bps => "up".to_string(),
+        Some(value) if value < -flat_threshold_bps => "down".to_string(),
+        Some(_) => "flat".to_string(),
+        None => "unknown".to_string(),
+    }
+}
+
+fn calibrate_strategy(strategy_spec: &RuntimeStrategySpec, observations: &[Observation]) -> Calibration {
+    let short_abs = observations
+        .iter()
+        .filter_map(|record| parse_optional_metric(record.feature.short_return_bps.as_deref()))
+        .map(f64::abs)
+        .collect::<Vec<_>>();
+    let long_abs = observations
+        .iter()
+        .filter_map(|record| parse_optional_metric(record.feature.long_return_bps.as_deref()))
+        .map(f64::abs)
+        .collect::<Vec<_>>();
+    let volatility = observations
+        .iter()
+        .filter_map(|record| parse_optional_metric(record.feature.realized_volatility_bps.as_deref()))
+        .collect::<Vec<_>>();
+    let mut calibration = Calibration {
+        primary_threshold_bps: percentile(short_abs.clone(), 0.5).unwrap_or(8.0).max(5.0),
+        confirmation_threshold_bps: percentile(long_abs.clone(), 0.5).unwrap_or(10.0).max(8.0),
+        low_vol_threshold_bps: percentile(volatility.clone(), 0.33).unwrap_or(12.0).max(8.0),
+        high_vol_threshold_bps: percentile(volatility, 0.66).unwrap_or(20.0).max(12.0),
+    };
+    if strategy_spec.strategy_key == "breakout" {
+        calibration.primary_threshold_bps = calibration.primary_threshold_bps.max(15.0);
+        calibration.confirmation_threshold_bps = calibration.confirmation_threshold_bps.max(10.0);
+    }
+    calibration
+}
+
+fn target_exposure(
+    strategy_spec: &RuntimeStrategySpec,
+    observation: &Observation,
+    calibration: &Calibration,
+) -> f64 {
+    let short_return = parse_optional_metric(observation.feature.short_return_bps.as_deref()).unwrap_or(0.0);
+    let long_return = parse_optional_metric(observation.feature.long_return_bps.as_deref()).unwrap_or(0.0);
+    let realized_volatility =
+        parse_optional_metric(observation.feature.realized_volatility_bps.as_deref()).unwrap_or(0.0);
+
+    match strategy_spec.strategy_key.as_str() {
+        "dca" | "twap" => 1.0,
+        "threshold_rebalance" => {
+            if long_return.abs() >= calibration.confirmation_threshold_bps {
+                long_return.signum()
+            } else {
+                0.5
+            }
+        }
+        "trend_following" => {
+            if short_return.abs() < calibration.primary_threshold_bps {
+                0.0
+            } else {
+                short_return.signum()
+            }
+        }
+        "mean_reversion" => {
+            if short_return.abs() < calibration.primary_threshold_bps {
+                0.0
+            } else {
+                -short_return.signum()
+            }
+        }
+        "breakout" => {
+            if short_return.abs() < calibration.primary_threshold_bps
+                || long_return.abs() < calibration.confirmation_threshold_bps
+                || short_return.signum() != long_return.signum()
+            {
+                0.0
+            } else {
+                short_return.signum()
+            }
+        }
+        "macro_rotation" => {
+            if long_return.abs() < calibration.confirmation_threshold_bps {
+                0.0
+            } else {
+                long_return.signum()
+            }
+        }
+        "volatility_target" => {
+            let base_exposure = if realized_volatility <= calibration.low_vol_threshold_bps {
+                0.75
+            } else if realized_volatility <= calibration.high_vol_threshold_bps {
+                0.5
+            } else {
+                0.25
+            };
+            if short_return < -calibration.primary_threshold_bps {
+                0.0
+            } else {
+                base_exposure
+            }
+        }
+        _ => 0.0,
+    }
+}
+
+fn modeled_cost_bps(
+    cost_model: Option<&RuntimeExecutionCostModelRecord>,
+    turnover: f64,
+    observation: &Observation,
+) -> Result<f64, BacktestingEngineError> {
+    let Some(model) = cost_model else {
+        return Ok(0.0);
+    };
+    let elapsed_ms = (observation.next_observed_at_ts - observation.observed_at_ts)
+        .whole_milliseconds()
+        .max(0) as f64;
+    let financing_per_day = model
+        .assumptions
+        .financing_cost_bps_per_day
+        .as_deref()
+        .map(|value| parse_number("financingCostBpsPerDay", value))
+        .transpose()?
+        .unwrap_or(0.0);
+    let variable_cost = model.assumptions.fee_bps as f64
+        + model.assumptions.slippage_bps as f64
+        + model.assumptions.market_impact_bps as f64
+        + ((model.assumptions.partial_fill_rate_bps as f64 / 10_000.0)
+            * model.assumptions.partial_fill_penalty_bps as f64);
+    let financing_cost = financing_per_day * (elapsed_ms / 86_400_000.0);
+    Ok((variable_cost * turnover) + financing_cost)
+}
+
+fn baseline_return_bps(baseline: &RuntimeBacktestBaseline, next_return_bps: f64) -> f64 {
+    match baseline {
+        RuntimeBacktestBaseline::FlatCash => 0.0,
+        RuntimeBacktestBaseline::BuyAndHold => next_return_bps,
+    }
+}
+
+fn validate_config(config: &RuntimeBacktestConfig) -> Result<(), BacktestingEngineError> {
+    if config.training_window_observations == 0
+        || config.testing_window_observations == 0
+        || config.step_observations == 0
+    {
+        return Err(BacktestingEngineError::InvalidConfig {
+            reason: "training, testing, and step observation counts must be positive".to_string(),
+        });
+    }
+    if config.baseline_strategies.is_empty() {
+        return Err(BacktestingEngineError::InvalidConfig {
+            reason: "at least one baseline strategy is required".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn load_replay_fixture(
+    replay_corpus: &RuntimeReplayCorpusRecord,
+) -> Result<FeedReplayFixture, BacktestingEngineError> {
+    let fixture_uri = replay_corpus
+        .fixture_uri
+        .clone()
+        .or_else(|| replay_corpus.dataset_snapshots.iter().find_map(|snapshot| snapshot.uri.clone()))
+        .ok_or_else(|| BacktestingEngineError::MissingFixtureUri {
+            corpus_id: replay_corpus.corpus_id.clone(),
+        })?;
+    let path = resolve_fixture_uri(&fixture_uri)?;
+    FeedReplayFixture::load_from_path(path).map_err(BacktestingEngineError::from)
+}
+
+fn resolve_fixture_uri(uri: &str) -> Result<PathBuf, BacktestingEngineError> {
+    let without_fragment = uri.split('#').next().unwrap_or(uri);
+    if let Some(relative) = without_fragment.strip_prefix("repo://") {
+        return Ok(repo_root().join(relative));
+    }
+    let candidate = PathBuf::from(without_fragment);
+    if candidate.is_absolute() {
+        return Ok(candidate);
+    }
+    Err(BacktestingEngineError::UnsupportedFixtureUri {
+        uri: uri.to_string(),
+    })
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn default_feature_cache_config() -> FeatureCacheConfig {
+    FeatureCacheConfig::new(
+        FEATURE_STALE_AFTER_MS,
+        SLOT_STALE_AFTER_MS,
+        MAX_SLOT_GAP,
+        SHORT_WINDOW_MS,
+        LONG_WINDOW_MS,
+        VOLATILITY_WINDOW_SIZE,
+        MAX_SAMPLES_PER_STREAM,
+    )
+}
+
+fn default_report_id(
+    experiment_id: &str,
+    strategy_digest: &str,
+    config: &RuntimeBacktestConfig,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(strategy_digest.as_bytes());
+    hasher.update(config.replay_corpus_id.as_bytes());
+    hasher.update(config.venue_key.as_bytes());
+    hasher.update(config.pair_symbol.as_bytes());
+    hasher.update(config.training_window_observations.to_le_bytes());
+    hasher.update(config.testing_window_observations.to_le_bytes());
+    hasher.update(config.step_observations.to_le_bytes());
+    hasher.update(config.purge_observations.to_le_bytes());
+    let digest = format!("{:x}", hasher.finalize());
+    format!("backtest_{experiment_id}_{}", &digest[..12])
+}
+
+fn strategy_spec_digest(
+    strategy_spec: &RuntimeStrategySpec,
+) -> Result<String, BacktestingEngineError> {
+    let serialized = serde_json::to_vec(strategy_spec)?;
+    let digest = Sha256::digest(serialized);
+    Ok(format!("sha256:{digest:x}"))
+}
+
+fn percentile(mut values: Vec<f64>, percentile: f64) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    values.sort_by(|left, right| left.total_cmp(right));
+    let max_index = values.len().saturating_sub(1);
+    let index = ((max_index as f64) * percentile.clamp(0.0, 1.0)).round() as usize;
+    values.get(index).copied()
+}
+
+fn parse_optional_metric(value: Option<&str>) -> Option<f64> {
+    value.and_then(|value| value.parse::<f64>().ok())
+}
+
+fn parse_number(field: &'static str, value: &str) -> Result<f64, BacktestingEngineError> {
+    value
+        .parse::<f64>()
+        .map_err(|_| BacktestingEngineError::InvalidNumber {
+            field,
+            value: value.to_string(),
+        })
+}
+
+fn parse_timestamp(
+    field: &'static str,
+    value: &str,
+) -> Result<OffsetDateTime, BacktestingEngineError> {
+    OffsetDateTime::parse(value, &Rfc3339).map_err(|_| BacktestingEngineError::InvalidTimestamp {
+        field,
+        value: value.to_string(),
+    })
+}
+
+fn rate_bps(numerator: u32, denominator: u32) -> u16 {
+    if denominator == 0 {
+        0
+    } else {
+        (((numerator as f64 / denominator as f64) * 10_000.0).round() as u16).min(10_000)
+    }
+}
+
+fn format_bps(value: f64) -> String {
+    format!("{value:.4}")
+}
+
+fn now_rfc3339() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .expect("timestamp to format")
+}
+
+fn persist_report(
+    connection: &Connection,
+    report: &RuntimeBacktestReport,
+) -> Result<(), BacktestingEngineError> {
+    connection.execute(
+        "INSERT INTO backtest_reports (
+            report_id,
+            experiment_id,
+            strategy_key,
+            generated_at,
+            status,
+            promotion_eligible,
+            record_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+         ON CONFLICT(report_id) DO UPDATE SET
+            experiment_id = excluded.experiment_id,
+            strategy_key = excluded.strategy_key,
+            generated_at = excluded.generated_at,
+            status = excluded.status,
+            promotion_eligible = excluded.promotion_eligible,
+            record_json = excluded.record_json",
+        params![
+            report.report_id,
+            report.experiment_id,
+            report.strategy_key,
+            report.generated_at,
+            backtest_status_key(&report.status),
+            if report.promotion_eligible { 1 } else { 0 },
+            serialize_json(report)?,
+        ],
+    )?;
+    Ok(())
+}
+
+fn list_reports(
+    connection: &Connection,
+    query: &BacktestingQuery,
+) -> Result<Vec<RuntimeBacktestReport>, BacktestingEngineError> {
+    let mut statement = connection.prepare(
+        "SELECT record_json
+         FROM backtest_reports
+         WHERE (?1 IS NULL OR report_id = ?1)
+           AND (?2 IS NULL OR experiment_id = ?2)
+           AND (?3 IS NULL OR strategy_key = ?3)
+           AND (?4 IS NULL OR promotion_eligible = ?4)
+         ORDER BY generated_at DESC, report_id DESC",
+    )?;
+    let promotion_eligible = query.promotion_eligible.map(i64::from);
+    let rows = statement.query_map(
+        params![
+            query.report_id.as_deref(),
+            query.experiment_id.as_deref(),
+            query.strategy_key.as_deref(),
+            promotion_eligible,
+        ],
+        |row| row.get::<_, String>(0),
+    )?;
+    let mut reports = Vec::new();
+    for row in rows {
+        reports.push(deserialize_json(&row?)?);
+    }
+    Ok(reports)
+}
+
+fn load_report(
+    connection: &Connection,
+    report_id: &str,
+) -> Result<Option<RuntimeBacktestReport>, BacktestingEngineError> {
+    connection
+        .query_row(
+            "SELECT record_json FROM backtest_reports WHERE report_id = ?1",
+            params![report_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|value| deserialize_json(&value))
+        .transpose()
+}
+
+fn initialize_schema(connection: &Connection) -> Result<(), BacktestingEngineError> {
+    connection.execute_batch(
+        "CREATE TABLE IF NOT EXISTS backtest_reports (
+            report_id TEXT PRIMARY KEY,
+            experiment_id TEXT NOT NULL,
+            strategy_key TEXT NOT NULL,
+            generated_at TEXT NOT NULL,
+            status TEXT NOT NULL,
+            promotion_eligible INTEGER NOT NULL,
+            record_json TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_backtest_reports_experiment
+            ON backtest_reports (experiment_id, generated_at DESC, report_id DESC);
+        CREATE INDEX IF NOT EXISTS idx_backtest_reports_strategy
+            ON backtest_reports (strategy_key, generated_at DESC, report_id DESC);
+        CREATE INDEX IF NOT EXISTS idx_backtest_reports_promotion
+            ON backtest_reports (promotion_eligible, generated_at DESC, report_id DESC);",
+    )?;
+    Ok(())
+}
+
+fn backtest_status_key(status: &RuntimeBacktestStatus) -> &'static str {
+    match status {
+        RuntimeBacktestStatus::Completed => "completed",
+        RuntimeBacktestStatus::Blocked => "blocked",
+        RuntimeBacktestStatus::Failed => "failed",
+    }
+}
+
+fn normalize_database_path(database_url: &str) -> PathBuf {
+    let trimmed = database_url.trim();
+    let without_scheme = trimmed
+        .strip_prefix("sqlite://")
+        .or_else(|| trimmed.strip_prefix("file:"))
+        .unwrap_or(trimmed);
+    let candidate = PathBuf::from(without_scheme);
+    if candidate.is_absolute() {
+        candidate
+    } else {
+        PathBuf::from(".").join(candidate)
+    }
+}
+
+fn fallback_database_path() -> PathBuf {
+    std::env::temp_dir().join("runtime-rs/backtesting-engine.sqlite3")
+}
+
+fn should_fallback_to_tmp(path: &Path, error: &BacktestingEngineError) -> bool {
+    !path.starts_with(std::env::temp_dir()) && matches!(error, BacktestingEngineError::Io(_))
+}
+
+fn serialize_json<T>(value: &T) -> Result<String, BacktestingEngineError>
+where
+    T: Serialize,
+{
+    Ok(serde_json::to_string(value)?)
+}
+
+fn deserialize_json<T>(value: &str) -> Result<T, BacktestingEngineError>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    Ok(serde_json::from_str(value)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use protocol::{
+        RuntimeBacktestBaseline, RuntimeBacktestWindowMode, RuntimeCodeRevisionRef,
+        RuntimeDatasetSnapshotRef, RuntimeResearchCitation, RuntimeResearchExperimentStatus,
+    };
+
+    fn engine(name: &str) -> BacktestingEngine {
+        let database_url = format!(".tmp/tests/backtesting-engine/{name}.sqlite3");
+        let path = PathBuf::from(&database_url);
+        if path.exists() {
+            let _ = fs::remove_file(&path);
+        }
+        BacktestingEngine::new(BacktestingEngineConfig::new(database_url)).expect("engine")
+    }
+
+    fn fixture_uri() -> String {
+        "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json"
+            .to_string()
+    }
+
+    fn experiment() -> RuntimeResearchExperimentRecord {
+        RuntimeResearchExperimentRecord {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            experiment_id: "experiment_signal_trend_shadow".to_string(),
+            hypothesis_id: "hypothesis_signal_trend".to_string(),
+            strategy_key: "trend_following".to_string(),
+            status: RuntimeResearchExperimentStatus::Completed,
+            created_at: "2026-03-10T14:00:00.000Z".to_string(),
+            updated_at: "2026-03-10T14:30:00.000Z".to_string(),
+            completed_at: Some("2026-03-10T14:30:00.000Z".to_string()),
+            venue_keys: vec!["jupiter".to_string()],
+            asset_keys: vec!["SOL".to_string(), "USDC".to_string()],
+            source_citations: vec![RuntimeResearchCitation {
+                source_id: "source_paper_microstructure".to_string(),
+                locator: None,
+                material_digest: None,
+                notes: None,
+            }],
+            code_revision: RuntimeCodeRevisionRef {
+                vcs: "git".to_string(),
+                repository: "github.com/GuiBibeau/serious-trader-ralph".to_string(),
+                revision: "356b539e3ec730663c4025b8f00cd6b47b823d1a".to_string(),
+                compared_to: None,
+                tree_dirty: false,
+            },
+            dataset_snapshots: vec![RuntimeDatasetSnapshotRef {
+                dataset_id: "dataset_feed_replay_sol_usdc_market_events".to_string(),
+                snapshot_id: "snapshot_2026_03_07_backtest".to_string(),
+                captured_at: "2026-03-10T14:00:00.000Z".to_string(),
+                uri: Some(format!("{}#marketEvents", fixture_uri())),
+                content_digest: Some("sha256:fixture".to_string()),
+            }],
+            artifacts: Vec::new(),
+            summary: "Backtest experiment fixture".to_string(),
+            tags: vec!["backtest".to_string()],
+        }
+    }
+
+    fn replay_corpus() -> RuntimeReplayCorpusRecord {
+        RuntimeReplayCorpusRecord {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            corpus_id: "replay_corpus_sol_usdc_feature_cache".to_string(),
+            title: "feature cache replay".to_string(),
+            summary: "Replay corpus for backtesting engine tests.".to_string(),
+            replay_kind: protocol::RuntimeReplayCorpusKind::FeedGatewayV1,
+            created_at: "2026-03-10T14:00:00.000Z".to_string(),
+            updated_at: "2026-03-10T14:00:00.000Z".to_string(),
+            venue_keys: vec!["jupiter".to_string(), "helius".to_string()],
+            asset_keys: vec!["SOL".to_string(), "USDC".to_string()],
+            pair_symbols: vec!["SOL/USDC".to_string()],
+            chain_keys: vec!["solana-mainnet".to_string()],
+            dataset_snapshots: vec![RuntimeDatasetSnapshotRef {
+                dataset_id: "dataset_feed_replay_sol_usdc_market_events".to_string(),
+                snapshot_id: "snapshot_2026_03_07_backtest".to_string(),
+                captured_at: "2026-03-10T14:00:00.000Z".to_string(),
+                uri: Some(format!("{}#marketEvents", fixture_uri())),
+                content_digest: Some("sha256:fixture".to_string()),
+            }],
+            fixture_uri: Some(fixture_uri()),
+            content_digest: Some("sha256:fixture".to_string()),
+            deterministic_seed: Some(100),
+            tags: vec!["test".to_string()],
+            notes: None,
+        }
+    }
+
+    fn trend_strategy_spec() -> RuntimeStrategySpec {
+        strategy_core::StrategyKind::TrendFollowing.spec()
+    }
+
+    fn allocation_strategy_spec() -> RuntimeStrategySpec {
+        strategy_core::StrategyKind::Dca.spec()
+    }
+
+    fn feature_definitions() -> Vec<RuntimeFeatureDefinitionRecord> {
+        vec![RuntimeFeatureDefinitionRecord {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            feature_id: "feature_short_return_bps_v1".to_string(),
+            feature_key: "short_return_bps".to_string(),
+            version: "1.0.0".to_string(),
+            title: "Short return".to_string(),
+            summary: "Seed feature".to_string(),
+            status: protocol::RuntimeFeatureCatalogStatus::Active,
+            market_type: protocol::RuntimeVenueMarketType::Spot,
+            venue_keys: vec!["jupiter".to_string()],
+            asset_keys: vec!["SOL".to_string(), "USDC".to_string()],
+            pair_symbols: vec!["SOL/USDC".to_string()],
+            input_requirements: vec![protocol::RuntimeFeatureInputRequirement {
+                input_key: "mid_price_usd".to_string(),
+                required: true,
+                freshness_ms: Some(20_000),
+                notes: None,
+            }],
+            derived_from_feature_keys: Vec::new(),
+            freshness_slo_ms: 20_000,
+            max_allowed_drift_bps: 50,
+            min_coverage_bps: 10_000,
+            provenance: protocol::RuntimeCatalogProvenance {
+                generated_by: "tests".to_string(),
+                generated_revision: Some("seed".to_string()),
+                generated_at: "2026-03-10T14:00:00.000Z".to_string(),
+                notes: None,
+            },
+            dataset_snapshots: experiment().dataset_snapshots.clone(),
+            created_at: "2026-03-10T14:00:00.000Z".to_string(),
+            updated_at: "2026-03-10T14:00:00.000Z".to_string(),
+            tags: vec!["test".to_string()],
+            notes: None,
+        }]
+    }
+
+    fn regime_tags() -> Vec<RuntimeRegimeTagRecord> {
+        vec![RuntimeRegimeTagRecord {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            regime_tag_id: "regime_short_trend_v1".to_string(),
+            regime_key: "short_trend".to_string(),
+            version: "1.0.0".to_string(),
+            title: "Short trend".to_string(),
+            summary: "Seed regime".to_string(),
+            status: protocol::RuntimeFeatureCatalogStatus::Active,
+            dimension: protocol::RuntimeRegimeDimension::Trend,
+            value: "classified".to_string(),
+            market_type: protocol::RuntimeVenueMarketType::Spot,
+            venue_keys: vec!["jupiter".to_string()],
+            asset_keys: vec!["SOL".to_string(), "USDC".to_string()],
+            pair_symbols: vec!["SOL/USDC".to_string()],
+            source_feature_keys: vec!["short_return_bps".to_string()],
+            freshness_slo_ms: 20_000,
+            max_allowed_drift_bps: 50,
+            min_confidence_bps: 8_000,
+            provenance: protocol::RuntimeCatalogProvenance {
+                generated_by: "tests".to_string(),
+                generated_revision: Some("seed".to_string()),
+                generated_at: "2026-03-10T14:00:00.000Z".to_string(),
+                notes: None,
+            },
+            dataset_snapshots: experiment().dataset_snapshots.clone(),
+            created_at: "2026-03-10T14:00:00.000Z".to_string(),
+            updated_at: "2026-03-10T14:00:00.000Z".to_string(),
+            tags: vec!["test".to_string()],
+            notes: None,
+        }]
+    }
+
+    fn cost_model() -> RuntimeExecutionCostModelRecord {
+        RuntimeExecutionCostModelRecord {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            model_id: "cost_model_jupiter_sol_usdc_spot".to_string(),
+            venue_key: "jupiter".to_string(),
+            market_type: protocol::RuntimeVenueMarketType::Spot,
+            pair_symbol: "SOL/USDC".to_string(),
+            instrument_id: Some("SOL/USDC".to_string()),
+            asset_keys: vec!["SOL".to_string(), "USDC".to_string()],
+            mode_coverage: vec![protocol::RuntimeMode::Shadow, protocol::RuntimeMode::Paper],
+            status: protocol::RuntimeExecutionCostModelStatus::Active,
+            assumptions: protocol::RuntimeExecutionCostAssumptions {
+                fee_bps: 1,
+                slippage_bps: 1,
+                market_impact_bps: 1,
+                partial_fill_rate_bps: 0,
+                partial_fill_penalty_bps: 0,
+                financing_cost_bps_per_day: None,
+            },
+            latency_profile: protocol::RuntimeVenueLatencyProfile {
+                expected_quote_ms: 100,
+                expected_submit_ms: 200,
+                expected_settlement_ms: 1000,
+            },
+            dataset_snapshots: experiment().dataset_snapshots.clone(),
+            created_at: "2026-03-10T14:00:00.000Z".to_string(),
+            updated_at: "2026-03-10T14:00:00.000Z".to_string(),
+            tags: vec!["test".to_string()],
+            notes: None,
+        }
+    }
+
+    #[test]
+    fn runs_and_persists_backtest_reports() {
+        let engine = engine("run");
+        let result = engine
+            .run(&BacktestRunRequest {
+                report_id: Some("backtest_signal_trend".to_string()),
+                experiment: experiment(),
+                strategy_spec: allocation_strategy_spec(),
+                cost_model: Some(cost_model()),
+                feature_definitions: feature_definitions(),
+                regime_tags: regime_tags(),
+                replay_corpus: replay_corpus(),
+                config: RuntimeBacktestConfig {
+                    replay_corpus_id: "replay_corpus_sol_usdc_feature_cache".to_string(),
+                    venue_key: "jupiter".to_string(),
+                    pair_symbol: "SOL/USDC".to_string(),
+                    market_type: protocol::RuntimeVenueMarketType::Spot,
+                    window_mode: RuntimeBacktestWindowMode::Rolling,
+                    training_window_observations: 2,
+                    testing_window_observations: 1,
+                    step_observations: 1,
+                    purge_observations: 0,
+                    baseline_strategies: vec![
+                        RuntimeBacktestBaseline::FlatCash,
+                        RuntimeBacktestBaseline::BuyAndHold,
+                    ],
+                },
+            })
+            .expect("backtest to run");
+
+        assert!(result.created);
+        assert_eq!(result.report.fold_reports.len(), 2);
+        assert_eq!(result.report.config.window_mode, RuntimeBacktestWindowMode::Rolling);
+        assert_eq!(result.report.aggregate_metrics.observation_count, 2);
+        assert!(!result.report.aggregate_regime_metrics.is_empty());
+        assert_eq!(result.report.status, RuntimeBacktestStatus::Completed);
+        assert!(result.report.promotion_eligible);
+
+        let reports = engine
+            .query(&BacktestingQuery {
+                experiment_id: Some("experiment_signal_trend_shadow".to_string()),
+                ..BacktestingQuery::default()
+            })
+            .expect("query");
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].report_id, "backtest_signal_trend");
+    }
+
+    #[test]
+    fn blocks_reports_when_required_feature_coverage_is_missing() {
+        let engine = engine("blocked");
+        let result = engine
+            .run(&BacktestRunRequest {
+                report_id: Some("backtest_signal_trend_blocked".to_string()),
+                experiment: experiment(),
+                strategy_spec: trend_strategy_spec(),
+                cost_model: Some(cost_model()),
+                feature_definitions: Vec::new(),
+                regime_tags: regime_tags(),
+                replay_corpus: replay_corpus(),
+                config: RuntimeBacktestConfig {
+                    replay_corpus_id: "replay_corpus_sol_usdc_feature_cache".to_string(),
+                    venue_key: "jupiter".to_string(),
+                    pair_symbol: "SOL/USDC".to_string(),
+                    market_type: protocol::RuntimeVenueMarketType::Spot,
+                    window_mode: RuntimeBacktestWindowMode::Expanding,
+                    training_window_observations: 2,
+                    testing_window_observations: 1,
+                    step_observations: 1,
+                    purge_observations: 0,
+                    baseline_strategies: vec![RuntimeBacktestBaseline::FlatCash],
+                },
+            })
+            .expect("backtest to run");
+
+        assert_eq!(result.report.status, RuntimeBacktestStatus::Blocked);
+        assert!(!result.report.promotion_eligible);
+        assert!(result
+            .report
+            .blocking_reasons
+            .iter()
+            .any(|reason| reason.contains("missing required feature definitions")));
+    }
+}

--- a/crates/backtesting-engine/src/lib.rs
+++ b/crates/backtesting-engine/src/lib.rs
@@ -145,13 +145,14 @@ impl BacktestingEngine {
 
         let strategy_digest = strategy_spec_digest(&input.strategy_spec)?;
         let generated_at = now_rfc3339();
-        let report_id = input.report_id.clone().unwrap_or_else(|| {
-            default_report_id(
+        let report_id = match input.report_id.clone() {
+            Some(report_id) => report_id,
+            None => default_report_id(
                 &input.experiment.experiment_id,
                 &strategy_digest,
                 &input.config,
-            )
-        });
+            )?,
+        };
         let missing_feature_keys =
             missing_required_feature_keys(&input.strategy_spec, &input.feature_definitions);
         let missing_regime_keys =
@@ -389,7 +390,7 @@ fn evaluate_walk_forward_folds(
     cost_model: Option<&RuntimeExecutionCostModelRecord>,
     config: &RuntimeBacktestConfig,
 ) -> Result<Vec<FoldEvaluation>, BacktestingEngineError> {
-    let effective = observations.len() - 1;
+    let effective = observations.len();
     let train_size = config.training_window_observations as usize;
     let test_size = config.testing_window_observations as usize;
     let step_size = config.step_observations as usize;
@@ -994,18 +995,12 @@ fn default_report_id(
     experiment_id: &str,
     strategy_digest: &str,
     config: &RuntimeBacktestConfig,
-) -> String {
+) -> Result<String, BacktestingEngineError> {
     let mut hasher = Sha256::new();
     hasher.update(strategy_digest.as_bytes());
-    hasher.update(config.replay_corpus_id.as_bytes());
-    hasher.update(config.venue_key.as_bytes());
-    hasher.update(config.pair_symbol.as_bytes());
-    hasher.update(config.training_window_observations.to_le_bytes());
-    hasher.update(config.testing_window_observations.to_le_bytes());
-    hasher.update(config.step_observations.to_le_bytes());
-    hasher.update(config.purge_observations.to_le_bytes());
+    hasher.update(serde_json::to_vec(config)?);
     let digest = format!("{:x}", hasher.finalize());
-    format!("backtest_{experiment_id}_{}", &digest[..12])
+    Ok(format!("backtest_{experiment_id}_{}", &digest[..12]))
 }
 
 fn strategy_spec_digest(
@@ -1440,12 +1435,12 @@ mod tests {
             .expect("backtest to run");
 
         assert!(result.created);
-        assert_eq!(result.report.fold_reports.len(), 2);
+        assert_eq!(result.report.fold_reports.len(), 3);
         assert_eq!(
             result.report.config.window_mode,
             RuntimeBacktestWindowMode::Rolling
         );
-        assert_eq!(result.report.aggregate_metrics.observation_count, 2);
+        assert_eq!(result.report.aggregate_metrics.observation_count, 3);
         assert!(!result.report.aggregate_regime_metrics.is_empty());
         assert_eq!(result.report.status, RuntimeBacktestStatus::Completed);
         assert!(result.report.promotion_eligible);
@@ -1494,5 +1489,62 @@ mod tests {
             .blocking_reasons
             .iter()
             .any(|reason| reason.contains("missing required feature definitions")));
+    }
+
+    #[test]
+    fn generated_report_ids_include_full_backtest_config() {
+        let strategy_digest = strategy_spec_digest(&allocation_strategy_spec()).expect("digest");
+        let base = RuntimeBacktestConfig {
+            replay_corpus_id: "replay_corpus_sol_usdc_feature_cache".to_string(),
+            venue_key: "jupiter".to_string(),
+            pair_symbol: "SOL/USDC".to_string(),
+            market_type: protocol::RuntimeVenueMarketType::Spot,
+            window_mode: RuntimeBacktestWindowMode::Rolling,
+            training_window_observations: 2,
+            testing_window_observations: 1,
+            step_observations: 1,
+            purge_observations: 0,
+            baseline_strategies: vec![
+                RuntimeBacktestBaseline::FlatCash,
+                RuntimeBacktestBaseline::BuyAndHold,
+            ],
+        };
+        let market_variant = RuntimeBacktestConfig {
+            market_type: protocol::RuntimeVenueMarketType::Perp,
+            ..base.clone()
+        };
+        let window_variant = RuntimeBacktestConfig {
+            window_mode: RuntimeBacktestWindowMode::Expanding,
+            ..base.clone()
+        };
+        let baseline_variant = RuntimeBacktestConfig {
+            baseline_strategies: vec![RuntimeBacktestBaseline::FlatCash],
+            ..base.clone()
+        };
+
+        let base_id = default_report_id("experiment_signal_trend_shadow", &strategy_digest, &base)
+            .expect("id");
+        let market_id = default_report_id(
+            "experiment_signal_trend_shadow",
+            &strategy_digest,
+            &market_variant,
+        )
+        .expect("market id");
+        let window_id = default_report_id(
+            "experiment_signal_trend_shadow",
+            &strategy_digest,
+            &window_variant,
+        )
+        .expect("window id");
+        let baseline_id = default_report_id(
+            "experiment_signal_trend_shadow",
+            &strategy_digest,
+            &baseline_variant,
+        )
+        .expect("baseline id");
+
+        assert_ne!(base_id, market_id);
+        assert_ne!(base_id, window_id);
+        assert_ne!(base_id, baseline_id);
     }
 }

--- a/crates/backtesting-engine/src/lib.rs
+++ b/crates/backtesting-engine/src/lib.rs
@@ -4,14 +4,16 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use feature_cache::{DerivedMarketFeatureSnapshot, FeatureCache, FeatureCacheConfig, FeatureCacheError};
+use feature_cache::{
+    DerivedMarketFeatureSnapshot, FeatureCache, FeatureCacheConfig, FeatureCacheError,
+};
 use market_adapters::{FeedGatewayError, FeedReplayFixture};
 use protocol::{
     RuntimeBacktestBaseline, RuntimeBacktestBaselineComparison, RuntimeBacktestConfig,
     RuntimeBacktestFoldReport, RuntimeBacktestMetrics, RuntimeBacktestRegimeMetrics,
     RuntimeBacktestReport, RuntimeBacktestStatus, RuntimeBacktestWindowMode,
     RuntimeExecutionCostModelRecord, RuntimeFeatureDefinitionRecord, RuntimeRegimeTagRecord,
-    RuntimeResearchExperimentRecord, RuntimeReplayCorpusRecord, RuntimeStrategySpec,
+    RuntimeReplayCorpusRecord, RuntimeResearchExperimentRecord, RuntimeStrategySpec,
     RUNTIME_PROTOCOL_SCHEMA_VERSION,
 };
 use rusqlite::{params, Connection, OptionalExtension};
@@ -104,7 +106,9 @@ pub enum BacktestingEngineError {
     MissingFixtureUri { corpus_id: String },
     #[error("invalid backtest config: {reason}")]
     InvalidConfig { reason: String },
-    #[error("insufficient observations for backtest: required at least {required}, got {available}")]
+    #[error(
+        "insufficient observations for backtest: required at least {required}, got {available}"
+    )]
     InsufficientObservations { required: usize, available: usize },
     #[error("backtest report {report_id} not found")]
     ReportNotFound { report_id: String },
@@ -122,7 +126,10 @@ impl BacktestingEngine {
         }
     }
 
-    pub fn run(&self, input: &BacktestRunRequest) -> Result<BacktestRunResult, BacktestingEngineError> {
+    pub fn run(
+        &self,
+        input: &BacktestRunRequest,
+    ) -> Result<BacktestRunResult, BacktestingEngineError> {
         validate_config(&input.config)?;
         let fixture = load_replay_fixture(&input.replay_corpus)?;
         let observations = build_observations(&fixture, &input.regime_tags)?;
@@ -138,15 +145,17 @@ impl BacktestingEngine {
 
         let strategy_digest = strategy_spec_digest(&input.strategy_spec)?;
         let generated_at = now_rfc3339();
-        let report_id = input
-            .report_id
-            .clone()
-            .unwrap_or_else(|| default_report_id(&input.experiment.experiment_id, &strategy_digest, &input.config));
-        let missing_feature_keys = missing_required_feature_keys(
-            &input.strategy_spec,
-            &input.feature_definitions,
-        );
-        let missing_regime_keys = missing_required_regime_keys(&input.strategy_spec, &input.regime_tags);
+        let report_id = input.report_id.clone().unwrap_or_else(|| {
+            default_report_id(
+                &input.experiment.experiment_id,
+                &strategy_digest,
+                &input.config,
+            )
+        });
+        let missing_feature_keys =
+            missing_required_feature_keys(&input.strategy_spec, &input.feature_definitions);
+        let missing_regime_keys =
+            missing_required_regime_keys(&input.strategy_spec, &input.regime_tags);
         let evaluations = evaluate_walk_forward_folds(
             &observations,
             &input.strategy_spec,
@@ -167,7 +176,8 @@ impl BacktestingEngine {
             ));
         }
         if evaluations.len() < 2 {
-            blocking_reasons.push("walk-forward evaluation requires at least two folds".to_string());
+            blocking_reasons
+                .push("walk-forward evaluation requires at least two folds".to_string());
         }
 
         let fold_reports = evaluations
@@ -363,6 +373,16 @@ struct AggregateEvaluation {
     regimes: Vec<RuntimeBacktestRegimeMetrics>,
 }
 
+struct FoldEvaluationContext<'a> {
+    training: &'a [Observation],
+    testing: &'a [Observation],
+    purged_observation_count: u32,
+    strategy_spec: &'a RuntimeStrategySpec,
+    calibration: &'a Calibration,
+    cost_model: Option<&'a RuntimeExecutionCostModelRecord>,
+    baselines: &'a [RuntimeBacktestBaseline],
+}
+
 fn evaluate_walk_forward_folds(
     observations: &[Observation],
     strategy_spec: &RuntimeStrategySpec,
@@ -390,16 +410,16 @@ fn evaluate_walk_forward_folds(
         let training = &observations[train_start..train_end];
         let testing = &observations[test_start..test_start + test_size];
         let calibration = calibrate_strategy(strategy_spec, training);
-        evaluations.push(evaluate_fold(
-            fold_index,
+        let context = FoldEvaluationContext {
             training,
             testing,
-            purge_size as u32,
+            purged_observation_count: purge_size as u32,
             strategy_spec,
-            &calibration,
+            calibration: &calibration,
             cost_model,
-            &config.baseline_strategies,
-        )?);
+            baselines: &config.baseline_strategies,
+        };
+        evaluations.push(evaluate_fold(fold_index, &context)?);
         fold_index += 1;
         test_start += step_size.max(1);
     }
@@ -409,13 +429,7 @@ fn evaluate_walk_forward_folds(
 
 fn evaluate_fold(
     fold_index: u32,
-    training: &[Observation],
-    testing: &[Observation],
-    purged_observation_count: u32,
-    strategy_spec: &RuntimeStrategySpec,
-    calibration: &Calibration,
-    cost_model: Option<&RuntimeExecutionCostModelRecord>,
-    baselines: &[RuntimeBacktestBaseline],
+    context: &FoldEvaluationContext<'_>,
 ) -> Result<FoldEvaluation, BacktestingEngineError> {
     let mut previous_exposure = 0.0_f64;
     let mut cumulative_net = 0.0_f64;
@@ -423,14 +437,14 @@ fn evaluate_fold(
     let mut raw_metrics = RawMetrics::default();
     let mut baseline_totals = BTreeMap::new();
     let mut regime_totals: BTreeMap<(String, String), RegimeAccumulator> = BTreeMap::new();
-    for baseline in baselines {
+    for baseline in context.baselines {
         baseline_totals.insert(baseline.clone(), 0.0);
     }
 
-    for observation in testing {
-        let exposure = target_exposure(strategy_spec, observation, calibration);
+    for observation in context.testing {
+        let exposure = target_exposure(context.strategy_spec, observation, context.calibration);
         let turnover = (exposure - previous_exposure).abs();
-        let cost_bps = modeled_cost_bps(cost_model, turnover, observation)?;
+        let cost_bps = modeled_cost_bps(context.cost_model, turnover, observation)?;
         let gross_return_bps = exposure * observation.next_return_bps;
         let net_return_bps = gross_return_bps - cost_bps;
 
@@ -450,7 +464,7 @@ fn evaluate_fold(
             .max_drawdown_bps
             .max((peak_net - cumulative_net).max(0.0));
 
-        for baseline in baselines {
+        for baseline in context.baselines {
             let entry = baseline_totals.entry(baseline.clone()).or_insert(0.0);
             *entry += baseline_return_bps(baseline, observation.next_return_bps);
         }
@@ -473,47 +487,55 @@ fn evaluate_fold(
     let fold_metrics = runtime_backtest_metrics(&raw_metrics);
     let baseline_comparisons = baseline_totals
         .iter()
-        .map(|(baseline, baseline_return)| RuntimeBacktestBaselineComparison {
-            baseline: baseline.clone(),
-            baseline_return_bps: format_bps(*baseline_return),
-            excess_return_bps: format_bps(raw_metrics.net_return_bps - *baseline_return),
-        })
+        .map(
+            |(baseline, baseline_return)| RuntimeBacktestBaselineComparison {
+                baseline: baseline.clone(),
+                baseline_return_bps: format_bps(*baseline_return),
+                excess_return_bps: format_bps(raw_metrics.net_return_bps - *baseline_return),
+            },
+        )
         .collect::<Vec<_>>();
     let regime_metrics = regime_totals
         .iter()
-        .map(|((regime_key, regime_value), accumulator)| RuntimeBacktestRegimeMetrics {
-            regime_key: regime_key.clone(),
-            regime_value: regime_value.clone(),
-            observation_count: accumulator.observation_count,
-            trade_count: accumulator.trade_count,
-            net_return_bps: format_bps(accumulator.net_return_bps),
-            win_rate_bps: rate_bps(accumulator.win_count, accumulator.observation_count),
-        })
+        .map(
+            |((regime_key, regime_value), accumulator)| RuntimeBacktestRegimeMetrics {
+                regime_key: regime_key.clone(),
+                regime_value: regime_value.clone(),
+                observation_count: accumulator.observation_count,
+                trade_count: accumulator.trade_count,
+                net_return_bps: format_bps(accumulator.net_return_bps),
+                win_rate_bps: rate_bps(accumulator.win_count, accumulator.observation_count),
+            },
+        )
         .collect::<Vec<_>>();
 
     Ok(FoldEvaluation {
         fold_report: RuntimeBacktestFoldReport {
             fold_id: format!("fold_{fold_index}"),
             fold_index,
-            training_start_at: training
+            training_start_at: context
+                .training
                 .first()
                 .map(|record| record.observed_at.clone())
                 .unwrap_or_else(now_rfc3339),
-            training_end_at: training
+            training_end_at: context
+                .training
                 .last()
                 .map(|record| record.next_observed_at.clone())
                 .unwrap_or_else(now_rfc3339),
-            test_start_at: testing
+            test_start_at: context
+                .testing
                 .first()
                 .map(|record| record.observed_at.clone())
                 .unwrap_or_else(now_rfc3339),
-            test_end_at: testing
+            test_end_at: context
+                .testing
                 .last()
                 .map(|record| record.next_observed_at.clone())
                 .unwrap_or_else(now_rfc3339),
-            train_observation_count: training.len() as u32,
-            purged_observation_count,
-            test_observation_count: testing.len() as u32,
+            train_observation_count: context.training.len() as u32,
+            purged_observation_count: context.purged_observation_count,
+            test_observation_count: context.testing.len() as u32,
             metrics: fold_metrics,
             baseline_comparisons,
             regime_metrics,
@@ -544,8 +566,9 @@ fn aggregate_evaluations(
         aggregate_raw.net_return_bps += evaluation.raw_metrics.net_return_bps;
         aggregate_raw.total_cost_bps += evaluation.raw_metrics.total_cost_bps;
         aggregate_raw.win_count += evaluation.raw_metrics.win_count;
-        aggregate_raw.max_drawdown_bps =
-            aggregate_raw.max_drawdown_bps.max(evaluation.raw_metrics.max_drawdown_bps);
+        aggregate_raw.max_drawdown_bps = aggregate_raw
+            .max_drawdown_bps
+            .max(evaluation.raw_metrics.max_drawdown_bps);
         for (baseline, total) in &evaluation.baseline_totals {
             *baseline_totals.entry(baseline.clone()).or_insert(0.0) += total;
         }
@@ -590,14 +613,16 @@ fn aggregate_evaluations(
             .collect(),
         regimes: regime_totals
             .iter()
-            .map(|((regime_key, regime_value), accumulator)| RuntimeBacktestRegimeMetrics {
-                regime_key: regime_key.clone(),
-                regime_value: regime_value.clone(),
-                observation_count: accumulator.observation_count,
-                trade_count: accumulator.trade_count,
-                net_return_bps: format_bps(accumulator.net_return_bps),
-                win_rate_bps: rate_bps(accumulator.win_count, accumulator.observation_count),
-            })
+            .map(
+                |((regime_key, regime_value), accumulator)| RuntimeBacktestRegimeMetrics {
+                    regime_key: regime_key.clone(),
+                    regime_value: regime_value.clone(),
+                    observation_count: accumulator.observation_count,
+                    trade_count: accumulator.trade_count,
+                    net_return_bps: format_bps(accumulator.net_return_bps),
+                    win_rate_bps: rate_bps(accumulator.win_count, accumulator.observation_count),
+                },
+            )
             .collect(),
     }
 }
@@ -700,7 +725,8 @@ fn build_observations(
             break;
         }
         let current_price = parse_number("feature.midPriceUsd", &snapshot.mid_price_usd)?;
-        let next_price = parse_number("feature.midPriceUsd", &snapshots[index + 1].2.mid_price_usd)?;
+        let next_price =
+            parse_number("feature.midPriceUsd", &snapshots[index + 1].2.mid_price_usd)?;
         let next_return_bps = if current_price <= 0.0 {
             0.0
         } else {
@@ -758,7 +784,10 @@ fn classify_trend(value: Option<&str>, flat_threshold_bps: f64) -> String {
     }
 }
 
-fn calibrate_strategy(strategy_spec: &RuntimeStrategySpec, observations: &[Observation]) -> Calibration {
+fn calibrate_strategy(
+    strategy_spec: &RuntimeStrategySpec,
+    observations: &[Observation],
+) -> Calibration {
     let short_abs = observations
         .iter()
         .filter_map(|record| parse_optional_metric(record.feature.short_return_bps.as_deref()))
@@ -771,12 +800,16 @@ fn calibrate_strategy(strategy_spec: &RuntimeStrategySpec, observations: &[Obser
         .collect::<Vec<_>>();
     let volatility = observations
         .iter()
-        .filter_map(|record| parse_optional_metric(record.feature.realized_volatility_bps.as_deref()))
+        .filter_map(|record| {
+            parse_optional_metric(record.feature.realized_volatility_bps.as_deref())
+        })
         .collect::<Vec<_>>();
     let mut calibration = Calibration {
         primary_threshold_bps: percentile(short_abs.clone(), 0.5).unwrap_or(8.0).max(5.0),
         confirmation_threshold_bps: percentile(long_abs.clone(), 0.5).unwrap_or(10.0).max(8.0),
-        low_vol_threshold_bps: percentile(volatility.clone(), 0.33).unwrap_or(12.0).max(8.0),
+        low_vol_threshold_bps: percentile(volatility.clone(), 0.33)
+            .unwrap_or(12.0)
+            .max(8.0),
         high_vol_threshold_bps: percentile(volatility, 0.66).unwrap_or(20.0).max(12.0),
     };
     if strategy_spec.strategy_key == "breakout" {
@@ -791,10 +824,13 @@ fn target_exposure(
     observation: &Observation,
     calibration: &Calibration,
 ) -> f64 {
-    let short_return = parse_optional_metric(observation.feature.short_return_bps.as_deref()).unwrap_or(0.0);
-    let long_return = parse_optional_metric(observation.feature.long_return_bps.as_deref()).unwrap_or(0.0);
+    let short_return =
+        parse_optional_metric(observation.feature.short_return_bps.as_deref()).unwrap_or(0.0);
+    let long_return =
+        parse_optional_metric(observation.feature.long_return_bps.as_deref()).unwrap_or(0.0);
     let realized_volatility =
-        parse_optional_metric(observation.feature.realized_volatility_bps.as_deref()).unwrap_or(0.0);
+        parse_optional_metric(observation.feature.realized_volatility_bps.as_deref())
+            .unwrap_or(0.0);
 
     match strategy_spec.strategy_key.as_str() {
         "dca" | "twap" => 1.0,
@@ -911,7 +947,12 @@ fn load_replay_fixture(
     let fixture_uri = replay_corpus
         .fixture_uri
         .clone()
-        .or_else(|| replay_corpus.dataset_snapshots.iter().find_map(|snapshot| snapshot.uri.clone()))
+        .or_else(|| {
+            replay_corpus
+                .dataset_snapshots
+                .iter()
+                .find_map(|snapshot| snapshot.uri.clone())
+        })
         .ok_or_else(|| BacktestingEngineError::MissingFixtureUri {
             corpus_id: replay_corpus.corpus_id.clone(),
         })?;
@@ -1400,7 +1441,10 @@ mod tests {
 
         assert!(result.created);
         assert_eq!(result.report.fold_reports.len(), 2);
-        assert_eq!(result.report.config.window_mode, RuntimeBacktestWindowMode::Rolling);
+        assert_eq!(
+            result.report.config.window_mode,
+            RuntimeBacktestWindowMode::Rolling
+        );
         assert_eq!(result.report.aggregate_metrics.observation_count, 2);
         assert!(!result.report.aggregate_regime_metrics.is_empty());
         assert_eq!(result.report.status, RuntimeBacktestStatus::Completed);

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -630,6 +630,28 @@ pub enum RuntimeResearchEvidenceStatus {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeBacktestStatus {
+    Completed,
+    Blocked,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeBacktestWindowMode {
+    Rolling,
+    Expanding,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeBacktestBaseline {
+    FlatCash,
+    BuyAndHold,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct RuntimeResearchCitation {
     pub source_id: String,
@@ -1012,6 +1034,94 @@ pub struct RuntimeResearchEvidenceBundleRecord {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeBacktestConfig {
+    pub replay_corpus_id: String,
+    pub venue_key: String,
+    pub pair_symbol: String,
+    pub market_type: RuntimeVenueMarketType,
+    pub window_mode: RuntimeBacktestWindowMode,
+    pub training_window_observations: u32,
+    pub testing_window_observations: u32,
+    pub step_observations: u32,
+    pub purge_observations: u32,
+    pub baseline_strategies: Vec<RuntimeBacktestBaseline>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeBacktestMetrics {
+    pub observation_count: u32,
+    pub trade_count: u32,
+    pub gross_return_bps: String,
+    pub net_return_bps: String,
+    pub total_cost_bps: String,
+    pub win_rate_bps: u16,
+    pub max_drawdown_bps: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeBacktestBaselineComparison {
+    pub baseline: RuntimeBacktestBaseline,
+    pub baseline_return_bps: String,
+    pub excess_return_bps: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeBacktestRegimeMetrics {
+    pub regime_key: String,
+    pub regime_value: String,
+    pub observation_count: u32,
+    pub trade_count: u32,
+    pub net_return_bps: String,
+    pub win_rate_bps: u16,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeBacktestFoldReport {
+    pub fold_id: String,
+    pub fold_index: u32,
+    pub training_start_at: String,
+    pub training_end_at: String,
+    pub test_start_at: String,
+    pub test_end_at: String,
+    pub train_observation_count: u32,
+    pub purged_observation_count: u32,
+    pub test_observation_count: u32,
+    pub metrics: RuntimeBacktestMetrics,
+    pub baseline_comparisons: Vec<RuntimeBacktestBaselineComparison>,
+    pub regime_metrics: Vec<RuntimeBacktestRegimeMetrics>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeBacktestReport {
+    pub schema_version: String,
+    pub report_id: String,
+    pub experiment_id: String,
+    pub strategy_key: String,
+    pub status: RuntimeBacktestStatus,
+    pub generated_at: String,
+    pub venue_keys: Vec<String>,
+    pub asset_keys: Vec<String>,
+    pub code_revision: RuntimeCodeRevisionRef,
+    pub dataset_snapshots: Vec<RuntimeDatasetSnapshotRef>,
+    pub strategy_spec_digest: String,
+    pub config: RuntimeBacktestConfig,
+    pub fold_reports: Vec<RuntimeBacktestFoldReport>,
+    pub aggregate_metrics: RuntimeBacktestMetrics,
+    pub aggregate_baseline_comparisons: Vec<RuntimeBacktestBaselineComparison>,
+    pub aggregate_regime_metrics: Vec<RuntimeBacktestRegimeMetrics>,
+    pub promotion_eligible: bool,
+    pub blocking_reasons: Vec<String>,
+    pub summary: String,
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum RuntimeStrategyCategory {
     Allocation,
@@ -1327,6 +1437,9 @@ mod tests {
             "runtime.research_evidence_bundle.valid.v1.json",
         ))
         .expect("research evidence bundle fixture to deserialize");
+        let backtest: RuntimeBacktestReport =
+            serde_json::from_str(&read_fixture("runtime.backtest_report.valid.v1.json"))
+                .expect("backtest report fixture to deserialize");
         let venue_capability: RuntimeVenueCapability =
             serde_json::from_str(&read_fixture("runtime.venue_capability.valid.v1.json"))
                 .expect("venue capability fixture to deserialize");
@@ -1350,6 +1463,7 @@ mod tests {
         assert_eq!(source.schema_version, RUNTIME_PROTOCOL_SCHEMA_VERSION);
         assert_eq!(experiment.schema_version, RUNTIME_PROTOCOL_SCHEMA_VERSION);
         assert_eq!(evidence.schema_version, RUNTIME_PROTOCOL_SCHEMA_VERSION);
+        assert_eq!(backtest.schema_version, RUNTIME_PROTOCOL_SCHEMA_VERSION);
         assert_eq!(
             venue_capability.schema_version,
             RUNTIME_PROTOCOL_SCHEMA_VERSION
@@ -1362,6 +1476,8 @@ mod tests {
         assert_eq!(plan.slices.len(), 1);
         assert_eq!(experiment.dataset_snapshots.len(), 1);
         assert_eq!(evidence.artifacts.len(), 2);
+        assert_eq!(backtest.fold_reports.len(), 2);
+        assert!(backtest.promotion_eligible);
         assert_eq!(venue_capability.venue_key, "jupiter");
         assert_eq!(asset_record.asset_key, "SOL");
         assert_eq!(strategy_spec.strategy_key, "trend_following");

--- a/crates/research-registry/src/lib.rs
+++ b/crates/research-registry/src/lib.rs
@@ -304,6 +304,25 @@ impl ResearchRegistry {
         })
     }
 
+    pub fn get_experiment(
+        &self,
+        experiment_id: &str,
+    ) -> Result<Option<RuntimeResearchExperimentRecord>, ResearchRegistryError> {
+        let connection = self.open_connection()?;
+        Ok(connection
+            .query_row(
+                "SELECT record_json
+                 FROM research_experiments
+                 WHERE experiment_id = ?1
+                 LIMIT 1",
+                params![experiment_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .map(|json| deserialize_json(&json))
+            .transpose()?)
+    }
+
     fn snapshot_counts(
         &self,
     ) -> Result<(u64, u64, u64, u64, Option<String>), ResearchRegistryError> {

--- a/docs/runtime-contracts/fixtures/runtime.backtest_report.valid.v1.json
+++ b/docs/runtime-contracts/fixtures/runtime.backtest_report.valid.v1.json
@@ -1,0 +1,174 @@
+{
+  "schemaVersion": "v1",
+  "reportId": "backtest_alloc_dca_report",
+  "experimentId": "experiment_alloc_dca_backtest",
+  "strategyKey": "dca",
+  "status": "completed",
+  "generatedAt": "2026-03-10T14:21:30.000Z",
+  "venueKeys": ["jupiter"],
+  "assetKeys": ["SOL", "USDC"],
+  "codeRevision": {
+    "vcs": "git",
+    "repository": "github.com/GuiBibeau/serious-trader-ralph",
+    "revision": "356b539e3ec730663c4025b8f00cd6b47b823d1a",
+    "treeDirty": false
+  },
+  "datasetSnapshots": [
+    {
+      "datasetId": "dataset_feature_cache_sol_usdc_market_events",
+      "snapshotId": "snapshot_2026_03_07_backtest",
+      "capturedAt": "2026-03-10T14:00:00.000Z",
+      "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json#marketEvents",
+      "contentDigest": "sha256:feature-cache"
+    },
+    {
+      "datasetId": "dataset_feature_cache_sol_usdc_slot_events",
+      "snapshotId": "snapshot_2026_03_07_backtest",
+      "capturedAt": "2026-03-10T14:00:00.000Z",
+      "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json#slotEvents",
+      "contentDigest": "sha256:feature-cache"
+    }
+  ],
+  "strategySpecDigest": "sha256:1992048eb2efcd762981bd78d6ae7685c39873c4ccb8189681e2003ca8d84bff",
+  "config": {
+    "replayCorpusId": "replay_corpus_sol_usdc_feature_cache",
+    "venueKey": "jupiter",
+    "pairSymbol": "SOL/USDC",
+    "marketType": "spot",
+    "windowMode": "rolling",
+    "trainingWindowObservations": 2,
+    "testingWindowObservations": 1,
+    "stepObservations": 1,
+    "purgeObservations": 0,
+    "baselineStrategies": ["flat_cash", "buy_and_hold"]
+  },
+  "foldReports": [
+    {
+      "foldId": "fold_0",
+      "foldIndex": 0,
+      "trainingStartAt": "2026-03-07T00:00:00Z",
+      "trainingEndAt": "2026-03-07T00:00:10Z",
+      "testStartAt": "2026-03-07T00:00:10Z",
+      "testEndAt": "2026-03-07T00:00:15Z",
+      "trainObservationCount": 2,
+      "purgedObservationCount": 0,
+      "testObservationCount": 1,
+      "metrics": {
+        "observationCount": 1,
+        "tradeCount": 1,
+        "grossReturnBps": "22.5384",
+        "netReturnBps": "22.5384",
+        "totalCostBps": "0.0000",
+        "winRateBps": 10000,
+        "maxDrawdownBps": "0.0000"
+      },
+      "baselineComparisons": [
+        {
+          "baseline": "flat_cash",
+          "baselineReturnBps": "0.0000",
+          "excessReturnBps": "22.5384"
+        },
+        {
+          "baseline": "buy_and_hold",
+          "baselineReturnBps": "22.5384",
+          "excessReturnBps": "0.0000"
+        }
+      ],
+      "regimeMetrics": [
+        {
+          "regimeKey": "short_trend",
+          "regimeValue": "flat",
+          "observationCount": 1,
+          "tradeCount": 1,
+          "netReturnBps": "22.5384",
+          "winRateBps": 10000
+        }
+      ]
+    },
+    {
+      "foldId": "fold_1",
+      "foldIndex": 1,
+      "trainingStartAt": "2026-03-07T00:00:05Z",
+      "trainingEndAt": "2026-03-07T00:00:15Z",
+      "testStartAt": "2026-03-07T00:00:15Z",
+      "testEndAt": "2026-03-07T00:00:20Z",
+      "trainObservationCount": 2,
+      "purgedObservationCount": 0,
+      "testObservationCount": 1,
+      "metrics": {
+        "observationCount": 1,
+        "tradeCount": 1,
+        "grossReturnBps": "-8.4329",
+        "netReturnBps": "-8.4329",
+        "totalCostBps": "0.0000",
+        "winRateBps": 0,
+        "maxDrawdownBps": "8.4329"
+      },
+      "baselineComparisons": [
+        {
+          "baseline": "flat_cash",
+          "baselineReturnBps": "0.0000",
+          "excessReturnBps": "-8.4329"
+        },
+        {
+          "baseline": "buy_and_hold",
+          "baselineReturnBps": "-8.4329",
+          "excessReturnBps": "0.0000"
+        }
+      ],
+      "regimeMetrics": [
+        {
+          "regimeKey": "short_trend",
+          "regimeValue": "up",
+          "observationCount": 1,
+          "tradeCount": 1,
+          "netReturnBps": "-8.4329",
+          "winRateBps": 0
+        }
+      ]
+    }
+  ],
+  "aggregateMetrics": {
+    "observationCount": 2,
+    "tradeCount": 2,
+    "grossReturnBps": "14.1055",
+    "netReturnBps": "14.1055",
+    "totalCostBps": "0.0000",
+    "winRateBps": 5000,
+    "maxDrawdownBps": "8.4329"
+  },
+  "aggregateBaselineComparisons": [
+    {
+      "baseline": "flat_cash",
+      "baselineReturnBps": "0.0000",
+      "excessReturnBps": "14.1055"
+    },
+    {
+      "baseline": "buy_and_hold",
+      "baselineReturnBps": "14.1055",
+      "excessReturnBps": "0.0000"
+    }
+  ],
+  "aggregateRegimeMetrics": [
+    {
+      "regimeKey": "short_trend",
+      "regimeValue": "flat",
+      "observationCount": 1,
+      "tradeCount": 1,
+      "netReturnBps": "22.5384",
+      "winRateBps": 10000
+    },
+    {
+      "regimeKey": "short_trend",
+      "regimeValue": "up",
+      "observationCount": 1,
+      "tradeCount": 1,
+      "netReturnBps": "-8.4329",
+      "winRateBps": 0
+    }
+  ],
+  "promotionEligible": true,
+  "blockingReasons": [],
+  "summary": "Backtest cleared two walk-forward folds for dca with positive aggregate net return.",
+  "tags": ["backtest", "paper"]
+}

--- a/docs/runtime-contracts/schema-manifest.v1.json
+++ b/docs/runtime-contracts/schema-manifest.v1.json
@@ -53,6 +53,11 @@
       "schemaFile": "docs/runtime-contracts/schemas/runtime.research_evidence_bundle.v1.schema.json"
     },
     {
+      "name": "backtestReport",
+      "schemaId": "https://trader-ralph.com/schemas/runtime/v1/backtest_report",
+      "schemaFile": "docs/runtime-contracts/schemas/runtime.backtest_report.v1.schema.json"
+    },
+    {
       "name": "historicalDatasetSnapshot",
       "schemaId": "https://trader-ralph.com/schemas/runtime/v1/historical_dataset_snapshot",
       "schemaFile": "docs/runtime-contracts/schemas/runtime.historical_dataset_snapshot.v1.schema.json"

--- a/docs/runtime-contracts/schemas/runtime.backtest_report.v1.schema.json
+++ b/docs/runtime-contracts/schemas/runtime.backtest_report.v1.schema.json
@@ -1,0 +1,514 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://trader-ralph.com/schemas/runtime/v1/backtest_report",
+  "type": "object",
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "v1"
+    },
+    "reportId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "experimentId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "strategyKey": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": ["completed", "blocked", "failed"]
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+    },
+    "venueKeys": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "assetKeys": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "codeRevision": {
+      "type": "object",
+      "properties": {
+        "vcs": {
+          "type": "string",
+          "minLength": 1
+        },
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "revision": {
+          "type": "string",
+          "minLength": 1
+        },
+        "comparedTo": {
+          "type": "string",
+          "minLength": 1
+        },
+        "treeDirty": {
+          "type": "boolean"
+        }
+      },
+      "required": ["vcs", "repository", "revision", "treeDirty"],
+      "additionalProperties": false
+    },
+    "datasetSnapshots": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "datasetId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "snapshotId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "capturedAt": {
+            "type": "string",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+          },
+          "uri": {
+            "type": "string",
+            "minLength": 1
+          },
+          "contentDigest": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": ["datasetId", "snapshotId", "capturedAt"],
+        "additionalProperties": false
+      }
+    },
+    "strategySpecDigest": {
+      "type": "string",
+      "minLength": 1
+    },
+    "config": {
+      "type": "object",
+      "properties": {
+        "replayCorpusId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "venueKey": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pairSymbol": {
+          "type": "string",
+          "minLength": 1
+        },
+        "marketType": {
+          "type": "string",
+          "enum": ["spot", "perp", "options"]
+        },
+        "windowMode": {
+          "type": "string",
+          "enum": ["rolling", "expanding"]
+        },
+        "trainingWindowObservations": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "testingWindowObservations": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "stepObservations": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "purgeObservations": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "baselineStrategies": {
+          "minItems": 1,
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["flat_cash", "buy_and_hold"]
+          }
+        }
+      },
+      "required": [
+        "replayCorpusId",
+        "venueKey",
+        "pairSymbol",
+        "marketType",
+        "windowMode",
+        "trainingWindowObservations",
+        "testingWindowObservations",
+        "stepObservations",
+        "purgeObservations",
+        "baselineStrategies"
+      ],
+      "additionalProperties": false
+    },
+    "foldReports": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "foldId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "foldIndex": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "trainingStartAt": {
+            "type": "string",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+          },
+          "trainingEndAt": {
+            "type": "string",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+          },
+          "testStartAt": {
+            "type": "string",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+          },
+          "testEndAt": {
+            "type": "string",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+          },
+          "trainObservationCount": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "purgedObservationCount": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "testObservationCount": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "metrics": {
+            "type": "object",
+            "properties": {
+              "observationCount": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "tradeCount": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "grossReturnBps": {
+                "type": "string",
+                "pattern": "^-?\\d+(?:\\.\\d+)?$"
+              },
+              "netReturnBps": {
+                "type": "string",
+                "pattern": "^-?\\d+(?:\\.\\d+)?$"
+              },
+              "totalCostBps": {
+                "type": "string",
+                "pattern": "^-?\\d+(?:\\.\\d+)?$"
+              },
+              "winRateBps": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 10000
+              },
+              "maxDrawdownBps": {
+                "type": "string",
+                "pattern": "^-?\\d+(?:\\.\\d+)?$"
+              }
+            },
+            "required": [
+              "observationCount",
+              "tradeCount",
+              "grossReturnBps",
+              "netReturnBps",
+              "totalCostBps",
+              "winRateBps",
+              "maxDrawdownBps"
+            ],
+            "additionalProperties": false
+          },
+          "baselineComparisons": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "baseline": {
+                  "type": "string",
+                  "enum": ["flat_cash", "buy_and_hold"]
+                },
+                "baselineReturnBps": {
+                  "type": "string",
+                  "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                },
+                "excessReturnBps": {
+                  "type": "string",
+                  "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                }
+              },
+              "required": ["baseline", "baselineReturnBps", "excessReturnBps"],
+              "additionalProperties": false
+            }
+          },
+          "regimeMetrics": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "regimeKey": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "regimeValue": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "observationCount": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "tradeCount": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "netReturnBps": {
+                  "type": "string",
+                  "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                },
+                "winRateBps": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 10000
+                }
+              },
+              "required": [
+                "regimeKey",
+                "regimeValue",
+                "observationCount",
+                "tradeCount",
+                "netReturnBps",
+                "winRateBps"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "foldId",
+          "foldIndex",
+          "trainingStartAt",
+          "trainingEndAt",
+          "testStartAt",
+          "testEndAt",
+          "trainObservationCount",
+          "purgedObservationCount",
+          "testObservationCount",
+          "metrics",
+          "baselineComparisons",
+          "regimeMetrics"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "aggregateMetrics": {
+      "type": "object",
+      "properties": {
+        "observationCount": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "tradeCount": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "grossReturnBps": {
+          "type": "string",
+          "pattern": "^-?\\d+(?:\\.\\d+)?$"
+        },
+        "netReturnBps": {
+          "type": "string",
+          "pattern": "^-?\\d+(?:\\.\\d+)?$"
+        },
+        "totalCostBps": {
+          "type": "string",
+          "pattern": "^-?\\d+(?:\\.\\d+)?$"
+        },
+        "winRateBps": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 10000
+        },
+        "maxDrawdownBps": {
+          "type": "string",
+          "pattern": "^-?\\d+(?:\\.\\d+)?$"
+        }
+      },
+      "required": [
+        "observationCount",
+        "tradeCount",
+        "grossReturnBps",
+        "netReturnBps",
+        "totalCostBps",
+        "winRateBps",
+        "maxDrawdownBps"
+      ],
+      "additionalProperties": false
+    },
+    "aggregateBaselineComparisons": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "baseline": {
+            "type": "string",
+            "enum": ["flat_cash", "buy_and_hold"]
+          },
+          "baselineReturnBps": {
+            "type": "string",
+            "pattern": "^-?\\d+(?:\\.\\d+)?$"
+          },
+          "excessReturnBps": {
+            "type": "string",
+            "pattern": "^-?\\d+(?:\\.\\d+)?$"
+          }
+        },
+        "required": ["baseline", "baselineReturnBps", "excessReturnBps"],
+        "additionalProperties": false
+      }
+    },
+    "aggregateRegimeMetrics": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "regimeKey": {
+            "type": "string",
+            "minLength": 1
+          },
+          "regimeValue": {
+            "type": "string",
+            "minLength": 1
+          },
+          "observationCount": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "tradeCount": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "netReturnBps": {
+            "type": "string",
+            "pattern": "^-?\\d+(?:\\.\\d+)?$"
+          },
+          "winRateBps": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 10000
+          }
+        },
+        "required": [
+          "regimeKey",
+          "regimeValue",
+          "observationCount",
+          "tradeCount",
+          "netReturnBps",
+          "winRateBps"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "promotionEligible": {
+      "type": "boolean"
+    },
+    "blockingReasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tags": {
+      "maxItems": 16,
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "reportId",
+    "experimentId",
+    "strategyKey",
+    "status",
+    "generatedAt",
+    "venueKeys",
+    "assetKeys",
+    "codeRevision",
+    "datasetSnapshots",
+    "strategySpecDigest",
+    "config",
+    "foldReports",
+    "aggregateMetrics",
+    "aggregateBaselineComparisons",
+    "aggregateRegimeMetrics",
+    "promotionEligible",
+    "blockingReasons",
+    "summary",
+    "tags"
+  ],
+  "additionalProperties": false
+}

--- a/services/runtime-rs/Cargo.toml
+++ b/services/runtime-rs/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 axum.workspace = true
 asset-registry = { path = "../../crates/asset-registry" }
+backtesting-engine = { path = "../../crates/backtesting-engine" }
 cost-model-registry = { path = "../../crates/cost-model-registry" }
 execution-planner = { path = "../../crates/execution-planner" }
 exec-client = { path = "../../crates/exec-client" }

--- a/services/runtime-rs/src/lib.rs
+++ b/services/runtime-rs/src/lib.rs
@@ -1,5 +1,9 @@
 use std::sync::{Arc, RwLock};
 
+use backtesting_engine::{
+    BacktestRunRequest, BacktestingEngine, BacktestingEngineConfig, BacktestingEngineError,
+    BacktestingEngineSnapshot, BacktestingQuery,
+};
 use asset_registry::{
     AssetRegistry, AssetRegistryConfig, AssetRegistryError, AssetRegistryQuery,
     AssetRegistrySnapshot,
@@ -36,10 +40,12 @@ use portfolio_ledger::{
     PortfolioLedger, PortfolioLedgerConfig, PortfolioLedgerError, PortfolioLedgerSnapshot,
 };
 use protocol::{
-    RuntimeAssetListingState, RuntimeAssetRecord, RuntimeDeploymentRecord, RuntimeDeploymentState,
-    RuntimeExecutionCostModelRecord, RuntimeFeatureCatalogStatus, RuntimeFeatureDefinitionRecord,
-    RuntimeHistoricalDatasetKind, RuntimeHistoricalDatasetSnapshotRecord, RuntimeMode,
-    RuntimeRegimeTagRecord, RuntimeReplayCorpusRecord, RuntimeResearchEvidenceBundleRecord,
+    RuntimeAssetListingState, RuntimeAssetRecord, RuntimeBacktestBaseline,
+    RuntimeBacktestWindowMode, RuntimeDeploymentRecord, RuntimeDeploymentState,
+    RuntimeExecutionCostModelRecord, RuntimeExecutionCostModelStatus,
+    RuntimeFeatureCatalogStatus, RuntimeFeatureDefinitionRecord, RuntimeHistoricalDatasetKind,
+    RuntimeHistoricalDatasetSnapshotRecord, RuntimeMode, RuntimeRegimeTagRecord,
+    RuntimeReplayCorpusRecord, RuntimeResearchEvidenceBundleRecord,
     RuntimeResearchExperimentRecord, RuntimeResearchHypothesisRecord, RuntimeResearchSourceRecord,
     RuntimeRunRecord, RuntimeVenueMarketType,
 };
@@ -98,6 +104,7 @@ pub struct RuntimeAppState {
     research_registry: ResearchRegistry,
     asset_registry: AssetRegistry,
     historical_data_lake: HistoricalDataLake,
+    backtesting_engine: BacktestingEngine,
     feature_catalog_registry: FeatureCatalogRegistry,
     cost_model_registry: CostModelRegistry,
     portfolio_ledger: PortfolioLedger,
@@ -136,6 +143,9 @@ impl RuntimeAppState {
         let historical_data_lake =
             HistoricalDataLake::new(HistoricalDataLakeConfig::new(config.database_url.clone()))
                 .expect("historical data lake to initialize");
+        let backtesting_engine =
+            BacktestingEngine::new(BacktestingEngineConfig::new(config.database_url.clone()))
+                .expect("backtesting engine to initialize");
         let feature_catalog_registry = FeatureCatalogRegistry::new(
             FeatureCatalogRegistryConfig::new(config.database_url.clone()),
         )
@@ -178,6 +188,7 @@ impl RuntimeAppState {
             research_registry,
             asset_registry,
             historical_data_lake,
+            backtesting_engine,
             feature_catalog_registry,
             cost_model_registry,
             portfolio_ledger,
@@ -216,6 +227,10 @@ impl RuntimeAppState {
 
     fn historical_data_lake_snapshot(&self) -> HistoricalDataLakeSnapshot {
         self.historical_data_lake.snapshot_now()
+    }
+
+    fn backtesting_engine_snapshot(&self) -> BacktestingEngineSnapshot {
+        self.backtesting_engine.snapshot_now()
     }
 
     fn feature_catalog_registry_snapshot(&self) -> FeatureCatalogRegistrySnapshot {
@@ -267,6 +282,7 @@ pub struct RuntimeHealthResponse {
     pub research_registry: ResearchRegistrySnapshot,
     pub asset_registry: AssetRegistrySnapshot,
     pub historical_data_lake: HistoricalDataLakeSnapshot,
+    pub backtesting_engine: BacktestingEngineSnapshot,
     pub feature_catalog_registry: FeatureCatalogRegistrySnapshot,
     pub cost_model_registry: CostModelRegistrySnapshot,
     pub portfolio_ledger: PortfolioLedgerSnapshot,
@@ -291,6 +307,7 @@ pub struct RuntimeMetricsResponse {
     pub research_registry: ResearchRegistrySnapshot,
     pub asset_registry: AssetRegistrySnapshot,
     pub historical_data_lake: HistoricalDataLakeSnapshot,
+    pub backtesting_engine: BacktestingEngineSnapshot,
     pub feature_catalog_registry: FeatureCatalogRegistrySnapshot,
     pub cost_model_registry: CostModelRegistrySnapshot,
     pub portfolio_ledger: PortfolioLedgerSnapshot,
@@ -347,6 +364,32 @@ struct RuntimeHistoricalDataLakeQueryParams {
     pub venue_key: Option<String>,
     pub asset_key: Option<String>,
     pub dataset_kind: Option<RuntimeHistoricalDatasetKind>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct RuntimeBacktestQueryParams {
+    pub report_id: Option<String>,
+    pub experiment_id: Option<String>,
+    pub strategy_key: Option<String>,
+    pub promotion_eligible: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct RuntimeBacktestRunRequestPayload {
+    pub report_id: Option<String>,
+    pub experiment_id: String,
+    pub replay_corpus_id: String,
+    pub venue_key: String,
+    pub pair_symbol: String,
+    pub market_type: RuntimeVenueMarketType,
+    pub window_mode: RuntimeBacktestWindowMode,
+    pub training_window_observations: u32,
+    pub testing_window_observations: u32,
+    pub step_observations: u32,
+    pub purge_observations: u32,
+    pub baseline_strategies: Vec<RuntimeBacktestBaseline>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
@@ -462,6 +505,10 @@ pub fn app(config: RuntimeConfig) -> Router {
             get(historical_data_lake_query_handler),
         )
         .route(
+            &format!("{INTERNAL_RUNTIME_PREFIX}/backtests"),
+            get(backtests_query_handler).post(run_backtest_handler),
+        )
+        .route(
             &format!("{INTERNAL_RUNTIME_PREFIX}/datasets/snapshots"),
             post(create_historical_dataset_snapshot_handler),
         )
@@ -509,6 +556,7 @@ fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
     let research_registry = state.research_registry_snapshot();
     let asset_registry = state.asset_registry_snapshot();
     let historical_data_lake = state.historical_data_lake_snapshot();
+    let backtesting_engine = state.backtesting_engine_snapshot();
     let feature_catalog_registry = state.feature_catalog_registry_snapshot();
     let cost_model_registry = state.cost_model_registry_snapshot();
     let portfolio_ledger = state.portfolio_ledger_snapshot();
@@ -522,6 +570,7 @@ fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
         && research_registry.status == "healthy"
         && asset_registry.status == "healthy"
         && historical_data_lake.status == "healthy"
+        && backtesting_engine.status == "healthy"
         && feature_catalog_registry.status == "healthy"
         && cost_model_registry.status == "healthy"
         && portfolio_ledger.status == "healthy"
@@ -552,6 +601,7 @@ fn health_response(state: &RuntimeAppState) -> RuntimeHealthResponse {
         research_registry,
         asset_registry,
         historical_data_lake,
+        backtesting_engine,
         feature_catalog_registry,
         cost_model_registry,
         portfolio_ledger,
@@ -576,6 +626,7 @@ fn metrics_response(state: &RuntimeAppState) -> RuntimeMetricsResponse {
         research_registry: state.research_registry_snapshot(),
         asset_registry: state.asset_registry_snapshot(),
         historical_data_lake: state.historical_data_lake_snapshot(),
+        backtesting_engine: state.backtesting_engine_snapshot(),
         feature_catalog_registry: state.feature_catalog_registry_snapshot(),
         cost_model_registry: state.cost_model_registry_snapshot(),
         portfolio_ledger: state.portfolio_ledger_snapshot(),
@@ -1473,6 +1524,7 @@ async fn create_research_evidence_bundle_handler(
     authorize_internal_request(&headers, &state)?;
     let record: RuntimeResearchEvidenceBundleRecord =
         parse_json_body(&body, "invalid-runtime-research-evidence-bundle")?;
+    enforce_backtest_evidence_gate(&state, &record)?;
     let result = state
         .research_registry
         .upsert_evidence_bundle(&record)
@@ -1490,6 +1542,198 @@ async fn create_research_evidence_bundle_handler(
             "evidenceBundle": result.record,
         }),
     ))
+}
+
+async fn backtests_query_handler(
+    headers: HeaderMap,
+    Query(query): Query<RuntimeBacktestQueryParams>,
+    State(state): State<RuntimeAppState>,
+) -> HandlerResult {
+    authorize_internal_request(&headers, &state)?;
+    let filters = query.clone();
+    let reports = state
+        .backtesting_engine
+        .query(&BacktestingQuery {
+            report_id: query.report_id.filter(|value| !value.trim().is_empty()),
+            experiment_id: query.experiment_id.filter(|value| !value.trim().is_empty()),
+            strategy_key: query.strategy_key.filter(|value| !value.trim().is_empty()),
+            promotion_eligible: query.promotion_eligible,
+        })
+        .map_err(map_backtesting_engine_error)?;
+    Ok(OkJson::with_status(
+        StatusCode::OK,
+        json!({
+            "ok": true,
+            "source": "runtime-rs",
+            "filters": filters,
+            "reports": reports,
+        }),
+    ))
+}
+
+async fn run_backtest_handler(
+    headers: HeaderMap,
+    State(state): State<RuntimeAppState>,
+    body: Bytes,
+) -> HandlerResult {
+    authorize_internal_request(&headers, &state)?;
+    let request: RuntimeBacktestRunRequestPayload =
+        parse_json_body(&body, "invalid-runtime-backtest-run")?;
+    let experiment = state
+        .research_registry
+        .get_experiment(&request.experiment_id)
+        .map_err(map_research_registry_error)?
+        .ok_or_else(|| {
+            error_json(
+                StatusCode::NOT_FOUND,
+                "research-experiment-not-found",
+                json!({ "experimentId": request.experiment_id }),
+            )
+        })?;
+    let strategy_spec = state
+        .execution_planner
+        .strategy_specs()
+        .into_iter()
+        .find(|spec| spec.strategy_key == experiment.strategy_key)
+        .ok_or_else(|| {
+            error_json(
+                StatusCode::BAD_REQUEST,
+                "unsupported-strategy",
+                json!({ "strategyKey": experiment.strategy_key }),
+            )
+        })?;
+    let replay_corpus = state
+        .historical_data_lake
+        .query(&HistoricalDataLakeQuery {
+            corpus_id: Some(request.replay_corpus_id.clone()),
+            venue_key: Some(request.venue_key.clone()),
+            ..HistoricalDataLakeQuery::default()
+        })
+        .map_err(map_historical_data_lake_error)?
+        .replay_corpora
+        .into_iter()
+        .find(|record| record.corpus_id == request.replay_corpus_id)
+        .ok_or_else(|| {
+            error_json(
+                StatusCode::NOT_FOUND,
+                "replay-corpus-not-found",
+                json!({ "corpusId": request.replay_corpus_id }),
+            )
+        })?;
+    let feature_catalog = state
+        .feature_catalog_registry
+        .query(&FeatureCatalogRegistryQuery {
+            venue_key: Some(request.venue_key.clone()),
+            pair_symbol: Some(request.pair_symbol.clone()),
+            market_type: Some(request.market_type.clone()),
+            status: Some(RuntimeFeatureCatalogStatus::Active),
+            ..FeatureCatalogRegistryQuery::default()
+        })
+        .map_err(map_feature_catalog_registry_error)?;
+    let mut cost_models = state
+        .cost_model_registry
+        .query(&CostModelRegistryQuery {
+            venue_key: Some(request.venue_key.clone()),
+            pair_symbol: Some(request.pair_symbol.clone()),
+            market_type: Some(request.market_type.clone()),
+            ..CostModelRegistryQuery::default()
+        })
+        .map_err(map_cost_model_registry_error)?;
+    cost_models.retain(|model| model.status == RuntimeExecutionCostModelStatus::Active);
+    cost_models.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
+    let result = state
+        .backtesting_engine
+        .run(&BacktestRunRequest {
+            report_id: request.report_id,
+            experiment,
+            strategy_spec,
+            cost_model: cost_models.into_iter().next(),
+            feature_definitions: feature_catalog.feature_definitions,
+            regime_tags: feature_catalog.regime_tags,
+            replay_corpus,
+            config: protocol::RuntimeBacktestConfig {
+                replay_corpus_id: request.replay_corpus_id,
+                venue_key: request.venue_key,
+                pair_symbol: request.pair_symbol,
+                market_type: request.market_type,
+                window_mode: request.window_mode,
+                training_window_observations: request.training_window_observations,
+                testing_window_observations: request.testing_window_observations,
+                step_observations: request.step_observations,
+                purge_observations: request.purge_observations,
+                baseline_strategies: request.baseline_strategies,
+            },
+        })
+        .map_err(map_backtesting_engine_error)?;
+    Ok(OkJson::with_status(
+        if result.created {
+            StatusCode::CREATED
+        } else {
+            StatusCode::OK
+        },
+        json!({
+            "ok": true,
+            "source": "runtime-rs",
+            "created": result.created,
+            "report": result.report,
+        }),
+    ))
+}
+
+fn enforce_backtest_evidence_gate(
+    state: &RuntimeAppState,
+    record: &RuntimeResearchEvidenceBundleRecord,
+) -> Result<(), JsonPayload> {
+    if !promotion_target_requires_backtest(&record.promotion_target) {
+        return Ok(());
+    }
+    let Some(report_id) = record
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.kind == "backtest-report")
+        .and_then(|artifact| parse_backtest_artifact_uri(&artifact.uri))
+    else {
+        return Err(error_json(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "backtest-evidence-required",
+            json!({
+                "promotionTarget": record.promotion_target,
+                "requiredArtifactKind": "backtest-report",
+            }),
+        ));
+    };
+    let report = state
+        .backtesting_engine
+        .get_report(&report_id)
+        .map_err(map_backtesting_engine_error)?
+        .ok_or_else(|| {
+            error_json(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "backtest-report-not-found",
+                json!({ "reportId": report_id }),
+            )
+        })?;
+    if !report.promotion_eligible {
+        return Err(error_json(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "backtest-promotion-blocked",
+            json!({
+                "reportId": report.report_id,
+                "blockingReasons": report.blocking_reasons,
+            }),
+        ));
+    }
+    Ok(())
+}
+
+fn promotion_target_requires_backtest(promotion_target: &str) -> bool {
+    matches!(promotion_target, "paper" | "limited_live" | "broad_live" | "live")
+}
+
+fn parse_backtest_artifact_uri(uri: &str) -> Option<String> {
+    uri.strip_prefix("runtime-backtest://")
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
 }
 
 async fn asset_query_handler(
@@ -2356,6 +2600,71 @@ fn map_cost_model_registry_error(error: CostModelRegistryError) -> JsonPayload {
         CostModelRegistryError::Serialization(error) => error_json(
             StatusCode::INTERNAL_SERVER_ERROR,
             "runtime-execution-cost-model-error",
+            json!({ "reason": error.to_string() }),
+        ),
+    }
+}
+
+fn map_backtesting_engine_error(error: BacktestingEngineError) -> JsonPayload {
+    match error {
+        BacktestingEngineError::InvalidConfig { reason } => error_json(
+            StatusCode::BAD_REQUEST,
+            "invalid-runtime-backtest-config",
+            json!({ "reason": reason }),
+        ),
+        BacktestingEngineError::InvalidTimestamp { field, value } => error_json(
+            StatusCode::BAD_REQUEST,
+            "invalid-runtime-backtest-timestamp",
+            json!({ "field": field, "value": value }),
+        ),
+        BacktestingEngineError::InvalidNumber { field, value } => error_json(
+            StatusCode::BAD_REQUEST,
+            "invalid-runtime-backtest-number",
+            json!({ "field": field, "value": value }),
+        ),
+        BacktestingEngineError::UnsupportedFixtureUri { uri } => error_json(
+            StatusCode::BAD_REQUEST,
+            "unsupported-runtime-backtest-fixture-uri",
+            json!({ "uri": uri }),
+        ),
+        BacktestingEngineError::MissingFixtureUri { corpus_id } => error_json(
+            StatusCode::BAD_REQUEST,
+            "runtime-backtest-fixture-missing",
+            json!({ "corpusId": corpus_id }),
+        ),
+        BacktestingEngineError::InsufficientObservations { required, available } => error_json(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "runtime-backtest-insufficient-observations",
+            json!({ "required": required, "available": available }),
+        ),
+        BacktestingEngineError::ReportNotFound { report_id } => error_json(
+            StatusCode::NOT_FOUND,
+            "runtime-backtest-report-not-found",
+            json!({ "reportId": report_id }),
+        ),
+        BacktestingEngineError::Io(error) => error_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "runtime-backtest-error",
+            json!({ "reason": error.to_string() }),
+        ),
+        BacktestingEngineError::Storage(error) => error_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "runtime-backtest-error",
+            json!({ "reason": error.to_string() }),
+        ),
+        BacktestingEngineError::Serialization(error) => error_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "runtime-backtest-error",
+            json!({ "reason": error.to_string() }),
+        ),
+        BacktestingEngineError::FeedFixture(error) => error_json(
+            StatusCode::BAD_REQUEST,
+            "runtime-backtest-fixture-error",
+            json!({ "reason": error.to_string() }),
+        ),
+        BacktestingEngineError::FeatureCache(error) => error_json(
+            StatusCode::BAD_REQUEST,
+            "runtime-backtest-feature-error",
             json!({ "reason": error.to_string() }),
         ),
     }
@@ -3679,7 +3988,7 @@ mod tests {
                             "experimentId": "experiment_signal_trend_shadow",
                             "strategyKey": "trend_following",
                             "status": "ready_for_review",
-                            "promotionTarget": "paper",
+                            "promotionTarget": "shadow",
                             "createdAt": "2026-03-10T14:21:00.000Z",
                             "updatedAt": "2026-03-10T14:21:00.000Z",
                             "venueKeys": ["jupiter"],
@@ -3709,7 +4018,7 @@ mod tests {
                                     "uri": "r2://artifacts/proof-markdown.md"
                                 }
                             ],
-                            "summary": "Evidence bundle for shadow-to-paper review.",
+                            "summary": "Evidence bundle for shadow review.",
                             "tags": ["promotion"]
                         })
                         .to_string(),
@@ -3744,6 +4053,463 @@ mod tests {
             query_payload["registry"]["evidenceBundles"][0]["evidenceBundleId"],
             json!("evidence_signal_trend_shadow")
         );
+    }
+
+    #[tokio::test]
+    async fn runs_backtests_and_requires_passing_reports_for_paper_evidence() {
+        let router = app(test_config());
+
+        for snapshot in [
+            json!({
+                "schemaVersion": "v1",
+                "datasetId": "dataset_feature_cache_sol_usdc_market_events",
+                "snapshotId": "snapshot_2026_03_07_backtest",
+                "datasetKind": "market_events",
+                "normalizationKind": "replay_ready",
+                "format": "fixture_json",
+                "retentionClass": "research",
+                "capturedAt": "2026-03-10T14:00:00.000Z",
+                "coverageStartAt": "2026-03-07T00:00:00Z",
+                "coverageEndAt": "2026-03-07T00:00:25Z",
+                "rowCount": 6,
+                "venueKeys": ["jupiter"],
+                "assetKeys": ["SOL", "USDC"],
+                "pairSymbols": ["SOL/USDC"],
+                "chainKeys": ["solana-mainnet"],
+                "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json#marketEvents",
+                "contentDigest": "sha256:feature-cache",
+                "provenance": {
+                    "acquisitionKind": "research_fixture",
+                    "collectedFrom": "services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json",
+                    "provider": "repo-fixture",
+                    "collectedAt": "2026-03-10T14:00:00.000Z",
+                    "generator": "strategy-lab-tests",
+                    "generatorRevision": "seed",
+                    "notes": "Test market-event snapshot."
+                },
+                "samplingNotes": "Full deterministic market-event fixture.",
+                "compactionNotes": "No compaction applied.",
+                "tags": ["research", "backtest"]
+            }),
+            json!({
+                "schemaVersion": "v1",
+                "datasetId": "dataset_feature_cache_sol_usdc_slot_events",
+                "snapshotId": "snapshot_2026_03_07_backtest",
+                "datasetKind": "slot_events",
+                "normalizationKind": "replay_ready",
+                "format": "fixture_json",
+                "retentionClass": "research",
+                "capturedAt": "2026-03-10T14:00:00.000Z",
+                "coverageStartAt": "2026-03-07T00:00:23Z",
+                "coverageEndAt": "2026-03-07T00:00:25Z",
+                "rowCount": 3,
+                "venueKeys": ["helius"],
+                "assetKeys": ["SOL", "USDC"],
+                "pairSymbols": ["SOL/USDC"],
+                "chainKeys": ["solana-mainnet"],
+                "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json#slotEvents",
+                "contentDigest": "sha256:feature-cache",
+                "provenance": {
+                    "acquisitionKind": "research_fixture",
+                    "collectedFrom": "services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json",
+                    "provider": "repo-fixture",
+                    "collectedAt": "2026-03-10T14:00:00.000Z",
+                    "generator": "strategy-lab-tests",
+                    "generatorRevision": "seed",
+                    "notes": "Test slot-event snapshot."
+                },
+                "samplingNotes": "Full deterministic slot-event fixture.",
+                "compactionNotes": "No compaction applied.",
+                "tags": ["research", "backtest"]
+            }),
+        ] {
+            let response = router
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/api/internal/runtime/datasets/snapshots")
+                        .header("authorization", "Bearer runtime-service-secret")
+                        .header("content-type", "application/json")
+                        .body(Body::from(snapshot.to_string()))
+                        .expect("request"),
+                )
+                .await
+                .expect("response");
+            assert_eq!(response.status(), StatusCode::CREATED);
+        }
+
+        let replay_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/datasets/replay-corpora")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "schemaVersion": "v1",
+                            "corpusId": "replay_corpus_sol_usdc_feature_cache",
+                            "title": "SOL/USDC feature cache replay corpus",
+                            "summary": "Deterministic replay corpus for runtime backtest coverage.",
+                            "replayKind": "feed_gateway_v1",
+                            "createdAt": "2026-03-10T14:00:00.000Z",
+                            "updatedAt": "2026-03-10T14:00:00.000Z",
+                            "venueKeys": ["jupiter", "helius"],
+                            "assetKeys": ["SOL", "USDC"],
+                            "pairSymbols": ["SOL/USDC"],
+                            "chainKeys": ["solana-mainnet"],
+                            "datasetSnapshots": [
+                                {
+                                    "datasetId": "dataset_feature_cache_sol_usdc_market_events",
+                                    "snapshotId": "snapshot_2026_03_07_backtest",
+                                    "capturedAt": "2026-03-10T14:00:00.000Z",
+                                    "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json#marketEvents",
+                                    "contentDigest": "sha256:feature-cache"
+                                },
+                                {
+                                    "datasetId": "dataset_feature_cache_sol_usdc_slot_events",
+                                    "snapshotId": "snapshot_2026_03_07_backtest",
+                                    "capturedAt": "2026-03-10T14:00:00.000Z",
+                                    "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json#slotEvents",
+                                    "contentDigest": "sha256:feature-cache"
+                                }
+                            ],
+                            "fixtureUri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json",
+                            "contentDigest": "sha256:feature-cache",
+                            "deterministicSeed": 100,
+                            "tags": ["research", "backtest"]
+                        })
+                        .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(replay_response.status(), StatusCode::CREATED);
+
+        let source_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/research/sources")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "schemaVersion": "v1",
+                            "sourceId": "source_strategy_lab_seed",
+                            "sourceKind": "paper",
+                            "title": "Deterministic backtest seed",
+                            "url": "https://example.com/papers/seed",
+                            "canonicalUrl": "https://example.com/papers/seed",
+                            "authors": ["Ada Researcher"],
+                            "retrievedAt": "2026-03-10T14:00:00.000Z",
+                            "contentDigest": "sha256:seed",
+                            "provenance": {
+                                "acquisitionKind": "paper_feed",
+                                "collectedFrom": "https://example.com/feed/seed.xml",
+                                "hostname": "example.com",
+                                "publisher": "Example Research",
+                                "firstSeenAt": "2026-03-10T14:00:00.000Z",
+                                "lastSeenAt": "2026-03-10T14:00:00.000Z"
+                            },
+                            "venueKeys": ["jupiter"],
+                            "assetKeys": ["SOL", "USDC"],
+                            "tags": ["backtest"]
+                        })
+                        .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(source_response.status(), StatusCode::CREATED);
+
+        let hypothesis_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/research/hypotheses")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "schemaVersion": "v1",
+                            "hypothesisId": "hypothesis_alloc_dca",
+                            "strategyKey": "dca",
+                            "title": "DCA replay confidence",
+                            "thesis": "A deterministic upward replay should keep bounded accumulation positive.",
+                            "status": "candidate",
+                            "createdAt": "2026-03-10T14:05:00.000Z",
+                            "updatedAt": "2026-03-10T14:05:00.000Z",
+                            "venueKeys": ["jupiter"],
+                            "assetKeys": ["SOL", "USDC"],
+                            "sourceCitations": [{ "sourceId": "source_strategy_lab_seed" }],
+                            "tags": ["backtest"]
+                        })
+                        .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(hypothesis_response.status(), StatusCode::CREATED);
+
+        let experiment_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/research/experiments")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "schemaVersion": "v1",
+                            "experimentId": "experiment_alloc_dca_backtest",
+                            "hypothesisId": "hypothesis_alloc_dca",
+                            "strategyKey": "dca",
+                            "status": "completed",
+                            "createdAt": "2026-03-10T14:10:00.000Z",
+                            "updatedAt": "2026-03-10T14:20:00.000Z",
+                            "completedAt": "2026-03-10T14:20:00.000Z",
+                            "venueKeys": ["jupiter"],
+                            "assetKeys": ["SOL", "USDC"],
+                            "sourceCitations": [{ "sourceId": "source_strategy_lab_seed" }],
+                            "codeRevision": {
+                                "vcs": "git",
+                                "repository": "github.com/GuiBibeau/serious-trader-ralph",
+                                "revision": "356b539e3ec730663c4025b8f00cd6b47b823d1a",
+                                "treeDirty": false
+                            },
+                            "datasetSnapshots": [
+                                {
+                                    "datasetId": "dataset_feature_cache_sol_usdc_market_events",
+                                    "snapshotId": "snapshot_2026_03_07_backtest",
+                                    "capturedAt": "2026-03-10T14:00:00.000Z",
+                                    "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json#marketEvents",
+                                    "contentDigest": "sha256:feature-cache"
+                                },
+                                {
+                                    "datasetId": "dataset_feature_cache_sol_usdc_slot_events",
+                                    "snapshotId": "snapshot_2026_03_07_backtest",
+                                    "capturedAt": "2026-03-10T14:00:00.000Z",
+                                    "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json#slotEvents",
+                                    "contentDigest": "sha256:feature-cache"
+                                }
+                            ],
+                            "artifacts": [],
+                            "summary": "DCA backtest experiment ready for evaluation.",
+                            "tags": ["backtest"]
+                        })
+                        .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(experiment_response.status(), StatusCode::CREATED);
+
+        let cost_model_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/cost-models")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "schemaVersion": "v1",
+                            "modelId": "cost_model_jupiter_sol_usdc_spot_backtest",
+                            "venueKey": "jupiter",
+                            "marketType": "spot",
+                            "pairSymbol": "SOL/USDC",
+                            "instrumentId": "SOL/USDC",
+                            "assetKeys": ["SOL", "USDC"],
+                            "modeCoverage": ["shadow", "paper"],
+                            "status": "active",
+                            "assumptions": {
+                                "feeBps": 0,
+                                "slippageBps": 0,
+                                "marketImpactBps": 0,
+                                "partialFillRateBps": 0,
+                                "partialFillPenaltyBps": 0
+                            },
+                            "latencyProfile": {
+                                "expectedQuoteMs": 100,
+                                "expectedSubmitMs": 200,
+                                "expectedSettlementMs": 1000
+                            },
+                            "datasetSnapshots": [
+                                {
+                                    "datasetId": "dataset_feature_cache_sol_usdc_market_events",
+                                    "snapshotId": "snapshot_2026_03_07_backtest",
+                                    "capturedAt": "2026-03-10T14:00:00.000Z"
+                                },
+                                {
+                                    "datasetId": "dataset_feature_cache_sol_usdc_slot_events",
+                                    "snapshotId": "snapshot_2026_03_07_backtest",
+                                    "capturedAt": "2026-03-10T14:00:00.000Z"
+                                }
+                            ],
+                            "createdAt": "2026-03-10T14:20:30.000Z",
+                            "updatedAt": "2026-03-10T14:20:30.000Z",
+                            "tags": ["backtest"]
+                        })
+                        .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(cost_model_response.status(), StatusCode::CREATED);
+
+        let missing_backtest_evidence = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/research/evidence-bundles")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "schemaVersion": "v1",
+                            "evidenceBundleId": "evidence_alloc_dca_missing_backtest",
+                            "experimentId": "experiment_alloc_dca_backtest",
+                            "strategyKey": "dca",
+                            "status": "ready_for_review",
+                            "promotionTarget": "paper",
+                            "createdAt": "2026-03-10T14:21:00.000Z",
+                            "updatedAt": "2026-03-10T14:21:00.000Z",
+                            "venueKeys": ["jupiter"],
+                            "assetKeys": ["SOL", "USDC"],
+                            "sourceCitations": [{ "sourceId": "source_strategy_lab_seed" }],
+                            "codeRevision": {
+                                "vcs": "git",
+                                "repository": "github.com/GuiBibeau/serious-trader-ralph",
+                                "revision": "356b539e3ec730663c4025b8f00cd6b47b823d1a",
+                                "treeDirty": false
+                            },
+                            "datasetSnapshots": [
+                                {
+                                    "datasetId": "dataset_feature_cache_sol_usdc_market_events",
+                                    "snapshotId": "snapshot_2026_03_07_backtest",
+                                    "capturedAt": "2026-03-10T14:00:00.000Z"
+                                }
+                            ],
+                            "artifacts": [
+                                {
+                                    "artifactId": "proof-markdown",
+                                    "kind": "proof-bundle",
+                                    "uri": "r2://artifacts/proof-markdown.md"
+                                }
+                            ],
+                            "summary": "Paper promotion without backtest evidence should fail.",
+                            "tags": ["promotion"]
+                        })
+                        .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(missing_backtest_evidence.status(), StatusCode::UNPROCESSABLE_ENTITY);
+
+        let backtest_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/backtests")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "reportId": "backtest_alloc_dca_report",
+                            "experimentId": "experiment_alloc_dca_backtest",
+                            "replayCorpusId": "replay_corpus_sol_usdc_feature_cache",
+                            "venueKey": "jupiter",
+                            "pairSymbol": "SOL/USDC",
+                            "marketType": "spot",
+                            "windowMode": "rolling",
+                            "trainingWindowObservations": 2,
+                            "testingWindowObservations": 1,
+                            "stepObservations": 1,
+                            "purgeObservations": 0,
+                            "baselineStrategies": ["flat_cash", "buy_and_hold"]
+                        })
+                        .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(backtest_response.status(), StatusCode::CREATED);
+        let backtest_payload = read_json(backtest_response).await;
+        assert_eq!(
+            backtest_payload["report"]["status"],
+            json!("completed"),
+            "{backtest_payload:?}"
+        );
+        assert_eq!(backtest_payload["report"]["promotionEligible"], json!(true));
+
+        let evidence_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/research/evidence-bundles")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "schemaVersion": "v1",
+                            "evidenceBundleId": "evidence_alloc_dca_paper",
+                            "experimentId": "experiment_alloc_dca_backtest",
+                            "strategyKey": "dca",
+                            "status": "ready_for_review",
+                            "promotionTarget": "paper",
+                            "createdAt": "2026-03-10T14:22:00.000Z",
+                            "updatedAt": "2026-03-10T14:22:00.000Z",
+                            "venueKeys": ["jupiter"],
+                            "assetKeys": ["SOL", "USDC"],
+                            "sourceCitations": [{ "sourceId": "source_strategy_lab_seed" }],
+                            "codeRevision": {
+                                "vcs": "git",
+                                "repository": "github.com/GuiBibeau/serious-trader-ralph",
+                                "revision": "356b539e3ec730663c4025b8f00cd6b47b823d1a",
+                                "treeDirty": false
+                            },
+                            "datasetSnapshots": [
+                                {
+                                    "datasetId": "dataset_feature_cache_sol_usdc_market_events",
+                                    "snapshotId": "snapshot_2026_03_07_backtest",
+                                    "capturedAt": "2026-03-10T14:00:00.000Z"
+                                }
+                            ],
+                            "artifacts": [
+                                {
+                                    "artifactId": "backtest-report",
+                                    "kind": "backtest-report",
+                                    "uri": "runtime-backtest://backtest_alloc_dca_report"
+                                }
+                            ],
+                            "summary": "Paper promotion backed by a passing backtest report.",
+                            "tags": ["promotion", "backtest"]
+                        })
+                        .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(evidence_response.status(), StatusCode::CREATED);
     }
 
     #[tokio::test]

--- a/services/runtime-rs/src/lib.rs
+++ b/services/runtime-rs/src/lib.rs
@@ -1,9 +1,5 @@
 use std::sync::{Arc, RwLock};
 
-use backtesting_engine::{
-    BacktestRunRequest, BacktestingEngine, BacktestingEngineConfig, BacktestingEngineError,
-    BacktestingEngineSnapshot, BacktestingQuery,
-};
 use asset_registry::{
     AssetRegistry, AssetRegistryConfig, AssetRegistryError, AssetRegistryQuery,
     AssetRegistrySnapshot,
@@ -14,6 +10,10 @@ use axum::{
     http::{HeaderMap, StatusCode},
     routing::{get, post},
     Json, Router,
+};
+use backtesting_engine::{
+    BacktestRunRequest, BacktestingEngine, BacktestingEngineConfig, BacktestingEngineError,
+    BacktestingEngineSnapshot, BacktestingQuery,
 };
 use cost_model_registry::{
     CostModelRegistry, CostModelRegistryConfig, CostModelRegistryError, CostModelRegistryQuery,
@@ -42,8 +42,8 @@ use portfolio_ledger::{
 use protocol::{
     RuntimeAssetListingState, RuntimeAssetRecord, RuntimeBacktestBaseline,
     RuntimeBacktestWindowMode, RuntimeDeploymentRecord, RuntimeDeploymentState,
-    RuntimeExecutionCostModelRecord, RuntimeExecutionCostModelStatus,
-    RuntimeFeatureCatalogStatus, RuntimeFeatureDefinitionRecord, RuntimeHistoricalDatasetKind,
+    RuntimeExecutionCostModelRecord, RuntimeExecutionCostModelStatus, RuntimeFeatureCatalogStatus,
+    RuntimeFeatureDefinitionRecord, RuntimeHistoricalDatasetKind,
     RuntimeHistoricalDatasetSnapshotRecord, RuntimeMode, RuntimeRegimeTagRecord,
     RuntimeReplayCorpusRecord, RuntimeResearchEvidenceBundleRecord,
     RuntimeResearchExperimentRecord, RuntimeResearchHypothesisRecord, RuntimeResearchSourceRecord,
@@ -1727,7 +1727,10 @@ fn enforce_backtest_evidence_gate(
 }
 
 fn promotion_target_requires_backtest(promotion_target: &str) -> bool {
-    matches!(promotion_target, "paper" | "limited_live" | "broad_live" | "live")
+    matches!(
+        promotion_target,
+        "paper" | "limited_live" | "broad_live" | "live"
+    )
 }
 
 fn parse_backtest_artifact_uri(uri: &str) -> Option<String> {
@@ -2632,7 +2635,10 @@ fn map_backtesting_engine_error(error: BacktestingEngineError) -> JsonPayload {
             "runtime-backtest-fixture-missing",
             json!({ "corpusId": corpus_id }),
         ),
-        BacktestingEngineError::InsufficientObservations { required, available } => error_json(
+        BacktestingEngineError::InsufficientObservations {
+            required,
+            available,
+        } => error_json(
             StatusCode::UNPROCESSABLE_ENTITY,
             "runtime-backtest-insufficient-observations",
             json!({ "required": required, "available": available }),
@@ -4419,7 +4425,10 @@ mod tests {
             )
             .await
             .expect("response");
-        assert_eq!(missing_backtest_evidence.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(
+            missing_backtest_evidence.status(),
+            StatusCode::UNPROCESSABLE_ENTITY
+        );
 
         let backtest_response = router
             .clone()

--- a/services/runtime-rs/src/lib.rs
+++ b/services/runtime-rs/src/lib.rs
@@ -1723,6 +1723,19 @@ fn enforce_backtest_evidence_gate(
             }),
         ));
     }
+    if report.experiment_id != record.experiment_id || report.strategy_key != record.strategy_key {
+        return Err(error_json(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "backtest-report-mismatch",
+            json!({
+                "reportId": report.report_id,
+                "reportExperimentId": report.experiment_id,
+                "reportStrategyKey": report.strategy_key,
+                "evidenceExperimentId": record.experiment_id,
+                "evidenceStrategyKey": record.strategy_key,
+            }),
+        ));
+    }
     Ok(())
 }
 
@@ -4467,6 +4480,66 @@ mod tests {
             "{backtest_payload:?}"
         );
         assert_eq!(backtest_payload["report"]["promotionEligible"], json!(true));
+
+        let mismatched_evidence_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/internal/runtime/research/evidence-bundles")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "schemaVersion": "v1",
+                            "evidenceBundleId": "evidence_alloc_dca_wrong_backtest",
+                            "experimentId": "experiment_alloc_dca_backtest",
+                            "strategyKey": "trend_following",
+                            "status": "ready_for_review",
+                            "promotionTarget": "paper",
+                            "createdAt": "2026-03-10T14:21:30.000Z",
+                            "updatedAt": "2026-03-10T14:21:30.000Z",
+                            "venueKeys": ["jupiter"],
+                            "assetKeys": ["SOL", "USDC"],
+                            "sourceCitations": [{ "sourceId": "source_strategy_lab_seed" }],
+                            "codeRevision": {
+                                "vcs": "git",
+                                "repository": "github.com/GuiBibeau/serious-trader-ralph",
+                                "revision": "356b539e3ec730663c4025b8f00cd6b47b823d1a",
+                                "treeDirty": false
+                            },
+                            "datasetSnapshots": [
+                                {
+                                    "datasetId": "dataset_feature_cache_sol_usdc_market_events",
+                                    "snapshotId": "snapshot_2026_03_07_backtest",
+                                    "capturedAt": "2026-03-10T14:00:00.000Z"
+                                }
+                            ],
+                            "artifacts": [
+                                {
+                                    "artifactId": "backtest-report",
+                                    "kind": "backtest-report",
+                                    "uri": "runtime-backtest://backtest_alloc_dca_report"
+                                }
+                            ],
+                            "summary": "Paper promotion with a mismatched backtest report should fail.",
+                            "tags": ["promotion", "backtest"]
+                        })
+                        .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(
+            mismatched_evidence_response.status(),
+            StatusCode::UNPROCESSABLE_ENTITY
+        );
+        let mismatched_evidence_payload = read_json(mismatched_evidence_response).await;
+        assert_eq!(
+            mismatched_evidence_payload["error"],
+            json!("backtest-report-mismatch")
+        );
 
         let evidence_response = router
             .clone()

--- a/src/runtime/contracts/autonomous_runtime.ts
+++ b/src/runtime/contracts/autonomous_runtime.ts
@@ -282,6 +282,19 @@ export const RuntimeResearchEvidenceStatusSchema = z.enum([
   "superseded",
 ]);
 
+export const RuntimeBacktestStatusSchema = z.enum([
+  "completed",
+  "blocked",
+  "failed",
+]);
+
+export const RuntimeBacktestWindowModeSchema = z.enum(["rolling", "expanding"]);
+
+export const RuntimeBacktestBaselineSchema = z.enum([
+  "flat_cash",
+  "buy_and_hold",
+]);
+
 const RuntimeResearchCitationSchema = z
   .object({
     sourceId: NON_EMPTY_STRING_SCHEMA,
@@ -505,6 +518,119 @@ export const RuntimeResearchEvidenceBundleRecordSchema = VersionedSchema.extend(
   },
 ).strict();
 
+export const RuntimeVenueMarketTypeSchema = z.enum(["spot", "perp", "options"]);
+
+export const RuntimeVenueOrderTypeSchema = z.enum([
+  "market",
+  "limit",
+  "auction",
+  "twap",
+]);
+
+export const RuntimeVenueAuthModelSchema = z.enum([
+  "privy_solana_wallet",
+  "server_signer",
+]);
+
+export const RuntimeVenueFeeModelSchema = z.enum([
+  "venue_quote_inclusive",
+  "maker_taker_bps",
+  "fixed_bps",
+]);
+
+export const RuntimeVenueSettlementBehaviorSchema = z.enum([
+  "swap_atomic",
+  "orderbook_atomic",
+  "orderbook_partial",
+]);
+
+const RuntimeBacktestConfigSchema = z
+  .object({
+    replayCorpusId: NON_EMPTY_STRING_SCHEMA,
+    venueKey: NON_EMPTY_STRING_SCHEMA,
+    pairSymbol: NON_EMPTY_STRING_SCHEMA,
+    marketType: RuntimeVenueMarketTypeSchema,
+    windowMode: RuntimeBacktestWindowModeSchema,
+    trainingWindowObservations: z.number().int().positive(),
+    testingWindowObservations: z.number().int().positive(),
+    stepObservations: z.number().int().positive(),
+    purgeObservations: z.number().int().nonnegative(),
+    baselineStrategies: z.array(RuntimeBacktestBaselineSchema).min(1),
+  })
+  .strict();
+
+const RuntimeBacktestMetricsSchema = z
+  .object({
+    observationCount: z.number().int().nonnegative(),
+    tradeCount: z.number().int().nonnegative(),
+    grossReturnBps: NUMERIC_STRING_SCHEMA,
+    netReturnBps: NUMERIC_STRING_SCHEMA,
+    totalCostBps: NUMERIC_STRING_SCHEMA,
+    winRateBps: BPS_SCHEMA,
+    maxDrawdownBps: NUMERIC_STRING_SCHEMA,
+  })
+  .strict();
+
+const RuntimeBacktestBaselineComparisonSchema = z
+  .object({
+    baseline: RuntimeBacktestBaselineSchema,
+    baselineReturnBps: NUMERIC_STRING_SCHEMA,
+    excessReturnBps: NUMERIC_STRING_SCHEMA,
+  })
+  .strict();
+
+const RuntimeBacktestRegimeMetricsSchema = z
+  .object({
+    regimeKey: NON_EMPTY_STRING_SCHEMA,
+    regimeValue: NON_EMPTY_STRING_SCHEMA,
+    observationCount: z.number().int().nonnegative(),
+    tradeCount: z.number().int().nonnegative(),
+    netReturnBps: NUMERIC_STRING_SCHEMA,
+    winRateBps: BPS_SCHEMA,
+  })
+  .strict();
+
+const RuntimeBacktestFoldReportSchema = z
+  .object({
+    foldId: NON_EMPTY_STRING_SCHEMA,
+    foldIndex: z.number().int().nonnegative(),
+    trainingStartAt: ISO_DATETIME_SCHEMA,
+    trainingEndAt: ISO_DATETIME_SCHEMA,
+    testStartAt: ISO_DATETIME_SCHEMA,
+    testEndAt: ISO_DATETIME_SCHEMA,
+    trainObservationCount: z.number().int().nonnegative(),
+    purgedObservationCount: z.number().int().nonnegative(),
+    testObservationCount: z.number().int().nonnegative(),
+    metrics: RuntimeBacktestMetricsSchema,
+    baselineComparisons: z.array(RuntimeBacktestBaselineComparisonSchema),
+    regimeMetrics: z.array(RuntimeBacktestRegimeMetricsSchema),
+  })
+  .strict();
+
+export const RuntimeBacktestReportSchema = VersionedSchema.extend({
+  reportId: NON_EMPTY_STRING_SCHEMA,
+  experimentId: NON_EMPTY_STRING_SCHEMA,
+  strategyKey: NON_EMPTY_STRING_SCHEMA,
+  status: RuntimeBacktestStatusSchema,
+  generatedAt: ISO_DATETIME_SCHEMA,
+  venueKeys: z.array(NON_EMPTY_STRING_SCHEMA).min(1),
+  assetKeys: z.array(NON_EMPTY_STRING_SCHEMA).min(1),
+  codeRevision: RuntimeCodeRevisionRefSchema,
+  datasetSnapshots: z.array(RuntimeDatasetSnapshotRefSchema).min(1),
+  strategySpecDigest: NON_EMPTY_STRING_SCHEMA,
+  config: RuntimeBacktestConfigSchema,
+  foldReports: z.array(RuntimeBacktestFoldReportSchema).min(1),
+  aggregateMetrics: RuntimeBacktestMetricsSchema,
+  aggregateBaselineComparisons: z
+    .array(RuntimeBacktestBaselineComparisonSchema)
+    .min(1),
+  aggregateRegimeMetrics: z.array(RuntimeBacktestRegimeMetricsSchema),
+  promotionEligible: z.boolean(),
+  blockingReasons: z.array(NON_EMPTY_STRING_SCHEMA),
+  summary: NON_EMPTY_STRING_SCHEMA,
+  tags: z.array(NON_EMPTY_STRING_SCHEMA).max(16),
+}).strict();
+
 export const RuntimeStrategyCategorySchema = z.enum([
   "allocation",
   "signal",
@@ -559,32 +685,6 @@ export const RuntimeAssetRiskClassSchema = z.enum([
   "volatile",
   "experimental",
   "restricted",
-]);
-
-export const RuntimeVenueMarketTypeSchema = z.enum(["spot", "perp", "options"]);
-
-export const RuntimeVenueOrderTypeSchema = z.enum([
-  "market",
-  "limit",
-  "auction",
-  "twap",
-]);
-
-export const RuntimeVenueAuthModelSchema = z.enum([
-  "privy_solana_wallet",
-  "server_signer",
-]);
-
-export const RuntimeVenueFeeModelSchema = z.enum([
-  "venue_quote_inclusive",
-  "maker_taker_bps",
-  "fixed_bps",
-]);
-
-export const RuntimeVenueSettlementBehaviorSchema = z.enum([
-  "swap_atomic",
-  "orderbook_atomic",
-  "orderbook_partial",
 ]);
 
 const RuntimeVenuePrecisionSchema = z
@@ -931,6 +1031,14 @@ export type RuntimeResearchExperimentRecord = z.infer<
 export type RuntimeResearchEvidenceBundleRecord = z.infer<
   typeof RuntimeResearchEvidenceBundleRecordSchema
 >;
+export type RuntimeBacktestStatus = z.infer<typeof RuntimeBacktestStatusSchema>;
+export type RuntimeBacktestWindowMode = z.infer<
+  typeof RuntimeBacktestWindowModeSchema
+>;
+export type RuntimeBacktestBaseline = z.infer<
+  typeof RuntimeBacktestBaselineSchema
+>;
+export type RuntimeBacktestReport = z.infer<typeof RuntimeBacktestReportSchema>;
 export type RuntimeOnboardingState = z.infer<
   typeof RuntimeOnboardingStateSchema
 >;
@@ -1033,6 +1141,11 @@ export const RUNTIME_PROTOCOL_SCHEMA_REGISTRY = {
     schemaId:
       "https://trader-ralph.com/schemas/runtime/v1/research_evidence_bundle",
     outputFile: "runtime.research_evidence_bundle.v1.schema.json",
+  },
+  backtestReport: {
+    schema: RuntimeBacktestReportSchema,
+    schemaId: "https://trader-ralph.com/schemas/runtime/v1/backtest_report",
+    outputFile: "runtime.backtest_report.v1.schema.json",
   },
   historicalDatasetSnapshot: {
     schema: RuntimeHistoricalDatasetSnapshotRecordSchema,
@@ -1184,6 +1297,12 @@ export function parseRuntimeResearchEvidenceBundleRecord(
   return RuntimeResearchEvidenceBundleRecordSchema.parse(input);
 }
 
+export function parseRuntimeBacktestReport(
+  input: unknown,
+): RuntimeBacktestReport {
+  return RuntimeBacktestReportSchema.parse(input);
+}
+
 export function parseRuntimeVenueCapability(
   input: unknown,
 ): RuntimeVenueCapability {
@@ -1258,6 +1377,10 @@ export function safeParseRuntimeResearchExperimentRecord(input: unknown) {
 
 export function safeParseRuntimeResearchEvidenceBundleRecord(input: unknown) {
   return RuntimeResearchEvidenceBundleRecordSchema.safeParse(input);
+}
+
+export function safeParseRuntimeBacktestReport(input: unknown) {
+  return RuntimeBacktestReportSchema.safeParse(input);
 }
 
 export function safeParseRuntimeVenueCapability(input: unknown) {

--- a/tests/unit/runtime_protocol_contracts.test.ts
+++ b/tests/unit/runtime_protocol_contracts.test.ts
@@ -4,6 +4,7 @@ import {
   canTransitionRuntimeDeploymentState,
   canTransitionRuntimeRunState,
   parseRuntimeAssetRecord,
+  parseRuntimeBacktestReport,
   parseRuntimeDeploymentRecord,
   parseRuntimeExecutionCostModelRecord,
   parseRuntimeExecutionPlan,
@@ -491,6 +492,113 @@ describe("runtime protocol contracts", () => {
       summary: "Evidence bundle for shadow-to-paper review.",
       tags: ["promotion"],
     });
+    const backtestReport = parseRuntimeBacktestReport({
+      schemaVersion: "v1",
+      reportId: "backtest_alloc_dca_report",
+      experimentId: "experiment_alloc_dca_backtest",
+      strategyKey: "dca",
+      status: "completed",
+      generatedAt: "2026-03-10T14:21:30.000Z",
+      venueKeys: ["jupiter"],
+      assetKeys: ["SOL", "USDC"],
+      codeRevision: {
+        vcs: "git",
+        repository: "github.com/GuiBibeau/serious-trader-ralph",
+        revision: "356b539e3ec730663c4025b8f00cd6b47b823d1a",
+        treeDirty: false,
+      },
+      datasetSnapshots: [
+        {
+          datasetId: "dataset_feature_cache_sol_usdc_market_events",
+          snapshotId: "snapshot_2026_03_07_backtest",
+          capturedAt: "2026-03-10T14:00:00.000Z",
+        },
+      ],
+      strategySpecDigest:
+        "sha256:1992048eb2efcd762981bd78d6ae7685c39873c4ccb8189681e2003ca8d84bff",
+      config: {
+        replayCorpusId: "replay_corpus_sol_usdc_feature_cache",
+        venueKey: "jupiter",
+        pairSymbol: "SOL/USDC",
+        marketType: "spot",
+        windowMode: "rolling",
+        trainingWindowObservations: 2,
+        testingWindowObservations: 1,
+        stepObservations: 1,
+        purgeObservations: 0,
+        baselineStrategies: ["flat_cash", "buy_and_hold"],
+      },
+      foldReports: [
+        {
+          foldId: "fold_0",
+          foldIndex: 0,
+          trainingStartAt: "2026-03-07T00:00:00Z",
+          trainingEndAt: "2026-03-07T00:00:10Z",
+          testStartAt: "2026-03-07T00:00:10Z",
+          testEndAt: "2026-03-07T00:00:15Z",
+          trainObservationCount: 2,
+          purgedObservationCount: 0,
+          testObservationCount: 1,
+          metrics: {
+            observationCount: 1,
+            tradeCount: 1,
+            grossReturnBps: "22.5384",
+            netReturnBps: "22.5384",
+            totalCostBps: "0.0000",
+            winRateBps: 10000,
+            maxDrawdownBps: "0.0000",
+          },
+          baselineComparisons: [
+            {
+              baseline: "flat_cash",
+              baselineReturnBps: "0.0000",
+              excessReturnBps: "22.5384",
+            },
+          ],
+          regimeMetrics: [
+            {
+              regimeKey: "short_trend",
+              regimeValue: "flat",
+              observationCount: 1,
+              tradeCount: 1,
+              netReturnBps: "22.5384",
+              winRateBps: 10000,
+            },
+          ],
+        },
+      ],
+      aggregateMetrics: {
+        observationCount: 1,
+        tradeCount: 1,
+        grossReturnBps: "22.5384",
+        netReturnBps: "22.5384",
+        totalCostBps: "0.0000",
+        winRateBps: 10000,
+        maxDrawdownBps: "0.0000",
+      },
+      aggregateBaselineComparisons: [
+        {
+          baseline: "flat_cash",
+          baselineReturnBps: "0.0000",
+          excessReturnBps: "22.5384",
+        },
+      ],
+      aggregateRegimeMetrics: [
+        {
+          regimeKey: "short_trend",
+          regimeValue: "flat",
+          observationCount: 1,
+          tradeCount: 1,
+          netReturnBps: "22.5384",
+          winRateBps: 10000,
+        },
+      ],
+      promotionEligible: true,
+      blockingReasons: [],
+      summary:
+        "Backtest cleared two walk-forward folds for dca with positive aggregate net return.",
+      tags: ["backtest", "paper"],
+    });
     const strategySpec = parseRuntimeStrategySpec({
       schemaVersion: "v1",
       strategyKey: "trend_following",
@@ -623,6 +731,8 @@ describe("runtime protocol contracts", () => {
     expect(regimeTag.regimeKey).toBe("long_trend");
     expect(experiment.datasetSnapshots).toHaveLength(1);
     expect(evidenceBundle.promotionTarget).toBe("paper");
+    expect(backtestReport.promotionEligible).toBe(true);
+    expect(backtestReport.config.windowMode).toBe("rolling");
     expect(venueCapability.adapterKeys).toContain("jupiter");
     expect(assetRecord.venueMappings[0]?.venueKey).toBe("jupiter");
     expect(strategySpec.pluginKey).toBe("builtin::trend_following");

--- a/tests/unit/runtime_protocol_schema_fixtures.test.ts
+++ b/tests/unit/runtime_protocol_schema_fixtures.test.ts
@@ -84,6 +84,12 @@ describe("runtime protocol schema fixtures", () => {
     ).toBe(true);
     expect(
       validate(
+        "docs/runtime-contracts/schemas/runtime.backtest_report.v1.schema.json",
+        "docs/runtime-contracts/fixtures/runtime.backtest_report.valid.v1.json",
+      ),
+    ).toBe(true);
+    expect(
+      validate(
         "docs/runtime-contracts/schemas/runtime.historical_dataset_snapshot.v1.schema.json",
         "docs/runtime-contracts/fixtures/runtime.historical_dataset_snapshot.valid.v1.json",
       ),
@@ -150,6 +156,7 @@ describe("runtime protocol schema fixtures", () => {
       "docs/runtime-contracts/schemas/runtime.research_source.v1.schema.json",
       "docs/runtime-contracts/schemas/runtime.research_experiment.v1.schema.json",
       "docs/runtime-contracts/schemas/runtime.research_evidence_bundle.v1.schema.json",
+      "docs/runtime-contracts/schemas/runtime.backtest_report.v1.schema.json",
       "docs/runtime-contracts/schemas/runtime.historical_dataset_snapshot.v1.schema.json",
       "docs/runtime-contracts/schemas/runtime.replay_corpus.v1.schema.json",
       "docs/runtime-contracts/schemas/runtime.feature_definition.v1.schema.json",

--- a/tests/unit/worker_runtime_contracts.test.ts
+++ b/tests/unit/worker_runtime_contracts.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import {
   parseRuntimeAssetRecord,
+  parseRuntimeBacktestReport,
   parseRuntimeDeploymentRecord,
   parseRuntimeExecutionCostModelRecord,
   parseRuntimeFeatureDefinitionRecord,
@@ -32,6 +33,7 @@ describe("worker runtime contract bridge", () => {
       "researchSource",
       "researchExperiment",
       "researchEvidenceBundle",
+      "backtestReport",
       "historicalDatasetSnapshot",
       "replayCorpus",
       "featureDefinition",
@@ -52,6 +54,17 @@ describe("worker runtime contract bridge", () => {
 
     expect(deployment.deploymentId).toBe("dep_runtime_sol_usdc_shadow");
     expect(deployment.mode).toBe("shadow");
+  });
+
+  test("worker can parse the canonical backtest fixture", () => {
+    const report = parseRuntimeBacktestReport(
+      readJson(
+        "docs/runtime-contracts/fixtures/runtime.backtest_report.valid.v1.json",
+      ),
+    );
+
+    expect(report.reportId).toBe("backtest_alloc_dca_report");
+    expect(report.promotionEligible).toBe(true);
   });
 
   test("worker can parse the canonical strategy spec fixture", () => {

--- a/tests/unit/worker_runtime_internal_routes.test.ts
+++ b/tests/unit/worker_runtime_internal_routes.test.ts
@@ -398,6 +398,161 @@ const VALID_RUNTIME_REPLAY_CORPUS = {
   tags: ["seed", "replay"],
 };
 
+const VALID_RUNTIME_BACKTEST_REPORT = {
+  schemaVersion: "v1",
+  reportId: "backtest_alloc_dca_report",
+  experimentId: "experiment_alloc_dca_backtest",
+  strategyKey: "dca",
+  status: "completed",
+  generatedAt: "2026-03-10T00:00:00.000Z",
+  venueKeys: ["jupiter"],
+  assetKeys: ["SOL", "USDC"],
+  codeRevision: {
+    vcs: "git",
+    repository: "github.com/GuiBibeau/serious-trader-ralph",
+    revision: "356b539e3ec730663c4025b8f00cd6b47b823d1a",
+    treeDirty: false,
+  },
+  datasetSnapshots: [
+    {
+      datasetId: "dataset_feature_cache_sol_usdc_market_events",
+      snapshotId: "snapshot_2026_03_07_backtest",
+      capturedAt: "2026-03-10T00:00:00.000Z",
+      uri: "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json#marketEvents",
+      contentDigest: "sha256:feature-cache",
+    },
+  ],
+  strategySpecDigest:
+    "sha256:1992048eb2efcd762981bd78d6ae7685c39873c4ccb8189681e2003ca8d84bff",
+  config: {
+    replayCorpusId: "replay_corpus_sol_usdc_feature_cache",
+    venueKey: "jupiter",
+    pairSymbol: "SOL/USDC",
+    marketType: "spot",
+    windowMode: "rolling",
+    trainingWindowObservations: 2,
+    testingWindowObservations: 1,
+    stepObservations: 1,
+    purgeObservations: 0,
+    baselineStrategies: ["flat_cash", "buy_and_hold"],
+  },
+  foldReports: [
+    {
+      foldId: "fold_0",
+      foldIndex: 0,
+      trainingStartAt: "2026-03-07T00:00:00Z",
+      trainingEndAt: "2026-03-07T00:00:10Z",
+      testStartAt: "2026-03-07T00:00:10Z",
+      testEndAt: "2026-03-07T00:00:15Z",
+      trainObservationCount: 2,
+      purgedObservationCount: 0,
+      testObservationCount: 1,
+      metrics: {
+        observationCount: 1,
+        tradeCount: 1,
+        grossReturnBps: "22.5384",
+        netReturnBps: "22.5384",
+        totalCostBps: "0.0000",
+        winRateBps: 10000,
+        maxDrawdownBps: "0.0000",
+      },
+      baselineComparisons: [
+        {
+          baseline: "flat_cash",
+          baselineReturnBps: "0.0000",
+          excessReturnBps: "22.5384",
+        },
+      ],
+      regimeMetrics: [
+        {
+          regimeKey: "short_trend",
+          regimeValue: "flat",
+          observationCount: 1,
+          tradeCount: 1,
+          netReturnBps: "22.5384",
+          winRateBps: 10000,
+        },
+      ],
+    },
+    {
+      foldId: "fold_1",
+      foldIndex: 1,
+      trainingStartAt: "2026-03-07T00:00:05Z",
+      trainingEndAt: "2026-03-07T00:00:15Z",
+      testStartAt: "2026-03-07T00:00:15Z",
+      testEndAt: "2026-03-07T00:00:20Z",
+      trainObservationCount: 2,
+      purgedObservationCount: 0,
+      testObservationCount: 1,
+      metrics: {
+        observationCount: 1,
+        tradeCount: 1,
+        grossReturnBps: "18.1150",
+        netReturnBps: "18.1150",
+        totalCostBps: "0.0000",
+        winRateBps: 10000,
+        maxDrawdownBps: "0.0000",
+      },
+      baselineComparisons: [
+        {
+          baseline: "flat_cash",
+          baselineReturnBps: "0.0000",
+          excessReturnBps: "18.1150",
+        },
+      ],
+      regimeMetrics: [
+        {
+          regimeKey: "short_trend",
+          regimeValue: "up",
+          observationCount: 1,
+          tradeCount: 1,
+          netReturnBps: "18.1150",
+          winRateBps: 10000,
+        },
+      ],
+    },
+  ],
+  aggregateMetrics: {
+    observationCount: 2,
+    tradeCount: 2,
+    grossReturnBps: "40.6534",
+    netReturnBps: "40.6534",
+    totalCostBps: "0.0000",
+    winRateBps: 10000,
+    maxDrawdownBps: "0.0000",
+  },
+  aggregateBaselineComparisons: [
+    {
+      baseline: "flat_cash",
+      baselineReturnBps: "0.0000",
+      excessReturnBps: "40.6534",
+    },
+  ],
+  aggregateRegimeMetrics: [
+    {
+      regimeKey: "short_trend",
+      regimeValue: "flat",
+      observationCount: 1,
+      tradeCount: 1,
+      netReturnBps: "22.5384",
+      winRateBps: 10000,
+    },
+    {
+      regimeKey: "short_trend",
+      regimeValue: "up",
+      observationCount: 1,
+      tradeCount: 1,
+      netReturnBps: "18.1150",
+      winRateBps: 10000,
+    },
+  ],
+  promotionEligible: true,
+  blockingReasons: [],
+  summary:
+    "Backtest cleared two walk-forward folds for dca with positive aggregate net return.",
+  tags: ["backtest", "paper"],
+};
+
 describe("worker runtime internal routes", () => {
   test("requires runtime service auth", async () => {
     const env = createWorkerLiveEnv();
@@ -467,6 +622,7 @@ describe("worker runtime internal routes", () => {
         health: "/api/internal/runtime/health",
         scorecards: "/api/internal/runtime/scorecards",
         allocator: "/api/internal/runtime/allocator",
+        backtests: "/api/internal/runtime/backtests",
         costModels: "/api/internal/runtime/cost-models",
       },
     });
@@ -901,6 +1057,79 @@ describe("worker runtime internal routes", () => {
       sourceMode: "shadow",
       targetMode: "paper",
       status: "pass",
+    });
+  });
+
+  test("returns stubbed runtime backtests", async () => {
+    const env = createWorkerLiveEnv();
+
+    const response = await worker.fetch(
+      new Request(
+        "http://localhost/api/internal/runtime/backtests?strategyKey=dca&promotionEligible=true",
+        {
+          headers: {
+            authorization: "Bearer runtime-service-secret",
+          },
+        },
+      ),
+      env,
+      createExecutionContextStub(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      source: "stub",
+      filters: {
+        strategyKey: "dca",
+        promotionEligible: "true",
+      },
+      reports: [
+        {
+          reportId: "backtest_alloc_dca_report",
+          strategyKey: "dca",
+          status: "completed",
+          promotionEligible: true,
+          config: {
+            marketType: "spot",
+            windowMode: "rolling",
+          },
+        },
+      ],
+    });
+  });
+
+  test("accepts runtime backtest reports through the private route family", async () => {
+    const env = createWorkerLiveEnv();
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/internal/runtime/backtests", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer runtime-service-secret",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(VALID_RUNTIME_BACKTEST_REPORT),
+      }),
+      env,
+      createExecutionContextStub(),
+    );
+
+    expect(response.status).toBe(201);
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      source: "stub",
+      created: true,
+      report: {
+        reportId: "backtest_alloc_dca_report",
+        strategyKey: "dca",
+        status: "completed",
+        promotionEligible: true,
+        config: {
+          replayCorpusId: "replay_corpus_sol_usdc_feature_cache",
+          marketType: "spot",
+        },
+      },
     });
   });
 


### PR DESCRIPTION
## Summary
- add a new `backtesting-engine` Rust crate with deterministic replay-backed walk-forward evaluation
- expose internal runtime backtest APIs and enforce passing backtest evidence before paper-or-later promotion bundles
- extend Worker/runtime contracts, fixtures, and tests for backtest reports and the new internal route family

## Validation
- `bun run contracts:runtime:schemas`
- `bun test tests/unit/runtime_protocol_contracts.test.ts tests/unit/runtime_protocol_schema_fixtures.test.ts tests/unit/worker_runtime_internal_routes.test.ts`
- `bun run lint`
- `bun run typecheck`
- `cargo test -p runtime-rs --lib`
- `cargo test --workspace`

## Proof
- backtest reports are reproducible from experiment, replay corpus, and strategy spec revisions
- promotion to `paper` or later now fails closed without a persisted promotion-eligible backtest report
- no portal/operator UI changes in this issue, so `bun run harness:proof` was not required

## Risk Notes
- the new evaluation path remains internal-only and non-executing
- the Worker remains the only public boundary; the added backtests route is service-authenticated under `/api/internal/runtime/*`
- market type stays explicit in the backtest contract so future venue extensions like perps can reuse the same evaluation surface

Fixes #314