### PR TITLE
Add strategy-lab candidate triage workflow

### DIFF
--- a/.github/workflows/strategy-lab-triage.yml
+++ b/.github/workflows/strategy-lab-triage.yml
@@ -1,0 +1,108 @@
+name: Strategy Lab Triage
+
+on:
+  workflow_dispatch:
+    inputs:
+      synthesis_file:
+        description: Repo-relative path to a checked-in synthesis JSON artifact
+        required: true
+      apply_disposition:
+        description: Archive the synthesized hypothesis automatically when triage recommends archival
+        required: false
+        default: "false"
+      issue_number:
+        description: Optional GitHub issue number to comment with the triage summary
+        required: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.0"
+
+      - name: Install deps
+        run: bun install
+
+      - name: Check admin credentials
+        env:
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ADMIN_TOKEN:-}" ]; then
+            echo "::error::Missing required secret ADMIN_TOKEN for strategy-lab triage."
+            exit 1
+          fi
+
+      - name: Build triage artifact
+        env:
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          SYNTHESIS_FILE: ${{ inputs.synthesis_file }}
+          APPLY_DISPOSITION: ${{ inputs.apply_disposition }}
+        run: |
+          set -euo pipefail
+          mkdir -p .tmp/strategy-lab-triage
+
+          args=(
+            --base-url https://api.trader-ralph.com
+            --admin-token "${ADMIN_TOKEN}"
+            --output-dir .tmp/strategy-lab-triage
+            --synthesis-file "${SYNTHESIS_FILE}"
+          )
+
+          if [ "${APPLY_DISPOSITION}" = "true" ]; then
+            args+=(--apply-disposition)
+          fi
+
+          bun run strategy-lab:triage "${args[@]}"
+
+          cat .tmp/strategy-lab-triage/triage.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload triage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: strategy-lab-triage-${{ github.run_id }}
+          path: .tmp/strategy-lab-triage
+          if-no-files-found: error
+
+      - name: Comment on issue
+        if: ${{ inputs.issue_number != '' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          set -euo pipefail
+
+          triage_id="$(jq -r '.triageId' .tmp/strategy-lab-triage/triage.json)"
+          disposition="$(jq -r '.disposition' .tmp/strategy-lab-triage/triage.json)"
+          priority_score="$(jq -r '.priorityScoreBps' .tmp/strategy-lab-triage/triage.json)"
+          run_url="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
+
+          body="$(cat <<EOF
+          Strategy-lab triage artifact ready.
+
+          - triageId: \`${triage_id}\`
+          - disposition: \`${disposition}\`
+          - priorityScoreBps: \`${priority_score}\`
+          - workflow run: ${run_url}
+          EOF
+          )"
+
+          payload="$(jq -n --arg body "$body" '{body:$body}')"
+          curl -fsS \
+            -X POST \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
+            -d "${payload}" >/dev/null

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,5 +1,6 @@
 import { parseRuntimeResearchBriefRequest } from "../../../src/runtime/research/briefs.js";
 import { parseRuntimeResearchSynthesisRequest } from "../../../src/runtime/research/synthesis.js";
+import { parseRuntimeResearchCandidateTriageRequest } from "../../../src/runtime/research/triage.js";
 import { buildAgentQueryResponse } from "./agent_query";
 import { requireUser } from "./auth";
 import { getUserSubscription, toSubscriptionView } from "./billing";
@@ -154,6 +155,7 @@ import {
 } from "./runtime_internal";
 import { runRuntimeResearchBriefWorkflow } from "./runtime_research_briefs";
 import { runRuntimeResearchSynthesisWorkflow } from "./runtime_research_synthesis";
+import { runRuntimeResearchCandidateTriageWorkflow } from "./runtime_research_triage";
 import { SolanaRpc } from "./solana_rpc";
 import type { Env, ExecutionConfig } from "./types";
 import type { UserRow } from "./users_db";
@@ -2314,6 +2316,50 @@ const worker = {
                   error instanceof Error
                     ? error.message
                     : "runtime-research-synthesis-failed",
+              },
+              { status: 400 },
+            ),
+            env,
+          );
+        }
+      }
+
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/admin/ops/runtime/research/triage"
+      ) {
+        const auth = authorizeAdminRoute(request, env);
+        if (!auth.ok) {
+          return withCors(
+            json({ ok: false, error: auth.error }, { status: auth.status }),
+            env,
+          );
+        }
+        try {
+          const triageRequest = parseRuntimeResearchCandidateTriageRequest(
+            await request.json(),
+          );
+          const result = await runRuntimeResearchCandidateTriageWorkflow({
+            env,
+            request: triageRequest,
+          });
+          return withCors(
+            json({
+              ok: true,
+              triage: result.triage,
+              markdown: result.markdown,
+            }),
+            env,
+          );
+        } catch (error) {
+          return withCors(
+            json(
+              {
+                ok: false,
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "runtime-research-triage-failed",
               },
               { status: 400 },
             ),

--- a/apps/worker/src/runtime_research_triage.ts
+++ b/apps/worker/src/runtime_research_triage.ts
@@ -1,0 +1,108 @@
+import { parseRuntimeResearchHypothesisRecord } from "../../../src/runtime/contracts/autonomous_runtime.js";
+import type {
+  RuntimeResearchCandidateTriageArtifact,
+  RuntimeResearchCandidateTriageRequest,
+} from "../../../src/runtime/research/triage.js";
+import {
+  buildRuntimeResearchCandidateTriage,
+  buildRuntimeResearchCandidateTriageMarkdown,
+} from "../../../src/runtime/research/triage.js";
+import {
+  readRuntimeResearchRegistry,
+  writeRuntimeResearchHypothesis,
+} from "./runtime_internal";
+import type { Env } from "./types";
+
+export type RuntimeResearchTriageWorkflowResult = {
+  triage: RuntimeResearchCandidateTriageArtifact;
+  markdown: string;
+};
+
+export async function runRuntimeResearchCandidateTriageWorkflow(input: {
+  env: Env;
+  request: RuntimeResearchCandidateTriageRequest;
+}): Promise<RuntimeResearchTriageWorkflowResult> {
+  const registryResponse = await readRuntimeResearchRegistry({
+    env: input.env,
+  });
+  if (!registryResponse.ok) {
+    throw new Error(
+      String(
+        registryResponse.payload.error ??
+          "runtime-research-triage-registry-read-failed",
+      ),
+    );
+  }
+
+  const rawHypotheses =
+    registryResponse.payload.registry &&
+    typeof registryResponse.payload.registry === "object" &&
+    Array.isArray(registryResponse.payload.registry.hypotheses)
+      ? registryResponse.payload.registry.hypotheses
+      : [];
+  const existingHypotheses = rawHypotheses
+    .map((entry) => {
+      try {
+        return parseRuntimeResearchHypothesisRecord(entry);
+      } catch {
+        return null;
+      }
+    })
+    .filter(
+      (
+        value,
+      ): value is RuntimeResearchCandidateTriageRequest["existingHypotheses"][number] =>
+        value !== null,
+    );
+
+  const triage = buildRuntimeResearchCandidateTriage({
+    request: {
+      ...input.request,
+      existingHypotheses,
+    },
+  });
+
+  let archivedHypothesisId: string | undefined;
+  if (
+    input.request.applyDisposition &&
+    triage.recommendedHypothesisStatus === "archived" &&
+    input.request.synthesis.hypothesis.status !== "archived"
+  ) {
+    const archivedHypothesis = parseRuntimeResearchHypothesisRecord({
+      ...input.request.synthesis.hypothesis,
+      status: "archived",
+      updatedAt: triage.generatedAt,
+      tags: Array.from(
+        new Set([
+          ...input.request.synthesis.hypothesis.tags,
+          "archived",
+          "triaged",
+        ]),
+      ).slice(0, 16),
+    });
+    const archiveResponse = await writeRuntimeResearchHypothesis({
+      env: input.env,
+      hypothesis: archivedHypothesis,
+    });
+    if (!archiveResponse.ok) {
+      throw new Error(
+        String(
+          archiveResponse.payload.error ??
+            "runtime-research-triage-archive-failed",
+        ),
+      );
+    }
+    archivedHypothesisId = archivedHypothesis.hypothesisId;
+  }
+
+  return {
+    triage: {
+      ...triage,
+      ...(archivedHypothesisId ? { archivedHypothesisId } : {}),
+    },
+    markdown: buildRuntimeResearchCandidateTriageMarkdown({
+      ...triage,
+      ...(archivedHypothesisId ? { archivedHypothesisId } : {}),
+    }),
+  };
+}

--- a/docs/repository-verification-index.md
+++ b/docs/repository-verification-index.md
@@ -295,6 +295,26 @@ Verify:
 - the Worker admin route writes the hypothesis through the existing runtime
   bridge instead of bypassing repo-owned contracts.
 
+### 3h. Strategy-lab triage verification
+
+For candidate triage, novelty scoring, and archival routing work:
+
+```bash
+bun run lint
+bun run typecheck
+bun test tests/unit/runtime_research_triage.test.ts tests/unit/worker_runtime_research_triage_route.test.ts
+bun test tests/unit/worker_runtime_research_synthesis_route.test.ts tests/unit/worker_runtime_internal_routes.test.ts tests/unit/worker_runtime_contracts.test.ts
+```
+
+Verify:
+
+- duplicate and near-duplicate candidates are detected with explainable reasons,
+- novelty, evidence, venue-fit, and implementation-cost signals are explicit,
+- weak or duplicate candidates can be archived without deleting provenance,
+- the triage route compares against the current research registry and repo-owned
+  built-in strategy references,
+- triage remains internal-only on the Worker admin boundary.
+
 ### 4. x402 and discovery verification
 
 Portal-side discovery:

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "harness:proof": "bun run src/bin/harness.ts proof",
     "strategy-lab:research": "bun run src/bin/strategy_lab_research.ts",
     "strategy-lab:synthesize": "bun run src/bin/strategy_lab_synthesis.ts",
+    "strategy-lab:triage": "bun run src/bin/strategy_lab_triage.ts",
     "runtime:fly:deploy": "node scripts/runtime_rs/fly_deploy.mjs",
     "runtime:fly:smoke": "node scripts/runtime_rs/fly_smoke.mjs",
     "runner:once": "bun run src/bin/runner.ts once",

--- a/services/runtime-rs/README.md
+++ b/services/runtime-rs/README.md
@@ -237,6 +237,7 @@ Operators should use the Worker as the public control plane:
 - `GET /api/admin/ops/runtime`
 - `POST /api/admin/ops/runtime/research/briefs`
 - `POST /api/admin/ops/runtime/research/synthesis`
+- `POST /api/admin/ops/runtime/research/triage`
 - `POST /api/admin/ops/runtime/deployments/:deploymentId/pause`
 - `POST /api/admin/ops/runtime/deployments/:deploymentId/resume`
 - `POST /api/admin/ops/runtime/deployments/:deploymentId/kill`
@@ -265,6 +266,16 @@ bun run strategy-lab:synthesize --brief-file .tmp/strategy-lab-research/brief.js
 That command writes `.tmp/strategy-lab-synthesis/synthesis.json` and
 `.tmp/strategy-lab-synthesis/synthesis.md`, including a draft hypothesis,
 StrategySpec scaffold, evaluation plan, and candidate-issue body.
+
+Candidate triage stays on the same internal-only pattern:
+
+```bash
+bun run strategy-lab:triage --synthesis-file .tmp/strategy-lab-synthesis/synthesis.json
+```
+
+That command writes `.tmp/strategy-lab-triage/triage.json` and
+`.tmp/strategy-lab-triage/triage.md`, including novelty scoring, duplicate
+matches, explainable rationale, and an optional archival recommendation.
 
 The runtime operator surface now includes allocator details for a deployment:
 

--- a/src/bin/strategy_lab_triage.ts
+++ b/src/bin/strategy_lab_triage.ts
@@ -1,0 +1,83 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { parseRuntimeResearchCandidateTriageRequest } from "../runtime/research/triage.js";
+
+function readArg(flag: string): string | null {
+  const index = process.argv.indexOf(flag);
+  if (index < 0) return null;
+  return process.argv[index + 1] ?? null;
+}
+
+function readJsonFile(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf8")) as unknown;
+}
+
+async function main(): Promise<void> {
+  const baseUrl = readArg("--base-url") ?? "http://127.0.0.1:8888";
+  const outputDir = resolve(
+    readArg("--output-dir") ?? ".tmp/strategy-lab-triage",
+  );
+  const adminToken =
+    readArg("--admin-token") ?? String(process.env.ADMIN_TOKEN ?? "").trim();
+  if (!adminToken) {
+    throw new Error("missing-admin-token");
+  }
+
+  const synthesisFile = readArg("--synthesis-file");
+  if (!synthesisFile) {
+    throw new Error("missing-arg:--synthesis-file");
+  }
+
+  const requestBody = parseRuntimeResearchCandidateTriageRequest({
+    synthesis: readJsonFile(resolve(synthesisFile)),
+    ...(process.argv.includes("--apply-disposition")
+      ? { applyDisposition: true }
+      : {}),
+  });
+
+  const response = await fetch(
+    `${baseUrl.replace(/\/$/, "")}/api/admin/ops/runtime/research/triage`,
+    {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${adminToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    },
+  );
+  const payload = (await response.json()) as Record<string, unknown>;
+  if (!response.ok || payload.ok !== true) {
+    throw new Error(
+      String(
+        payload.error ?? `runtime-research-triage-failed:${response.status}`,
+      ),
+    );
+  }
+
+  mkdirSync(outputDir, { recursive: true });
+  const jsonPath = join(outputDir, "triage.json");
+  const markdownPath = join(outputDir, "triage.md");
+  writeFileSync(jsonPath, `${JSON.stringify(payload.triage, null, 2)}\n`);
+  writeFileSync(markdownPath, `${String(payload.markdown ?? "")}\n`);
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        baseUrl,
+        outputDir,
+        triagePath: jsonPath,
+        markdownPath,
+        triageId:
+          typeof payload.triage === "object" && payload.triage
+            ? (payload.triage as Record<string, unknown>).triageId
+            : null,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+await main();

--- a/src/runtime/research/triage.ts
+++ b/src/runtime/research/triage.ts
@@ -1,0 +1,721 @@
+import {
+  parseRuntimeResearchHypothesisRecord,
+  parseRuntimeStrategySpec,
+  type RuntimeResearchHypothesisRecord,
+  type RuntimeStrategySpec,
+} from "../contracts/autonomous_runtime.js";
+import { getRuntimeVenueCapability } from "../venues/catalog.js";
+import type {
+  RuntimeResearchImplementationPlan,
+  RuntimeResearchSynthesisArtifact,
+  RuntimeResearchSynthesisEvaluationPlan,
+} from "./synthesis.js";
+
+export type RuntimeResearchCandidateTriageRequest = {
+  synthesis: RuntimeResearchSynthesisArtifact;
+  existingHypotheses?: RuntimeResearchHypothesisRecord[];
+  applyDisposition?: boolean;
+};
+
+export type RuntimeResearchCandidateDuplicateMatch = {
+  matchType: "exact" | "near_duplicate" | "family_overlap";
+  source: "builtin" | "candidate" | "production";
+  strategyKey: string;
+  similarityBps: number;
+  reasons: string[];
+};
+
+export type RuntimeResearchCandidateTriageArtifact = {
+  triageId: string;
+  generatedAt: string;
+  synthesisId: string;
+  hypothesisId: string;
+  disposition: "promote_to_candidate" | "review" | "archive";
+  recommendedHypothesisStatus: RuntimeResearchHypothesisRecord["status"];
+  noveltyScoreBps: number;
+  evidenceScoreBps: number;
+  venueFitScoreBps: number;
+  implementationCostScoreBps: number;
+  priorityScoreBps: number;
+  duplicateMatches: RuntimeResearchCandidateDuplicateMatch[];
+  rationale: string[];
+  archivedHypothesisId?: string;
+};
+
+type StrategyReference = {
+  strategyKey: string;
+  title: string;
+  category: RuntimeStrategySpec["category"];
+  marketType: string;
+  featureKeys: string[];
+  regimeKeys: string[];
+  tags: string[];
+  source: "builtin" | "candidate" | "production";
+};
+
+const BUILTIN_STRATEGY_REFERENCES: StrategyReference[] = [
+  reference(
+    "dca",
+    "DCA",
+    "allocation",
+    "spot",
+    [],
+    [],
+    ["allocation"],
+    "production",
+  ),
+  reference(
+    "threshold_rebalance",
+    "Threshold rebalance",
+    "allocation",
+    "spot",
+    ["long_return_bps"],
+    ["long_trend"],
+    ["allocation", "rebalance"],
+    "production",
+  ),
+  reference(
+    "twap",
+    "TWAP",
+    "allocation",
+    "spot",
+    [],
+    [],
+    ["execution"],
+    "production",
+  ),
+  reference(
+    "trend_following",
+    "Trend following",
+    "signal",
+    "spot",
+    ["short_return_bps", "long_return_bps", "realized_volatility_bps"],
+    ["short_trend", "long_trend"],
+    ["trend", "signal"],
+    "builtin",
+  ),
+  reference(
+    "mean_reversion",
+    "Mean reversion",
+    "signal",
+    "spot",
+    ["short_return_bps", "spread_bps", "realized_volatility_bps"],
+    ["volatility_band", "liquidity_state"],
+    ["mean-reversion", "signal"],
+    "builtin",
+  ),
+  reference(
+    "breakout",
+    "Breakout",
+    "advanced",
+    "spot",
+    ["long_return_bps", "realized_volatility_bps", "spread_bps"],
+    ["long_trend", "volatility_band"],
+    ["advanced", "breakout"],
+    "builtin",
+  ),
+  reference(
+    "macro_rotation",
+    "Macro rotation",
+    "allocation",
+    "spot",
+    ["long_return_bps", "realized_volatility_bps"],
+    ["long_trend", "volatility_band"],
+    ["allocation", "rotation"],
+    "builtin",
+  ),
+  reference(
+    "volatility_target",
+    "Volatility target",
+    "advanced",
+    "spot",
+    ["realized_volatility_bps", "long_return_bps"],
+    ["volatility_band"],
+    ["advanced", "volatility"],
+    "builtin",
+  ),
+];
+
+const BUILTIN_FEATURE_KEYS = new Set([
+  "short_return_bps",
+  "long_return_bps",
+  "realized_volatility_bps",
+  "spread_bps",
+]);
+
+export function parseRuntimeResearchCandidateTriageRequest(
+  input: unknown,
+): RuntimeResearchCandidateTriageRequest {
+  if (!isRecord(input)) {
+    throw new Error("invalid-runtime-research-triage-request");
+  }
+  const synthesis = parseRuntimeResearchSynthesisArtifact(input.synthesis);
+  const existingHypotheses = Array.isArray(input.existingHypotheses)
+    ? input.existingHypotheses.map((entry) =>
+        parseRuntimeResearchHypothesisRecord(entry),
+      )
+    : undefined;
+  return {
+    synthesis,
+    ...(existingHypotheses ? { existingHypotheses } : {}),
+    ...(typeof input.applyDisposition === "boolean"
+      ? { applyDisposition: input.applyDisposition }
+      : {}),
+  };
+}
+
+export function buildRuntimeResearchCandidateTriage(input: {
+  request: RuntimeResearchCandidateTriageRequest;
+}): RuntimeResearchCandidateTriageArtifact {
+  const synthesis = input.request.synthesis;
+  const candidateReference = toReference(synthesis);
+  const comparisons = [
+    ...BUILTIN_STRATEGY_REFERENCES,
+    ...(input.request.existingHypotheses ?? [])
+      .filter(
+        (hypothesis) =>
+          hypothesis.hypothesisId !== synthesis.hypothesis.hypothesisId,
+      )
+      .map((hypothesis) => hypothesisToReference(hypothesis, synthesis)),
+  ];
+  const duplicateMatches = comparisons
+    .map((reference) => compareReference(candidateReference, reference))
+    .filter(
+      (match): match is RuntimeResearchCandidateDuplicateMatch =>
+        match !== null,
+    )
+    .sort((left, right) => right.similarityBps - left.similarityBps);
+
+  const maxSimilarity = duplicateMatches[0]?.similarityBps ?? 0;
+  const noveltyScoreBps = clampBps(10000 - maxSimilarity);
+  const evidenceScoreBps = scoreEvidenceQuality(synthesis);
+  const venueFitScoreBps = scoreVenueFit(synthesis);
+  const implementationCostScoreBps = scoreImplementationCost(synthesis);
+  const priorityScoreBps = clampBps(
+    Math.round(
+      noveltyScoreBps * 0.35 +
+        evidenceScoreBps * 0.25 +
+        venueFitScoreBps * 0.2 +
+        implementationCostScoreBps * 0.2,
+    ),
+  );
+
+  const rationale = buildRationale({
+    duplicateMatches,
+    noveltyScoreBps,
+    evidenceScoreBps,
+    venueFitScoreBps,
+    implementationCostScoreBps,
+    priorityScoreBps,
+    synthesis,
+  });
+  const disposition = decideDisposition({
+    duplicateMatches,
+    evidenceScoreBps,
+    venueFitScoreBps,
+    priorityScoreBps,
+  });
+  const recommendedHypothesisStatus =
+    disposition === "archive" ? "archived" : "candidate";
+  const triageId = `triage_${hash(
+    JSON.stringify({
+      synthesisId: synthesis.synthesisId,
+      hypothesisId: synthesis.hypothesis.hypothesisId,
+      priorityScoreBps,
+      maxSimilarity,
+    }),
+  )}`;
+
+  return {
+    triageId,
+    generatedAt: new Date().toISOString(),
+    synthesisId: synthesis.synthesisId,
+    hypothesisId: synthesis.hypothesis.hypothesisId,
+    disposition,
+    recommendedHypothesisStatus,
+    noveltyScoreBps,
+    evidenceScoreBps,
+    venueFitScoreBps,
+    implementationCostScoreBps,
+    priorityScoreBps,
+    duplicateMatches,
+    rationale,
+  };
+}
+
+export function buildRuntimeResearchCandidateTriageMarkdown(
+  triage: RuntimeResearchCandidateTriageArtifact,
+): string {
+  const lines = [
+    `# Candidate triage for ${triage.hypothesisId}`,
+    "",
+    `- Triage id: ${triage.triageId}`,
+    `- Generated at: ${triage.generatedAt}`,
+    `- Disposition: ${triage.disposition}`,
+    `- Recommended hypothesis status: ${triage.recommendedHypothesisStatus}`,
+    `- Novelty score: ${formatBps(triage.noveltyScoreBps)}`,
+    `- Evidence score: ${formatBps(triage.evidenceScoreBps)}`,
+    `- Venue fit score: ${formatBps(triage.venueFitScoreBps)}`,
+    `- Implementation cost score: ${formatBps(triage.implementationCostScoreBps)}`,
+    `- Priority score: ${formatBps(triage.priorityScoreBps)}`,
+    "",
+    "## Rationale",
+    "",
+  ];
+
+  for (const entry of triage.rationale) {
+    lines.push(`- ${entry}`);
+  }
+
+  lines.push("", "## Duplicate Matches", "");
+  if (triage.duplicateMatches.length === 0) {
+    lines.push("- none");
+  } else {
+    for (const match of triage.duplicateMatches) {
+      lines.push(
+        `- ${match.strategyKey} (${match.source}, ${match.matchType}, ${formatBps(
+          match.similarityBps,
+        )})`,
+      );
+      for (const reason of match.reasons) {
+        lines.push(`  ${reason}`);
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function compareReference(
+  candidate: StrategyReference,
+  reference: StrategyReference,
+): RuntimeResearchCandidateDuplicateMatch | null {
+  const featureOverlap = jaccard(candidate.featureKeys, reference.featureKeys);
+  const regimeOverlap = jaccard(candidate.regimeKeys, reference.regimeKeys);
+  const tagOverlap = jaccard(candidate.tags, reference.tags);
+  const titleOverlap = candidate.title === reference.title ? 10000 : 0;
+  const categoryOverlap = candidate.category === reference.category ? 10000 : 0;
+  const marketTypeOverlap =
+    candidate.marketType === reference.marketType ? 10000 : 0;
+  const similarityBps = clampBps(
+    Math.round(
+      featureOverlap * 0.35 +
+        regimeOverlap * 0.2 +
+        tagOverlap * 0.1 +
+        titleOverlap * 0.2 +
+        categoryOverlap * 0.1 +
+        marketTypeOverlap * 0.05,
+    ),
+  );
+  if (similarityBps < 3500) {
+    return null;
+  }
+
+  const reasons: string[] = [];
+  if (titleOverlap === 10000) {
+    reasons.push("same synthesized title");
+  }
+  if (featureOverlap >= 6000) {
+    reasons.push("high feature overlap");
+  }
+  if (regimeOverlap >= 5000) {
+    reasons.push("high regime overlap");
+  }
+  if (candidate.category === reference.category) {
+    reasons.push("same strategy category");
+  }
+
+  return {
+    matchType:
+      similarityBps >= 8500
+        ? "exact"
+        : similarityBps >= 6000
+          ? "near_duplicate"
+          : "family_overlap",
+    source: reference.source,
+    strategyKey: reference.strategyKey,
+    similarityBps,
+    reasons,
+  };
+}
+
+function scoreEvidenceQuality(
+  synthesis: RuntimeResearchSynthesisArtifact,
+): number {
+  const citationScore = Math.min(4000, synthesis.citations.length * 1500);
+  const paperBonus = synthesis.citations.some((citation) =>
+    citation.title.toLowerCase().includes("paper"),
+  )
+    ? 1500
+    : 0;
+  const recencyBonus = synthesis.hypothesis.sourceCitations.some((citation) =>
+    (citation.notes ?? "").includes("published"),
+  )
+    ? 1500
+    : 0;
+  const riskPenalty = synthesis.riskNotes.some((note) =>
+    note.toLowerCase().includes("requires new venue"),
+  )
+    ? 1500
+    : 0;
+  return clampBps(
+    citationScore + paperBonus + recencyBonus + 1000 - riskPenalty,
+  );
+}
+
+function scoreVenueFit(synthesis: RuntimeResearchSynthesisArtifact): number {
+  const capability = getRuntimeVenueCapability(
+    synthesis.evaluationPlan.venueKey,
+  );
+  if (!capability) {
+    return 1500;
+  }
+
+  if (!capability.marketTypes.includes(synthesis.evaluationPlan.marketType)) {
+    return 2000;
+  }
+
+  let score = 4500;
+  score += 2500;
+  if (capability.supportedModes.includes("shadow")) {
+    score += 1000;
+  }
+  if (capability.supportedModes.includes("paper")) {
+    score += 1000;
+  }
+  switch (capability.onboardingState) {
+    case "broad_live_ready":
+      score += 1000;
+      break;
+    case "paper_ready":
+      score += 500;
+      break;
+    case "candidate":
+      score -= 1500;
+      break;
+    default:
+      score -= 500;
+  }
+  return clampBps(score);
+}
+
+function scoreImplementationCost(
+  synthesis: RuntimeResearchSynthesisArtifact,
+): number {
+  let score = 9000;
+  const unknownFeatureCount =
+    synthesis.evaluationPlan.requiredFeatureKeys.filter(
+      (featureKey) => !BUILTIN_FEATURE_KEYS.has(featureKey),
+    ).length;
+  score -= unknownFeatureCount * 1500;
+  if (synthesis.evaluationPlan.marketType === "perp") {
+    score -= 2500;
+  }
+  if (
+    synthesis.implementationPlan.scaffoldFiles.some((file) =>
+      file.path.includes("crates/execution-planner"),
+    )
+  ) {
+    score -= 750;
+  }
+  return clampBps(score);
+}
+
+function buildRationale(input: {
+  duplicateMatches: RuntimeResearchCandidateDuplicateMatch[];
+  noveltyScoreBps: number;
+  evidenceScoreBps: number;
+  venueFitScoreBps: number;
+  implementationCostScoreBps: number;
+  priorityScoreBps: number;
+  synthesis: RuntimeResearchSynthesisArtifact;
+}): string[] {
+  const lines = [
+    `Novelty ${formatBps(input.noveltyScoreBps)} based on similarity against built-in and existing candidates.`,
+    `Evidence ${formatBps(input.evidenceScoreBps)} from ${input.synthesis.citations.length} linked citations and published-source coverage.`,
+    `Venue fit ${formatBps(input.venueFitScoreBps)} for ${input.synthesis.evaluationPlan.venueKey} ${input.synthesis.evaluationPlan.marketType}.`,
+    `Implementation cost ${formatBps(input.implementationCostScoreBps)} based on required new features and market-type complexity.`,
+    `Priority ${formatBps(input.priorityScoreBps)} after weighting novelty, evidence, venue fit, and implementation cost.`,
+  ];
+  if (input.duplicateMatches[0]) {
+    lines.push(
+      `Closest overlap is ${input.duplicateMatches[0].strategyKey} at ${formatBps(
+        input.duplicateMatches[0].similarityBps,
+      )}.`,
+    );
+  }
+  return lines;
+}
+
+function decideDisposition(input: {
+  duplicateMatches: RuntimeResearchCandidateDuplicateMatch[];
+  evidenceScoreBps: number;
+  venueFitScoreBps: number;
+  priorityScoreBps: number;
+}): RuntimeResearchCandidateTriageArtifact["disposition"] {
+  const topMatch = input.duplicateMatches[0];
+  if (topMatch && topMatch.matchType === "exact") {
+    return "archive";
+  }
+  if (input.evidenceScoreBps < 3500 || input.venueFitScoreBps < 3000) {
+    return "review";
+  }
+  if (input.priorityScoreBps < 4500) {
+    return "review";
+  }
+  return "promote_to_candidate";
+}
+
+function toReference(
+  synthesis: RuntimeResearchSynthesisArtifact,
+): StrategyReference {
+  return {
+    strategyKey: synthesis.hypothesis.strategyKey,
+    title: synthesis.hypothesis.title,
+    category: synthesis.strategySpecDraft.category,
+    marketType: synthesis.evaluationPlan.marketType,
+    featureKeys: synthesis.evaluationPlan.requiredFeatureKeys,
+    regimeKeys: synthesis.evaluationPlan.requiredRegimeKeys,
+    tags: synthesis.strategySpecDraft.tags,
+    source: "candidate",
+  };
+}
+
+function hypothesisToReference(
+  hypothesis: RuntimeResearchHypothesisRecord,
+  synthesis: RuntimeResearchSynthesisArtifact,
+): StrategyReference {
+  return {
+    strategyKey: hypothesis.strategyKey,
+    title: hypothesis.title,
+    category: synthesis.strategySpecDraft.category,
+    marketType: synthesis.evaluationPlan.marketType,
+    featureKeys: synthesis.evaluationPlan.requiredFeatureKeys,
+    regimeKeys: synthesis.evaluationPlan.requiredRegimeKeys,
+    tags: hypothesis.tags,
+    source: "candidate",
+  };
+}
+
+function parseRuntimeResearchSynthesisArtifact(
+  input: unknown,
+): RuntimeResearchSynthesisArtifact {
+  if (!isRecord(input)) {
+    throw new Error("invalid-runtime-research-synthesis-artifact");
+  }
+  return {
+    synthesisId: readRequiredString(input.synthesisId, "synthesisId"),
+    generatedAt: readRequiredString(input.generatedAt, "generatedAt"),
+    briefId: readRequiredString(input.briefId, "briefId"),
+    briefTitle: readRequiredString(input.briefTitle, "briefTitle"),
+    expectedMechanism: readRequiredString(
+      input.expectedMechanism,
+      "expectedMechanism",
+    ),
+    hypothesis: parseRuntimeResearchHypothesisRecord(input.hypothesis),
+    strategySpecDraft: parseRuntimeStrategySpec(input.strategySpecDraft),
+    evaluationPlan: parseEvaluationPlan(input.evaluationPlan),
+    implementationPlan: parseImplementationPlan(input.implementationPlan),
+    riskNotes: normalizeStringArray(input.riskNotes),
+    citations: Array.isArray(input.citations)
+      ? input.citations.map((entry) => parseCitation(entry))
+      : [],
+  };
+}
+
+function parseEvaluationPlan(
+  input: unknown,
+): RuntimeResearchSynthesisEvaluationPlan {
+  if (!isRecord(input)) {
+    throw new Error("invalid-runtime-research-triage-evaluation-plan");
+  }
+  return {
+    marketType: readRequiredString(
+      input.marketType,
+      "evaluationPlan.marketType",
+    ) as RuntimeResearchSynthesisEvaluationPlan["marketType"],
+    venueKey: readRequiredString(input.venueKey, "evaluationPlan.venueKey"),
+    pairSymbol: readRequiredString(
+      input.pairSymbol,
+      "evaluationPlan.pairSymbol",
+    ),
+    assetKeys: normalizeStringArray(input.assetKeys),
+    datasetRequirements: normalizeStringArray(input.datasetRequirements),
+    requiredFeatureKeys: normalizeStringArray(input.requiredFeatureKeys),
+    requiredRegimeKeys: normalizeStringArray(input.requiredRegimeKeys),
+    backtestPlan: isRecord(input.backtestPlan)
+      ? {
+          windowMode: "rolling",
+          trainingWindowObservations: readRequiredNumber(
+            input.backtestPlan.trainingWindowObservations,
+            "evaluationPlan.backtestPlan.trainingWindowObservations",
+          ),
+          testingWindowObservations: readRequiredNumber(
+            input.backtestPlan.testingWindowObservations,
+            "evaluationPlan.backtestPlan.testingWindowObservations",
+          ),
+          stepObservations: readRequiredNumber(
+            input.backtestPlan.stepObservations,
+            "evaluationPlan.backtestPlan.stepObservations",
+          ),
+          purgeObservations: readRequiredNumber(
+            input.backtestPlan.purgeObservations,
+            "evaluationPlan.backtestPlan.purgeObservations",
+          ),
+          baselineStrategies: normalizeStringArray(
+            input.backtestPlan.baselineStrategies,
+          ),
+        }
+      : (() => {
+          throw new Error("invalid-runtime-research-triage-backtest-plan");
+        })(),
+    paperPlan: isRecord(input.paperPlan)
+      ? {
+          required: true,
+          minPaperRuns: readRequiredNumber(
+            input.paperPlan.minPaperRuns,
+            "evaluationPlan.paperPlan.minPaperRuns",
+          ),
+          notes: normalizeStringArray(input.paperPlan.notes),
+        }
+      : (() => {
+          throw new Error("invalid-runtime-research-triage-paper-plan");
+        })(),
+    successCriteria: normalizeStringArray(input.successCriteria),
+    failureModes: normalizeStringArray(input.failureModes),
+  };
+}
+
+function parseImplementationPlan(
+  input: unknown,
+): RuntimeResearchImplementationPlan {
+  if (!isRecord(input)) {
+    throw new Error("invalid-runtime-research-triage-implementation-plan");
+  }
+  return {
+    branchName: readRequiredString(
+      input.branchName,
+      "implementationPlan.branchName",
+    ),
+    issueTitle: readRequiredString(
+      input.issueTitle,
+      "implementationPlan.issueTitle",
+    ),
+    issueBody: readRequiredString(
+      input.issueBody,
+      "implementationPlan.issueBody",
+    ),
+    scaffoldFiles: Array.isArray(input.scaffoldFiles)
+      ? input.scaffoldFiles.map((entry) =>
+          parsePlanEntry(entry, "scaffoldFiles"),
+        )
+      : [],
+    testFiles: Array.isArray(input.testFiles)
+      ? input.testFiles.map((entry) => parsePlanEntry(entry, "testFiles"))
+      : [],
+    validationCommands: normalizeStringArray(input.validationCommands),
+  };
+}
+
+function parsePlanEntry(
+  input: unknown,
+  label: string,
+): RuntimeResearchImplementationPlan["scaffoldFiles"][number] {
+  if (!isRecord(input)) {
+    throw new Error(`invalid-runtime-research-triage-${label}`);
+  }
+  return {
+    path: readRequiredString(input.path, `${label}.path`),
+    purpose: readRequiredString(input.purpose, `${label}.purpose`),
+  };
+}
+
+function parseCitation(input: unknown) {
+  if (!isRecord(input)) {
+    throw new Error("invalid-runtime-research-triage-citation");
+  }
+  return {
+    sourceId: readRequiredString(input.sourceId, "citation.sourceId"),
+    title: readRequiredString(input.title, "citation.title"),
+    canonicalUrl: readRequiredString(
+      input.canonicalUrl,
+      "citation.canonicalUrl",
+    ),
+  };
+}
+
+function jaccard(left: string[], right: string[]): number {
+  const leftSet = new Set(left);
+  const rightSet = new Set(right);
+  const intersection = Array.from(leftSet).filter((value) =>
+    rightSet.has(value),
+  ).length;
+  const union = new Set([...leftSet, ...rightSet]).size;
+  if (union === 0) {
+    return 0;
+  }
+  return clampBps(Math.round((intersection / union) * 10000));
+}
+
+function formatBps(value: number): string {
+  return `${(value / 100).toFixed(2)}%`;
+}
+
+function clampBps(value: number): number {
+  return Math.max(0, Math.min(10000, Math.trunc(value)));
+}
+
+function reference(
+  strategyKey: string,
+  title: string,
+  category: RuntimeStrategySpec["category"],
+  marketType: string,
+  featureKeys: string[],
+  regimeKeys: string[],
+  tags: string[],
+  source: StrategyReference["source"],
+): StrategyReference {
+  return {
+    strategyKey,
+    title,
+    category,
+    marketType,
+    featureKeys,
+    regimeKeys,
+    tags,
+    source,
+  };
+}
+
+function readRequiredString(input: unknown, field: string): string {
+  if (typeof input !== "string" || !input.trim()) {
+    throw new Error(`invalid-runtime-research-triage-${field}`);
+  }
+  return input.trim();
+}
+
+function readRequiredNumber(input: unknown, field: string): number {
+  if (typeof input !== "number" || !Number.isFinite(input)) {
+    throw new Error(`invalid-runtime-research-triage-${field}`);
+  }
+  return Math.trunc(input);
+}
+
+function normalizeStringArray(input: unknown): string[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+  return input.map((value) => String(value ?? "").trim()).filter(Boolean);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function hash(value: string): string {
+  let hashValue = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hashValue = (hashValue * 31 + value.charCodeAt(index)) >>> 0;
+  }
+  return hashValue.toString(16).padStart(8, "0");
+}

--- a/tests/unit/runtime_research_triage.test.ts
+++ b/tests/unit/runtime_research_triage.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import { buildRuntimeResearchSynthesis } from "../../src/runtime/research/synthesis.js";
+import {
+  buildRuntimeResearchCandidateTriage,
+  buildRuntimeResearchCandidateTriageMarkdown,
+  parseRuntimeResearchCandidateTriageRequest,
+} from "../../src/runtime/research/triage.js";
+
+const briefFixture = {
+  briefId: "brief_latest_signal",
+  generatedAt: "2026-03-11T12:00:00.000Z",
+  profile: "custom",
+  title: "Latest signal research",
+  summary:
+    "Reviewed 1 approved source across 1 acquisition request. Most recent coverage: Momentum Alpha in Crypto.",
+  findings: [
+    "Momentum Alpha in Crypto (published 2026-03-11T08:00:00.000Z): Measure momentum across venue fragments and validate liquidity persistence.",
+  ],
+  approvedHosts: ["research.example.com"],
+  requestCount: 1,
+  sourceCount: 1,
+  createdCount: 1,
+  existingCount: 0,
+  citations: [
+    {
+      sourceId: "source_article_momentum",
+      materialDigest: "sha256:source_article_momentum",
+      notes: "published 2026-03-11T08:00:00.000Z",
+    },
+  ],
+  sources: [
+    {
+      sourceId: "source_article_momentum",
+      sourceKind: "article",
+      title: "Momentum Alpha in Crypto",
+      url: "https://research.example.com/posts/momentum-alpha",
+      canonicalUrl: "https://research.example.com/posts/momentum-alpha",
+      authors: ["Ada Researcher"],
+      publishedAt: "2026-03-11T08:00:00.000Z",
+      retrievedAt: "2026-03-11T12:00:00.000Z",
+      venueKeys: ["jupiter"],
+      assetKeys: ["SOL", "USDC"],
+      tags: ["signal", "momentum"],
+      digest: "sha256:source_article_momentum",
+    },
+  ],
+} as const;
+
+describe("runtime research triage", () => {
+  test("parses triage requests with a synthesis artifact", () => {
+    const synthesis = buildRuntimeResearchSynthesis({
+      request: {
+        brief: briefFixture,
+      },
+    });
+
+    const request = parseRuntimeResearchCandidateTriageRequest({
+      synthesis,
+      applyDisposition: true,
+    });
+
+    expect(request.applyDisposition).toBe(true);
+    expect(request.synthesis.synthesisId).toBe(synthesis.synthesisId);
+  });
+
+  test("detects duplicate trend candidates and recommends archival", () => {
+    const synthesis = buildRuntimeResearchSynthesis({
+      request: {
+        brief: briefFixture,
+      },
+    });
+
+    const triage = buildRuntimeResearchCandidateTriage({
+      request: {
+        synthesis,
+      },
+    });
+
+    expect(triage.duplicateMatches.length).toBeGreaterThan(0);
+    expect(triage.disposition).toBe("archive");
+    expect(triage.recommendedHypothesisStatus).toBe("archived");
+
+    const markdown = buildRuntimeResearchCandidateTriageMarkdown(triage);
+    expect(markdown).toContain("## Duplicate Matches");
+    expect(markdown).toContain("trend_following");
+  });
+
+  test("keeps novel perp carry candidates in review instead of archival", () => {
+    const synthesis = buildRuntimeResearchSynthesis({
+      request: {
+        brief: {
+          ...briefFixture,
+          title: "Perp funding dislocations",
+          summary:
+            "Reviewed 1 approved source covering basis, funding, and perp carry.",
+          findings: [
+            "Perp carry stays attractive when funding and basis dislocations persist.",
+          ],
+          sources: [
+            {
+              ...briefFixture.sources[0],
+              title: "Perp carry and basis dislocations",
+              tags: ["perp", "funding", "carry"],
+            },
+          ],
+        },
+      },
+    });
+
+    const triage = buildRuntimeResearchCandidateTriage({
+      request: {
+        synthesis,
+      },
+    });
+
+    expect(triage.disposition).toBe("review");
+    expect(triage.noveltyScoreBps).toBeGreaterThan(4000);
+    expect(triage.implementationCostScoreBps).toBeLessThan(7000);
+  });
+});

--- a/tests/unit/worker_runtime_research_triage_route.test.ts
+++ b/tests/unit/worker_runtime_research_triage_route.test.ts
@@ -1,0 +1,184 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Env } from "../../apps/worker/src/types";
+import { buildRuntimeResearchSynthesis } from "../../src/runtime/research/synthesis.js";
+import {
+  createExecutionContextStub,
+  createWorkerLiveEnv,
+} from "../integration/_worker_live_test_utils";
+
+const worker = (await import("../../apps/worker/src/index")).default;
+
+function createSqliteD1Adapter(db: Database): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          return {
+            async run() {
+              const statement = db.query(sql);
+              const result = statement.run(...(params as never[])) as {
+                changes?: number;
+              };
+              return {
+                meta: {
+                  changes:
+                    typeof result.changes === "number" ? result.changes : 0,
+                },
+              };
+            },
+            async first() {
+              const statement = db.query(sql);
+              return (statement.get(...(params as never[])) as unknown) ?? null;
+            },
+            async all() {
+              const statement = db.query(sql);
+              return {
+                results: (statement.all(...(params as never[])) ??
+                  []) as unknown[],
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+function createOpsEnv(overrides?: Partial<Env>) {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA foreign_keys = ON;");
+
+  for (const migrationName of [
+    "0025_execution_fabric.sql",
+    "0026_execution_canary.sql",
+    "0027_runtime_canary.sql",
+  ]) {
+    const migrationPath = resolve(
+      import.meta.dir,
+      "..",
+      "..",
+      "apps/worker/migrations",
+      migrationName,
+    );
+    sqlite.exec(readFileSync(migrationPath, "utf8"));
+  }
+
+  const env = createWorkerLiveEnv({
+    overrides: {
+      WAITLIST_DB: createSqliteD1Adapter(sqlite),
+      ADMIN_TOKEN: "admin-secret",
+      ...overrides,
+    },
+  });
+
+  return { env, sqlite };
+}
+
+const synthesisFixture = buildRuntimeResearchSynthesis({
+  request: {
+    brief: {
+      briefId: "brief_latest_signal",
+      generatedAt: "2026-03-11T12:00:00.000Z",
+      profile: "custom",
+      title: "Latest signal research",
+      summary:
+        "Reviewed 1 approved source across 1 acquisition request. Most recent coverage: Momentum Alpha in Crypto.",
+      findings: [
+        "Momentum Alpha in Crypto (published 2026-03-11T08:00:00.000Z): Measure momentum across venue fragments and validate liquidity persistence.",
+      ],
+      approvedHosts: ["research.example.com"],
+      requestCount: 1,
+      sourceCount: 1,
+      createdCount: 1,
+      existingCount: 0,
+      citations: [
+        {
+          sourceId: "source_article_momentum",
+          materialDigest: "sha256:source_article_momentum",
+          notes: "published 2026-03-11T08:00:00.000Z",
+        },
+      ],
+      sources: [
+        {
+          sourceId: "source_article_momentum",
+          sourceKind: "article",
+          title: "Momentum Alpha in Crypto",
+          url: "https://research.example.com/posts/momentum-alpha",
+          canonicalUrl: "https://research.example.com/posts/momentum-alpha",
+          authors: ["Ada Researcher"],
+          publishedAt: "2026-03-11T08:00:00.000Z",
+          retrievedAt: "2026-03-11T12:00:00.000Z",
+          venueKeys: ["jupiter"],
+          assetKeys: ["SOL", "USDC"],
+          tags: ["signal", "momentum"],
+          digest: "sha256:source_article_momentum",
+        },
+      ],
+    },
+  },
+});
+
+describe("worker runtime research triage route", () => {
+  test("requires admin auth", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/admin/ops/runtime/research/triage", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ synthesis: synthesisFixture }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({
+        ok: false,
+        error: "auth-required",
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("builds a triage artifact and can archive duplicates", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/admin/ops/runtime/research/triage", {
+          method: "POST",
+          headers: {
+            authorization: "Bearer admin-secret",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            synthesis: synthesisFixture,
+            applyDisposition: true,
+          }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(200);
+      const payload = await response.json();
+      expect(payload.ok).toBe(true);
+      expect(payload.triage.disposition).toBe("archive");
+      expect(payload.triage.recommendedHypothesisStatus).toBe("archived");
+      expect(payload.triage.archivedHypothesisId).toBe(
+        synthesisFixture.hypothesis.hypothesisId,
+      );
+      expect(Array.isArray(payload.triage.duplicateMatches)).toBe(true);
+      expect(payload.triage.duplicateMatches.length).toBeGreaterThan(0);
+      expect(String(payload.markdown)).toContain("## Duplicate Matches");
+    } finally {
+      sqlite.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a deterministic triage layer that scores synthesized candidates for novelty, evidence quality, venue fit, and implementation cost
- expose triage through a Worker admin route, local CLI, and manual GitHub Actions workflow
- document verification and operator usage for candidate ranking and archival recommendations

Fixes #320

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun test tests/unit/runtime_research_triage.test.ts tests/unit/worker_runtime_research_triage_route.test.ts`
- `bun test tests/unit/worker_runtime_research_synthesis_route.test.ts tests/unit/worker_runtime_internal_routes.test.ts tests/unit/worker_runtime_contracts.test.ts`
