### PR TITLE
[Phase 2] Build research scorecards, significance gates, and leaderboards

### DIFF
--- a/apps/portal/app/api/runtime/operator/route.ts
+++ b/apps/portal/app/api/runtime/operator/route.ts
@@ -199,6 +199,7 @@ function normalizeRuntimeSnapshot(payload: Record<string, unknown>) {
     deployments: parseDeployments(runtime.deployments),
     controls: normalizeControls(runtime.controls),
     canary: isRecord(runtime.canary) ? runtime.canary : null,
+    leaderboard: isRecord(runtime.leaderboard) ? runtime.leaderboard : null,
     error: readString(runtime.error),
   };
 }

--- a/apps/portal/app/proof/runtime/page.tsx
+++ b/apps/portal/app/proof/runtime/page.tsx
@@ -125,6 +125,23 @@ function buildPayload(selectedDeploymentId: string): RuntimeOperatorApiPayload {
           },
         ],
       },
+      leaderboard: {
+        generatedAt: FIXTURE_TIME,
+        entryCount: 1,
+        entries: [
+          {
+            candidateId: "trend_following::jupiter::SOL/USDC::spot",
+            strategyKey: "trend_following",
+            pairSymbol: "SOL/USDC",
+            netReturnBps: "11.1667",
+            flatCashExcessReturnBps: "11.1667",
+            significanceConfidenceBps: 9200,
+            promotionGateStatus: "pass",
+            summary:
+              "Trend following candidate cleared significance and robustness gates.",
+          },
+        ],
+      },
       error: null,
     },
     selectedDeploymentId: deployment.deploymentId,

--- a/apps/portal/app/terminal/runtime/runtime-operator-view.tsx
+++ b/apps/portal/app/terminal/runtime/runtime-operator-view.tsx
@@ -110,6 +110,77 @@ function renderCanarySummary(snapshot: RuntimeOperatorSnapshot | null) {
   );
 }
 
