### PR TITLE
Add strategy-lab research brief workflow

### DIFF
--- a/.github/workflows/strategy-lab-research.yml
+++ b/.github/workflows/strategy-lab-research.yml
@@ -1,0 +1,144 @@
+name: Strategy Lab Research
+
+on:
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: Built-in research profile to run
+        required: false
+        default: latest_strategy_papers
+      request_file:
+        description: Optional repo-relative JSON request file for custom source acquisition requests
+        required: false
+      title:
+        description: Optional brief title override
+        required: false
+      allow_hosts:
+        description: Optional comma-separated host allowlist extensions
+        required: false
+      max_sources:
+        description: Optional maximum number of sources to include in the brief
+        required: false
+      issue_number:
+        description: Optional GitHub issue number to comment with the research brief summary
+        required: false
+  schedule:
+    - cron: "0 */12 * * *"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  research:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.0"
+
+      - name: Install deps
+        run: bun install
+
+      - name: Check admin credentials
+        env:
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ADMIN_TOKEN:-}" ]; then
+            echo "::error::Missing required secret ADMIN_TOKEN for strategy-lab research."
+            exit 1
+          fi
+
+      - name: Build research brief
+        env:
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          PROFILE: ${{ inputs.profile || 'latest_strategy_papers' }}
+          REQUEST_FILE: ${{ inputs.request_file }}
+          TITLE: ${{ inputs.title }}
+          ALLOW_HOSTS: ${{ inputs.allow_hosts }}
+          MAX_SOURCES: ${{ inputs.max_sources }}
+        run: |
+          set -euo pipefail
+          mkdir -p .tmp/strategy-lab-research
+
+          args=(
+            --base-url https://api.trader-ralph.com
+            --admin-token "${ADMIN_TOKEN}"
+            --output-dir .tmp/strategy-lab-research
+            --profile "${PROFILE}"
+          )
+
+          if [ -n "${REQUEST_FILE:-}" ]; then
+            args+=(--request-file "${REQUEST_FILE}")
+          fi
+
+          if [ -n "${TITLE:-}" ]; then
+            args+=(--title "${TITLE}")
+          fi
+
+          if [ -n "${MAX_SOURCES:-}" ]; then
+            args+=(--max-sources "${MAX_SOURCES}")
+          fi
+
+          if [ -n "${ALLOW_HOSTS:-}" ]; then
+            IFS=',' read -ra host_values <<< "${ALLOW_HOSTS}"
+            for host in "${host_values[@]}"; do
+              trimmed="$(echo "${host}" | xargs)"
+              if [ -n "${trimmed}" ]; then
+                args+=(--allow-host "${trimmed}")
+              fi
+            done
+          fi
+
+          bun run strategy-lab:research "${args[@]}"
+
+          cat .tmp/strategy-lab-research/brief.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload research artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: strategy-lab-research-${{ github.run_id }}
+          path: .tmp/strategy-lab-research
+          if-no-files-found: error
+
+      - name: Comment on issue
+        if: ${{ inputs.issue_number != '' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          set -euo pipefail
+
+          summary="$(jq -r '.summary' .tmp/strategy-lab-research/brief.json)"
+          brief_id="$(jq -r '.briefId' .tmp/strategy-lab-research/brief.json)"
+          generated_at="$(jq -r '.generatedAt' .tmp/strategy-lab-research/brief.json)"
+          findings="$(jq -r '.findings[:3][]?' .tmp/strategy-lab-research/brief.json | sed 's/^/- /')"
+          run_url="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
+
+          body="$(cat <<EOF
+          Strategy-lab research brief ready.
+
+          - briefId: \`${brief_id}\`
+          - generatedAt: \`${generated_at}\`
+          - workflow run: ${run_url}
+
+          ${summary}
+
+          ${findings}
+          EOF
+          )"
+
+          payload="$(jq -n --arg body "$body" '{body:$body}')"
+          curl -fsS \
+            -X POST \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
+            -d "${payload}" >/dev/null

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,6 +1,6 @@
+import { parseRuntimeResearchBriefRequest } from "../../../src/runtime/research/briefs.js";
 import { buildAgentQueryResponse } from "./agent_query";
 import { requireUser } from "./auth";
-
 import { getUserSubscription, toSubscriptionView } from "./billing";
 import {
   SOL_MINT,
@@ -151,6 +151,7 @@ import {
   readRuntimePositionSnapshot,
   readRuntimeScorecard,
 } from "./runtime_internal";
+import { runRuntimeResearchBriefWorkflow } from "./runtime_research_briefs";
 import { SolanaRpc } from "./solana_rpc";
 import type { Env, ExecutionConfig } from "./types";
 import type { UserRow } from "./users_db";
@@ -2224,6 +2225,51 @@ const worker = {
                     : "ops-control-reset-failed",
               },
               { status: 503 },
+            ),
+            env,
+          );
+        }
+      }
+
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/admin/ops/runtime/research/briefs"
+      ) {
+        const auth = authorizeAdminRoute(request, env);
+        if (!auth.ok) {
+          return withCors(
+            json({ ok: false, error: auth.error }, { status: auth.status }),
+            env,
+          );
+        }
+        try {
+          const briefRequest = parseRuntimeResearchBriefRequest(
+            await request.json(),
+          );
+          const result = await runRuntimeResearchBriefWorkflow({
+            env,
+            request: briefRequest,
+          });
+          return withCors(
+            json({
+              ok: true,
+              brief: result.brief,
+              markdown: result.markdown,
+              storedSources: result.storedSources,
+            }),
+            env,
+          );
+        } catch (error) {
+          return withCors(
+            json(
+              {
+                ok: false,
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "runtime-research-brief-failed",
+              },
+              { status: 400 },
             ),
             env,
           );

--- a/apps/worker/src/runtime_research_briefs.ts
+++ b/apps/worker/src/runtime_research_briefs.ts
@@ -1,0 +1,84 @@
+import type {
+  RuntimeResearchBriefArtifact,
+  RuntimeResearchBriefRequest,
+} from "../../../src/runtime/research/briefs.js";
+import {
+  buildRuntimeResearchBrief,
+  buildRuntimeResearchBriefMarkdown,
+  resolveRuntimeResearchApprovedHosts,
+  resolveRuntimeResearchBriefRequests,
+  validateRuntimeResearchBriefRequests,
+} from "../../../src/runtime/research/briefs.js";
+import type { FetchLike } from "../../../src/runtime/research/source_acquisition.js";
+import type { RuntimeResearchSourceRecord } from "./runtime_contracts";
+import { acquireAndStoreRuntimeResearchSources } from "./runtime_research_sources";
+import type { Env } from "./types";
+
+export type RuntimeResearchBriefWorkflowResult = {
+  brief: RuntimeResearchBriefArtifact;
+  markdown: string;
+  storedSources: RuntimeResearchSourceRecord[];
+};
+
+export async function runRuntimeResearchBriefWorkflow(input: {
+  env: Env;
+  request: RuntimeResearchBriefRequest;
+  fetchImpl?: FetchLike;
+}): Promise<RuntimeResearchBriefWorkflowResult> {
+  const requests = resolveRuntimeResearchBriefRequests(input.request);
+  if (requests.length === 0) {
+    throw new Error("runtime-research-brief-no-requests");
+  }
+
+  const approvedHosts = resolveRuntimeResearchApprovedHosts(input.request);
+  validateRuntimeResearchBriefRequests({
+    requests,
+    approvedHosts,
+  });
+
+  const storedSourcesById = new Map<string, RuntimeResearchSourceRecord>();
+  const sourceMaterialsById = new Map<
+    string,
+    { record: RuntimeResearchSourceRecord; contentMaterial: string }
+  >();
+  let createdCount = 0;
+  let existingCount = 0;
+
+  for (const request of requests) {
+    const result = await acquireAndStoreRuntimeResearchSources({
+      env: input.env,
+      request,
+      fetchImpl: input.fetchImpl,
+    });
+    createdCount += result.createdCount;
+    existingCount += result.existingCount;
+    for (const record of result.records) {
+      storedSourcesById.set(record.sourceId, record);
+    }
+    for (const sourceMaterial of result.sourceMaterials) {
+      const current = sourceMaterialsById.get(sourceMaterial.record.sourceId);
+      if (
+        !current ||
+        Date.parse(sourceMaterial.record.retrievedAt) >=
+          Date.parse(current.record.retrievedAt)
+      ) {
+        sourceMaterialsById.set(sourceMaterial.record.sourceId, sourceMaterial);
+      }
+    }
+  }
+
+  const brief = buildRuntimeResearchBrief({
+    request: input.request,
+    sourceMaterials: Array.from(sourceMaterialsById.values()),
+    createdCount,
+    existingCount,
+  });
+
+  return {
+    brief,
+    markdown: buildRuntimeResearchBriefMarkdown(brief),
+    storedSources: Array.from(storedSourcesById.values()).sort((left, right) =>
+      right.retrievedAt.localeCompare(left.retrievedAt),
+    ),
+  };
+}

--- a/apps/worker/src/runtime_research_sources.ts
+++ b/apps/worker/src/runtime_research_sources.ts
@@ -1,7 +1,8 @@
 import {
-  acquireRuntimeResearchSources,
+  acquireRuntimeResearchSourceMaterials,
   type FetchLike,
   type RuntimeResearchSourceAcquisitionRequest,
+  type RuntimeResearchSourceMaterial,
 } from "../../../src/runtime/research/source_acquisition.js";
 import {
   parseRuntimeResearchSourceRecord,
@@ -17,6 +18,7 @@ export type RuntimeResearchSourceAcquireResult = {
   records: RuntimeResearchSourceRecord[];
   createdCount: number;
   existingCount: number;
+  sourceMaterials: RuntimeResearchSourceMaterial[];
 };
 
 export type RuntimeLatestResearchSourceQuery = {
@@ -55,7 +57,7 @@ export async function acquireAndStoreRuntimeResearchSources(input: {
     assetKey: input.request.assetKeys?.[0],
     limit: 250,
   });
-  const acquired = await acquireRuntimeResearchSources({
+  const acquired = await acquireRuntimeResearchSourceMaterials({
     request: input.request,
     fetchImpl: input.fetchImpl,
   });
@@ -69,7 +71,10 @@ export async function acquireAndStoreRuntimeResearchSources(input: {
   let createdCount = 0;
   let existingCount = 0;
 
-  for (const record of acquired) {
+  const sourceMaterials: RuntimeResearchSourceMaterial[] = [];
+
+  for (const acquiredRecord of acquired) {
+    const record = acquiredRecord.record;
     const existingRecord =
       existingBySourceId.get(record.sourceId) ??
       existingByCanonicalUrl.get(record.canonicalUrl) ??
@@ -90,7 +95,12 @@ export async function acquireAndStoreRuntimeResearchSources(input: {
     }
     const payloadRecord =
       response.payload.sourceRecord ?? response.payload.record ?? merged;
-    records.push(parseRuntimeResearchSourceRecord(payloadRecord));
+    const parsedRecord = parseRuntimeResearchSourceRecord(payloadRecord);
+    records.push(parsedRecord);
+    sourceMaterials.push({
+      record: parsedRecord,
+      contentMaterial: acquiredRecord.contentMaterial,
+    });
     if (response.payload.created === true) {
       createdCount += 1;
     } else {
@@ -102,6 +112,7 @@ export async function acquireAndStoreRuntimeResearchSources(input: {
     records,
     createdCount,
     existingCount,
+    sourceMaterials,
   };
 }
 

--- a/docs/repository-verification-index.md
+++ b/docs/repository-verification-index.md
@@ -250,6 +250,28 @@ Verify:
 - later phases can retrieve latest source material with citations and dates from
   the research registry without widening the public Worker boundary.
 
+### 3f. Strategy-lab research brief verification
+
+For automated research-brief ingestion and summarization work:
+
+```bash
+bun run lint
+bun run typecheck
+bun test tests/unit/runtime_research_source_acquisition.test.ts tests/unit/worker_runtime_research_sources.test.ts tests/unit/runtime_research_briefs.test.ts tests/unit/worker_runtime_research_briefs_route.test.ts
+bun test tests/unit/runtime_protocol_contracts.test.ts tests/unit/runtime_protocol_schema_fixtures.test.ts tests/unit/worker_runtime_internal_routes.test.ts tests/unit/worker_runtime_contracts.test.ts
+```
+
+Verify:
+
+- the admin route fails closed without admin auth and rejects unapproved hosts,
+- every brief preserves citations, dates, source ids, and approved-host
+  provenance,
+- the CLI writes both `brief.json` and `brief.md`,
+- the scheduled or manual workflow uploads the same artifacts without widening
+  the public Worker boundary,
+- research ingestion stays autonomous while paper and real-money promotion
+  remain human-gated.
+
 ### 4. x402 and discovery verification
 
 Portal-side discovery:

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "harness:down": "bun run src/bin/harness.ts down",
     "harness:status": "bun run src/bin/harness.ts status",
     "harness:proof": "bun run src/bin/harness.ts proof",
+    "strategy-lab:research": "bun run src/bin/strategy_lab_research.ts",
     "runtime:fly:deploy": "node scripts/runtime_rs/fly_deploy.mjs",
     "runtime:fly:smoke": "node scripts/runtime_rs/fly_smoke.mjs",
     "runner:once": "bun run src/bin/runner.ts once",

--- a/services/runtime-rs/README.md
+++ b/services/runtime-rs/README.md
@@ -235,11 +235,24 @@ curl -fsS "http://127.0.0.1:8081/api/internal/runtime/risk?deploymentId=dep_runt
 Operators should use the Worker as the public control plane:
 
 - `GET /api/admin/ops/runtime`
+- `POST /api/admin/ops/runtime/research/briefs`
 - `POST /api/admin/ops/runtime/deployments/:deploymentId/pause`
 - `POST /api/admin/ops/runtime/deployments/:deploymentId/resume`
 - `POST /api/admin/ops/runtime/deployments/:deploymentId/kill`
 - `POST /api/admin/ops/controls` with `runtime.shadowOnly=true` to keep the
   runtime shadow-only until live rollout is explicitly enabled in a later issue
+
+Research briefs stay on the Worker-admin surface so source acquisition remains
+approved-host-only and public APIs stay unchanged. The same brief flow can run
+locally or in CI:
+
+```bash
+bun run strategy-lab:research --profile latest_strategy_papers
+```
+
+That command writes `.tmp/strategy-lab-research/brief.json` and
+`.tmp/strategy-lab-research/brief.md`, and the scheduled GitHub Actions
+workflow uploads the same artifacts every 12 hours.
 
 The runtime operator surface now includes allocator details for a deployment:
 

--- a/src/bin/strategy_lab_research.ts
+++ b/src/bin/strategy_lab_research.ts
@@ -1,0 +1,110 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { parseRuntimeResearchBriefRequest } from "../runtime/research/briefs.js";
+
+function readArg(flag: string): string | null {
+  const index = process.argv.indexOf(flag);
+  if (index < 0) return null;
+  return process.argv[index + 1] ?? null;
+}
+
+function readMultiArg(flag: string): string[] {
+  const values: string[] = [];
+  for (let index = 0; index < process.argv.length; index += 1) {
+    if (process.argv[index] === flag) {
+      const value = process.argv[index + 1];
+      if (!value) {
+        throw new Error(`missing-arg:${flag}`);
+      }
+      values.push(value);
+      index += 1;
+    }
+  }
+  return values;
+}
+
+function readJsonFile(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf8")) as unknown;
+}
+
+async function main(): Promise<void> {
+  const baseUrl = readArg("--base-url") ?? "http://127.0.0.1:8888";
+  const outputDir = resolve(
+    readArg("--output-dir") ?? ".tmp/strategy-lab-research",
+  );
+  const adminToken =
+    readArg("--admin-token") ?? String(process.env.ADMIN_TOKEN ?? "").trim();
+  if (!adminToken) {
+    throw new Error("missing-admin-token");
+  }
+
+  const requestFile = readArg("--request-file");
+  const requestPayload = requestFile ? readJsonFile(resolve(requestFile)) : {};
+  const mergedPayload =
+    Array.isArray(requestPayload) || !requestPayload
+      ? { requests: requestPayload ?? [] }
+      : { ...(requestPayload as Record<string, unknown>) };
+
+  const profile = readArg("--profile");
+  const title = readArg("--title");
+  const maxSourcesRaw = readArg("--max-sources");
+  const maxSources =
+    maxSourcesRaw && Number.isFinite(Number(maxSourcesRaw))
+      ? Number(maxSourcesRaw)
+      : undefined;
+  const explicitAllowedHosts = readMultiArg("--allow-host");
+
+  const requestBody = parseRuntimeResearchBriefRequest({
+    ...mergedPayload,
+    ...(profile ? { profile } : {}),
+    ...(title ? { title } : {}),
+    ...(typeof maxSources === "number" ? { maxSources } : {}),
+    ...(explicitAllowedHosts.length > 0 ? { explicitAllowedHosts } : {}),
+  });
+
+  const response = await fetch(
+    `${baseUrl.replace(/\/$/, "")}/api/admin/ops/runtime/research/briefs`,
+    {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${adminToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    },
+  );
+  const payload = (await response.json()) as Record<string, unknown>;
+  if (!response.ok || payload.ok !== true) {
+    throw new Error(
+      String(
+        payload.error ?? `runtime-research-brief-failed:${response.status}`,
+      ),
+    );
+  }
+
+  mkdirSync(outputDir, { recursive: true });
+  const jsonPath = join(outputDir, "brief.json");
+  const markdownPath = join(outputDir, "brief.md");
+  writeFileSync(jsonPath, `${JSON.stringify(payload.brief, null, 2)}\n`);
+  writeFileSync(markdownPath, `${String(payload.markdown ?? "")}\n`);
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        baseUrl,
+        outputDir,
+        briefPath: jsonPath,
+        markdownPath,
+        briefId:
+          typeof payload.brief === "object" && payload.brief
+            ? (payload.brief as Record<string, unknown>).briefId
+            : null,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+await main();

--- a/src/runtime/research/briefs.ts
+++ b/src/runtime/research/briefs.ts
@@ -1,0 +1,453 @@
+import { createHash } from "node:crypto";
+import type {
+  RuntimeResearchSourceKind,
+  RuntimeResearchSourceRecord,
+} from "../contracts/autonomous_runtime.js";
+import type {
+  RuntimeResearchSourceAcquisitionRequest,
+  RuntimeResearchSourceMaterial,
+} from "./source_acquisition.js";
+import { normalizeResearchUrl } from "./source_acquisition.js";
+
+export type RuntimeResearchBriefProfileKey =
+  | "latest_strategy_papers"
+  | "custom";
+
+export type RuntimeResearchBriefRequest = {
+  profile?: RuntimeResearchBriefProfileKey;
+  title?: string;
+  requests?: RuntimeResearchSourceAcquisitionRequest[];
+  explicitAllowedHosts?: string[];
+  maxSources?: number;
+  generatedAt?: string;
+};
+
+export type RuntimeResearchBriefSource = {
+  sourceId: string;
+  sourceKind: RuntimeResearchSourceKind;
+  title: string;
+  url: string;
+  canonicalUrl: string;
+  authors: string[];
+  publishedAt?: string;
+  retrievedAt: string;
+  venueKeys: string[];
+  assetKeys: string[];
+  tags: string[];
+  digest: string;
+};
+
+export type RuntimeResearchBriefArtifact = {
+  briefId: string;
+  generatedAt: string;
+  profile: RuntimeResearchBriefProfileKey;
+  title: string;
+  summary: string;
+  findings: string[];
+  approvedHosts: string[];
+  requestCount: number;
+  sourceCount: number;
+  createdCount: number;
+  existingCount: number;
+  citations: Array<{
+    sourceId: string;
+    materialDigest: string;
+    notes?: string;
+  }>;
+  sources: RuntimeResearchBriefSource[];
+};
+
+const BUILTIN_RESEARCH_BRIEF_REQUESTS: Record<
+  Exclude<RuntimeResearchBriefProfileKey, "custom">,
+  RuntimeResearchSourceAcquisitionRequest[]
+> = {
+  latest_strategy_papers: [
+    {
+      kind: "paper_feed",
+      feedUrl:
+        "https://export.arxiv.org/api/query?search_query=all:%22algorithmic+trading%22+OR+all:%22market+microstructure%22+OR+all:%22crypto+trading%22&start=0&max_results=8&sortBy=submittedDate&sortOrder=descending",
+      tags: ["strategy-lab", "latest-research", "papers"],
+    },
+  ],
+};
+
+const BUILTIN_APPROVED_HOSTS = new Set([
+  "arxiv.org",
+  "export.arxiv.org",
+  "github.com",
+  "raw.githubusercontent.com",
+  "station.jup.ag",
+  "docs.phoenix.trade",
+  "solana.com",
+  "www.solana.com",
+]);
+
+export function resolveRuntimeResearchBriefRequests(
+  input: RuntimeResearchBriefRequest,
+): RuntimeResearchSourceAcquisitionRequest[] {
+  const profile = input.profile ?? "latest_strategy_papers";
+  const builtIn =
+    profile === "custom" ? [] : BUILTIN_RESEARCH_BRIEF_REQUESTS[profile];
+  return [...builtIn, ...(input.requests ?? [])];
+}
+
+export function resolveRuntimeResearchApprovedHosts(
+  input: RuntimeResearchBriefRequest,
+): string[] {
+  return Array.from(
+    new Set([
+      ...BUILTIN_APPROVED_HOSTS,
+      ...(input.explicitAllowedHosts ?? [])
+        .map((value) => value.trim().toLowerCase())
+        .filter(Boolean),
+    ]),
+  ).sort();
+}
+
+export function parseRuntimeResearchBriefRequest(
+  input: unknown,
+): RuntimeResearchBriefRequest {
+  const record = isRecord(input) ? input : {};
+  const profile =
+    record.profile === "latest_strategy_papers" || record.profile === "custom"
+      ? record.profile
+      : undefined;
+  const requests = Array.isArray(record.requests)
+    ? record.requests
+        .map(parseSourceAcquisitionRequest)
+        .filter(
+          (value): value is RuntimeResearchSourceAcquisitionRequest =>
+            value !== null,
+        )
+    : undefined;
+  const explicitAllowedHosts = Array.isArray(record.explicitAllowedHosts)
+    ? record.explicitAllowedHosts
+        .map((value) => String(value ?? "").trim())
+        .filter(Boolean)
+    : undefined;
+  const title = String(record.title ?? "").trim() || undefined;
+  const generatedAt = String(record.generatedAt ?? "").trim() || undefined;
+  const maxSources =
+    typeof record.maxSources === "number" && Number.isFinite(record.maxSources)
+      ? record.maxSources
+      : undefined;
+  return {
+    ...(profile ? { profile } : {}),
+    ...(title ? { title } : {}),
+    ...(generatedAt ? { generatedAt } : {}),
+    ...(typeof maxSources === "number" ? { maxSources } : {}),
+    ...(requests && requests.length > 0 ? { requests } : {}),
+    ...(explicitAllowedHosts && explicitAllowedHosts.length > 0
+      ? { explicitAllowedHosts }
+      : {}),
+  };
+}
+
+export function validateRuntimeResearchBriefRequests(input: {
+  requests: RuntimeResearchSourceAcquisitionRequest[];
+  approvedHosts: string[];
+}) {
+  const approvedHosts = new Set(
+    input.approvedHosts.map((value) => value.trim().toLowerCase()),
+  );
+  for (const request of input.requests) {
+    const urls =
+      request.kind === "paper_feed" ? [request.feedUrl] : [request.url];
+    for (const rawUrl of urls) {
+      const normalized = normalizeResearchUrl(rawUrl);
+      const hostname = new URL(normalized).hostname.toLowerCase();
+      if (!approvedHosts.has(hostname)) {
+        throw new Error(`research-source-not-allowed:${hostname}`);
+      }
+    }
+  }
+}
+
+export function buildRuntimeResearchBrief(input: {
+  request: RuntimeResearchBriefRequest;
+  sourceMaterials: RuntimeResearchSourceMaterial[];
+  createdCount: number;
+  existingCount: number;
+}): RuntimeResearchBriefArtifact {
+  const generatedAt = new Date(
+    input.request.generatedAt ?? new Date().toISOString(),
+  ).toISOString();
+  const profile = input.request.profile ?? "latest_strategy_papers";
+  const approvedHosts = resolveRuntimeResearchApprovedHosts(input.request);
+  const requestCount = resolveRuntimeResearchBriefRequests(
+    input.request,
+  ).length;
+  const selectedSources = [...input.sourceMaterials]
+    .sort(compareSourceMaterialRecency)
+    .slice(0, normalizeMaxSources(input.request.maxSources))
+    .map(toBriefSource);
+  const findings = input.sourceMaterials
+    .sort(compareSourceMaterialRecency)
+    .slice(0, 3)
+    .map((entry) => summarizeSourceMaterial(entry))
+    .filter(Boolean);
+  const titles = selectedSources.slice(0, 3).map((source) => source.title);
+  const summary =
+    selectedSources.length === 0
+      ? "No approved research sources were retrieved for this brief."
+      : [
+          `Reviewed ${selectedSources.length} approved sources across ${requestCount} acquisition request${requestCount === 1 ? "" : "s"}.`,
+          titles.length > 0
+            ? `Most recent coverage: ${titles.join("; ")}.`
+            : null,
+        ]
+          .filter(Boolean)
+          .join(" ");
+  const title =
+    input.request.title?.trim() ||
+    (profile === "latest_strategy_papers"
+      ? "Latest strategy research brief"
+      : "Custom research brief");
+  const briefId = `brief_${sha256Hex(
+    JSON.stringify({
+      profile,
+      generatedAt,
+      sourceIds: selectedSources.map((source) => source.sourceId),
+    }),
+  ).slice(0, 20)}`;
+
+  return {
+    briefId,
+    generatedAt,
+    profile,
+    title,
+    summary,
+    findings,
+    approvedHosts,
+    requestCount,
+    sourceCount: selectedSources.length,
+    createdCount: input.createdCount,
+    existingCount: input.existingCount,
+    citations: selectedSources.map((source) => ({
+      sourceId: source.sourceId,
+      materialDigest: source.digest,
+      notes: source.publishedAt
+        ? `published ${source.publishedAt}`
+        : `retrieved ${source.retrievedAt}`,
+    })),
+    sources: selectedSources,
+  };
+}
+
+export function buildRuntimeResearchBriefMarkdown(
+  brief: RuntimeResearchBriefArtifact,
+): string {
+  const lines = [
+    `# ${brief.title}`,
+    "",
+    `- Generated at: ${brief.generatedAt}`,
+    `- Profile: ${brief.profile}`,
+    `- Sources reviewed: ${brief.sourceCount}`,
+    `- Requests executed: ${brief.requestCount}`,
+    `- Created sources: ${brief.createdCount}`,
+    `- Existing sources refreshed: ${brief.existingCount}`,
+    "",
+    "## Summary",
+    "",
+    brief.summary,
+    "",
+  ];
+
+  if (brief.findings.length > 0) {
+    lines.push("## Findings", "");
+    for (const finding of brief.findings) {
+      lines.push(`- ${finding}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("## Citations", "");
+  for (const source of brief.sources) {
+    const dating = source.publishedAt
+      ? `published ${source.publishedAt}`
+      : `retrieved ${source.retrievedAt}`;
+    const authors =
+      source.authors.length > 0 ? ` by ${source.authors.join(", ")}` : "";
+    lines.push(
+      `- ${source.title}${authors} (${dating})`,
+      `  ${source.canonicalUrl}`,
+      `  sourceId: ${source.sourceId}`,
+    );
+  }
+  lines.push("");
+
+  lines.push("## Provenance", "");
+  lines.push(
+    `- Approved hosts: ${brief.approvedHosts.join(", ") || "none"}`,
+    `- Brief id: ${brief.briefId}`,
+  );
+
+  return lines.join("\n");
+}
+
+function toBriefSource(
+  sourceMaterial: RuntimeResearchSourceMaterial,
+): RuntimeResearchBriefSource {
+  const record = sourceMaterial.record;
+  return {
+    sourceId: record.sourceId,
+    sourceKind: record.sourceKind,
+    title: record.title,
+    url: record.url,
+    canonicalUrl: record.canonicalUrl,
+    authors: record.authors,
+    publishedAt: record.publishedAt,
+    retrievedAt: record.retrievedAt,
+    venueKeys: record.venueKeys,
+    assetKeys: record.assetKeys,
+    tags: record.tags,
+    digest: record.contentDigest,
+  };
+}
+
+function summarizeSourceMaterial(
+  sourceMaterial: RuntimeResearchSourceMaterial,
+): string {
+  const source = toBriefSource(sourceMaterial);
+  const sentences = sourceMaterial.contentMaterial
+    .split(/(?<=[.!?])\s+/)
+    .map((value) => value.trim())
+    .filter((value) => value.length >= 24)
+    .filter((value) => normalizeText(value) !== normalizeText(source.title));
+  const firstSentence =
+    sentences[0] ??
+    sourceMaterial.contentMaterial
+      .replace(source.title, "")
+      .trim()
+      .slice(0, 180)
+      .trim();
+  const dating = source.publishedAt
+    ? `published ${source.publishedAt}`
+    : `retrieved ${source.retrievedAt}`;
+  return `${source.title} (${dating}): ${firstSentence}`;
+}
+
+function compareSourceMaterialRecency(
+  left: RuntimeResearchSourceMaterial,
+  right: RuntimeResearchSourceMaterial,
+): number {
+  return recencyTimestamp(right.record) - recencyTimestamp(left.record);
+}
+
+function recencyTimestamp(record: RuntimeResearchSourceRecord): number {
+  const value = Date.parse(record.publishedAt ?? record.retrievedAt);
+  return Number.isNaN(value) ? 0 : value;
+}
+
+function normalizeMaxSources(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 8;
+  }
+  return Math.max(1, Math.min(20, Math.trunc(value)));
+}
+
+function normalizeText(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function parseSourceAcquisitionRequest(
+  input: unknown,
+): RuntimeResearchSourceAcquisitionRequest | null {
+  if (!isRecord(input) || typeof input.kind !== "string") {
+    return null;
+  }
+  const venueKeys = normalizeStringArray(input.venueKeys);
+  const assetKeys = normalizeStringArray(input.assetKeys);
+  const tags = normalizeStringArray(input.tags);
+  const retrievedAt = String(input.retrievedAt ?? "").trim() || undefined;
+
+  if (input.kind === "manual_url") {
+    const url = String(input.url ?? "").trim();
+    if (!url) return null;
+    const sourceKind = parseResearchSourceKind(input.sourceKind);
+    return {
+      kind: "manual_url",
+      url,
+      ...(sourceKind ? { sourceKind } : {}),
+      ...(venueKeys.length > 0 ? { venueKeys } : {}),
+      ...(assetKeys.length > 0 ? { assetKeys } : {}),
+      ...(tags.length > 0 ? { tags } : {}),
+      ...(retrievedAt ? { retrievedAt } : {}),
+    };
+  }
+
+  if (input.kind === "paper_feed") {
+    const feedUrl = String(input.feedUrl ?? "").trim();
+    if (!feedUrl) return null;
+    const maxItems =
+      typeof input.maxItems === "number" && Number.isFinite(input.maxItems)
+        ? input.maxItems
+        : undefined;
+    return {
+      kind: "paper_feed",
+      feedUrl,
+      ...(typeof maxItems === "number" ? { maxItems } : {}),
+      ...(venueKeys.length > 0 ? { venueKeys } : {}),
+      ...(assetKeys.length > 0 ? { assetKeys } : {}),
+      ...(tags.length > 0 ? { tags } : {}),
+      ...(retrievedAt ? { retrievedAt } : {}),
+    };
+  }
+
+  if (input.kind === "venue_docs") {
+    const url = String(input.url ?? "").trim();
+    const venueKey = String(input.venueKey ?? "").trim();
+    if (!url || !venueKey) return null;
+    const documentKind =
+      input.documentKind === "docs" || input.documentKind === "changelog"
+        ? input.documentKind
+        : undefined;
+    const sourceKind = parseResearchSourceKind(input.sourceKind);
+    return {
+      kind: "venue_docs",
+      url,
+      venueKey,
+      ...(documentKind ? { documentKind } : {}),
+      ...(sourceKind ? { sourceKind } : {}),
+      ...(venueKeys.length > 0 ? { venueKeys } : {}),
+      ...(assetKeys.length > 0 ? { assetKeys } : {}),
+      ...(tags.length > 0 ? { tags } : {}),
+      ...(retrievedAt ? { retrievedAt } : {}),
+    };
+  }
+
+  return null;
+}
+
+function parseResearchSourceKind(
+  input: unknown,
+): RuntimeResearchSourceKind | undefined {
+  if (typeof input !== "string") {
+    return undefined;
+  }
+  switch (input) {
+    case "paper":
+    case "article":
+    case "repository":
+    case "dataset":
+    case "notebook":
+    case "internal_note":
+    case "market_report":
+      return input;
+    default:
+      return undefined;
+  }
+}
+
+function normalizeStringArray(input: unknown): string[] {
+  if (!Array.isArray(input)) return [];
+  return input.map((value) => String(value ?? "").trim()).filter(Boolean);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/runtime/research/source_acquisition.ts
+++ b/src/runtime/research/source_acquisition.ts
@@ -11,6 +11,11 @@ export type FetchLike = (
   init?: RequestInit,
 ) => Promise<Response>;
 
+export type RuntimeResearchSourceMaterial = {
+  record: RuntimeResearchSourceRecord;
+  contentMaterial: string;
+};
+
 type SourceAcquisitionBase = {
   venueKeys?: string[];
   assetKeys?: string[];
@@ -81,6 +86,14 @@ export async function acquireRuntimeResearchSources(input: {
   request: RuntimeResearchSourceAcquisitionRequest;
   fetchImpl?: FetchLike;
 }): Promise<RuntimeResearchSourceRecord[]> {
+  const materials = await acquireRuntimeResearchSourceMaterials(input);
+  return materials.map((entry) => entry.record);
+}
+
+export async function acquireRuntimeResearchSourceMaterials(input: {
+  request: RuntimeResearchSourceAcquisitionRequest;
+  fetchImpl?: FetchLike;
+}): Promise<RuntimeResearchSourceMaterial[]> {
   const fetchImpl = input.fetchImpl ?? DEFAULT_FETCH;
   const request = input.request;
   const retrievedAt = request.retrievedAt ?? new Date().toISOString();
@@ -143,7 +156,7 @@ async function acquireHtmlLikeSource(input: {
   venueKeys: string[];
   assetKeys: string[];
   tags: string[];
-}): Promise<RuntimeResearchSourceRecord> {
+}): Promise<RuntimeResearchSourceMaterial> {
   const response = await input.fetchImpl(input.url, {
     headers: {
       accept: "text/html,application/xhtml+xml;q=0.9,*/*;q=0.8",
@@ -190,7 +203,7 @@ async function acquirePaperFeedSources(input: {
   assetKeys: string[];
   tags: string[];
   maxItems: number;
-}): Promise<RuntimeResearchSourceRecord[]> {
+}): Promise<RuntimeResearchSourceMaterial[]> {
   const response = await input.fetchImpl(input.feedUrl, {
     headers: {
       accept: "application/atom+xml,application/xml,text/xml;q=0.9,*/*;q=0.8",
@@ -204,7 +217,7 @@ async function acquirePaperFeedSources(input: {
   const xml = await response.text();
   const feedPublisher =
     extractXmlText(xml, "title") ?? new URL(input.feedUrl).hostname;
-  const records = new Map<string, RuntimeResearchSourceRecord>();
+  const records = new Map<string, RuntimeResearchSourceMaterial>();
 
   for (const entryXml of matchBlocks(xml, "entry").slice(0, input.maxItems)) {
     const title = extractXmlText(entryXml, "title");
@@ -237,22 +250,23 @@ async function acquirePaperFeedSources(input: {
       tags: input.tags,
       contentMaterial: `${title}\n${summary}`,
     });
-    records.set(record.sourceId, record);
+    records.set(record.record.sourceId, record);
   }
 
   return Array.from(records.values()).sort((left, right) =>
-    right.retrievedAt.localeCompare(left.retrievedAt),
+    right.record.retrievedAt.localeCompare(left.record.retrievedAt),
   );
 }
 
 function createNormalizedResearchSource(
   input: NormalizedResearchSourceInput,
-): RuntimeResearchSourceRecord {
+): RuntimeResearchSourceMaterial {
   const normalizedTitle = collapseWhitespace(input.title);
   const canonicalUrl = normalizeResearchUrl(input.canonicalUrl);
   const publishedAt = normalizeOptionalIsoDatetime(input.publishedAt);
   const authors = normalizePeople(input.authors);
   const publisher = collapseWhitespace(input.publisher ?? "");
+  const contentMaterial = collapseWhitespace(input.contentMaterial);
   const stableIdentity = createStableSourceIdentity({
     sourceKind: input.sourceKind,
     canonicalUrl,
@@ -262,31 +276,34 @@ function createNormalizedResearchSource(
     publisher,
   });
   const sourceId = `source_${input.sourceKind}_${stableIdentity.slice(0, 20)}`;
-  return parseRuntimeResearchSourceRecord({
-    schemaVersion: "v1",
-    sourceId,
-    sourceKind: input.sourceKind,
-    title: normalizedTitle,
-    url: normalizeResearchUrl(input.url),
-    canonicalUrl,
-    authors,
-    publishedAt,
-    retrievedAt: normalizeIsoDatetime(input.retrievedAt),
-    contentDigest: `sha256:${sha256Hex(
-      `${normalizedTitle}\n${canonicalUrl}\n${collapseWhitespace(input.contentMaterial)}`,
-    )}`,
-    provenance: {
-      acquisitionKind: input.acquisitionKind,
-      collectedFrom: normalizeResearchUrl(input.collectedFrom),
-      hostname: input.hostname.toLowerCase(),
-      ...(publisher ? { publisher } : {}),
-      firstSeenAt: normalizeIsoDatetime(input.retrievedAt),
-      lastSeenAt: normalizeIsoDatetime(input.retrievedAt),
-    },
-    venueKeys: normalizeKeys(input.venueKeys),
-    assetKeys: normalizeKeys(input.assetKeys),
-    tags: normalizeTags(input.tags),
-  });
+  return {
+    record: parseRuntimeResearchSourceRecord({
+      schemaVersion: "v1",
+      sourceId,
+      sourceKind: input.sourceKind,
+      title: normalizedTitle,
+      url: normalizeResearchUrl(input.url),
+      canonicalUrl,
+      authors,
+      publishedAt,
+      retrievedAt: normalizeIsoDatetime(input.retrievedAt),
+      contentDigest: `sha256:${sha256Hex(
+        `${normalizedTitle}\n${canonicalUrl}\n${contentMaterial}`,
+      )}`,
+      provenance: {
+        acquisitionKind: input.acquisitionKind,
+        collectedFrom: normalizeResearchUrl(input.collectedFrom),
+        hostname: input.hostname.toLowerCase(),
+        ...(publisher ? { publisher } : {}),
+        firstSeenAt: normalizeIsoDatetime(input.retrievedAt),
+        lastSeenAt: normalizeIsoDatetime(input.retrievedAt),
+      },
+      venueKeys: normalizeKeys(input.venueKeys),
+      assetKeys: normalizeKeys(input.assetKeys),
+      tags: normalizeTags(input.tags),
+    }),
+    contentMaterial,
+  };
 }
 
 export function normalizeResearchUrl(url: string): string {

--- a/tests/unit/runtime_research_briefs.test.ts
+++ b/tests/unit/runtime_research_briefs.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import { parseRuntimeResearchSourceRecord } from "../../src/runtime/contracts/autonomous_runtime.js";
+import {
+  buildRuntimeResearchBrief,
+  buildRuntimeResearchBriefMarkdown,
+  parseRuntimeResearchBriefRequest,
+  resolveRuntimeResearchBriefRequests,
+  validateRuntimeResearchBriefRequests,
+} from "../../src/runtime/research/briefs.js";
+import type { RuntimeResearchSourceMaterial } from "../../src/runtime/research/source_acquisition.js";
+
+function sourceMaterialFixture(input: {
+  sourceId: string;
+  title: string;
+  url: string;
+  publishedAt?: string;
+  retrievedAt: string;
+  contentMaterial: string;
+}): RuntimeResearchSourceMaterial {
+  return {
+    record: parseRuntimeResearchSourceRecord({
+      schemaVersion: "v1",
+      sourceId: input.sourceId,
+      sourceKind: "article",
+      title: input.title,
+      url: input.url,
+      canonicalUrl: input.url,
+      authors: ["Ada Researcher"],
+      ...(input.publishedAt ? { publishedAt: input.publishedAt } : {}),
+      retrievedAt: input.retrievedAt,
+      contentDigest: `sha256:${input.sourceId}`,
+      provenance: {
+        acquisitionKind: "manual_url",
+        collectedFrom: input.url,
+        hostname: new URL(input.url).hostname,
+        publisher: "Research Example",
+        firstSeenAt: input.retrievedAt,
+        lastSeenAt: input.retrievedAt,
+      },
+      venueKeys: ["jupiter"],
+      assetKeys: ["SOL"],
+      tags: ["strategy-lab"],
+    }),
+    contentMaterial: input.contentMaterial,
+  };
+}
+
+describe("runtime research briefs", () => {
+  test("parses brief requests and preserves explicit source requests", () => {
+    const request = parseRuntimeResearchBriefRequest({
+      profile: "custom",
+      title: "Venue watch",
+      explicitAllowedHosts: ["docs.example.com"],
+      requests: [
+        {
+          kind: "venue_docs",
+          url: "https://docs.example.com/changelog",
+          venueKey: "jupiter",
+          documentKind: "changelog",
+          tags: ["venue-watch"],
+        },
+      ],
+    });
+
+    expect(request.profile).toBe("custom");
+    expect(request.explicitAllowedHosts).toEqual(["docs.example.com"]);
+    expect(resolveRuntimeResearchBriefRequests(request)).toEqual([
+      {
+        kind: "venue_docs",
+        url: "https://docs.example.com/changelog",
+        venueKey: "jupiter",
+        documentKind: "changelog",
+        tags: ["venue-watch"],
+      },
+    ]);
+  });
+
+  test("rejects requests outside the approved host set", () => {
+    expect(() =>
+      validateRuntimeResearchBriefRequests({
+        requests: [
+          {
+            kind: "manual_url",
+            url: "https://unapproved.example.com/post",
+          },
+        ],
+        approvedHosts: ["research.example.com"],
+      }),
+    ).toThrow("research-source-not-allowed:unapproved.example.com");
+  });
+
+  test("builds audit-friendly briefs with dates and citations", () => {
+    const brief = buildRuntimeResearchBrief({
+      request: {
+        profile: "custom",
+        title: "Latest signal research",
+        requests: [
+          {
+            kind: "manual_url",
+            url: "https://research.example.com/posts/momentum-alpha",
+          },
+        ],
+        explicitAllowedHosts: ["research.example.com"],
+      },
+      sourceMaterials: [
+        sourceMaterialFixture({
+          sourceId: "source_article_latest",
+          title: "Momentum Alpha in Crypto",
+          url: "https://research.example.com/posts/momentum-alpha",
+          publishedAt: "2026-03-11T08:00:00.000Z",
+          retrievedAt: "2026-03-11T12:00:00.000Z",
+          contentMaterial:
+            "Momentum Alpha in Crypto. Measure momentum across venue fragments and validate liquidity persistence.",
+        }),
+      ],
+      createdCount: 1,
+      existingCount: 0,
+    });
+
+    expect(brief.summary).toContain("Reviewed 1 approved sources");
+    expect(brief.findings[0]).toContain("published 2026-03-11T08:00:00.000Z");
+    expect(brief.citations[0]).toEqual({
+      sourceId: "source_article_latest",
+      materialDigest: "sha256:source_article_latest",
+      notes: "published 2026-03-11T08:00:00.000Z",
+    });
+
+    const markdown = buildRuntimeResearchBriefMarkdown(brief);
+    expect(markdown).toContain("# Latest signal research");
+    expect(markdown).toContain("Momentum Alpha in Crypto");
+    expect(markdown).toContain(
+      "https://research.example.com/posts/momentum-alpha",
+    );
+  });
+});

--- a/tests/unit/worker_runtime_research_briefs_route.test.ts
+++ b/tests/unit/worker_runtime_research_briefs_route.test.ts
@@ -1,0 +1,227 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Env } from "../../apps/worker/src/types";
+import {
+  createExecutionContextStub,
+  createWorkerLiveEnv,
+} from "../integration/_worker_live_test_utils";
+
+const worker = (await import("../../apps/worker/src/index")).default;
+const originalFetch = globalThis.fetch;
+
+function createSqliteD1Adapter(db: Database): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          return {
+            async run() {
+              const statement = db.query(sql);
+              const result = statement.run(...(params as never[])) as {
+                changes?: number;
+              };
+              return {
+                meta: {
+                  changes:
+                    typeof result.changes === "number" ? result.changes : 0,
+                },
+              };
+            },
+            async first() {
+              const statement = db.query(sql);
+              return (statement.get(...(params as never[])) as unknown) ?? null;
+            },
+            async all() {
+              const statement = db.query(sql);
+              return {
+                results: (statement.all(...(params as never[])) ??
+                  []) as unknown[],
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+function createOpsEnv(overrides?: Partial<Env>) {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA foreign_keys = ON;");
+
+  for (const migrationName of [
+    "0025_execution_fabric.sql",
+    "0026_execution_canary.sql",
+    "0027_runtime_canary.sql",
+  ]) {
+    const migrationPath = resolve(
+      import.meta.dir,
+      "..",
+      "..",
+      "apps/worker/migrations",
+      migrationName,
+    );
+    sqlite.exec(readFileSync(migrationPath, "utf8"));
+  }
+
+  const env = createWorkerLiveEnv({
+    overrides: {
+      WAITLIST_DB: createSqliteD1Adapter(sqlite),
+      ADMIN_TOKEN: "admin-secret",
+      ...overrides,
+    },
+  });
+
+  return { env, sqlite };
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("worker runtime research brief route", () => {
+  test("requires admin auth", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/admin/ops/runtime/research/briefs", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ profile: "latest_strategy_papers" }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({
+        ok: false,
+        error: "auth-required",
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("builds and returns a research brief through the admin route", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "https://research.example.com/posts/momentum-alpha") {
+          return new Response(
+            `
+              <html>
+                <head>
+                  <title>Momentum Alpha in Crypto</title>
+                  <meta name="author" content="Ada Researcher" />
+                  <meta property="article:published_time" content="2026-03-11T08:00:00Z" />
+                </head>
+                <body>
+                  <p>Measure momentum across venue fragments and validate liquidity persistence.</p>
+                </body>
+              </html>
+            `,
+            { status: 200, headers: { "content-type": "text/html" } },
+          );
+        }
+        throw new Error(`unexpected fetch ${url}`);
+      }) as typeof fetch;
+
+      const response = await worker.fetch(
+        new Request("http://localhost/api/admin/ops/runtime/research/briefs", {
+          method: "POST",
+          headers: {
+            authorization: "Bearer admin-secret",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            profile: "custom",
+            title: "Manual strategy brief",
+            explicitAllowedHosts: ["research.example.com"],
+            requests: [
+              {
+                kind: "manual_url",
+                url: "https://research.example.com/posts/momentum-alpha",
+                sourceKind: "article",
+                venueKeys: ["jupiter"],
+                assetKeys: ["SOL"],
+                tags: ["signal"],
+              },
+            ],
+          }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        ok: true,
+        brief: {
+          title: "Manual strategy brief",
+          profile: "custom",
+          sourceCount: 1,
+          createdCount: 1,
+          citations: [
+            {
+              notes: "published 2026-03-11T08:00:00.000Z",
+            },
+          ],
+          sources: [
+            {
+              title: "Momentum Alpha in Crypto",
+              canonicalUrl: "https://research.example.com/posts/momentum-alpha",
+            },
+          ],
+        },
+        markdown: expect.stringContaining("Momentum Alpha in Crypto"),
+        storedSources: [
+          {
+            title: "Momentum Alpha in Crypto",
+          },
+        ],
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("fails closed when a request host is not approved", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/admin/ops/runtime/research/briefs", {
+          method: "POST",
+          headers: {
+            authorization: "Bearer admin-secret",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            profile: "custom",
+            requests: [
+              {
+                kind: "manual_url",
+                url: "https://unapproved.example.com/posts/alpha",
+              },
+            ],
+          }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({
+        ok: false,
+        error: "research-source-not-allowed:unapproved.example.com",
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a Worker-admin research brief workflow that acquires approved sources, stores them in the runtime research registry, and emits JSON/Markdown brief artifacts
- add a local CLI and scheduled/manual GitHub Actions workflow for strategy-lab research briefs
- document verification and operator usage for the new research brief path

Fixes #318

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun test tests/unit/runtime_research_source_acquisition.test.ts tests/unit/worker_runtime_research_sources.test.ts tests/unit/runtime_research_briefs.test.ts tests/unit/worker_runtime_research_briefs_route.test.ts`
- `bun test tests/unit/runtime_protocol_contracts.test.ts tests/unit/runtime_protocol_schema_fixtures.test.ts tests/unit/worker_runtime_internal_routes.test.ts tests/unit/worker_runtime_contracts.test.ts`