+function renderLeaderboard(snapshot: RuntimeOperatorSnapshot | null) {
+  const leaderboard = isRecord(snapshot?.leaderboard)
+    ? snapshot?.leaderboard
+    : {};
+  const entries = Array.isArray(leaderboard.entries) ? leaderboard.entries : [];
+  if (entries.length === 0) {
+    return (
+      <div className="rounded border border-dashed border-border p-4 text-sm text-muted">
+        Candidate leaderboard not available yet.
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-3">
+      {entries.slice(0, 5).map((entry, index) => {
+        const candidate = isRecord(entry) ? entry : {};
+        const strategyKey = readString(candidate.strategyKey) ?? "unknown";
+        const pairSymbol = readString(candidate.pairSymbol) ?? "n/a";
+        const significance =
+          readString(candidate.significanceConfidenceBps) ??
+          String(candidate.significanceConfidenceBps ?? "0");
+        const gateStatus =
+          readString(candidate.promotionGateStatus) ?? "candidate";
+        const candidateId =
+          readString(candidate.candidateId) ??
+          readString(candidate.reportId) ??
+          `${strategyKey}:${pairSymbol}`;
+        return (
+          <article
+            key={candidateId}
+            className="rounded border border-border bg-surface/80 p-4"
+          >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                  Candidate rank #{index + 1}
+                </p>
+                <h3 className="mt-2 text-sm font-medium text-ink">
+                  {strategyKey} · {pairSymbol}
+                </h3>
+              </div>
+              <span
+                className={`inline-flex rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.24em] ${statusClasses(
+                  gateStatus,
+                )}`}
+              >
+                {gateStatus.replaceAll("_", " ")}
+              </span>
+            </div>
+            <div className="mt-3 grid gap-3 sm:grid-cols-3">
+              {summaryItem(
+                "Net return",
+                `${readString(candidate.netReturnBps) ?? "0.0000"} bps`,
+              )}
+              {summaryItem("Significance", `${significance} bps`)}
+              {summaryItem(
+                "Flat-cash excess",
+                `${readString(candidate.flatCashExcessReturnBps) ?? "n/a"} bps`,
+              )}
+            </div>
+            <p className="mt-3 text-sm text-muted">
+              {readString(candidate.summary) ??
+                "No candidate summary available."}
+            </p>
+          </article>
+        );
+      })}
+    </div>
+  );
+}
+
 function renderRuns(detail: RuntimeOperatorDetail | null) {
   if (!detail || detail.runs.length === 0) {
     return (
@@ -235,10 +306,11 @@ function renderPositions(detail: RuntimeOperatorDetail | null) {
 
 function renderPromotion(detail: RuntimeOperatorDetail | null) {
   const report = isRecord(detail?.scorecard) ? detail?.scorecard : {};
+  const research = isRecord(report.research) ? report.research : null;
   const promotionGates = Array.isArray(report.promotionGates)
     ? report.promotionGates
     : [];
-  if (promotionGates.length === 0) {
+  if (!research && promotionGates.length === 0) {
     return (
       <div className="rounded border border-dashed border-border p-4 text-sm text-muted">
         Promotion evidence not available yet.
@@ -247,6 +319,50 @@ function renderPromotion(detail: RuntimeOperatorDetail | null) {
   }
   return (
     <div className="space-y-3">
+      {research ? (
+        <article className="rounded border border-border bg-surface/80 p-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                Research scorecard
+              </p>
+              <h3 className="mt-2 text-sm font-medium text-ink">
+                backtest {readString(research.backtestReportId) ?? "missing"}
+              </h3>
+            </div>
+            <span
+              className={`inline-flex rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.24em] ${statusClasses(
+                readBoolean(research.promotionEligible, false)
+                  ? "pass"
+                  : "blocked",
+              )}`}
+            >
+              {readBoolean(research.promotionEligible, false)
+                ? "eligible"
+                : "blocked"}
+            </span>
+          </div>
+          <div className="mt-3 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            {summaryItem(
+              "Net return",
+              `${readString(research.netReturnBps) ?? "0.0000"} bps`,
+            )}
+            {summaryItem(
+              "Significance",
+              `${readString(research.significanceConfidenceBps) ?? String(research.significanceConfidenceBps ?? "0")} bps`,
+            )}
+            {summaryItem(
+              "Flat-cash excess",
+              `${readString(research.flatCashExcessReturnBps) ?? "n/a"} bps`,
+            )}
+            {summaryItem(
+              "Weak regimes",
+              readString(research.weakRegimeCount) ??
+                String(research.weakRegimeCount ?? "0"),
+            )}
+          </div>
+        </article>
+      ) : null}
       {promotionGates.map((gate) => {
         const gateRecord = isRecord(gate) ? gate : {};
         const gateId = readString(gateRecord.gateId) ?? "promotion-gate";
@@ -567,6 +683,17 @@ export function RuntimeOperatorView({
         <div className="space-y-6">
           <section className="card p-4">{renderHealthSummary(runtime)}</section>
           <section className="card p-4">{renderCanarySummary(runtime)}</section>
+          <section className="card p-5">
+            <div className="mb-4">
+              <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                Candidate leaderboard
+              </p>
+              <h2 className="mt-2 text-lg font-semibold text-ink">
+                Ranked research candidates and promotion readiness
+              </h2>
+            </div>
+            {renderLeaderboard(runtime)}
+          </section>
 
           <section className="card p-5">
             <div className="flex flex-wrap items-start justify-between gap-4">

--- a/apps/portal/app/terminal/runtime/types.ts
+++ b/apps/portal/app/terminal/runtime/types.ts
@@ -21,6 +21,7 @@ export type RuntimeOperatorSnapshot = {
   deployments: RuntimeDeploymentRecord[];
   controls: RuntimeOperatorControls;
   canary: Record<string, unknown> | null;
+  leaderboard: Record<string, unknown> | null;
   error: string | null;
 };
 

--- a/apps/worker/src/runtime_internal.ts
+++ b/apps/worker/src/runtime_internal.ts
@@ -49,6 +49,7 @@ const INTERNAL_RUNTIME_DEPLOYMENTS_PREFIX = `${INTERNAL_RUNTIME_PREFIX}/deployme
 const INTERNAL_RUNTIME_RUNS_PREFIX = `${INTERNAL_RUNTIME_PREFIX}/runs/`;
 const INTERNAL_RUNTIME_EXECUTION_PLANS_PATH = `${INTERNAL_RUNTIME_PREFIX}/execution-plans`;
 const INTERNAL_RUNTIME_SCORECARDS_PATH = `${INTERNAL_RUNTIME_PREFIX}/scorecards`;
+const INTERNAL_RUNTIME_LEADERBOARDS_PATH = `${INTERNAL_RUNTIME_PREFIX}/leaderboards`;
 const INTERNAL_RUNTIME_ALLOCATOR_PATH = `${INTERNAL_RUNTIME_PREFIX}/allocator`;
 const INTERNAL_RUNTIME_RESEARCH_PATH = `${INTERNAL_RUNTIME_PREFIX}/research`;
 const INTERNAL_RUNTIME_RESEARCH_HYPOTHESES_PATH = `${INTERNAL_RUNTIME_RESEARCH_PATH}/hypotheses`;
@@ -89,6 +90,7 @@ export type RuntimeAdminSnapshot = {
   };
   health: Record<string, unknown> | null;
   deployments: RuntimeDeploymentRecord[];
+  leaderboard: Record<string, unknown> | null;
   error: string | null;
 };
 
@@ -384,6 +386,48 @@ function createRuntimeScorecardFixture(deploymentId: string) {
         zeroGrantCount: 0,
         fullGrantRateBps: 10000,
       },
+      research: {
+        backtestReportId: "backtest_trend_following_candidate",
+        backtestStatus: "completed",
+        promotionEligible: true,
+        foldCount: 3,
+        positiveFoldCount: 3,
+        positiveFoldRateBps: 10000,
+        baselineComparisonCount: 2,
+        baselinePassCount: 2,
+        baselineOutperformanceRateBps: 10000,
+        significanceConfidenceBps: 9200,
+        netReturnBps: "11.1667",
+        maxDrawdownBps: "4.5000",
+        flatCashExcessReturnBps: "11.1667",
+        buyAndHoldExcessReturnBps: "3.6667",
+        regimeCount: 2,
+        weakRegimeCount: 0,
+        regimeStabilityBps: 10000,
+        aggregateBaselineComparisons: [
+          {
+            baseline: "flat_cash",
+            baselineReturnBps: "0.0000",
+            excessReturnBps: "11.1667",
+          },
+          {
+            baseline: "buy_and_hold",
+            baselineReturnBps: "7.5000",
+            excessReturnBps: "3.6667",
+          },
+        ],
+        aggregateRegimeMetrics: [
+          {
+            regimeKey: "short_trend",
+            regimeValue: "positive",
+            observationCount: 12,
+            tradeCount: 4,
+            netReturnBps: "8.5000",
+            winRateBps: 7500,
+          },
+        ],
+        blockingReasons: [],
+      },
     },
     promotionGates: [
       {
@@ -421,6 +465,40 @@ function createRuntimeScorecardFixture(deploymentId: string) {
       },
     ],
     proofArtifactMarkdown: "## Runtime Promotion Readiness",
+  };
+}
+
+function createRuntimeLeaderboardFixture() {
+  return {
+    schemaVersion: RUNTIME_PROTOCOL_SCHEMA_VERSION,
+    generatedAt: FIXTURE_TIMESTAMP,
+    entryCount: 1,
+    entries: [
+      {
+        candidateId: "trend_following::jupiter::SOL/USDC::spot",
+        strategyKey: "trend_following",
+        venueKey: "jupiter",
+        pairSymbol: "SOL/USDC",
+        marketType: "spot",
+        reportId: "backtest_trend_following_candidate",
+        generatedAt: FIXTURE_TIMESTAMP,
+        deploymentId: "deployment_shadow_fixture",
+        deploymentMode: "shadow",
+        deploymentState: "shadow",
+        promotionEligible: true,
+        leaderboardScore: 17610,
+        positiveFoldRateBps: 10000,
+        significanceConfidenceBps: 9200,
+        weakRegimeCount: 0,
+        netReturnBps: "11.1667",
+        flatCashExcessReturnBps: "11.1667",
+        buyAndHoldExcessReturnBps: "3.6667",
+        promotionGateStatus: "pass",
+        blockingReasons: [],
+        summary:
+          "Trend following candidate cleared significance and robustness gates.",
+      },
+    ],
   };
 }
 
@@ -1339,6 +1417,7 @@ function buildRuntimeHealthPayload(env: Env, service: string) {
       positions: `${INTERNAL_RUNTIME_PREFIX}/positions`,
       pnl: `${INTERNAL_RUNTIME_PREFIX}/pnl`,
       scorecards: INTERNAL_RUNTIME_SCORECARDS_PATH,
+      leaderboards: INTERNAL_RUNTIME_LEADERBOARDS_PATH,
       allocator: INTERNAL_RUNTIME_ALLOCATOR_PATH,
       research: INTERNAL_RUNTIME_RESEARCH_PATH,
       assets: INTERNAL_RUNTIME_ASSETS_PATH,
@@ -1537,11 +1616,18 @@ export async function readRuntimeAdminSnapshot(
   env: Env,
 ): Promise<RuntimeAdminSnapshot> {
   const integration = buildRuntimeIntegration(env);
-  const healthResult = await dispatchRuntimeInternalJson({
-    env,
-    method: "GET",
-    pathname: INTERNAL_RUNTIME_HEALTH_PATH,
-  });
+  const [healthResult, leaderboardResult] = await Promise.all([
+    dispatchRuntimeInternalJson({
+      env,
+      method: "GET",
+      pathname: INTERNAL_RUNTIME_HEALTH_PATH,
+    }),
+    dispatchRuntimeInternalJson({
+      env,
+      method: "GET",
+      pathname: INTERNAL_RUNTIME_LEADERBOARDS_PATH,
+    }),
+  ]);
   if (!healthResult.ok) {
     return {
       ok: false,
@@ -1549,6 +1635,7 @@ export async function readRuntimeAdminSnapshot(
       integration,
       health: null,
       deployments: [],
+      leaderboard: null,
       error: runtimeErrorFromPayload(
         healthResult.payload,
         "runtime-health-unavailable",
@@ -1577,6 +1664,11 @@ export async function readRuntimeAdminSnapshot(
       integration,
       health,
       deployments: [],
+      leaderboard: isRecord(leaderboardResult.payload.leaderboard)
+        ? leaderboardResult.payload.leaderboard
+        : integration.stubModeEnabled
+          ? createRuntimeLeaderboardFixture()
+          : null,
       error: runtimeErrorFromPayload(
         deploymentsResult.payload,
         "runtime-deployments-unavailable",
@@ -1592,6 +1684,11 @@ export async function readRuntimeAdminSnapshot(
     deployments: parseRuntimeDeploymentList(
       deploymentsResult.payload.deployments,
     ),
+    leaderboard: isRecord(leaderboardResult.payload.leaderboard)
+      ? leaderboardResult.payload.leaderboard
+      : integration.stubModeEnabled
+        ? createRuntimeLeaderboardFixture()
+        : null,
     error: null,
   };
 }
@@ -1659,6 +1756,16 @@ export async function readRuntimeScorecard(
     pathname: `${INTERNAL_RUNTIME_SCORECARDS_PATH}?deploymentId=${encodeURIComponent(
       deploymentId,
     )}`,
+  });
+}
+
+export async function readRuntimeStrategyLeaderboard(
+  env: Env,
+): Promise<RuntimeInternalJsonResult> {
+  return await dispatchRuntimeInternalJson({
+    env,
+    method: "GET",
+    pathname: INTERNAL_RUNTIME_LEADERBOARDS_PATH,
   });
 }
 
@@ -2072,6 +2179,7 @@ export async function handleRuntimeInternalRoute(
     url.pathname === `${INTERNAL_RUNTIME_PREFIX}/positions` ||
     url.pathname === `${INTERNAL_RUNTIME_PREFIX}/pnl` ||
     url.pathname === INTERNAL_RUNTIME_SCORECARDS_PATH ||
+    url.pathname === INTERNAL_RUNTIME_LEADERBOARDS_PATH ||
     url.pathname === INTERNAL_RUNTIME_ALLOCATOR_PATH ||
     url.pathname === INTERNAL_RUNTIME_RESEARCH_PATH ||
     url.pathname === INTERNAL_RUNTIME_RESEARCH_HYPOTHESES_PATH ||
@@ -2442,6 +2550,17 @@ export async function handleRuntimeInternalRoute(
       source: "stub",
       deploymentId,
       report: createRuntimeScorecardFixture(deploymentId),
+    });
+  }
+
+  if (
+    request.method === "GET" &&
+    url.pathname === INTERNAL_RUNTIME_LEADERBOARDS_PATH
+  ) {
+    return json({
+      ok: true,
+      source: "stub",
+      leaderboard: createRuntimeLeaderboardFixture(),
     });
   }
 

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -544,6 +544,31 @@ pub struct RuntimeAllocatorScorecard {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub struct RuntimeResearchScorecard {
+    pub backtest_report_id: Option<String>,
+    pub backtest_status: Option<RuntimeBacktestStatus>,
+    pub promotion_eligible: bool,
+    pub fold_count: u32,
+    pub positive_fold_count: u32,
+    pub positive_fold_rate_bps: u16,
+    pub baseline_comparison_count: u32,
+    pub baseline_pass_count: u32,
+    pub baseline_outperformance_rate_bps: u16,
+    pub significance_confidence_bps: u16,
+    pub net_return_bps: String,
+    pub max_drawdown_bps: String,
+    pub flat_cash_excess_return_bps: Option<String>,
+    pub buy_and_hold_excess_return_bps: Option<String>,
+    pub regime_count: u32,
+    pub weak_regime_count: u32,
+    pub regime_stability_bps: u16,
+    pub aggregate_baseline_comparisons: Vec<RuntimeBacktestBaselineComparison>,
+    pub aggregate_regime_metrics: Vec<RuntimeBacktestRegimeMetrics>,
+    pub blocking_reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct RuntimeScorecard {
     pub trigger_quality: RuntimeTriggerQualityScorecard,
     pub plan_quality: RuntimePlanQualityScorecard,
@@ -553,6 +578,7 @@ pub struct RuntimeScorecard {
     pub cost: RuntimeCostScorecard,
     pub feature_catalog: RuntimeFeatureCatalogScorecard,
     pub allocator: RuntimeAllocatorScorecard,
+    pub research: RuntimeResearchScorecard,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -587,6 +613,41 @@ pub struct RuntimePromotionReadinessReport {
     pub scorecard: RuntimeScorecard,
     pub promotion_gates: Vec<RuntimePromotionGateDecision>,
     pub proof_artifact_markdown: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeStrategyLeaderboardEntry {
+    pub candidate_id: String,
+    pub strategy_key: String,
+    pub venue_key: String,
+    pub pair_symbol: String,
+    pub market_type: RuntimeVenueMarketType,
+    pub report_id: String,
+    pub generated_at: String,
+    pub deployment_id: Option<String>,
+    pub deployment_mode: Option<RuntimeMode>,
+    pub deployment_state: Option<RuntimeDeploymentState>,
+    pub promotion_eligible: bool,
+    pub leaderboard_score: i64,
+    pub positive_fold_rate_bps: u16,
+    pub significance_confidence_bps: u16,
+    pub weak_regime_count: u32,
+    pub net_return_bps: String,
+    pub flat_cash_excess_return_bps: Option<String>,
+    pub buy_and_hold_excess_return_bps: Option<String>,
+    pub promotion_gate_status: Option<RuntimePromotionGateStatus>,
+    pub blocking_reasons: Vec<String>,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeStrategyLeaderboard {
+    pub schema_version: String,
+    pub generated_at: String,
+    pub entry_count: u32,
+    pub entries: Vec<RuntimeStrategyLeaderboardEntry>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/runtime-scorecards/src/lib.rs
+++ b/crates/runtime-scorecards/src/lib.rs
@@ -1,17 +1,18 @@
 use std::collections::{BTreeSet, HashMap};
 
 use protocol::{
-    RuntimeAllocatorDecisionRecord, RuntimeAllocatorScorecard, RuntimeCostScorecard,
-    RuntimeDeploymentRecord, RuntimeDeploymentState, RuntimeExecutionCostModelRecord,
-    RuntimeExecutionCostModelStatus, RuntimeExecutionCostObservationRecord, RuntimeExecutionPlan,
-    RuntimeExpectedObservedScorecard, RuntimeFeatureCatalogScorecard,
-    RuntimeFeatureDefinitionRecord, RuntimeLedgerSnapshot, RuntimeMode,
-    RuntimePlanQualityScorecard, RuntimePnlScorecard, RuntimePromotionGateCheck,
+    RuntimeAllocatorDecisionRecord, RuntimeAllocatorScorecard, RuntimeBacktestBaseline,
+    RuntimeBacktestBaselineComparison, RuntimeBacktestReport, RuntimeBacktestStatus,
+    RuntimeCostScorecard, RuntimeDeploymentRecord, RuntimeDeploymentState,
+    RuntimeExecutionCostModelRecord, RuntimeExecutionCostModelStatus,
+    RuntimeExecutionCostObservationRecord, RuntimeExecutionPlan, RuntimeExpectedObservedScorecard,
+    RuntimeFeatureCatalogScorecard, RuntimeFeatureDefinitionRecord, RuntimeLedgerSnapshot,
+    RuntimeMode, RuntimePlanQualityScorecard, RuntimePnlScorecard, RuntimePromotionGateCheck,
     RuntimePromotionGateDecision, RuntimePromotionGateStatus, RuntimePromotionReadinessReport,
     RuntimeReconciliationResult, RuntimeReconciliationStatus, RuntimeRegimeTagRecord,
-    RuntimeRiskDecision, RuntimeRiskScorecard, RuntimeRiskVerdict, RuntimeRunRecord,
-    RuntimeRunState, RuntimeScorecard, RuntimeStrategySpec, RuntimeTriggerQualityScorecard,
-    RUNTIME_PROTOCOL_SCHEMA_VERSION,
+    RuntimeResearchScorecard, RuntimeRiskDecision, RuntimeRiskScorecard, RuntimeRiskVerdict,
+    RuntimeRunRecord, RuntimeRunState, RuntimeScorecard, RuntimeStrategySpec,
+    RuntimeTriggerQualityScorecard, RUNTIME_PROTOCOL_SCHEMA_VERSION,
 };
 use thiserror::Error;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
@@ -38,6 +39,12 @@ pub struct RuntimeScorecardConfig {
     pub paper_max_cost_drift_bps: u16,
     pub shadow_max_latency_drift_ms: u64,
     pub paper_max_latency_drift_ms: u64,
+    pub shadow_min_significance_confidence_bps: u16,
+    pub paper_min_significance_confidence_bps: u16,
+    pub shadow_max_backtest_drawdown_bps: i64,
+    pub paper_max_backtest_drawdown_bps: i64,
+    pub shadow_max_weak_regime_count: u32,
+    pub paper_max_weak_regime_count: u32,
 }
 
 impl Default for RuntimeScorecardConfig {
@@ -63,6 +70,12 @@ impl Default for RuntimeScorecardConfig {
             paper_max_cost_drift_bps: 75,
             shadow_max_latency_drift_ms: 15_000,
             paper_max_latency_drift_ms: 10_000,
+            shadow_min_significance_confidence_bps: 6_600,
+            paper_min_significance_confidence_bps: 7_500,
+            shadow_max_backtest_drawdown_bps: 750,
+            paper_max_backtest_drawdown_bps: 500,
+            shadow_max_weak_regime_count: 1,
+            paper_max_weak_regime_count: 0,
         }
     }
 }
@@ -71,6 +84,7 @@ impl Default for RuntimeScorecardConfig {
 pub struct RuntimeScorecardInput {
     pub deployment: RuntimeDeploymentRecord,
     pub strategy_spec: RuntimeStrategySpec,
+    pub backtest_report: Option<RuntimeBacktestReport>,
     pub runs: Vec<RuntimeRunRecord>,
     pub verdicts: Vec<RuntimeRiskVerdict>,
     pub plans: Vec<RuntimeExecutionPlan>,
@@ -90,6 +104,8 @@ pub struct RuntimeScorecardInput {
 pub enum RuntimeScorecardError {
     #[error("invalid usd amount for {field}: {value}")]
     InvalidUsdAmount { field: &'static str, value: String },
+    #[error("invalid numeric value for {field}: {value}")]
+    InvalidNumericValue { field: &'static str, value: String },
     #[error("invalid timestamp for {field}: {value}")]
     InvalidTimestamp { field: &'static str, value: String },
 }
@@ -322,6 +338,7 @@ fn build_scorecard(
     let max_drawdown_usd = format_usd_cents(max_drawdown_cents(input)?);
     let cost = build_cost_scorecard(input)?;
     let feature_catalog = build_feature_catalog_scorecard(input);
+    let research = build_research_scorecard(input)?;
 
     Ok(RuntimeScorecard {
         trigger_quality: RuntimeTriggerQualityScorecard {
@@ -386,6 +403,7 @@ fn build_scorecard(
             zero_grant_count: allocator_zero_grant_count,
             full_grant_rate_bps: ratio_bps(allocator_full_grant_count, allocator_decision_count),
         },
+        research,
     })
 }
 
@@ -623,13 +641,143 @@ fn build_feature_catalog_scorecard(
     }
 }
 
+fn build_research_scorecard(
+    input: &RuntimeScorecardInput,
+) -> Result<RuntimeResearchScorecard, RuntimeScorecardError> {
+    build_research_scorecard_from_backtest(input.backtest_report.as_ref())
+}
+
+pub fn build_research_scorecard_from_backtest(
+    report: Option<&RuntimeBacktestReport>,
+) -> Result<RuntimeResearchScorecard, RuntimeScorecardError> {
+    let Some(report) = report else {
+        return Ok(RuntimeResearchScorecard {
+            backtest_report_id: None,
+            backtest_status: None,
+            promotion_eligible: false,
+            fold_count: 0,
+            positive_fold_count: 0,
+            positive_fold_rate_bps: 0,
+            baseline_comparison_count: 0,
+            baseline_pass_count: 0,
+            baseline_outperformance_rate_bps: 0,
+            significance_confidence_bps: 0,
+            net_return_bps: "0.0000".to_string(),
+            max_drawdown_bps: "0.0000".to_string(),
+            flat_cash_excess_return_bps: None,
+            buy_and_hold_excess_return_bps: None,
+            regime_count: 0,
+            weak_regime_count: 0,
+            regime_stability_bps: 0,
+            aggregate_baseline_comparisons: Vec::new(),
+            aggregate_regime_metrics: Vec::new(),
+            blocking_reasons: Vec::new(),
+        });
+    };
+
+    let fold_count = report.fold_reports.len() as u32;
+    let positive_fold_count = report.fold_reports.iter().try_fold(0_u32, |count, fold| {
+        let net_return_bps =
+            parse_numeric_value("fold.metrics.netReturnBps", &fold.metrics.net_return_bps)?;
+        Ok::<u32, RuntimeScorecardError>(count + u32::from(net_return_bps > 0.0))
+    })?;
+    let positive_fold_rate_bps = ratio_bps(u64::from(positive_fold_count), u64::from(fold_count));
+    let baseline_pass_count =
+        report
+            .aggregate_baseline_comparisons
+            .iter()
+            .try_fold(0_u32, |count, comparison| {
+                let excess_return_bps = parse_numeric_value(
+                    "aggregateBaselineComparisons.excessReturnBps",
+                    &comparison.excess_return_bps,
+                )?;
+                Ok::<u32, RuntimeScorecardError>(count + u32::from(excess_return_bps > 0.0))
+            })?;
+    let baseline_comparison_count = report.aggregate_baseline_comparisons.len() as u32;
+    let baseline_outperformance_rate_bps = full_ratio_bps(
+        u64::from(baseline_pass_count),
+        u64::from(baseline_comparison_count),
+    );
+    let flat_cash_excess_return_bps = baseline_excess_return(
+        &report.aggregate_baseline_comparisons,
+        RuntimeBacktestBaseline::FlatCash,
+    );
+    let buy_and_hold_excess_return_bps = baseline_excess_return(
+        &report.aggregate_baseline_comparisons,
+        RuntimeBacktestBaseline::BuyAndHold,
+    );
+    let regime_count = report.aggregate_regime_metrics.len() as u32;
+    let weak_regime_count =
+        report
+            .aggregate_regime_metrics
+            .iter()
+            .try_fold(0_u32, |count, metric| {
+                let net_return_bps = parse_numeric_value(
+                    "aggregateRegimeMetrics.netReturnBps",
+                    &metric.net_return_bps,
+                )?;
+                Ok::<u32, RuntimeScorecardError>(count + u32::from(net_return_bps < 0.0))
+            })?;
+    let regime_stability_bps = full_ratio_bps(
+        u64::from(regime_count.saturating_sub(weak_regime_count)),
+        u64::from(regime_count),
+    );
+    let baseline_signal_bps = if flat_cash_excess_return_bps
+        .as_deref()
+        .and_then(|value| parse_numeric_value("flatCashExcessReturnBps", value).ok())
+        .is_some_and(|value| value > 0.0)
+    {
+        10_000
+    } else {
+        baseline_outperformance_rate_bps
+    };
+    let significance_confidence_bps = average_bps(&[
+        positive_fold_rate_bps,
+        baseline_signal_bps,
+        regime_stability_bps,
+    ]);
+
+    Ok(RuntimeResearchScorecard {
+        backtest_report_id: Some(report.report_id.clone()),
+        backtest_status: Some(report.status.clone()),
+        promotion_eligible: report.promotion_eligible,
+        fold_count,
+        positive_fold_count,
+        positive_fold_rate_bps,
+        baseline_comparison_count,
+        baseline_pass_count,
+        baseline_outperformance_rate_bps,
+        significance_confidence_bps,
+        net_return_bps: report.aggregate_metrics.net_return_bps.clone(),
+        max_drawdown_bps: report.aggregate_metrics.max_drawdown_bps.clone(),
+        flat_cash_excess_return_bps,
+        buy_and_hold_excess_return_bps,
+        regime_count,
+        weak_regime_count,
+        regime_stability_bps,
+        aggregate_baseline_comparisons: report.aggregate_baseline_comparisons.clone(),
+        aggregate_regime_metrics: report.aggregate_regime_metrics.clone(),
+        blocking_reasons: report.blocking_reasons.clone(),
+    })
+}
+
+fn baseline_excess_return(
+    comparisons: &[RuntimeBacktestBaselineComparison],
+    baseline: RuntimeBacktestBaseline,
+) -> Option<String> {
+    comparisons
+        .iter()
+        .find(|comparison| comparison.baseline == baseline)
+        .map(|comparison| comparison.excess_return_bps.clone())
+}
+
 fn build_promotion_gates(
     config: &RuntimeScorecardConfig,
     input: &RuntimeScorecardInput,
     scorecard: &RuntimeScorecard,
 ) -> Result<Vec<RuntimePromotionGateDecision>, RuntimeScorecardError> {
     Ok(vec![
-        shadow_to_paper_gate(config, input, scorecard),
+        shadow_to_paper_gate(config, input, scorecard)?,
         paper_to_live_gate(config, input, scorecard)?,
     ])
 }
@@ -638,16 +786,16 @@ fn shadow_to_paper_gate(
     config: &RuntimeScorecardConfig,
     input: &RuntimeScorecardInput,
     scorecard: &RuntimeScorecard,
-) -> RuntimePromotionGateDecision {
+) -> Result<RuntimePromotionGateDecision, RuntimeScorecardError> {
     if input.deployment.mode != RuntimeMode::Shadow {
-        return not_applicable_gate(
+        return Ok(not_applicable_gate(
             RuntimeMode::Shadow,
             RuntimeMode::Paper,
             "deployment-mode",
             input.deployment.mode.as_ref(),
             "shadow",
             "Shadow-to-paper promotion only applies to shadow deployments.",
-        );
+        ));
     }
 
     let mut checks = vec![
@@ -756,14 +904,19 @@ fn shadow_to_paper_gate(
             "Allocator zero-grant outcomes block promotion until sleeve coordination is stable.",
         ));
     }
+    checks.extend(optional_research_gate_checks(
+        config,
+        &scorecard.research,
+        RuntimeMode::Shadow,
+    )?);
 
-    gate_from_checks(
+    Ok(gate_from_checks(
         RuntimeMode::Shadow,
         RuntimeMode::Paper,
         true,
         checks,
         "Shadow promotion gate evaluation complete.",
-    )
+    ))
 }
 
 fn paper_to_live_gate(
@@ -920,6 +1073,11 @@ fn paper_to_live_gate(
             "Allocator zero-grant paper runs block bounded live promotion.",
         ));
     }
+    checks.extend(optional_research_gate_checks(
+        config,
+        &scorecard.research,
+        RuntimeMode::Paper,
+    )?);
 
     Ok(gate_from_checks(
         RuntimeMode::Paper,
@@ -973,6 +1131,87 @@ fn allocator_coordination_required(deployment: &RuntimeDeploymentRecord) -> bool
         deployment.state,
         RuntimeDeploymentState::Killed | RuntimeDeploymentState::Archived
     )
+}
+
+fn optional_research_gate_checks(
+    config: &RuntimeScorecardConfig,
+    research: &RuntimeResearchScorecard,
+    source_mode: RuntimeMode,
+) -> Result<Vec<RuntimePromotionGateCheck>, RuntimeScorecardError> {
+    let Some(status) = research.backtest_status.as_ref() else {
+        return Ok(Vec::new());
+    };
+    let min_significance_confidence_bps = match source_mode {
+        RuntimeMode::Shadow => config.shadow_min_significance_confidence_bps,
+        RuntimeMode::Paper | RuntimeMode::Live => config.paper_min_significance_confidence_bps,
+    };
+    let max_backtest_drawdown_bps = match source_mode {
+        RuntimeMode::Shadow => config.shadow_max_backtest_drawdown_bps,
+        RuntimeMode::Paper | RuntimeMode::Live => config.paper_max_backtest_drawdown_bps,
+    };
+    let max_weak_regime_count = match source_mode {
+        RuntimeMode::Shadow => config.shadow_max_weak_regime_count,
+        RuntimeMode::Paper | RuntimeMode::Live => config.paper_max_weak_regime_count,
+    };
+    let max_drawdown_bps =
+        parse_numeric_value("research.maxDrawdownBps", &research.max_drawdown_bps)?
+            .round()
+            .max(0.0) as i64;
+    let flat_cash_excess_positive = research
+        .flat_cash_excess_return_bps
+        .as_deref()
+        .map(|value| {
+            parse_numeric_value("research.flatCashExcessReturnBps", value)
+                .map(|parsed| parsed > 0.0)
+        })
+        .transpose()?
+        .unwrap_or(false);
+
+    let mode_prefix = source_mode.as_ref();
+    Ok(vec![
+        exact_match_check(
+            &format!("{mode_prefix}-research-backtest-status"),
+            *status == RuntimeBacktestStatus::Completed,
+            backtest_status_value(status),
+            "completed",
+            "Candidate backtest evidence must be completed before promotion.",
+        ),
+        exact_match_check(
+            &format!("{mode_prefix}-research-backtest-eligible"),
+            research.promotion_eligible,
+            if research.promotion_eligible { "true" } else { "false" },
+            "true",
+            "Candidate backtest evidence must clear the backtest promotion gates.",
+        ),
+        minimum_bps_check(
+            &format!("{mode_prefix}-research-significance-confidence"),
+            research.significance_confidence_bps,
+            min_significance_confidence_bps,
+            "Research significance confidence must remain above the configured promotion threshold.",
+        ),
+        exact_match_check(
+            &format!("{mode_prefix}-research-flat-cash-excess"),
+            flat_cash_excess_positive,
+            research
+                .flat_cash_excess_return_bps
+                .as_deref()
+                .unwrap_or("missing"),
+            "> 0.0000",
+            "Candidate backtests must outperform the flat-cash baseline before promotion.",
+        ),
+        maximum_check(
+            &format!("{mode_prefix}-research-max-drawdown-bps"),
+            u64::try_from(max_drawdown_bps).unwrap_or(u64::MAX),
+            u64::try_from(max_backtest_drawdown_bps).unwrap_or(u64::MAX),
+            "Candidate backtest drawdown must remain inside the configured risk budget.",
+        ),
+        maximum_check(
+            &format!("{mode_prefix}-research-weak-regimes"),
+            u64::from(research.weak_regime_count),
+            u64::from(max_weak_regime_count),
+            "Negative regime buckets must remain below the configured robustness threshold.",
+        ),
+    ])
 }
 
 fn gate_from_checks(
@@ -1230,6 +1469,26 @@ fn build_proof_artifact_markdown(
             .map(|value| format!(", slo {}ms", value))
             .unwrap_or_default(),
     ));
+    markdown.push_str(&format!(
+        "- Research: report `{}`, significance {}, positive folds {} / {} ({}), flat-cash excess {}, weak regimes {} / {} ({})\n",
+        scorecard
+            .research
+            .backtest_report_id
+            .as_deref()
+            .unwrap_or("missing"),
+        format_bps(scorecard.research.significance_confidence_bps),
+        scorecard.research.positive_fold_count,
+        scorecard.research.fold_count,
+        format_bps(scorecard.research.positive_fold_rate_bps),
+        scorecard
+            .research
+            .flat_cash_excess_return_bps
+            .as_deref()
+            .unwrap_or("missing"),
+        scorecard.research.weak_regime_count,
+        scorecard.research.regime_count,
+        format_bps(scorecard.research.regime_stability_bps),
+    ));
     markdown.push_str("\n### Promotion Gates\n");
     for gate in promotion_gates {
         markdown.push_str(&format!(
@@ -1473,6 +1732,22 @@ fn parse_usd_cents(field: &'static str, value: &str) -> Result<i64, RuntimeScore
     Ok(if negative { -cents } else { cents })
 }
 
+fn parse_numeric_value(field: &'static str, value: &str) -> Result<f64, RuntimeScorecardError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(RuntimeScorecardError::InvalidNumericValue {
+            field,
+            value: value.to_string(),
+        });
+    }
+    trimmed
+        .parse::<f64>()
+        .map_err(|_| RuntimeScorecardError::InvalidNumericValue {
+            field,
+            value: value.to_string(),
+        })
+}
+
 fn format_usd_cents(cents: i64) -> String {
     let sign = if cents < 0 { "-" } else { "" };
     let absolute = cents.unsigned_abs();
@@ -1481,6 +1756,22 @@ fn format_usd_cents(cents: i64) -> String {
 
 fn format_bps(value: u16) -> String {
     format!("{value}bps")
+}
+
+fn average_bps(values: &[u16]) -> u16 {
+    if values.is_empty() {
+        return 0;
+    }
+    let total = values.iter().map(|value| u64::from(*value)).sum::<u64>();
+    (total / values.len() as u64) as u16
+}
+
+fn backtest_status_value(status: &RuntimeBacktestStatus) -> &'static str {
+    match status {
+        RuntimeBacktestStatus::Completed => "completed",
+        RuntimeBacktestStatus::Blocked => "blocked",
+        RuntimeBacktestStatus::Failed => "failed",
+    }
 }
 
 fn now_rfc3339() -> String {
@@ -1612,6 +1903,7 @@ mod tests {
             &RuntimeScorecardInput {
                 deployment: deployment.clone(),
                 strategy_spec: strategy_spec(&deployment),
+                backtest_report: Some(backtest_report(&deployment, true)),
                 runs: runs.clone(),
                 verdicts,
                 plans: plans.clone(),
@@ -1709,6 +2001,7 @@ mod tests {
             &RuntimeScorecardInput {
                 deployment: deployment.clone(),
                 strategy_spec: strategy_spec(&deployment),
+                backtest_report: Some(backtest_report(&deployment, true)),
                 runs: runs.clone(),
                 verdicts,
                 plans: plans.clone(),
@@ -1776,6 +2069,7 @@ mod tests {
             &RuntimeScorecardInput {
                 deployment: deployment.clone(),
                 strategy_spec: strategy_spec(&deployment),
+                backtest_report: Some(backtest_report(&deployment, true)),
                 runs,
                 verdicts,
                 plans,
@@ -1875,6 +2169,7 @@ mod tests {
             &RuntimeScorecardInput {
                 deployment: deployment.clone(),
                 strategy_spec: strategy_spec(&deployment),
+                backtest_report: Some(backtest_report(&deployment, true)),
                 runs: runs.clone(),
                 verdicts,
                 plans: plans.clone(),
@@ -1966,6 +2261,7 @@ mod tests {
             &RuntimeScorecardInput {
                 deployment: deployment.clone(),
                 strategy_spec: strategy_spec(&deployment),
+                backtest_report: Some(backtest_report(&deployment, true)),
                 runs: runs.clone(),
                 verdicts,
                 plans: plans.clone(),
@@ -2054,6 +2350,7 @@ mod tests {
             &RuntimeScorecardInput {
                 deployment: deployment.clone(),
                 strategy_spec: strategy_spec(&deployment),
+                backtest_report: Some(backtest_report(&deployment, true)),
                 runs: runs.clone(),
                 verdicts,
                 plans: plans.clone(),
@@ -2136,6 +2433,7 @@ mod tests {
             &RuntimeScorecardInput {
                 deployment: deployment.clone(),
                 strategy_spec: strategy_spec(&deployment),
+                backtest_report: Some(backtest_report(&deployment, true)),
                 runs: runs.clone(),
                 verdicts,
                 plans: plans.clone(),
@@ -2224,6 +2522,7 @@ mod tests {
             &RuntimeScorecardInput {
                 deployment: deployment.clone(),
                 strategy_spec: strategy_spec(&deployment),
+                backtest_report: Some(backtest_report(&deployment, true)),
                 runs: runs.clone(),
                 verdicts,
                 plans: plans.clone(),
@@ -2306,6 +2605,7 @@ mod tests {
             &RuntimeScorecardInput {
                 deployment: deployment.clone(),
                 strategy_spec: strategy_spec(&deployment),
+                backtest_report: Some(backtest_report(&deployment, true)),
                 runs: runs.clone(),
                 verdicts,
                 plans: plans.clone(),
@@ -2334,6 +2634,80 @@ mod tests {
             .iter()
             .any(|check| check.gate_id == "paper-allocator-constrained-runs"
                 && check.status == RuntimePromotionGateStatus::Blocked));
+    }
+
+    #[test]
+    fn blocks_research_backed_live_promotion_when_backtest_confidence_is_weak() {
+        let deployment = deployment(
+            "deployment_research_weak_paper",
+            RuntimeMode::Paper,
+            RuntimeDeploymentState::Paper,
+        );
+        let runs = (1..=5)
+            .map(|index| {
+                run(
+                    &format!("run_research_weak_{index}"),
+                    RuntimeRunState::Completed,
+                    trigger("operator"),
+                )
+            })
+            .collect::<Vec<_>>();
+        let verdicts = runs
+            .iter()
+            .map(|run| allow_verdict(&deployment, run))
+            .collect::<Vec<_>>();
+        let plans = runs
+            .iter()
+            .map(|run| plan(&deployment, run, true, false))
+            .collect::<Vec<_>>();
+        let reconciliations = runs
+            .iter()
+            .map(|run| reconciliation(&deployment, run, RuntimeReconciliationStatus::Passed, false))
+            .collect::<Vec<_>>();
+        let snapshots = vec![ledger_snapshot(
+            &deployment,
+            "1000.00",
+            "5.00",
+            "995.00",
+            "1.00",
+            "0.00",
+            "2026-03-08T10:00:00Z",
+        )];
+
+        let report = build_readiness_report(
+            &RuntimeScorecardConfig::default(),
+            &RuntimeScorecardInput {
+                deployment: deployment.clone(),
+                strategy_spec: strategy_spec(&deployment),
+                backtest_report: Some(backtest_report(&deployment, false)),
+                runs: runs.clone(),
+                verdicts,
+                plans: plans.clone(),
+                cost_model: Some(cost_model(&deployment)),
+                cost_observations: cost_observations(&deployment, &runs, &plans, &reconciliations),
+                feature_definitions: feature_definitions(&deployment),
+                regime_tags: regime_tags(&deployment),
+                allocator_decisions: vec![],
+                submit_attempt_count: 5,
+                receipt_count: 5,
+                reconciliations,
+                observed_ledger_snapshots: snapshots.clone(),
+                latest_ledger_snapshot: snapshots.last().cloned(),
+            },
+        )
+        .expect("report to build");
+
+        assert_eq!(
+            report.promotion_gates[1].status,
+            RuntimePromotionGateStatus::Blocked
+        );
+        assert!(report.promotion_gates[1]
+            .checks
+            .iter()
+            .any(|check| check.gate_id == "paper-research-backtest-eligible"
+                && check.status == RuntimePromotionGateStatus::Blocked));
+        assert!(report.scorecard.research.significance_confidence_bps < 7_500);
+        assert_eq!(report.scorecard.research.weak_regime_count, 1);
     }
 
     fn deployment(
@@ -2625,6 +2999,180 @@ mod tests {
                 .expect("cost observation to build")
             })
             .collect()
+    }
+
+    fn backtest_report(
+        deployment: &RuntimeDeploymentRecord,
+        promotion_eligible: bool,
+    ) -> protocol::RuntimeBacktestReport {
+        protocol::RuntimeBacktestReport {
+            schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+            report_id: format!("backtest_{}", deployment.deployment_id),
+            experiment_id: format!("experiment_{}", deployment.strategy_key),
+            strategy_key: deployment.strategy_key.clone(),
+            status: if promotion_eligible {
+                protocol::RuntimeBacktestStatus::Completed
+            } else {
+                protocol::RuntimeBacktestStatus::Blocked
+            },
+            generated_at: "2026-03-10T00:00:00.000Z".to_string(),
+            venue_keys: vec![deployment.venue_key.clone()],
+            asset_keys: vec!["SOL".to_string(), "USDC".to_string()],
+            code_revision: protocol::RuntimeCodeRevisionRef {
+                vcs: "git".to_string(),
+                repository: "github.com/GuiBibeau/serious-trader-ralph".to_string(),
+                revision: "f8168f48f0f484917f866c88b9ce4f89a055fa31".to_string(),
+                compared_to: None,
+                tree_dirty: false,
+            },
+            dataset_snapshots: vec![protocol::RuntimeDatasetSnapshotRef {
+                dataset_id: "dataset_feed_replay_sol_usdc_market_events".to_string(),
+                snapshot_id: "snapshot_2026_03_07_seed".to_string(),
+                captured_at: "2026-03-10T00:00:00.000Z".to_string(),
+                uri: Some(
+                    "repo://services/runtime-rs/fixtures/runtime-feed-replay.sol_usdc.v1.json#marketEvents"
+                        .to_string(),
+                ),
+                content_digest: Some("sha256:fixture".to_string()),
+            }],
+            strategy_spec_digest: format!("digest_{}", deployment.strategy_key),
+            config: protocol::RuntimeBacktestConfig {
+                replay_corpus_id: "replay_corpus_sol_usdc_feed_gateway_seed".to_string(),
+                venue_key: deployment.venue_key.clone(),
+                pair_symbol: deployment.pair.symbol.clone(),
+                market_type: RuntimeVenueMarketType::Spot,
+                window_mode: protocol::RuntimeBacktestWindowMode::Rolling,
+                training_window_observations: 24,
+                testing_window_observations: 8,
+                step_observations: 4,
+                purge_observations: 2,
+                baseline_strategies: vec![
+                    protocol::RuntimeBacktestBaseline::FlatCash,
+                    protocol::RuntimeBacktestBaseline::BuyAndHold,
+                ],
+            },
+            fold_reports: vec![
+                fold_report("fold_0", 0, "12.5000", "4.0000", 8_000),
+                fold_report("fold_1", 1, "11.7500", "4.5000", 7_500),
+                fold_report("fold_2", 2, "9.2500", "5.0000", 7_000),
+            ],
+            aggregate_metrics: protocol::RuntimeBacktestMetrics {
+                observation_count: 24,
+                trade_count: 7,
+                gross_return_bps: "15.7500".to_string(),
+                net_return_bps: if promotion_eligible {
+                    "11.1667".to_string()
+                } else {
+                    "-2.2500".to_string()
+                },
+                total_cost_bps: "4.5833".to_string(),
+                win_rate_bps: 7_500,
+                max_drawdown_bps: if promotion_eligible {
+                    "4.5000".to_string()
+                } else {
+                    "12.0000".to_string()
+                },
+            },
+            aggregate_baseline_comparisons: vec![
+                protocol::RuntimeBacktestBaselineComparison {
+                    baseline: protocol::RuntimeBacktestBaseline::FlatCash,
+                    baseline_return_bps: "0.0000".to_string(),
+                    excess_return_bps: if promotion_eligible {
+                        "11.1667".to_string()
+                    } else {
+                        "-2.2500".to_string()
+                    },
+                },
+                protocol::RuntimeBacktestBaselineComparison {
+                    baseline: protocol::RuntimeBacktestBaseline::BuyAndHold,
+                    baseline_return_bps: "7.5000".to_string(),
+                    excess_return_bps: if promotion_eligible {
+                        "3.6667".to_string()
+                    } else {
+                        "-9.7500".to_string()
+                    },
+                },
+            ],
+            aggregate_regime_metrics: vec![
+                protocol::RuntimeBacktestRegimeMetrics {
+                    regime_key: "short_trend".to_string(),
+                    regime_value: "positive".to_string(),
+                    observation_count: 12,
+                    trade_count: 4,
+                    net_return_bps: "8.5000".to_string(),
+                    win_rate_bps: 7_500,
+                },
+                protocol::RuntimeBacktestRegimeMetrics {
+                    regime_key: "volatility_band".to_string(),
+                    regime_value: "medium".to_string(),
+                    observation_count: 12,
+                    trade_count: 3,
+                    net_return_bps: if promotion_eligible {
+                        "2.6667".to_string()
+                    } else {
+                        "-4.2500".to_string()
+                    },
+                    win_rate_bps: if promotion_eligible { 6_666 } else { 4_000 },
+                },
+            ],
+            promotion_eligible,
+            blocking_reasons: if promotion_eligible {
+                Vec::new()
+            } else {
+                vec![
+                    "aggregate out-of-sample net return must be positive".to_string(),
+                    "aggregate return must exceed flat-cash baseline".to_string(),
+                ]
+            },
+            summary: if promotion_eligible {
+                "Backtest cleared the shadow candidate threshold.".to_string()
+            } else {
+                "Backtest blocked on negative out-of-sample returns.".to_string()
+            },
+            tags: vec!["backtest".to_string(), "candidate".to_string()],
+        }
+    }
+
+    fn fold_report(
+        fold_id: &str,
+        fold_index: u32,
+        net_return_bps: &str,
+        max_drawdown_bps: &str,
+        win_rate_bps: u16,
+    ) -> protocol::RuntimeBacktestFoldReport {
+        protocol::RuntimeBacktestFoldReport {
+            fold_id: fold_id.to_string(),
+            fold_index,
+            training_start_at: "2026-03-01T00:00:00.000Z".to_string(),
+            training_end_at: "2026-03-05T00:00:00.000Z".to_string(),
+            test_start_at: "2026-03-05T00:00:00.000Z".to_string(),
+            test_end_at: "2026-03-06T00:00:00.000Z".to_string(),
+            train_observation_count: 24,
+            purged_observation_count: 2,
+            test_observation_count: 8,
+            metrics: protocol::RuntimeBacktestMetrics {
+                observation_count: 8,
+                trade_count: 2,
+                gross_return_bps: net_return_bps.to_string(),
+                net_return_bps: net_return_bps.to_string(),
+                total_cost_bps: "1.5000".to_string(),
+                win_rate_bps,
+                max_drawdown_bps: max_drawdown_bps.to_string(),
+            },
+            baseline_comparisons: vec![protocol::RuntimeBacktestBaselineComparison {
+                baseline: protocol::RuntimeBacktestBaseline::FlatCash,
+                baseline_return_bps: "0.0000".to_string(),
+                excess_return_bps: net_return_bps.to_string(),
+            }],
+            regime_metrics: vec![protocol::RuntimeBacktestRegimeMetrics {
+                regime_key: "short_trend".to_string(),
+                regime_value: "positive".to_string(),
+                observation_count: 8,
+                trade_count: 2,
+                net_return_bps: net_return_bps.to_string(),
+                win_rate_bps,
+            }],
+        }
     }
 
     fn strategy_spec(deployment: &RuntimeDeploymentRecord) -> RuntimeStrategySpec {

--- a/docs/generated/runtime-api.md
+++ b/docs/generated/runtime-api.md
@@ -15,6 +15,7 @@ so Worker and runtime-rs do not invent separate shapes.
 | `GET /api/internal/runtime/positions` | `RuntimeLedgerSnapshot` |
 | `GET /api/internal/runtime/pnl` | `RuntimeLedgerSnapshot.totals` projection |
 | `GET /api/internal/runtime/scorecards` | `RuntimePromotionReadinessReport` |
+| `GET /api/internal/runtime/leaderboards` | `RuntimeStrategyLeaderboard` |
 | execution coordination payloads | `RuntimeRiskVerdict`, `RuntimeExecutionPlan`, `RuntimeReconciliationResult` |
 
 ## Artifact locations

--- a/services/runtime-rs/README.md
+++ b/services/runtime-rs/README.md
@@ -170,7 +170,14 @@ Route surface:
 - `GET /api/internal/runtime/positions?deploymentId=:deploymentId`
 - `GET /api/internal/runtime/pnl?deploymentId=:deploymentId`
 - `GET /api/internal/runtime/scorecards?deploymentId=:deploymentId`
+- `GET /api/internal/runtime/leaderboards`
 - `GET /api/internal/runtime/allocator?deploymentId=:deploymentId`
+
+Scorecards now include the latest linked backtest evidence, significance and
+regime-stability metrics, and optional research-backed promotion gate checks.
+The leaderboard route ranks candidate strategies from the same research
+scorecard signals plus deployment readiness when a candidate already has a
+runtime deployment.
 
 Example shadow evaluation flow:
 

--- a/services/runtime-rs/src/lib.rs
+++ b/services/runtime-rs/src/lib.rs
@@ -1,6 +1,9 @@
 mod paper_execution;
 
-use std::sync::{Arc, RwLock};
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, RwLock},
+};
 
 use asset_registry::{
     AssetRegistry, AssetRegistryConfig, AssetRegistryError, AssetRegistryQuery,
@@ -43,15 +46,17 @@ use portfolio_ledger::{
     PortfolioLedger, PortfolioLedgerConfig, PortfolioLedgerError, PortfolioLedgerSnapshot,
 };
 use protocol::{
-    RuntimeAssetListingState, RuntimeAssetRecord, RuntimeBacktestBaseline,
+    RuntimeAssetListingState, RuntimeAssetRecord, RuntimeBacktestBaseline, RuntimeBacktestReport,
     RuntimeBacktestWindowMode, RuntimeDeploymentRecord, RuntimeDeploymentState,
     RuntimeExecutionCostModelRecord, RuntimeExecutionCostModelStatus,
     RuntimeExecutionCostObservationRecord, RuntimeFeatureCatalogStatus,
     RuntimeFeatureDefinitionRecord, RuntimeHistoricalDatasetKind,
-    RuntimeHistoricalDatasetSnapshotRecord, RuntimeMode, RuntimeRegimeTagRecord,
-    RuntimeReplayCorpusRecord, RuntimeResearchEvidenceBundleRecord,
-    RuntimeResearchExperimentRecord, RuntimeResearchHypothesisRecord, RuntimeResearchSourceRecord,
-    RuntimeRunRecord, RuntimeVenueMarketType,
+    RuntimeHistoricalDatasetSnapshotRecord, RuntimeMode, RuntimePromotionGateStatus,
+    RuntimePromotionReadinessReport, RuntimeRegimeTagRecord, RuntimeReplayCorpusRecord,
+    RuntimeResearchEvidenceBundleRecord, RuntimeResearchExperimentRecord,
+    RuntimeResearchHypothesisRecord, RuntimeResearchSourceRecord, RuntimeRunRecord,
+    RuntimeStrategyLeaderboard, RuntimeStrategyLeaderboardEntry, RuntimeVenueMarketType,
+    RUNTIME_PROTOCOL_SCHEMA_VERSION,
 };
 use reconciler::{Reconciler, ReconcilerConfig, ReconcilerError, ReconcilerSnapshot};
 use research_registry::{
@@ -67,8 +72,9 @@ use runtime_allocator::{
 };
 use runtime_ops::{health_snapshot, RuntimeConfig};
 use runtime_scorecards::{
-    build_cost_observation, build_readiness_report, RuntimeCostObservationInput,
-    RuntimeScorecardConfig, RuntimeScorecardError, RuntimeScorecardInput,
+    build_cost_observation, build_readiness_report, build_research_scorecard_from_backtest,
+    RuntimeCostObservationInput, RuntimeScorecardConfig, RuntimeScorecardError,
+    RuntimeScorecardInput,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -380,6 +386,15 @@ struct RuntimeBacktestQueryParams {
     pub promotion_eligible: Option<bool>,
 }
 
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct RuntimeStrategyLeaderboardQueryParams {
+    pub strategy_key: Option<String>,
+    pub venue_key: Option<String>,
+    pub market_type: Option<RuntimeVenueMarketType>,
+    pub limit: Option<usize>,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 struct RuntimeBacktestRunRequestPayload {
@@ -490,6 +505,10 @@ pub fn app(config: RuntimeConfig) -> Router {
         .route(
             &format!("{INTERNAL_RUNTIME_PREFIX}/scorecards"),
             get(scorecards_handler),
+        )
+        .route(
+            &format!("{INTERNAL_RUNTIME_PREFIX}/leaderboards"),
+            get(strategy_leaderboards_handler),
         )
         .route(
             &format!("{INTERNAL_RUNTIME_PREFIX}/allocator"),
@@ -1251,24 +1270,11 @@ async fn reconciliations_handler(
     ))
 }
 
-async fn scorecards_handler(
-    headers: HeaderMap,
-    Query(query): Query<RuntimeDeploymentQuery>,
-    State(state): State<RuntimeAppState>,
-) -> HandlerResult {
-    authorize_internal_request(&headers, &state)?;
-    let deployment_id = require_deployment_id(query)?;
-    let deployment = state
-        .strategy_registry
-        .get_deployment(&deployment_id)
-        .map_err(map_registry_error)?
-        .ok_or_else(|| {
-            error_json(
-                StatusCode::NOT_FOUND,
-                "deployment-not-found",
-                json!({ "deploymentId": deployment_id }),
-            )
-        })?;
+fn build_runtime_scorecard_report(
+    state: &RuntimeAppState,
+    deployment: RuntimeDeploymentRecord,
+) -> Result<RuntimePromotionReadinessReport, JsonPayload> {
+    let deployment_id = deployment.deployment_id.clone();
     let runs = state
         .strategy_registry
         .list_runs(&deployment_id)
@@ -1320,11 +1326,21 @@ async fn scorecards_handler(
             ..CostObservationQuery::default()
         })
         .map_err(map_cost_model_registry_error)?;
-    let report = build_readiness_report(
+    let backtest_report = latest_relevant_backtest_report(
+        state,
+        &deployment.strategy_key,
+        &deployment.venue_key,
+        &deployment.pair.symbol,
+        &deployment.pair.market_type,
+    )
+    .map_err(map_backtesting_engine_error)?;
+
+    build_readiness_report(
         &RuntimeScorecardConfig::default(),
         &RuntimeScorecardInput {
             deployment,
             strategy_spec,
+            backtest_report,
             runs,
             verdicts,
             plans,
@@ -1344,7 +1360,46 @@ async fn scorecards_handler(
             latest_ledger_snapshot: Some(latest_ledger_snapshot),
         },
     )
-    .map_err(map_scorecard_error)?;
+    .map_err(map_scorecard_error)
+}
+
+fn latest_relevant_backtest_report(
+    state: &RuntimeAppState,
+    strategy_key: &str,
+    venue_key: &str,
+    pair_symbol: &str,
+    market_type: &RuntimeVenueMarketType,
+) -> Result<Option<RuntimeBacktestReport>, BacktestingEngineError> {
+    let reports = state.backtesting_engine.query(&BacktestingQuery {
+        strategy_key: Some(strategy_key.to_string()),
+        ..BacktestingQuery::default()
+    })?;
+    Ok(reports.into_iter().find(|report| {
+        report.config.venue_key == venue_key
+            && report.config.pair_symbol == pair_symbol
+            && report.config.market_type == *market_type
+    }))
+}
+
+async fn scorecards_handler(
+    headers: HeaderMap,
+    Query(query): Query<RuntimeDeploymentQuery>,
+    State(state): State<RuntimeAppState>,
+) -> HandlerResult {
+    authorize_internal_request(&headers, &state)?;
+    let deployment_id = require_deployment_id(query)?;
+    let deployment = state
+        .strategy_registry
+        .get_deployment(&deployment_id)
+        .map_err(map_registry_error)?
+        .ok_or_else(|| {
+            error_json(
+                StatusCode::NOT_FOUND,
+                "deployment-not-found",
+                json!({ "deploymentId": deployment_id }),
+            )
+        })?;
+    let report = build_runtime_scorecard_report(&state, deployment)?;
     Ok(OkJson::with_status(
         StatusCode::OK,
         json!({
@@ -1354,6 +1409,223 @@ async fn scorecards_handler(
             "report": report,
         }),
     ))
+}
+
+async fn strategy_leaderboards_handler(
+    headers: HeaderMap,
+    Query(query): Query<RuntimeStrategyLeaderboardQueryParams>,
+    State(state): State<RuntimeAppState>,
+) -> HandlerResult {
+    authorize_internal_request(&headers, &state)?;
+    let reports = state
+        .backtesting_engine
+        .query(&BacktestingQuery {
+            strategy_key: query
+                .strategy_key
+                .clone()
+                .filter(|value| !value.trim().is_empty()),
+            ..BacktestingQuery::default()
+        })
+        .map_err(map_backtesting_engine_error)?;
+    let mut deployments = state
+        .strategy_registry
+        .list_deployments()
+        .map_err(map_registry_error)?;
+    deployments.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
+
+    let mut latest_reports = BTreeMap::<String, RuntimeBacktestReport>::new();
+    for report in reports {
+        if query
+            .venue_key
+            .as_ref()
+            .is_some_and(|venue_key| report.config.venue_key != *venue_key)
+        {
+            continue;
+        }
+        if query
+            .market_type
+            .as_ref()
+            .is_some_and(|market_type| report.config.market_type != *market_type)
+        {
+            continue;
+        }
+        latest_reports
+            .entry(candidate_key(
+                &report.strategy_key,
+                &report.config.venue_key,
+                &report.config.pair_symbol,
+                &report.config.market_type,
+            ))
+            .or_insert(report);
+    }
+
+    let deployment_by_candidate = deployments
+        .into_iter()
+        .filter(|deployment| {
+            query
+                .venue_key
+                .as_ref()
+                .is_none_or(|venue_key| deployment.venue_key == *venue_key)
+                && query
+                    .market_type
+                    .as_ref()
+                    .is_none_or(|market_type| deployment.pair.market_type == *market_type)
+                && query
+                    .strategy_key
+                    .as_ref()
+                    .is_none_or(|strategy_key| deployment.strategy_key == *strategy_key)
+        })
+        .fold(
+            BTreeMap::<String, RuntimeDeploymentRecord>::new(),
+            |mut map, deployment| {
+                map.entry(candidate_key(
+                    &deployment.strategy_key,
+                    &deployment.venue_key,
+                    &deployment.pair.symbol,
+                    &deployment.pair.market_type,
+                ))
+                .or_insert(deployment);
+                map
+            },
+        );
+
+    let mut entries = latest_reports
+        .into_iter()
+        .map(|(candidate_id, report)| {
+            let deployment = deployment_by_candidate.get(&candidate_id).cloned();
+            build_strategy_leaderboard_entry(&state, candidate_id, report, deployment)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    entries.sort_by(|left, right| {
+        right
+            .leaderboard_score
+            .cmp(&left.leaderboard_score)
+            .then(
+                right
+                    .significance_confidence_bps
+                    .cmp(&left.significance_confidence_bps),
+            )
+            .then(right.generated_at.cmp(&left.generated_at))
+    });
+    if let Some(limit) = query.limit {
+        entries.truncate(limit);
+    }
+    let leaderboard = RuntimeStrategyLeaderboard {
+        schema_version: RUNTIME_PROTOCOL_SCHEMA_VERSION.to_string(),
+        generated_at: OffsetDateTime::now_utc()
+            .format(&time::format_description::well_known::Rfc3339)
+            .expect("leaderboard timestamp"),
+        entry_count: entries.len() as u32,
+        entries,
+    };
+    Ok(OkJson::with_status(
+        StatusCode::OK,
+        json!({
+            "ok": true,
+            "source": "runtime-rs",
+            "filters": query,
+            "leaderboard": leaderboard,
+        }),
+    ))
+}
+
+fn build_strategy_leaderboard_entry(
+    state: &RuntimeAppState,
+    candidate_id: String,
+    report: RuntimeBacktestReport,
+    deployment: Option<RuntimeDeploymentRecord>,
+) -> Result<RuntimeStrategyLeaderboardEntry, JsonPayload> {
+    let research =
+        build_research_scorecard_from_backtest(Some(&report)).map_err(map_scorecard_error)?;
+    let readiness = deployment
+        .clone()
+        .map(|deployment_record| build_runtime_scorecard_report(state, deployment_record))
+        .transpose()?;
+    let promotion_gate_status = readiness.as_ref().and_then(|readiness_report| {
+        readiness_report
+            .promotion_gates
+            .iter()
+            .find(|gate| gate.status != RuntimePromotionGateStatus::NotApplicable)
+            .map(|gate| gate.status.clone())
+    });
+    let leaderboard_score = compute_leaderboard_score(&research)?;
+    Ok(RuntimeStrategyLeaderboardEntry {
+        candidate_id,
+        strategy_key: report.strategy_key.clone(),
+        venue_key: report.config.venue_key.clone(),
+        pair_symbol: report.config.pair_symbol.clone(),
+        market_type: report.config.market_type.clone(),
+        report_id: report.report_id.clone(),
+        generated_at: report.generated_at.clone(),
+        deployment_id: deployment
+            .as_ref()
+            .map(|record| record.deployment_id.clone()),
+        deployment_mode: deployment.as_ref().map(|record| record.mode.clone()),
+        deployment_state: deployment.as_ref().map(|record| record.state.clone()),
+        promotion_eligible: research.promotion_eligible,
+        leaderboard_score,
+        positive_fold_rate_bps: research.positive_fold_rate_bps,
+        significance_confidence_bps: research.significance_confidence_bps,
+        weak_regime_count: research.weak_regime_count,
+        net_return_bps: research.net_return_bps.clone(),
+        flat_cash_excess_return_bps: research.flat_cash_excess_return_bps.clone(),
+        buy_and_hold_excess_return_bps: research.buy_and_hold_excess_return_bps.clone(),
+        promotion_gate_status,
+        blocking_reasons: research.blocking_reasons.clone(),
+        summary: report.summary.clone(),
+    })
+}
+
+fn candidate_key(
+    strategy_key: &str,
+    venue_key: &str,
+    pair_symbol: &str,
+    market_type: &RuntimeVenueMarketType,
+) -> String {
+    format!(
+        "{}::{}::{}::{}",
+        strategy_key,
+        venue_key,
+        pair_symbol,
+        market_type_key(market_type)
+    )
+}
+
+fn market_type_key(market_type: &RuntimeVenueMarketType) -> &'static str {
+    match market_type {
+        RuntimeVenueMarketType::Spot => "spot",
+        RuntimeVenueMarketType::Perp => "perp",
+        RuntimeVenueMarketType::Options => "options",
+    }
+}
+
+fn compute_leaderboard_score(
+    research: &protocol::RuntimeResearchScorecard,
+) -> Result<i64, JsonPayload> {
+    let net_return_bps = parse_numeric_metric("research.netReturnBps", &research.net_return_bps)?;
+    let flat_cash_excess_bps = research
+        .flat_cash_excess_return_bps
+        .as_deref()
+        .map(|value| parse_numeric_metric("research.flatCashExcessReturnBps", value))
+        .transpose()?
+        .unwrap_or_default();
+    let drawdown_penalty_bps =
+        parse_numeric_metric("research.maxDrawdownBps", &research.max_drawdown_bps)?.max(0.0);
+    Ok((net_return_bps.round() as i64)
+        + (flat_cash_excess_bps.round() as i64)
+        + i64::from(research.significance_confidence_bps)
+        - (drawdown_penalty_bps.round() as i64)
+        - i64::from(research.weak_regime_count) * 100)
+}
+
+fn parse_numeric_metric(field: &'static str, value: &str) -> Result<f64, JsonPayload> {
+    value.trim().parse::<f64>().map_err(|_| {
+        error_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "runtime-scorecard-error",
+            json!({ "field": field, "value": value }),
+        )
+    })
 }
 
 async fn positions_handler(
@@ -2610,6 +2882,11 @@ fn map_reconciler_error(error: ReconcilerError) -> JsonPayload {
 fn map_scorecard_error(error: RuntimeScorecardError) -> JsonPayload {
     match error {
         RuntimeScorecardError::InvalidUsdAmount { field, value } => error_json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "runtime-scorecard-error",
+            json!({ "field": field, "value": value }),
+        ),
+        RuntimeScorecardError::InvalidNumericValue { field, value } => error_json(
             StatusCode::INTERNAL_SERVER_ERROR,
             "runtime-scorecard-error",
             json!({ "field": field, "value": value }),
@@ -3997,6 +4274,10 @@ mod tests {
             json!(1)
         );
         assert_eq!(
+            scorecards_payload["report"]["scorecard"]["research"]["foldCount"],
+            json!(0)
+        );
+        assert_eq!(
             scorecards_payload["report"]["promotionGates"][0]["targetMode"],
             json!("paper")
         );
@@ -4004,6 +4285,21 @@ mod tests {
             .as_str()
             .expect("markdown")
             .contains("Runtime Promotion Readiness"));
+
+        let leaderboards_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/internal/runtime/leaderboards")
+                    .header("authorization", "Bearer runtime-service-secret")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(leaderboards_response.status(), StatusCode::OK);
+        let leaderboards_payload = read_json(leaderboards_response).await;
+        assert_eq!(leaderboards_payload["leaderboard"]["entryCount"], json!(0));
 
         let allocator_response = router
             .clone()

--- a/tests/unit/worker_runtime_internal_routes.test.ts
+++ b/tests/unit/worker_runtime_internal_routes.test.ts
@@ -621,6 +621,7 @@ describe("worker runtime internal routes", () => {
         executionPlans: "/api/internal/runtime/execution-plans",
         health: "/api/internal/runtime/health",
         scorecards: "/api/internal/runtime/scorecards",
+        leaderboards: "/api/internal/runtime/leaderboards",
         allocator: "/api/internal/runtime/allocator",
         backtests: "/api/internal/runtime/backtests",
         costModels: "/api/internal/runtime/cost-models",
@@ -1057,6 +1058,36 @@ describe("worker runtime internal routes", () => {
       sourceMode: "shadow",
       targetMode: "paper",
       status: "pass",
+    });
+  });
+
+  test("returns stubbed strategy leaderboards", async () => {
+    const env = createWorkerLiveEnv();
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/internal/runtime/leaderboards", {
+        headers: {
+          authorization: "Bearer runtime-service-secret",
+        },
+      }),
+      env,
+      createExecutionContextStub(),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      source: "stub",
+      leaderboard: {
+        entryCount: 1,
+        entries: [
+          {
+            strategyKey: "trend_following",
+            pairSymbol: "SOL/USDC",
+            promotionEligible: true,
+          },
+        ],
+      },
     });
   });
 


### PR DESCRIPTION
Closes #316

## Summary
- add research-aware runtime scorecards with backtest significance, regime stability, and promotion gating evidence
- expose runtime candidate leaderboards from `runtime-rs` and bridge them through the Worker admin snapshot
- surface the leaderboard and research scorecard evidence in the operator UI and proof fixtures

## Validation
- `cargo fmt --all`
- `PATH="$HOME/.bun/bin:$PATH" bun run lint`
- `PATH="$HOME/.bun/bin:$PATH" bun run typecheck`
- `PATH="$HOME/.bun/bin:$PATH" bun test tests/unit/worker_runtime_internal_routes.test.ts tests/unit/portal_runtime_operator_route.test.ts`
- `cargo test -p runtime-scorecards`
- `cargo test -p runtime-rs --lib`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`