### PR TITLE
Add strategy-lab policy gates

### DIFF
--- a/.github/workflows/strategy-lab-policy-gate.yml
+++ b/.github/workflows/strategy-lab-policy-gate.yml
@@ -1,0 +1,125 @@
+name: Strategy Lab Policy Gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      synthesis_file:
+        description: Repo-relative path to a checked-in synthesis JSON artifact
+        required: true
+      triage_file:
+        description: Repo-relative path to a checked-in triage JSON artifact
+        required: true
+      limited_live_canary_passed:
+        description: Mark the limited-live canary prerequisite as passed
+        required: false
+        default: "false"
+      limited_live_soak_passed:
+        description: Mark the limited-live soak prerequisite as passed
+        required: false
+        default: "false"
+      issue_number:
+        description: Optional GitHub issue number to comment with the policy summary
+        required: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  policy-gate:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.0"
+
+      - name: Install deps
+        run: bun install
+
+      - name: Check admin credentials
+        env:
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ADMIN_TOKEN:-}" ]; then
+            echo "::error::Missing required secret ADMIN_TOKEN for strategy-lab policy gate."
+            exit 1
+          fi
+
+      - name: Build policy gate artifact
+        env:
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          SYNTHESIS_FILE: ${{ inputs.synthesis_file }}
+          TRIAGE_FILE: ${{ inputs.triage_file }}
+          LIMITED_LIVE_CANARY_PASSED: ${{ inputs.limited_live_canary_passed }}
+          LIMITED_LIVE_SOAK_PASSED: ${{ inputs.limited_live_soak_passed }}
+        run: |
+          set -euo pipefail
+          mkdir -p .tmp/strategy-lab-policy-gate
+
+          args=(
+            --base-url https://api.trader-ralph.com
+            --admin-token "${ADMIN_TOKEN}"
+            --output-dir .tmp/strategy-lab-policy-gate
+            --synthesis-file "${SYNTHESIS_FILE}"
+            --triage-file "${TRIAGE_FILE}"
+          )
+
+          if [ "${LIMITED_LIVE_CANARY_PASSED}" = "true" ]; then
+            args+=(--limited-live-canary-passed)
+          fi
+          if [ "${LIMITED_LIVE_SOAK_PASSED}" = "true" ]; then
+            args+=(--limited-live-soak-passed)
+          fi
+
+          bun run strategy-lab:policy-gate "${args[@]}"
+
+          cat .tmp/strategy-lab-policy-gate/policy-gate.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload policy gate artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: strategy-lab-policy-gate-${{ github.run_id }}
+          path: .tmp/strategy-lab-policy-gate
+          if-no-files-found: error
+
+      - name: Comment on issue
+        if: ${{ inputs.issue_number != '' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          set -euo pipefail
+
+          policy_gate_id="$(jq -r '.policyGateId' .tmp/strategy-lab-policy-gate/policy-gate.json)"
+          shadow_status="$(jq -r '.gates[] | select(.targetMode=="shadow") | .status' .tmp/strategy-lab-policy-gate/policy-gate.json)"
+          paper_status="$(jq -r '.gates[] | select(.targetMode=="paper") | .status' .tmp/strategy-lab-policy-gate/policy-gate.json)"
+          limited_live_status="$(jq -r '.gates[] | select(.targetMode=="limited_live") | .status' .tmp/strategy-lab-policy-gate/policy-gate.json)"
+          broad_live_status="$(jq -r '.gates[] | select(.targetMode=="broad_live") | .status' .tmp/strategy-lab-policy-gate/policy-gate.json)"
+          run_url="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
+
+          body="$(cat <<EOF
+          Strategy-lab policy gate artifact ready.
+
+          - policyGateId: \`${policy_gate_id}\`
+          - shadow: \`${shadow_status}\`
+          - paper: \`${paper_status}\`
+          - limited_live: \`${limited_live_status}\`
+          - broad_live: \`${broad_live_status}\`
+          - workflow run: ${run_url}
+          EOF
+          )"
+
+          payload="$(jq -n --arg body "$body" '{body:$body}')"
+          curl -fsS \
+            -X POST \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
+            -d "${payload}" >/dev/null

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,4 +1,5 @@
 import { parseRuntimeResearchBriefRequest } from "../../../src/runtime/research/briefs.js";
+import { parseRuntimeResearchPolicyGateRequest } from "../../../src/runtime/research/policy_gate.js";
 import { parseRuntimeResearchSynthesisRequest } from "../../../src/runtime/research/synthesis.js";
 import { parseRuntimeResearchCandidateTriageRequest } from "../../../src/runtime/research/triage.js";
 import { buildAgentQueryResponse } from "./agent_query";
@@ -154,6 +155,7 @@ import {
   readRuntimeScorecard,
 } from "./runtime_internal";
 import { runRuntimeResearchBriefWorkflow } from "./runtime_research_briefs";
+import { runRuntimeResearchPolicyGateWorkflow } from "./runtime_research_policy_gate";
 import { runRuntimeResearchSynthesisWorkflow } from "./runtime_research_synthesis";
 import { runRuntimeResearchCandidateTriageWorkflow } from "./runtime_research_triage";
 import { SolanaRpc } from "./solana_rpc";
@@ -2360,6 +2362,50 @@ const worker = {
                   error instanceof Error
                     ? error.message
                     : "runtime-research-triage-failed",
+              },
+              { status: 400 },
+            ),
+            env,
+          );
+        }
+      }
+
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/admin/ops/runtime/research/policy-gate"
+      ) {
+        const auth = authorizeAdminRoute(request, env);
+        if (!auth.ok) {
+          return withCors(
+            json({ ok: false, error: auth.error }, { status: auth.status }),
+            env,
+          );
+        }
+        try {
+          const policyGateRequest = parseRuntimeResearchPolicyGateRequest(
+            await request.json(),
+          );
+          const result = await runRuntimeResearchPolicyGateWorkflow({
+            env,
+            request: policyGateRequest,
+          });
+          return withCors(
+            json({
+              ok: true,
+              policyGate: result.policyGate,
+              markdown: result.markdown,
+            }),
+            env,
+          );
+        } catch (error) {
+          return withCors(
+            json(
+              {
+                ok: false,
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "runtime-research-policy-gate-failed",
               },
               { status: 400 },
             ),

--- a/apps/worker/src/runtime_research_policy_gate.ts
+++ b/apps/worker/src/runtime_research_policy_gate.ts
@@ -1,0 +1,164 @@
+import {
+  parseRuntimeAssetRecord,
+  parseRuntimeBacktestReport,
+  parseRuntimeResearchEvidenceBundleRecord,
+  parseRuntimeResearchReproducibilityBundleRecord,
+} from "../../../src/runtime/contracts/autonomous_runtime.js";
+import type {
+  RuntimeResearchPolicyGateArtifact,
+  RuntimeResearchPolicyGateRequest,
+} from "../../../src/runtime/research/policy_gate.js";
+import {
+  buildRuntimeResearchPolicyGate,
+  buildRuntimeResearchPolicyGateMarkdown,
+} from "../../../src/runtime/research/policy_gate.js";
+import {
+  readRuntimeAssetRegistry,
+  readRuntimeBacktests,
+  readRuntimeResearchRegistry,
+} from "./runtime_internal";
+import type { Env } from "./types";
+
+export type RuntimeResearchPolicyGateWorkflowResult = {
+  policyGate: RuntimeResearchPolicyGateArtifact;
+  markdown: string;
+};
+
+export async function runRuntimeResearchPolicyGateWorkflow(input: {
+  env: Env;
+  request: RuntimeResearchPolicyGateRequest;
+}): Promise<RuntimeResearchPolicyGateWorkflowResult> {
+  const synthesis = input.request.synthesis;
+  const strategyKey = synthesis.strategySpecDraft.strategyKey;
+  const venueKey = synthesis.evaluationPlan.venueKey;
+  const marketType = synthesis.evaluationPlan.marketType;
+
+  const [registryResponse, assetRegistryResponse, backtestsResponse] =
+    await Promise.all([
+      readRuntimeResearchRegistry({
+        env: input.env,
+        strategyKey,
+        venueKey,
+      }),
+      readRuntimeAssetRegistry({
+        env: input.env,
+      }),
+      readRuntimeBacktests({
+        env: input.env,
+        strategyKey,
+        venueKey,
+        marketType,
+      }),
+    ]);
+
+  if (!registryResponse.ok) {
+    throw new Error(
+      String(
+        registryResponse.payload.error ??
+          "runtime-research-policy-gate-registry-read-failed",
+      ),
+    );
+  }
+  if (!assetRegistryResponse.ok) {
+    throw new Error(
+      String(
+        assetRegistryResponse.payload.error ??
+          "runtime-research-policy-gate-assets-read-failed",
+      ),
+    );
+  }
+  if (!backtestsResponse.ok) {
+    throw new Error(
+      String(
+        backtestsResponse.payload.error ??
+          "runtime-research-policy-gate-backtests-read-failed",
+      ),
+    );
+  }
+
+  const rawRegistry = asRecord(registryResponse.payload.registry);
+  const rawAssetRegistry = asRecord(assetRegistryResponse.payload.registry);
+  const rawAssetRecords = Array.isArray(assetRegistryResponse.payload.assets)
+    ? assetRegistryResponse.payload.assets
+    : Array.isArray(rawAssetRegistry.assets)
+      ? rawAssetRegistry.assets
+      : [];
+  const assetRecords = rawAssetRecords
+    .map((entry) => {
+      try {
+        return parseRuntimeAssetRecord(entry);
+      } catch {
+        return null;
+      }
+    })
+    .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+    .filter((entry) =>
+      synthesis.evaluationPlan.assetKeys.includes(entry.assetKey),
+    );
+  const evidenceBundles = Array.isArray(rawRegistry.evidenceBundles)
+    ? (rawRegistry.evidenceBundles ?? [])
+        .map((entry) => {
+          try {
+            return parseRuntimeResearchEvidenceBundleRecord(entry);
+          } catch {
+            return null;
+          }
+        })
+        .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+        .filter((entry) => entry.strategyKey === strategyKey)
+    : [];
+  const reproducibilityBundle = Array.isArray(
+    rawRegistry.reproducibilityBundles,
+  )
+    ? (rawRegistry.reproducibilityBundles ?? [])
+        .map((entry) => {
+          try {
+            return parseRuntimeResearchReproducibilityBundleRecord(entry);
+          } catch {
+            return null;
+          }
+        })
+        .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+        .filter((entry) => entry.strategyKey === strategyKey)
+        .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))[0]
+    : undefined;
+  const rawBacktests = Array.isArray(backtestsResponse.payload.backtests)
+    ? backtestsResponse.payload.backtests
+    : Array.isArray(backtestsResponse.payload.reports)
+      ? backtestsResponse.payload.reports
+      : [];
+  const backtestReport = rawBacktests
+    .map((entry) => {
+      try {
+        return parseRuntimeBacktestReport(entry);
+      } catch {
+        return null;
+      }
+    })
+    .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+    .filter((entry) => entry.strategyKey === strategyKey)
+    .sort((left, right) =>
+      right.generatedAt.localeCompare(left.generatedAt),
+    )[0];
+
+  const policyGate = buildRuntimeResearchPolicyGate({
+    request: {
+      ...input.request,
+      assetRecords,
+      ...(backtestReport ? { backtestReport } : {}),
+      ...(reproducibilityBundle ? { reproducibilityBundle } : {}),
+      ...(evidenceBundles.length > 0 ? { evidenceBundles } : {}),
+    },
+  });
+
+  return {
+    policyGate,
+    markdown: buildRuntimeResearchPolicyGateMarkdown(policyGate),
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}

--- a/docs/repository-verification-index.md
+++ b/docs/repository-verification-index.md
@@ -315,6 +315,25 @@ Verify:
   built-in strategy references,
 - triage remains internal-only on the Worker admin boundary.
 
+### 3i. Strategy-lab policy gate verification
+
+For policy and safety gates around agent-generated strategies:
+
+```bash
+bun run lint
+bun run typecheck
+bun test tests/unit/runtime_research_policy_gate.test.ts tests/unit/worker_runtime_research_policy_gate_route.test.ts
+bun test tests/unit/runtime_research_triage.test.ts tests/unit/worker_runtime_research_triage_route.test.ts tests/unit/worker_runtime_internal_routes.test.ts tests/unit/worker_runtime_contracts.test.ts
+```
+
+Verify:
+
+- shadow, paper, limited-live, and broad-live gates are explicit and machine-readable,
+- unsupported venue or asset combinations fail closed before promotion,
+- paper and money-state transitions require explicit human approval records,
+- newly generated strategies cannot auto-promote straight to broad live,
+- the policy gate stays on the Worker admin boundary and consumes repo-owned runtime evidence instead of bypassing contracts.
+
 ### 4. x402 and discovery verification
 
 Portal-side discovery:

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "strategy-lab:research": "bun run src/bin/strategy_lab_research.ts",
     "strategy-lab:synthesize": "bun run src/bin/strategy_lab_synthesis.ts",
     "strategy-lab:triage": "bun run src/bin/strategy_lab_triage.ts",
+    "strategy-lab:policy-gate": "bun run src/bin/strategy_lab_policy_gate.ts",
     "runtime:fly:deploy": "node scripts/runtime_rs/fly_deploy.mjs",
     "runtime:fly:smoke": "node scripts/runtime_rs/fly_smoke.mjs",
     "runner:once": "bun run src/bin/runner.ts once",

--- a/services/runtime-rs/README.md
+++ b/services/runtime-rs/README.md
@@ -238,6 +238,7 @@ Operators should use the Worker as the public control plane:
 - `POST /api/admin/ops/runtime/research/briefs`
 - `POST /api/admin/ops/runtime/research/synthesis`
 - `POST /api/admin/ops/runtime/research/triage`
+- `POST /api/admin/ops/runtime/research/policy-gate`
 - `POST /api/admin/ops/runtime/deployments/:deploymentId/pause`
 - `POST /api/admin/ops/runtime/deployments/:deploymentId/resume`
 - `POST /api/admin/ops/runtime/deployments/:deploymentId/kill`
@@ -276,6 +277,19 @@ bun run strategy-lab:triage --synthesis-file .tmp/strategy-lab-synthesis/synthes
 That command writes `.tmp/strategy-lab-triage/triage.json` and
 `.tmp/strategy-lab-triage/triage.md`, including novelty scoring, duplicate
 matches, explainable rationale, and an optional archival recommendation.
+
+Policy gating keeps candidate progression explicit and fail-closed:
+
+```bash
+bun run strategy-lab:policy-gate \
+  --synthesis-file .tmp/strategy-lab-synthesis/synthesis.json \
+  --triage-file .tmp/strategy-lab-triage/triage.json
+```
+
+That command writes `.tmp/strategy-lab-policy-gate/policy-gate.json` and
+`.tmp/strategy-lab-policy-gate/policy-gate.md`, including machine-readable
+shadow, paper, limited-live, and broad-live gates, unsafe-pattern detection,
+and explicit human-approval requirements before paper or real-money promotion.
 
 The runtime operator surface now includes allocator details for a deployment:
 

--- a/src/bin/strategy_lab_policy_gate.ts
+++ b/src/bin/strategy_lab_policy_gate.ts
@@ -1,0 +1,110 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { parseRuntimeResearchPolicyGateRequest } from "../runtime/research/policy_gate.js";
+
+function readArg(flag: string): string | null {
+  const index = process.argv.indexOf(flag);
+  if (index < 0) return null;
+  return process.argv[index + 1] ?? null;
+}
+
+function readJsonFile(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf8")) as unknown;
+}
+
+function maybeApproval(targetMode: "paper" | "limited_live" | "broad_live") {
+  const approvedBy = readArg(`--${targetMode}-approved-by`);
+  const approvedAt = readArg(`--${targetMode}-approved-at`);
+  if (!approvedBy || !approvedAt) return null;
+  return {
+    targetMode,
+    approvedBy,
+    approvedAt,
+  };
+}
+
+async function main(): Promise<void> {
+  const baseUrl = readArg("--base-url") ?? "http://127.0.0.1:8888";
+  const outputDir = resolve(
+    readArg("--output-dir") ?? ".tmp/strategy-lab-policy-gate",
+  );
+  const adminToken =
+    readArg("--admin-token") ?? String(process.env.ADMIN_TOKEN ?? "").trim();
+  if (!adminToken) {
+    throw new Error("missing-admin-token");
+  }
+
+  const synthesisFile = readArg("--synthesis-file");
+  const triageFile = readArg("--triage-file");
+  if (!synthesisFile) {
+    throw new Error("missing-arg:--synthesis-file");
+  }
+  if (!triageFile) {
+    throw new Error("missing-arg:--triage-file");
+  }
+
+  const approvals = [
+    maybeApproval("paper"),
+    maybeApproval("limited_live"),
+    maybeApproval("broad_live"),
+  ].filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+
+  const requestBody = parseRuntimeResearchPolicyGateRequest({
+    synthesis: readJsonFile(resolve(synthesisFile)),
+    triage: readJsonFile(resolve(triageFile)),
+    ...(approvals.length > 0 ? { approvals } : {}),
+    ...(process.argv.includes("--limited-live-canary-passed")
+      ? { limitedLiveCanaryPassed: true }
+      : {}),
+    ...(process.argv.includes("--limited-live-soak-passed")
+      ? { limitedLiveSoakPassed: true }
+      : {}),
+  });
+
+  const response = await fetch(
+    `${baseUrl.replace(/\/$/, "")}/api/admin/ops/runtime/research/policy-gate`,
+    {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${adminToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    },
+  );
+  const payload = (await response.json()) as Record<string, unknown>;
+  if (!response.ok || payload.ok !== true) {
+    throw new Error(
+      String(
+        payload.error ??
+          `runtime-research-policy-gate-failed:${response.status}`,
+      ),
+    );
+  }
+
+  mkdirSync(outputDir, { recursive: true });
+  const jsonPath = join(outputDir, "policy-gate.json");
+  const markdownPath = join(outputDir, "policy-gate.md");
+  writeFileSync(jsonPath, `${JSON.stringify(payload.policyGate, null, 2)}\n`);
+  writeFileSync(markdownPath, `${String(payload.markdown ?? "")}\n`);
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        baseUrl,
+        outputDir,
+        policyGatePath: jsonPath,
+        markdownPath,
+        policyGateId:
+          typeof payload.policyGate === "object" && payload.policyGate
+            ? (payload.policyGate as Record<string, unknown>).policyGateId
+            : null,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+await main();

--- a/src/runtime/contracts/autonomous_runtime.ts
+++ b/src/runtime/contracts/autonomous_runtime.ts
@@ -1020,6 +1020,64 @@ export const RuntimeStrategySpecSchema = VersionedSchema.extend({
   tags: z.array(NON_EMPTY_STRING_SCHEMA).max(16),
 }).strict();
 
+export const RuntimeResearchPolicyTargetModeSchema = z.enum([
+  "shadow",
+  "paper",
+  "limited_live",
+  "broad_live",
+]);
+
+export const RuntimeResearchPolicyGateStatusSchema = z.enum([
+  "pass",
+  "blocked",
+  "requires_human_approval",
+  "not_applicable",
+]);
+
+const RuntimeResearchHumanApprovalRecordSchema = z
+  .object({
+    targetMode: RuntimeResearchPolicyTargetModeSchema,
+    approvedBy: NON_EMPTY_STRING_SCHEMA,
+    approvedAt: ISO_DATETIME_SCHEMA,
+    notes: NON_EMPTY_STRING_SCHEMA.optional(),
+  })
+  .strict();
+
+const RuntimeResearchPolicyGateCheckSchema = z
+  .object({
+    checkId: NON_EMPTY_STRING_SCHEMA,
+    status: RuntimeResearchPolicyGateStatusSchema,
+    observedValue: NON_EMPTY_STRING_SCHEMA.optional(),
+    thresholdValue: NON_EMPTY_STRING_SCHEMA.optional(),
+    message: NON_EMPTY_STRING_SCHEMA,
+  })
+  .strict();
+
+const RuntimeResearchPolicyGateDecisionSchema = z
+  .object({
+    targetMode: RuntimeResearchPolicyTargetModeSchema,
+    automatedChecksPassed: z.boolean(),
+    requiresHumanApproval: z.boolean(),
+    eligible: z.boolean(),
+    status: RuntimeResearchPolicyGateStatusSchema,
+    summary: NON_EMPTY_STRING_SCHEMA,
+    checks: z.array(RuntimeResearchPolicyGateCheckSchema).min(1),
+    approval: RuntimeResearchHumanApprovalRecordSchema.optional(),
+  })
+  .strict();
+
+export const RuntimeResearchPolicyGateArtifactSchema = VersionedSchema.extend({
+  policyGateId: NON_EMPTY_STRING_SCHEMA,
+  generatedAt: ISO_DATETIME_SCHEMA,
+  synthesisId: NON_EMPTY_STRING_SCHEMA,
+  hypothesisId: NON_EMPTY_STRING_SCHEMA,
+  triageId: NON_EMPTY_STRING_SCHEMA,
+  candidateDisposition: NON_EMPTY_STRING_SCHEMA,
+  bannedPatterns: z.array(NON_EMPTY_STRING_SCHEMA).max(16),
+  gates: z.array(RuntimeResearchPolicyGateDecisionSchema).min(1),
+  summary: z.array(NON_EMPTY_STRING_SCHEMA).max(16),
+}).strict();
+
 export const RuntimeExecutionCostModelStatusSchema = z.enum([
   "draft",
   "active",
@@ -1230,6 +1288,18 @@ export type RuntimeVenueCapability = z.infer<
 >;
 export type RuntimeAssetRecord = z.infer<typeof RuntimeAssetRecordSchema>;
 export type RuntimeStrategySpec = z.infer<typeof RuntimeStrategySpecSchema>;
+export type RuntimeResearchPolicyTargetMode = z.infer<
+  typeof RuntimeResearchPolicyTargetModeSchema
+>;
+export type RuntimeResearchPolicyGateStatus = z.infer<
+  typeof RuntimeResearchPolicyGateStatusSchema
+>;
+export type RuntimeResearchHumanApprovalRecord = z.infer<
+  typeof RuntimeResearchHumanApprovalRecordSchema
+>;
+export type RuntimeResearchPolicyGateArtifact = z.infer<
+  typeof RuntimeResearchPolicyGateArtifactSchema
+>;
 
 export const RUNTIME_DEPLOYMENT_STATE_TRANSITIONS = {
   draft: ["shadow", "paper", "live", "archived"],
@@ -1508,6 +1578,12 @@ export function parseRuntimeAssetRecord(input: unknown): RuntimeAssetRecord {
 
 export function parseRuntimeStrategySpec(input: unknown): RuntimeStrategySpec {
   return RuntimeStrategySpecSchema.parse(input);
+}
+
+export function parseRuntimeResearchPolicyGateArtifact(
+  input: unknown,
+): RuntimeResearchPolicyGateArtifact {
+  return RuntimeResearchPolicyGateArtifactSchema.parse(input);
 }
 
 export function safeParseRuntimeDeploymentRecord(input: unknown) {

--- a/src/runtime/research/policy_gate.ts
+++ b/src/runtime/research/policy_gate.ts
@@ -1,0 +1,1243 @@
+import { createHash } from "node:crypto";
+import {
+  parseRuntimeAssetRecord,
+  parseRuntimeBacktestReport,
+  parseRuntimeResearchEvidenceBundleRecord,
+  parseRuntimeResearchHypothesisRecord,
+  parseRuntimeResearchPolicyGateArtifact,
+  parseRuntimeResearchReproducibilityBundleRecord,
+  parseRuntimeStrategySpec,
+  type RuntimeAssetListingState,
+  type RuntimeAssetRecord,
+  type RuntimeBacktestReport,
+  type RuntimeOnboardingState,
+  type RuntimeResearchEvidenceBundleRecord,
+  type RuntimeResearchHumanApprovalRecord,
+  type RuntimeResearchPolicyGateArtifact,
+  type RuntimeResearchPolicyGateStatus,
+  type RuntimeResearchPolicyTargetMode,
+  type RuntimeResearchReproducibilityBundleRecord,
+  type RuntimeStrategySpec,
+} from "../contracts/autonomous_runtime.js";
+import {
+  getRuntimeVenueCapability,
+  runtimeVenueSupportsMode,
+} from "../venues/catalog.js";
+import type {
+  RuntimeResearchImplementationPlan,
+  RuntimeResearchSynthesisArtifact,
+  RuntimeResearchSynthesisEvaluationPlan,
+} from "./synthesis.js";
+import type { RuntimeResearchCandidateTriageArtifact } from "./triage.js";
+
+export type RuntimeResearchPolicyGateRequest = {
+  synthesis: RuntimeResearchSynthesisArtifact;
+  triage: RuntimeResearchCandidateTriageArtifact;
+  assetRecords?: RuntimeAssetRecord[];
+  backtestReport?: RuntimeBacktestReport;
+  reproducibilityBundle?: RuntimeResearchReproducibilityBundleRecord;
+  evidenceBundles?: RuntimeResearchEvidenceBundleRecord[];
+  approvals?: RuntimeResearchHumanApprovalRecord[];
+  limitedLiveCanaryPassed?: boolean;
+  limitedLiveSoakPassed?: boolean;
+};
+
+type RuntimeResearchPolicyGateCheck =
+  RuntimeResearchPolicyGateArtifact["gates"][number]["checks"][number];
+type RuntimeResearchPolicyGateDecision =
+  RuntimeResearchPolicyGateArtifact["gates"][number];
+
+type RequiredVenueStateMap = Record<
+  RuntimeResearchPolicyTargetMode,
+  RuntimeOnboardingState
+>;
+type RequiredAssetStateMap = Record<
+  RuntimeResearchPolicyTargetMode,
+  RuntimeAssetListingState
+>;
+
+const VENUE_ONBOARDING_ORDER: RuntimeOnboardingState[] = [
+  "candidate",
+  "integrated",
+  "shadow_ready",
+  "paper_ready",
+  "limited_live_ready",
+  "broad_live_ready",
+  "paused",
+  "deprecated",
+];
+
+const ASSET_LISTING_ORDER: RuntimeAssetListingState[] = [
+  "candidate",
+  "shadow",
+  "paper",
+  "live",
+  "paused",
+  "deprecated",
+];
+
+const REQUIRED_VENUE_STATE: RequiredVenueStateMap = {
+  shadow: "shadow_ready",
+  paper: "paper_ready",
+  limited_live: "limited_live_ready",
+  broad_live: "broad_live_ready",
+};
+
+const REQUIRED_ASSET_STATE: RequiredAssetStateMap = {
+  shadow: "shadow",
+  paper: "paper",
+  limited_live: "live",
+  broad_live: "live",
+};
+
+const HUMAN_APPROVAL_TARGETS = new Set<RuntimeResearchPolicyTargetMode>([
+  "paper",
+  "limited_live",
+  "broad_live",
+]);
+
+const UNSAFE_PATTERN_RULES = [
+  {
+    id: "martingale",
+    pattern: /\bmartingale\b|doubling down|double-down/i,
+    reason:
+      "Martingale or doubling-down strategies are not allowed for agent-generated promotion.",
+  },
+  {
+    id: "unbounded_leverage",
+    pattern: /unbounded leverage|infinite leverage|leveraged loop/i,
+    reason:
+      "Unbounded leverage strategies are not allowed for agent-generated promotion.",
+  },
+  {
+    id: "guaranteed_edge",
+    pattern: /guaranteed alpha|risk[- ]free/i,
+    reason: "Claims of guaranteed or risk-free returns fail policy review.",
+  },
+] as const;
+
+export function parseRuntimeResearchPolicyGateRequest(
+  input: unknown,
+): RuntimeResearchPolicyGateRequest {
+  if (!isRecord(input)) {
+    throw new Error("invalid-runtime-research-policy-gate-request");
+  }
+
+  const synthesis = parseRuntimeResearchSynthesisArtifact(input.synthesis);
+  const triage = parseRuntimeResearchCandidateTriageArtifact(input.triage);
+
+  return {
+    synthesis,
+    triage,
+    ...(Array.isArray(input.assetRecords)
+      ? {
+          assetRecords: input.assetRecords.map((entry) =>
+            parseRuntimeAssetRecord(entry),
+          ),
+        }
+      : {}),
+    ...(input.backtestReport
+      ? { backtestReport: parseRuntimeBacktestReport(input.backtestReport) }
+      : {}),
+    ...(input.reproducibilityBundle
+      ? {
+          reproducibilityBundle:
+            parseRuntimeResearchReproducibilityBundleRecord(
+              input.reproducibilityBundle,
+            ),
+        }
+      : {}),
+    ...(Array.isArray(input.evidenceBundles)
+      ? {
+          evidenceBundles: input.evidenceBundles.map((entry) =>
+            parseRuntimeResearchEvidenceBundleRecord(entry),
+          ),
+        }
+      : {}),
+    ...(Array.isArray(input.approvals)
+      ? {
+          approvals: input.approvals.map((entry) =>
+            parseRuntimeResearchHumanApprovalRecord(entry),
+          ),
+        }
+      : {}),
+    ...(typeof input.limitedLiveCanaryPassed === "boolean"
+      ? { limitedLiveCanaryPassed: input.limitedLiveCanaryPassed }
+      : {}),
+    ...(typeof input.limitedLiveSoakPassed === "boolean"
+      ? { limitedLiveSoakPassed: input.limitedLiveSoakPassed }
+      : {}),
+  };
+}
+
+export function buildRuntimeResearchPolicyGate(input: {
+  request: RuntimeResearchPolicyGateRequest;
+}): RuntimeResearchPolicyGateArtifact {
+  const { request } = input;
+  const synthesis = request.synthesis;
+  const spec = synthesis.strategySpecDraft;
+  const approvals = new Map(
+    (request.approvals ?? []).map((approval) => [
+      approval.targetMode,
+      approval,
+    ]),
+  );
+  const bannedPatterns = collectBannedPatterns(synthesis);
+  const paperEvidence = findEvidenceBundle(request.evidenceBundles, {
+    strategyKey: spec.strategyKey,
+    promotionTarget: "paper",
+    acceptedStatuses: new Set(["ready_for_review", "approved"]),
+  });
+  const limitedLiveEvidence = findEvidenceBundle(request.evidenceBundles, {
+    strategyKey: spec.strategyKey,
+    promotionTarget: "limited_live",
+    acceptedStatuses: new Set(["approved"]),
+  });
+
+  const shadowChecks = [
+    buildTriageCheck(request.triage),
+    buildCitationCheck(synthesis),
+    buildUnsafePatternCheck(bannedPatterns),
+    buildStrategyModeCheck(spec, "shadow"),
+    buildVenueCapabilityCheck(synthesis, spec, "shadow"),
+    buildVenueOnboardingCheck(spec, "shadow"),
+    buildAssetReadinessCheck(
+      request.assetRecords ?? [],
+      synthesis,
+      spec,
+      "shadow",
+    ),
+  ];
+  const shadowGate = finalizeGate({
+    targetMode: "shadow",
+    checks: shadowChecks,
+    approval: approvals.get("shadow"),
+  });
+
+  const paperChecks = [
+    buildPrerequisiteGateCheck("shadow-gate", "shadow", shadowGate),
+    buildStrategyModeCheck(spec, "paper"),
+    buildVenueCapabilityCheck(synthesis, spec, "paper"),
+    buildVenueOnboardingCheck(spec, "paper"),
+    buildAssetReadinessCheck(
+      request.assetRecords ?? [],
+      synthesis,
+      spec,
+      "paper",
+    ),
+    buildBacktestCheck(request.backtestReport),
+    buildBacktestPromotionCheck(request.backtestReport),
+    buildReproducibilityCheck(request.reproducibilityBundle),
+    buildPaperEvidenceCheck(paperEvidence),
+  ];
+  const paperGate = finalizeGate({
+    targetMode: "paper",
+    checks: paperChecks,
+    approval: approvals.get("paper"),
+  });
+
+  const limitedLiveChecks = [
+    buildPrerequisiteGateCheck("paper-gate", "paper", paperGate),
+    buildStrategyModeCheck(spec, "limited_live"),
+    buildVenueCapabilityCheck(synthesis, spec, "limited_live"),
+    buildVenueOnboardingCheck(spec, "limited_live"),
+    buildAssetReadinessCheck(
+      request.assetRecords ?? [],
+      synthesis,
+      spec,
+      "limited_live",
+    ),
+    buildLaneAllowlistCheck(spec),
+    buildHumanApprovalPolicyCheck(spec),
+    buildLimitedLiveConstraintCheck(spec),
+    buildLimitedLiveEvidenceCheck(limitedLiveEvidence),
+  ];
+  const limitedLiveGate = finalizeGate({
+    targetMode: "limited_live",
+    checks: limitedLiveChecks,
+    approval: approvals.get("limited_live"),
+  });
+
+  const broadLiveChecks = [
+    buildPrerequisiteGateCheck(
+      "limited-live-gate",
+      "limited_live",
+      limitedLiveGate,
+    ),
+    buildStrategyModeCheck(spec, "broad_live"),
+    buildVenueCapabilityCheck(synthesis, spec, "broad_live"),
+    buildVenueOnboardingCheck(spec, "broad_live"),
+    buildAssetReadinessCheck(
+      request.assetRecords ?? [],
+      synthesis,
+      spec,
+      "broad_live",
+    ),
+    buildLimitedLiveCanaryCheck(request.limitedLiveCanaryPassed === true),
+    buildLimitedLiveSoakCheck(request.limitedLiveSoakPassed === true),
+  ];
+  const broadLiveGate = finalizeGate({
+    targetMode: "broad_live",
+    checks: broadLiveChecks,
+    approval: approvals.get("broad_live"),
+  });
+
+  const summary = buildSummary([
+    shadowGate,
+    paperGate,
+    limitedLiveGate,
+    broadLiveGate,
+  ]);
+  const policyGateId = `policy_${hash(
+    JSON.stringify({
+      synthesisId: synthesis.synthesisId,
+      triageId: request.triage.triageId,
+      gateStatuses: [
+        shadowGate.status,
+        paperGate.status,
+        limitedLiveGate.status,
+        broadLiveGate.status,
+      ],
+    }),
+  )}`;
+
+  return parseRuntimeResearchPolicyGateArtifact({
+    schemaVersion: "v1",
+    policyGateId,
+    generatedAt: new Date().toISOString(),
+    synthesisId: synthesis.synthesisId,
+    hypothesisId: synthesis.hypothesis.hypothesisId,
+    triageId: request.triage.triageId,
+    candidateDisposition: request.triage.disposition,
+    bannedPatterns,
+    gates: [shadowGate, paperGate, limitedLiveGate, broadLiveGate],
+    summary,
+  });
+}
+
+export function buildRuntimeResearchPolicyGateMarkdown(
+  artifact: RuntimeResearchPolicyGateArtifact,
+): string {
+  const lines = [
+    `# Strategy policy gate for ${artifact.hypothesisId}`,
+    "",
+    `- Policy gate id: ${artifact.policyGateId}`,
+    `- Generated at: ${artifact.generatedAt}`,
+    `- Candidate disposition: ${artifact.candidateDisposition}`,
+    `- Banned patterns: ${artifact.bannedPatterns.length > 0 ? artifact.bannedPatterns.join(", ") : "none"}`,
+    "",
+    "## Summary",
+    "",
+  ];
+
+  for (const entry of artifact.summary) {
+    lines.push(`- ${entry}`);
+  }
+
+  for (const gate of artifact.gates) {
+    lines.push(
+      "",
+      `## ${formatTargetMode(gate.targetMode)}`,
+      "",
+      `- Status: ${gate.status}`,
+      `- Automated checks passed: ${gate.automatedChecksPassed ? "yes" : "no"}`,
+      `- Requires human approval: ${gate.requiresHumanApproval ? "yes" : "no"}`,
+      `- Eligible: ${gate.eligible ? "yes" : "no"}`,
+      `- Summary: ${gate.summary}`,
+    );
+    if (gate.approval) {
+      lines.push(
+        `- Approval: ${gate.approval.approvedBy} at ${gate.approval.approvedAt}`,
+      );
+    }
+    lines.push("", "### Checks", "");
+    for (const check of gate.checks) {
+      const observed = check.observedValue
+        ? ` observed=${check.observedValue}`
+        : "";
+      const threshold = check.thresholdValue
+        ? ` threshold=${check.thresholdValue}`
+        : "";
+      lines.push(
+        `- ${check.checkId}: ${check.status}${observed}${threshold} (${check.message})`,
+      );
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export function requireRuntimeResearchPolicyGatePass(input: {
+  artifact: RuntimeResearchPolicyGateArtifact;
+  targetMode: RuntimeResearchPolicyTargetMode;
+}): RuntimeResearchPolicyGateArtifact["gates"][number] {
+  const gate = input.artifact.gates.find(
+    (entry) => entry.targetMode === input.targetMode,
+  );
+  if (!gate || gate.status !== "pass") {
+    throw new Error(
+      `runtime-research-policy-blocked:${input.targetMode}:${gate?.status ?? "missing"}`,
+    );
+  }
+  return gate;
+}
+
+function buildSummary(
+  gates: RuntimeResearchPolicyGateArtifact["gates"],
+): string[] {
+  return gates.map(
+    (gate) =>
+      `${formatTargetMode(gate.targetMode)}: ${gate.status} (${gate.summary})`,
+  );
+}
+
+function buildTriageCheck(
+  triage: RuntimeResearchCandidateTriageArtifact,
+): RuntimeResearchPolicyGateCheck {
+  return triage.disposition === "archive"
+    ? blockedCheck(
+        "triage-disposition",
+        triage.disposition,
+        "promote_to_candidate|review",
+        "Archived candidates cannot progress into runtime validation.",
+      )
+    : passCheck(
+        "triage-disposition",
+        triage.disposition,
+        "promote_to_candidate|review",
+        "Candidate cleared triage and remains eligible for bounded progression.",
+      );
+}
+
+function buildCitationCheck(
+  synthesis: RuntimeResearchSynthesisArtifact,
+): RuntimeResearchPolicyGateCheck {
+  return synthesis.hypothesis.sourceCitations.length > 0
+    ? passCheck(
+        "source-provenance",
+        String(synthesis.hypothesis.sourceCitations.length),
+        ">=1 citations",
+        "Candidate includes source provenance for the underlying hypothesis.",
+      )
+    : blockedCheck(
+        "source-provenance",
+        "0",
+        ">=1 citations",
+        "Candidates without source provenance fail closed before shadow activation.",
+      );
+}
+
+function buildUnsafePatternCheck(
+  bannedPatterns: string[],
+): RuntimeResearchPolicyGateCheck {
+  return bannedPatterns.length === 0
+    ? passCheck(
+        "unsafe-patterns",
+        "none",
+        "none",
+        "No banned strategy classes or unsafe claims were detected.",
+      )
+    : blockedCheck(
+        "unsafe-patterns",
+        bannedPatterns.join(", "),
+        "none",
+        "Unsafe or unsupported strategy classes are blocked from promotion.",
+      );
+}
+
+function buildStrategyModeCheck(
+  spec: RuntimeStrategySpec,
+  targetMode: RuntimeResearchPolicyTargetMode,
+): RuntimeResearchPolicyGateCheck {
+  const requiredMode = toRuntimeMode(targetMode);
+  return spec.supportedModes.includes(requiredMode)
+    ? passCheck(
+        "strategy-supported-mode",
+        spec.supportedModes.join(", "),
+        requiredMode,
+        `StrategySpec explicitly supports ${requiredMode}.`,
+      )
+    : blockedCheck(
+        "strategy-supported-mode",
+        spec.supportedModes.join(", ") || "none",
+        requiredMode,
+        `StrategySpec does not support ${requiredMode}, so promotion fails closed.`,
+      );
+}
+
+function buildVenueCapabilityCheck(
+  synthesis: RuntimeResearchSynthesisArtifact,
+  spec: RuntimeStrategySpec,
+  targetMode: RuntimeResearchPolicyTargetMode,
+): RuntimeResearchPolicyGateCheck {
+  const reasons: string[] = [];
+  for (const venue of spec.supportedVenues) {
+    const capability = getRuntimeVenueCapability(venue.venueKey);
+    if (!capability) {
+      reasons.push(`missing-capability:${venue.venueKey}`);
+      continue;
+    }
+    if (!capability.marketTypes.includes(synthesis.evaluationPlan.marketType)) {
+      reasons.push(
+        `unsupported-market-type:${venue.venueKey}:${synthesis.evaluationPlan.marketType}`,
+      );
+    }
+    if (!runtimeVenueSupportsMode(capability, toRuntimeMode(targetMode))) {
+      reasons.push(
+        `unsupported-mode:${venue.venueKey}:${toRuntimeMode(targetMode)}`,
+      );
+    }
+  }
+  return reasons.length === 0
+    ? passCheck(
+        "venue-capability",
+        spec.supportedVenues.map((entry) => entry.venueKey).join(", "),
+        `${synthesis.evaluationPlan.marketType}/${toRuntimeMode(targetMode)}`,
+        "All supported venues advertise the required market type and runtime mode.",
+      )
+    : blockedCheck(
+        "venue-capability",
+        reasons.join(", "),
+        `${synthesis.evaluationPlan.marketType}/${toRuntimeMode(targetMode)}`,
+        "Unsupported venue or market-type combinations are blocked automatically.",
+      );
+}
+
+function buildVenueOnboardingCheck(
+  spec: RuntimeStrategySpec,
+  targetMode: RuntimeResearchPolicyTargetMode,
+): RuntimeResearchPolicyGateCheck {
+  const requiredState = REQUIRED_VENUE_STATE[targetMode];
+  const reasons = spec.supportedVenues
+    .filter(
+      (venue) =>
+        !stateAtLeast(
+          VENUE_ONBOARDING_ORDER,
+          venue.onboardingState,
+          requiredState,
+        ),
+    )
+    .map((venue) => `${venue.venueKey}:${venue.onboardingState}`);
+
+  return reasons.length === 0
+    ? passCheck(
+        "venue-onboarding",
+        spec.supportedVenues
+          .map((venue) => `${venue.venueKey}:${venue.onboardingState}`)
+          .join(", "),
+        requiredState,
+        `Venue onboarding states satisfy the ${targetMode} threshold.`,
+      )
+    : blockedCheck(
+        "venue-onboarding",
+        reasons.join(", "),
+        requiredState,
+        `Venues below ${requiredState} cannot progress to ${targetMode}.`,
+      );
+}
+
+function buildAssetReadinessCheck(
+  assetRecords: RuntimeAssetRecord[],
+  synthesis: RuntimeResearchSynthesisArtifact,
+  spec: RuntimeStrategySpec,
+  targetMode: RuntimeResearchPolicyTargetMode,
+): RuntimeResearchPolicyGateCheck {
+  const requiredState = REQUIRED_ASSET_STATE[targetMode];
+  const requestedAssets = synthesis.evaluationPlan.assetKeys;
+  const recordMap = new Map(
+    assetRecords.map((record) => [record.assetKey, record]),
+  );
+  const reasons: string[] = [];
+
+  for (const assetKey of requestedAssets) {
+    const record = recordMap.get(assetKey);
+    if (!record) {
+      reasons.push(`missing:${assetKey}`);
+      continue;
+    }
+    if (
+      !stateAtLeast(ASSET_LISTING_ORDER, record.listingState, requiredState)
+    ) {
+      reasons.push(`asset:${assetKey}:${record.listingState}`);
+    }
+    for (const venue of spec.supportedVenues) {
+      const mapping = record.venueMappings.find(
+        (entry) => entry.venueKey === venue.venueKey,
+      );
+      if (!mapping) {
+        reasons.push(`mapping-missing:${assetKey}:${venue.venueKey}`);
+        continue;
+      }
+      if (
+        !stateAtLeast(ASSET_LISTING_ORDER, mapping.listingState, requiredState)
+      ) {
+        reasons.push(
+          `mapping:${assetKey}:${venue.venueKey}:${mapping.listingState}`,
+        );
+      }
+    }
+  }
+
+  return reasons.length === 0
+    ? passCheck(
+        "asset-readiness",
+        requestedAssets.join(", "),
+        requiredState,
+        `Asset registry coverage satisfies the ${targetMode} threshold.`,
+      )
+    : blockedCheck(
+        "asset-readiness",
+        reasons.join(", "),
+        requiredState,
+        `Unsupported or unready asset and venue mappings fail closed for ${targetMode}.`,
+      );
+}
+
+function buildBacktestCheck(
+  backtestReport: RuntimeBacktestReport | undefined,
+): RuntimeResearchPolicyGateCheck {
+  return backtestReport
+    ? passCheck(
+        "backtest-report",
+        backtestReport.reportId,
+        "candidate-specific backtest",
+        "A candidate-specific backtest report is available.",
+      )
+    : blockedCheck(
+        "backtest-report",
+        "missing",
+        "candidate-specific backtest",
+        "Paper and live consideration require a candidate-specific backtest report.",
+      );
+}
+
+function buildBacktestPromotionCheck(
+  backtestReport: RuntimeBacktestReport | undefined,
+): RuntimeResearchPolicyGateCheck {
+  if (!backtestReport) {
+    return blockedCheck(
+      "backtest-promotion-eligible",
+      "missing",
+      "true",
+      "Promotion cannot proceed without a backtest verdict.",
+    );
+  }
+
+  return backtestReport.promotionEligible
+    ? passCheck(
+        "backtest-promotion-eligible",
+        "true",
+        "true",
+        "Backtest report cleared the promotion gate.",
+      )
+    : blockedCheck(
+        "backtest-promotion-eligible",
+        "false",
+        "true",
+        `Backtest report remains blocked: ${joinReasons(backtestReport.blockingReasons)}`,
+      );
+}
+
+function buildReproducibilityCheck(
+  reproducibilityBundle: RuntimeResearchReproducibilityBundleRecord | undefined,
+): RuntimeResearchPolicyGateCheck {
+  if (!reproducibilityBundle) {
+    return blockedCheck(
+      "reproducibility",
+      "missing",
+      "latest verification passed",
+      "Promotion requires a reproducibility bundle with a passing verification result.",
+    );
+  }
+  const passed = reproducibilityBundle.latestVerification?.passed === true;
+  return passed
+    ? passCheck(
+        "reproducibility",
+        reproducibilityBundle.reproducibilityBundleId,
+        "latest verification passed",
+        "Reproducibility verification passed for the candidate evidence bundle.",
+      )
+    : blockedCheck(
+        "reproducibility",
+        reproducibilityBundle.reproducibilityBundleId,
+        "latest verification passed",
+        "Reproducibility verification has not passed yet.",
+      );
+}
+
+function buildPaperEvidenceCheck(
+  evidenceBundle: RuntimeResearchEvidenceBundleRecord | undefined,
+): RuntimeResearchPolicyGateCheck {
+  return evidenceBundle
+    ? passCheck(
+        "paper-evidence-bundle",
+        `${evidenceBundle.evidenceBundleId}:${evidenceBundle.status}`,
+        "ready_for_review|approved",
+        "Paper promotion has an auditable evidence bundle attached.",
+      )
+    : blockedCheck(
+        "paper-evidence-bundle",
+        "missing",
+        "ready_for_review|approved",
+        "Paper consideration requires a shadow-to-paper evidence bundle.",
+      );
+}
+
+function buildLaneAllowlistCheck(
+  spec: RuntimeStrategySpec,
+): RuntimeResearchPolicyGateCheck {
+  return spec.promotionPolicy.liveLaneAllowlist.length > 0
+    ? passCheck(
+        "live-lane-allowlist",
+        spec.promotionPolicy.liveLaneAllowlist.join(", "),
+        ">=1 lane",
+        "Live-capable candidates are restricted to explicit allowlisted lanes.",
+      )
+    : blockedCheck(
+        "live-lane-allowlist",
+        "none",
+        ">=1 lane",
+        "Real-money promotion requires an explicit live lane allowlist.",
+      );
+}
+
+function buildHumanApprovalPolicyCheck(
+  spec: RuntimeStrategySpec,
+): RuntimeResearchPolicyGateCheck {
+  return spec.promotionPolicy.requiresHumanApproval
+    ? passCheck(
+        "human-approval-policy",
+        "true",
+        "true",
+        "Strategy promotion policy preserves human approval at money-state boundaries.",
+      )
+    : blockedCheck(
+        "human-approval-policy",
+        "false",
+        "true",
+        "Agent-generated strategies must require human approval before real-money promotion.",
+      );
+}
+
+function buildLimitedLiveConstraintCheck(
+  spec: RuntimeStrategySpec,
+): RuntimeResearchPolicyGateCheck {
+  return spec.promotionPolicy.limitedLiveOnly
+    ? passCheck(
+        "limited-live-only",
+        "true",
+        "true",
+        "Candidate remains bounded to limited-live posture by policy.",
+      )
+    : blockedCheck(
+        "limited-live-only",
+        "false",
+        "true",
+        "Newly generated strategies cannot skip bounded limited-live validation.",
+      );
+}
+
+function buildLimitedLiveEvidenceCheck(
+  evidenceBundle: RuntimeResearchEvidenceBundleRecord | undefined,
+): RuntimeResearchPolicyGateCheck {
+  return evidenceBundle
+    ? passCheck(
+        "limited-live-evidence-bundle",
+        `${evidenceBundle.evidenceBundleId}:${evidenceBundle.status}`,
+        "approved",
+        "Limited-live consideration has an approved evidence bundle.",
+      )
+    : blockedCheck(
+        "limited-live-evidence-bundle",
+        "missing",
+        "approved",
+        "Limited-live consideration requires an approved evidence bundle.",
+      );
+}
+
+function buildLimitedLiveCanaryCheck(
+  passed: boolean,
+): RuntimeResearchPolicyGateCheck {
+  return passed
+    ? passCheck(
+        "limited-live-canary",
+        "passed",
+        "passed",
+        "A bounded limited-live canary has completed successfully.",
+      )
+    : blockedCheck(
+        "limited-live-canary",
+        "missing_or_failed",
+        "passed",
+        "Broad-live promotion requires a successful limited-live canary.",
+      );
+}
+
+function buildLimitedLiveSoakCheck(
+  passed: boolean,
+): RuntimeResearchPolicyGateCheck {
+  return passed
+    ? passCheck(
+        "limited-live-soak",
+        "passed",
+        "passed",
+        "Limited-live soak evidence is available for broader rollout review.",
+      )
+    : blockedCheck(
+        "limited-live-soak",
+        "missing_or_failed",
+        "passed",
+        "Broad-live promotion requires a successful limited-live soak.",
+      );
+}
+
+function buildPrerequisiteGateCheck(
+  checkId: string,
+  targetMode: RuntimeResearchPolicyTargetMode,
+  gate: RuntimeResearchPolicyGateDecision,
+): RuntimeResearchPolicyGateCheck {
+  return gate.status === "pass"
+    ? passCheck(
+        checkId,
+        gate.status,
+        "pass",
+        `${formatTargetMode(targetMode)} gate already passed.`,
+      )
+    : blockedCheck(
+        checkId,
+        gate.status,
+        "pass",
+        `${formatTargetMode(targetMode)} gate must pass before continuing.`,
+      );
+}
+
+function finalizeGate(input: {
+  targetMode: RuntimeResearchPolicyTargetMode;
+  checks: RuntimeResearchPolicyGateCheck[];
+  approval?: RuntimeResearchHumanApprovalRecord;
+}): RuntimeResearchPolicyGateDecision {
+  const automatedChecksPassed = input.checks.every(
+    (check) => check.status === "pass",
+  );
+  const requiresHumanApproval = HUMAN_APPROVAL_TARGETS.has(input.targetMode);
+  const approval = input.approval;
+  const checks = requiresHumanApproval
+    ? [
+        ...input.checks,
+        approval
+          ? passCheck(
+              "human-approval",
+              `${approval.approvedBy}:${approval.approvedAt}`,
+              "recorded",
+              `${formatTargetMode(input.targetMode)} approval has been recorded.`,
+            )
+          : requiresHumanApprovalCheck(input.targetMode),
+      ]
+    : input.checks;
+
+  let status: RuntimeResearchPolicyGateStatus = automatedChecksPassed
+    ? "pass"
+    : "blocked";
+  if (automatedChecksPassed && requiresHumanApproval && !approval) {
+    status = "requires_human_approval";
+  }
+
+  const summary =
+    status === "pass"
+      ? `${formatTargetMode(input.targetMode)} is cleared under current policy.`
+      : status === "requires_human_approval"
+        ? `${formatTargetMode(input.targetMode)} passed automated checks but still requires explicit human approval.`
+        : `${formatTargetMode(input.targetMode)} is blocked by policy gates.`;
+
+  return {
+    targetMode: input.targetMode,
+    automatedChecksPassed,
+    requiresHumanApproval,
+    eligible: status === "pass",
+    status,
+    summary,
+    checks,
+    ...(approval ? { approval } : {}),
+  };
+}
+
+function findEvidenceBundle(
+  evidenceBundles: RuntimeResearchEvidenceBundleRecord[] | undefined,
+  input: {
+    strategyKey: string;
+    promotionTarget: string;
+    acceptedStatuses: Set<RuntimeResearchEvidenceBundleRecord["status"]>;
+  },
+): RuntimeResearchEvidenceBundleRecord | undefined {
+  const candidates = (evidenceBundles ?? [])
+    .filter(
+      (bundle) =>
+        bundle.strategyKey === input.strategyKey &&
+        bundle.promotionTarget === input.promotionTarget &&
+        input.acceptedStatuses.has(bundle.status),
+    )
+    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+  return candidates[0];
+}
+
+function collectBannedPatterns(
+  synthesis: RuntimeResearchSynthesisArtifact,
+): string[] {
+  const searchable = [
+    synthesis.briefTitle,
+    synthesis.expectedMechanism,
+    synthesis.hypothesis.title,
+    synthesis.hypothesis.thesis,
+    synthesis.strategySpecDraft.summary,
+    ...synthesis.hypothesis.tags,
+    ...synthesis.strategySpecDraft.tags,
+  ].join("\n");
+  const matches = UNSAFE_PATTERN_RULES.filter((rule) =>
+    rule.pattern.test(searchable),
+  ).map((rule) => rule.id);
+  return Array.from(new Set(matches)).slice(0, 16);
+}
+
+function requiresHumanApprovalCheck(
+  targetMode: RuntimeResearchPolicyTargetMode,
+): RuntimeResearchPolicyGateCheck {
+  return {
+    checkId: "human-approval",
+    status: "requires_human_approval",
+    observedValue: "missing",
+    thresholdValue: "recorded",
+    message: `${formatTargetMode(targetMode)} requires explicit human approval before promotion.`,
+  };
+}
+
+function passCheck(
+  checkId: string,
+  observedValue: string,
+  thresholdValue: string,
+  message: string,
+): RuntimeResearchPolicyGateCheck {
+  return {
+    checkId,
+    status: "pass",
+    observedValue,
+    thresholdValue,
+    message,
+  };
+}
+
+function blockedCheck(
+  checkId: string,
+  observedValue: string,
+  thresholdValue: string,
+  message: string,
+): RuntimeResearchPolicyGateCheck {
+  return {
+    checkId,
+    status: "blocked",
+    observedValue,
+    thresholdValue,
+    message,
+  };
+}
+
+function stateAtLeast<T extends string>(
+  order: readonly T[],
+  actual: T,
+  minimum: T,
+): boolean {
+  return order.indexOf(actual) >= order.indexOf(minimum);
+}
+
+function toRuntimeMode(
+  targetMode: RuntimeResearchPolicyTargetMode,
+): RuntimeStrategySpec["supportedModes"][number] {
+  if (targetMode === "shadow") return "shadow";
+  if (targetMode === "paper") return "paper";
+  return "live";
+}
+
+function formatTargetMode(targetMode: RuntimeResearchPolicyTargetMode): string {
+  return targetMode
+    .split("_")
+    .map((segment) => segment[0]?.toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+function joinReasons(reasons: string[]): string {
+  return reasons.length > 0 ? reasons.join(", ") : "none";
+}
+
+function hash(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 24);
+}
+
+function parseRuntimeResearchCandidateTriageArtifact(
+  input: unknown,
+): RuntimeResearchCandidateTriageArtifact {
+  if (!isRecord(input)) {
+    throw new Error("invalid-runtime-research-triage-artifact");
+  }
+  return {
+    triageId: readRequiredString(input.triageId, "triageId"),
+    generatedAt: readRequiredString(input.generatedAt, "generatedAt"),
+    synthesisId: readRequiredString(input.synthesisId, "synthesisId"),
+    hypothesisId: readRequiredString(input.hypothesisId, "hypothesisId"),
+    disposition: readRequiredString(
+      input.disposition,
+      "disposition",
+    ) as RuntimeResearchCandidateTriageArtifact["disposition"],
+    recommendedHypothesisStatus: readRequiredString(
+      input.recommendedHypothesisStatus,
+      "recommendedHypothesisStatus",
+    ) as RuntimeResearchCandidateTriageArtifact["recommendedHypothesisStatus"],
+    noveltyScoreBps: readRequiredNumber(
+      input.noveltyScoreBps,
+      "noveltyScoreBps",
+    ),
+    evidenceScoreBps: readRequiredNumber(
+      input.evidenceScoreBps,
+      "evidenceScoreBps",
+    ),
+    venueFitScoreBps: readRequiredNumber(
+      input.venueFitScoreBps,
+      "venueFitScoreBps",
+    ),
+    implementationCostScoreBps: readRequiredNumber(
+      input.implementationCostScoreBps,
+      "implementationCostScoreBps",
+    ),
+    priorityScoreBps: readRequiredNumber(
+      input.priorityScoreBps,
+      "priorityScoreBps",
+    ),
+    duplicateMatches: Array.isArray(input.duplicateMatches)
+      ? input.duplicateMatches.map((entry) => parseDuplicateMatch(entry))
+      : [],
+    rationale: normalizeStringArray(input.rationale),
+    ...(typeof input.archivedHypothesisId === "string" &&
+    input.archivedHypothesisId.trim()
+      ? { archivedHypothesisId: input.archivedHypothesisId.trim() }
+      : {}),
+  };
+}
+
+function parseDuplicateMatch(
+  input: unknown,
+): RuntimeResearchCandidateTriageArtifact["duplicateMatches"][number] {
+  if (!isRecord(input)) {
+    throw new Error("invalid-runtime-research-triage-duplicate-match");
+  }
+  return {
+    matchType: readRequiredString(
+      input.matchType,
+      "duplicateMatches.matchType",
+    ) as RuntimeResearchCandidateTriageArtifact["duplicateMatches"][number]["matchType"],
+    source: readRequiredString(
+      input.source,
+      "duplicateMatches.source",
+    ) as RuntimeResearchCandidateTriageArtifact["duplicateMatches"][number]["source"],
+    strategyKey: readRequiredString(
+      input.strategyKey,
+      "duplicateMatches.strategyKey",
+    ),
+    similarityBps: readRequiredNumber(
+      input.similarityBps,
+      "duplicateMatches.similarityBps",
+    ),
+    reasons: normalizeStringArray(input.reasons),
+  };
+}
+
+function parseRuntimeResearchSynthesisArtifact(
+  input: unknown,
+): RuntimeResearchSynthesisArtifact {
+  if (!isRecord(input)) {
+    throw new Error("invalid-runtime-research-synthesis-artifact");
+  }
+  return {
+    synthesisId: readRequiredString(input.synthesisId, "synthesisId"),
+    generatedAt: readRequiredString(input.generatedAt, "generatedAt"),
+    briefId: readRequiredString(input.briefId, "briefId"),
+    briefTitle: readRequiredString(input.briefTitle, "briefTitle"),
+    expectedMechanism: readRequiredString(
+      input.expectedMechanism,
+      "expectedMechanism",
+    ),
+    hypothesis: parseRuntimeResearchHypothesisRecord(input.hypothesis),
+    strategySpecDraft: parseRuntimeStrategySpec(input.strategySpecDraft),
+    evaluationPlan: parseEvaluationPlan(input.evaluationPlan),
+    implementationPlan: parseImplementationPlan(input.implementationPlan),
+    riskNotes: normalizeStringArray(input.riskNotes),
+    citations: Array.isArray(input.citations)
+      ? input.citations.map((entry) => parseCitation(entry))
+      : [],
+  };
+}
+
+function parseEvaluationPlan(
+  input: unknown,
+): RuntimeResearchSynthesisEvaluationPlan {
+  if (!isRecord(input)) {
+    throw new Error("invalid-runtime-research-policy-evaluation-plan");
+  }
+  return {
+    marketType: readRequiredString(
+      input.marketType,
+      "evaluationPlan.marketType",
+    ) as RuntimeResearchSynthesisEvaluationPlan["marketType"],
+    venueKey: readRequiredString(input.venueKey, "evaluationPlan.venueKey"),
+    pairSymbol: readRequiredString(
+      input.pairSymbol,
+      "evaluationPlan.pairSymbol",
+    ),
+    assetKeys: normalizeStringArray(input.assetKeys),
+    datasetRequirements: normalizeStringArray(input.datasetRequirements),
+    requiredFeatureKeys: normalizeStringArray(input.requiredFeatureKeys),
+    requiredRegimeKeys: normalizeStringArray(input.requiredRegimeKeys),
+    backtestPlan: isRecord(input.backtestPlan)
+      ? {
+          windowMode: "rolling",
+          trainingWindowObservations: readRequiredNumber(
+            input.backtestPlan.trainingWindowObservations,
+            "evaluationPlan.backtestPlan.trainingWindowObservations",
+          ),
+          testingWindowObservations: readRequiredNumber(
+            input.backtestPlan.testingWindowObservations,
+            "evaluationPlan.backtestPlan.testingWindowObservations",
+          ),
+          stepObservations: readRequiredNumber(
+            input.backtestPlan.stepObservations,
+            "evaluationPlan.backtestPlan.stepObservations",
+          ),
+          purgeObservations: readRequiredNumber(
+            input.backtestPlan.purgeObservations,
+            "evaluationPlan.backtestPlan.purgeObservations",
+          ),
+          baselineStrategies: normalizeStringArray(
+            input.backtestPlan.baselineStrategies,
+          ),
+        }
+      : (() => {
+          throw new Error("invalid-runtime-research-policy-backtest-plan");
+        })(),
+    paperPlan: isRecord(input.paperPlan)
+      ? {
+          required: true,
+          minPaperRuns: readRequiredNumber(
+            input.paperPlan.minPaperRuns,
+            "evaluationPlan.paperPlan.minPaperRuns",
+          ),
+          notes: normalizeStringArray(input.paperPlan.notes),
+        }
+      : (() => {
+          throw new Error("invalid-runtime-research-policy-paper-plan");
+        })(),
+    successCriteria: normalizeStringArray(input.successCriteria),
+    failureModes: normalizeStringArray(input.failureModes),
+  };
+}
+
+function parseImplementationPlan(
+  input: unknown,
+): RuntimeResearchImplementationPlan {
+  if (!isRecord(input)) {
+    throw new Error("invalid-runtime-research-policy-implementation-plan");
+  }
+  return {
+    branchName: readRequiredString(
+      input.branchName,
+      "implementationPlan.branchName",
+    ),
+    issueTitle: readRequiredString(
+      input.issueTitle,
+      "implementationPlan.issueTitle",
+    ),
+    issueBody: readRequiredString(
+      input.issueBody,
+      "implementationPlan.issueBody",
+    ),
+    scaffoldFiles: Array.isArray(input.scaffoldFiles)
+      ? input.scaffoldFiles.map((entry) =>
+          parsePlanEntry(entry, "scaffoldFiles"),
+        )
+      : [],
+    testFiles: Array.isArray(input.testFiles)
+      ? input.testFiles.map((entry) => parsePlanEntry(entry, "testFiles"))
+      : [],
+    validationCommands: normalizeStringArray(input.validationCommands),
+  };
+}
+
+function parsePlanEntry(
+  input: unknown,
+  path: string,
+): RuntimeResearchImplementationPlan["scaffoldFiles"][number] {
+  if (!isRecord(input)) {
+    throw new Error(`invalid-runtime-research-policy-${path}-entry`);
+  }
+  return {
+    path: readRequiredString(input.path, `${path}.path`),
+    purpose: readRequiredString(input.purpose, `${path}.purpose`),
+  };
+}
+
+function parseCitation(
+  input: unknown,
+): RuntimeResearchSynthesisArtifact["citations"][number] {
+  if (!isRecord(input)) {
+    throw new Error("invalid-runtime-research-policy-citation");
+  }
+  return {
+    sourceId: readRequiredString(input.sourceId, "citations.sourceId"),
+    title: readRequiredString(input.title, "citations.title"),
+    canonicalUrl: readRequiredString(
+      input.canonicalUrl,
+      "citations.canonicalUrl",
+    ),
+  };
+}
+
+function parseRuntimeResearchHumanApprovalRecord(
+  input: unknown,
+): RuntimeResearchHumanApprovalRecord {
+  if (!isRecord(input)) {
+    throw new Error("invalid-runtime-research-human-approval-record");
+  }
+  return {
+    targetMode: readRequiredString(
+      input.targetMode,
+      "approvals.targetMode",
+    ) as RuntimeResearchHumanApprovalRecord["targetMode"],
+    approvedBy: readRequiredString(input.approvedBy, "approvals.approvedBy"),
+    approvedAt: readRequiredString(input.approvedAt, "approvals.approvedAt"),
+    ...(typeof input.notes === "string" && input.notes.trim()
+      ? { notes: input.notes.trim() }
+      : {}),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readRequiredString(value: unknown, path: string): string {
+  const normalized = String(value ?? "").trim();
+  if (!normalized) {
+    throw new Error(`missing-runtime-research-policy-field:${path}`);
+  }
+  return normalized;
+}
+
+function readRequiredNumber(value: unknown, path: string): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  throw new Error(`invalid-runtime-research-policy-number:${path}`);
+}
+
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => String(entry ?? "").trim())
+    .filter((entry) => entry.length > 0);
+}

--- a/tests/unit/runtime_research_policy_gate.test.ts
+++ b/tests/unit/runtime_research_policy_gate.test.ts
@@ -1,0 +1,563 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseRuntimeAssetRecord,
+  parseRuntimeBacktestReport,
+  parseRuntimeResearchEvidenceBundleRecord,
+  parseRuntimeResearchPolicyGateArtifact,
+  parseRuntimeResearchReproducibilityBundleRecord,
+} from "../../src/runtime/contracts/autonomous_runtime.js";
+import {
+  buildRuntimeResearchPolicyGate,
+  buildRuntimeResearchPolicyGateMarkdown,
+  parseRuntimeResearchPolicyGateRequest,
+  requireRuntimeResearchPolicyGatePass,
+} from "../../src/runtime/research/policy_gate.js";
+import { buildRuntimeResearchSynthesis } from "../../src/runtime/research/synthesis.js";
+import { buildRuntimeResearchCandidateTriage } from "../../src/runtime/research/triage.js";
+
+const briefFixture = {
+  briefId: "brief_latest_signal",
+  generatedAt: "2026-03-11T12:00:00.000Z",
+  profile: "custom",
+  title: "Latest signal research",
+  summary:
+    "Reviewed 1 approved source across 1 acquisition request. Most recent coverage: Momentum Alpha in Crypto.",
+  findings: [
+    "Momentum Alpha in Crypto (published 2026-03-11T08:00:00.000Z): Measure momentum across venue fragments and validate liquidity persistence.",
+  ],
+  approvedHosts: ["research.example.com"],
+  requestCount: 1,
+  sourceCount: 1,
+  createdCount: 1,
+  existingCount: 0,
+  citations: [
+    {
+      sourceId: "source_article_momentum",
+      materialDigest: "sha256:source_article_momentum",
+      notes: "published 2026-03-11T08:00:00.000Z",
+    },
+  ],
+  sources: [
+    {
+      sourceId: "source_article_momentum",
+      sourceKind: "article",
+      title: "Momentum Alpha in Crypto",
+      url: "https://research.example.com/posts/momentum-alpha",
+      canonicalUrl: "https://research.example.com/posts/momentum-alpha",
+      authors: ["Ada Researcher"],
+      publishedAt: "2026-03-11T08:00:00.000Z",
+      retrievedAt: "2026-03-11T12:00:00.000Z",
+      venueKeys: ["jupiter"],
+      assetKeys: ["SOL", "USDC"],
+      tags: ["signal", "momentum"],
+      digest: "sha256:source_article_momentum",
+    },
+  ],
+} as const;
+
+function buildCandidateArtifacts(options?: {
+  strategyKey?: string;
+  title?: string;
+  marketType?: "spot" | "perp" | "options";
+}) {
+  const synthesis = buildRuntimeResearchSynthesis({
+    request: {
+      brief: briefFixture,
+      strategyKey:
+        options?.strategyKey ?? "candidate_trend_following_jupiter_sol_usdc",
+      title: options?.title ?? "Trend continuation alpha",
+      ...(options?.marketType ? { marketType: options.marketType } : {}),
+    },
+  });
+  const triage = buildRuntimeResearchCandidateTriage({
+    request: {
+      synthesis,
+    },
+  });
+  return { synthesis, triage };
+}
+
+function buildAssetRecord(assetKey: "SOL" | "USDC") {
+  const isSol = assetKey === "SOL";
+  const nativeId = isSol
+    ? "So11111111111111111111111111111111111111112"
+    : "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+  return parseRuntimeAssetRecord({
+    schemaVersion: "v1",
+    assetKey,
+    displayName: isSol ? "Solana" : "USD Coin",
+    symbol: assetKey,
+    chainKey: "solana-mainnet",
+    canonicalId: nativeId,
+    assetKind: isSol ? "native" : "stablecoin",
+    riskClass: "core",
+    listingState: "live",
+    decimals: isSol ? 9 : 6,
+    aliases: isSol ? ["WSOL"] : ["USD Coin"],
+    quoteAssetKeys: ["USDC"],
+    venueMappings: [
+      {
+        venueKey: "jupiter",
+        nativeId,
+        venueSymbol: assetKey,
+        decimals: isSol ? 9 : 6,
+        listingState: "live",
+        quoteAssetKeys: ["USDC"],
+        priceDecimals: 6,
+        sizeDecimals: isSol ? 9 : 6,
+        minNotionalUsd: "0.01",
+      },
+    ],
+    createdAt: "2026-03-11T12:00:00.000Z",
+    updatedAt: "2026-03-11T12:00:00.000Z",
+    promotedAt: "2026-03-11T12:00:00.000Z",
+    tags: ["asset-registry"],
+  });
+}
+
+function buildBacktestReport(strategyKey: string) {
+  return parseRuntimeBacktestReport({
+    schemaVersion: "v1",
+    reportId: `backtest_${strategyKey}`,
+    experimentId: `experiment_${strategyKey}`,
+    strategyKey,
+    status: "completed",
+    generatedAt: "2026-03-11T13:00:00.000Z",
+    venueKeys: ["jupiter"],
+    assetKeys: ["SOL", "USDC"],
+    codeRevision: {
+      vcs: "git",
+      repository: "github.com/GuiBibeau/serious-trader-ralph",
+      revision: "64c6a2327fab56cb970acfeb4676720cf0bd6c0c",
+      treeDirty: false,
+    },
+    datasetSnapshots: [
+      {
+        datasetId: "dataset_feature_cache_sol_usdc_market_events",
+        snapshotId: "snapshot_2026_03_11_backtest",
+        capturedAt: "2026-03-11T12:30:00.000Z",
+      },
+    ],
+    strategySpecDigest: "sha256:strategy",
+    config: {
+      replayCorpusId: "replay_corpus_sol_usdc_feature_cache",
+      venueKey: "jupiter",
+      pairSymbol: "SOL/USDC",
+      marketType: "spot",
+      windowMode: "rolling",
+      trainingWindowObservations: 32,
+      testingWindowObservations: 8,
+      stepObservations: 4,
+      purgeObservations: 2,
+      baselineStrategies: ["flat_cash", "buy_and_hold"],
+    },
+    foldReports: [
+      {
+        foldId: "fold_0",
+        foldIndex: 0,
+        trainingStartAt: "2026-03-10T00:00:00.000Z",
+        trainingEndAt: "2026-03-10T12:00:00.000Z",
+        testStartAt: "2026-03-10T12:00:00.000Z",
+        testEndAt: "2026-03-11T00:00:00.000Z",
+        trainObservationCount: 32,
+        purgedObservationCount: 2,
+        testObservationCount: 8,
+        metrics: {
+          observationCount: 8,
+          tradeCount: 3,
+          grossReturnBps: "42.1500",
+          netReturnBps: "39.4000",
+          totalCostBps: "2.7500",
+          winRateBps: 6667,
+          maxDrawdownBps: "8.1000",
+        },
+        baselineComparisons: [
+          {
+            baseline: "flat_cash",
+            baselineReturnBps: "0.0000",
+            excessReturnBps: "39.4000",
+          },
+          {
+            baseline: "buy_and_hold",
+            baselineReturnBps: "10.5000",
+            excessReturnBps: "28.9000",
+          },
+        ],
+        regimeMetrics: [
+          {
+            regimeKey: "short_trend",
+            regimeValue: "positive",
+            observationCount: 8,
+            tradeCount: 3,
+            netReturnBps: "39.4000",
+            winRateBps: 6667,
+          },
+        ],
+      },
+    ],
+    aggregateMetrics: {
+      observationCount: 8,
+      tradeCount: 3,
+      grossReturnBps: "42.1500",
+      netReturnBps: "39.4000",
+      totalCostBps: "2.7500",
+      winRateBps: 6667,
+      maxDrawdownBps: "8.1000",
+    },
+    aggregateBaselineComparisons: [
+      {
+        baseline: "flat_cash",
+        baselineReturnBps: "0.0000",
+        excessReturnBps: "39.4000",
+      },
+      {
+        baseline: "buy_and_hold",
+        baselineReturnBps: "10.5000",
+        excessReturnBps: "28.9000",
+      },
+    ],
+    aggregateRegimeMetrics: [
+      {
+        regimeKey: "short_trend",
+        regimeValue: "positive",
+        observationCount: 8,
+        tradeCount: 3,
+        netReturnBps: "39.4000",
+        winRateBps: 6667,
+      },
+    ],
+    promotionEligible: true,
+    blockingReasons: [],
+    summary: "Backtest cleared the bounded promotion gate.",
+    tags: ["backtest", "paper"],
+  });
+}
+
+function buildReproducibilityBundle(strategyKey: string) {
+  return parseRuntimeResearchReproducibilityBundleRecord({
+    schemaVersion: "v1",
+    reproducibilityBundleId: `repro_${strategyKey}`,
+    experimentId: `experiment_${strategyKey}`,
+    strategyKey,
+    createdAt: "2026-03-11T13:05:00.000Z",
+    updatedAt: "2026-03-11T13:05:00.000Z",
+    venueKeys: ["jupiter"],
+    assetKeys: ["SOL", "USDC"],
+    sourceCitations: [{ sourceId: "source_article_momentum" }],
+    codeRevision: {
+      vcs: "git",
+      repository: "github.com/GuiBibeau/serious-trader-ralph",
+      revision: "64c6a2327fab56cb970acfeb4676720cf0bd6c0c",
+      treeDirty: false,
+    },
+    datasetSnapshots: [
+      {
+        datasetId: "dataset_feature_cache_sol_usdc_market_events",
+        snapshotId: "snapshot_2026_03_11_backtest",
+        capturedAt: "2026-03-11T12:30:00.000Z",
+      },
+    ],
+    manifest: {
+      manifestId: `manifest_${strategyKey}`,
+      generatedAt: "2026-03-11T13:05:00.000Z",
+      codeRevision: {
+        vcs: "git",
+        repository: "github.com/GuiBibeau/serious-trader-ralph",
+        revision: "64c6a2327fab56cb970acfeb4676720cf0bd6c0c",
+        treeDirty: false,
+      },
+      datasetSnapshots: [
+        {
+          datasetId: "dataset_feature_cache_sol_usdc_market_events",
+          snapshotId: "snapshot_2026_03_11_backtest",
+          capturedAt: "2026-03-11T12:30:00.000Z",
+        },
+      ],
+      replayCorpusId: "replay_corpus_sol_usdc_feature_cache",
+      venueKey: "jupiter",
+      pairSymbol: "SOL/USDC",
+      marketType: "spot",
+      strategySpecDigest: "sha256:strategy",
+      featureVersions: [
+        {
+          recordId: "feature_short_return",
+          key: "short_return_bps",
+          version: "v1",
+          updatedAt: "2026-03-11T12:30:00.000Z",
+        },
+      ],
+      regimeVersions: [
+        {
+          recordId: "regime_short_trend",
+          key: "short_trend",
+          version: "v1",
+          updatedAt: "2026-03-11T12:30:00.000Z",
+        },
+      ],
+      costModel: {
+        modelId: "cost_model_jupiter_sol_usdc_spot",
+        calibrationId: "calibration_seed",
+        updatedAt: "2026-03-11T12:30:00.000Z",
+      },
+      backtestConfig: {
+        replayCorpusId: "replay_corpus_sol_usdc_feature_cache",
+        venueKey: "jupiter",
+        pairSymbol: "SOL/USDC",
+        marketType: "spot",
+        windowMode: "rolling",
+        trainingWindowObservations: 32,
+        testingWindowObservations: 8,
+        stepObservations: 4,
+        purgeObservations: 2,
+        baselineStrategies: ["flat_cash", "buy_and_hold"],
+      },
+    },
+    expectedResult: {
+      reportId: `backtest_${strategyKey}`,
+      status: "completed",
+      promotionEligible: true,
+      aggregateMetrics: {
+        observationCount: 8,
+        tradeCount: 3,
+        grossReturnBps: "42.1500",
+        netReturnBps: "39.4000",
+        totalCostBps: "2.7500",
+        winRateBps: 6667,
+        maxDrawdownBps: "8.1000",
+      },
+      aggregateBaselineComparisons: [
+        {
+          baseline: "flat_cash",
+          baselineReturnBps: "0.0000",
+          excessReturnBps: "39.4000",
+        },
+      ],
+      aggregateRegimeMetrics: [
+        {
+          regimeKey: "short_trend",
+          regimeValue: "positive",
+          observationCount: 8,
+          tradeCount: 3,
+          netReturnBps: "39.4000",
+          winRateBps: 6667,
+        },
+      ],
+      blockingReasons: [],
+    },
+    artifacts: [
+      {
+        artifactId: `repro-manifest-${strategyKey}`,
+        kind: "reproducibility-manifest",
+        uri: `runtime-reproducibility://${strategyKey}`,
+      },
+    ],
+    linkedEvidenceBundleIds: [`evidence_${strategyKey}_paper`],
+    verificationTolerance: {
+      maxNetReturnDeltaBps: "0.1000",
+      maxTotalCostDeltaBps: "0.1000",
+      maxDrawdownDeltaBps: "0.1000",
+      maxWinRateDeltaBps: 1,
+      maxTradeCountDelta: 0,
+    },
+    latestVerification: {
+      verifiedAt: "2026-03-11T13:10:00.000Z",
+      verificationMode: "bounded_tolerance",
+      passed: true,
+      reportId: `backtest_${strategyKey}`,
+      rerunReportId: `backtest_${strategyKey}`,
+      netReturnDeltaBps: "0.0000",
+      totalCostDeltaBps: "0.0000",
+      maxDrawdownDeltaBps: "0.0000",
+      winRateDeltaBps: 0,
+      tradeCountDelta: 0,
+      blockingReasons: [],
+    },
+    summary: "Reproducibility verification passed for the candidate.",
+    tags: ["reproducible"],
+  });
+}
+
+function buildEvidenceBundle(strategyKey: string, promotionTarget: string) {
+  return parseRuntimeResearchEvidenceBundleRecord({
+    schemaVersion: "v1",
+    evidenceBundleId: `evidence_${strategyKey}_${promotionTarget}`,
+    experimentId: `experiment_${strategyKey}`,
+    strategyKey,
+    status: promotionTarget === "paper" ? "ready_for_review" : "approved",
+    promotionTarget,
+    createdAt: "2026-03-11T13:15:00.000Z",
+    updatedAt: "2026-03-11T13:15:00.000Z",
+    venueKeys: ["jupiter"],
+    assetKeys: ["SOL", "USDC"],
+    sourceCitations: [{ sourceId: "source_article_momentum" }],
+    codeRevision: {
+      vcs: "git",
+      repository: "github.com/GuiBibeau/serious-trader-ralph",
+      revision: "64c6a2327fab56cb970acfeb4676720cf0bd6c0c",
+      treeDirty: false,
+    },
+    datasetSnapshots: [
+      {
+        datasetId: "dataset_feature_cache_sol_usdc_market_events",
+        snapshotId: "snapshot_2026_03_11_backtest",
+        capturedAt: "2026-03-11T12:30:00.000Z",
+      },
+    ],
+    artifacts: [
+      {
+        artifactId: `artifact_${strategyKey}_${promotionTarget}`,
+        kind: "proof-bundle",
+        uri: `r2://artifacts/${strategyKey}/${promotionTarget}.md`,
+      },
+    ],
+    summary: `Evidence bundle for ${promotionTarget}.`,
+    tags: ["promotion"],
+  });
+}
+
+describe("runtime research policy gate", () => {
+  test("parses a policy-gate request", () => {
+    const { synthesis, triage } = buildCandidateArtifacts();
+    const request = parseRuntimeResearchPolicyGateRequest({
+      synthesis,
+      triage,
+      limitedLiveCanaryPassed: true,
+    });
+
+    expect(request.synthesis.synthesisId).toBe(synthesis.synthesisId);
+    expect(request.triage.triageId).toBe(triage.triageId);
+    expect(request.limitedLiveCanaryPassed).toBe(true);
+  });
+
+  test("passes shadow and blocks later modes when evidence is missing", () => {
+    const { synthesis, triage } = buildCandidateArtifacts();
+    const policyGate = buildRuntimeResearchPolicyGate({
+      request: {
+        synthesis,
+        triage,
+        assetRecords: [buildAssetRecord("SOL"), buildAssetRecord("USDC")],
+      },
+    });
+
+    parseRuntimeResearchPolicyGateArtifact(policyGate);
+    expect(
+      policyGate.gates.find((gate) => gate.targetMode === "shadow")?.status,
+    ).toBe("pass");
+    expect(
+      policyGate.gates.find((gate) => gate.targetMode === "paper")?.status,
+    ).toBe("blocked");
+    expect(
+      policyGate.gates.find((gate) => gate.targetMode === "limited_live")
+        ?.status,
+    ).toBe("blocked");
+    expect(
+      policyGate.gates.find((gate) => gate.targetMode === "broad_live")?.status,
+    ).toBe("blocked");
+
+    const markdown = buildRuntimeResearchPolicyGateMarkdown(policyGate);
+    expect(markdown).toContain("## Shadow");
+    expect(markdown).toContain("## Broad Live");
+    expect(() =>
+      requireRuntimeResearchPolicyGatePass({
+        artifact: policyGate,
+        targetMode: "paper",
+      }),
+    ).toThrow("runtime-research-policy-blocked:paper:blocked");
+  });
+
+  test("fails closed for unsupported perp venue combinations", () => {
+    const { synthesis, triage } = buildCandidateArtifacts({
+      strategyKey: "candidate_funding_carry_perp",
+      title: "Funding carry alpha",
+      marketType: "perp",
+    });
+    const policyGate = buildRuntimeResearchPolicyGate({
+      request: {
+        synthesis,
+        triage,
+        assetRecords: [buildAssetRecord("SOL"), buildAssetRecord("USDC")],
+      },
+    });
+
+    const shadowGate = policyGate.gates.find(
+      (gate) => gate.targetMode === "shadow",
+    );
+    expect(shadowGate?.status).toBe("blocked");
+    expect(
+      shadowGate?.checks.find((check) => check.checkId === "venue-capability")
+        ?.status,
+    ).toBe("blocked");
+  });
+
+  test("requires explicit approval before broader live even after automated checks pass", () => {
+    const { synthesis, triage } = buildCandidateArtifacts({
+      strategyKey: "candidate_breakout_live_ready",
+      title: "Breakout rotation alpha",
+    });
+    const liveCapableSynthesis = {
+      ...synthesis,
+      strategySpecDraft: {
+        ...synthesis.strategySpecDraft,
+        supportedModes: ["shadow", "paper", "live"],
+        supportedVenues: [
+          {
+            venueKey: "jupiter",
+            onboardingState: "broad_live_ready",
+            notes: "Fully onboarded for this test fixture.",
+          },
+        ],
+        promotionPolicy: {
+          ...synthesis.strategySpecDraft.promotionPolicy,
+          liveLaneAllowlist: ["safe"],
+          limitedLiveOnly: true,
+        },
+      },
+    };
+    const strategyKey = liveCapableSynthesis.strategySpecDraft.strategyKey;
+    const policyGate = buildRuntimeResearchPolicyGate({
+      request: {
+        synthesis: liveCapableSynthesis,
+        triage,
+        assetRecords: [buildAssetRecord("SOL"), buildAssetRecord("USDC")],
+        backtestReport: buildBacktestReport(strategyKey),
+        reproducibilityBundle: buildReproducibilityBundle(strategyKey),
+        evidenceBundles: [
+          buildEvidenceBundle(strategyKey, "paper"),
+          buildEvidenceBundle(strategyKey, "limited_live"),
+        ],
+        approvals: [
+          {
+            targetMode: "paper",
+            approvedBy: "operator@example.com",
+            approvedAt: "2026-03-11T13:20:00.000Z",
+          },
+          {
+            targetMode: "limited_live",
+            approvedBy: "operator@example.com",
+            approvedAt: "2026-03-11T13:25:00.000Z",
+          },
+        ],
+        limitedLiveCanaryPassed: true,
+        limitedLiveSoakPassed: true,
+      },
+    });
+
+    expect(
+      policyGate.gates.find((gate) => gate.targetMode === "paper")?.status,
+    ).toBe("pass");
+    expect(
+      policyGate.gates.find((gate) => gate.targetMode === "limited_live")
+        ?.status,
+    ).toBe("pass");
+    expect(
+      policyGate.gates.find((gate) => gate.targetMode === "broad_live")?.status,
+    ).toBe("requires_human_approval");
+
+    expect(
+      requireRuntimeResearchPolicyGatePass({
+        artifact: policyGate,
+        targetMode: "limited_live",
+      }).status,
+    ).toBe("pass");
+  });
+});

--- a/tests/unit/worker_runtime_research_policy_gate_route.test.ts
+++ b/tests/unit/worker_runtime_research_policy_gate_route.test.ts
@@ -1,0 +1,211 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Env } from "../../apps/worker/src/types";
+import { buildRuntimeResearchSynthesis } from "../../src/runtime/research/synthesis.js";
+import { buildRuntimeResearchCandidateTriage } from "../../src/runtime/research/triage.js";
+import {
+  createExecutionContextStub,
+  createWorkerLiveEnv,
+} from "../integration/_worker_live_test_utils";
+
+const worker = (await import("../../apps/worker/src/index")).default;
+
+function createSqliteD1Adapter(db: Database): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          return {
+            async run() {
+              const statement = db.query(sql);
+              const result = statement.run(...(params as never[])) as {
+                changes?: number;
+              };
+              return {
+                meta: {
+                  changes:
+                    typeof result.changes === "number" ? result.changes : 0,
+                },
+              };
+            },
+            async first() {
+              const statement = db.query(sql);
+              return (statement.get(...(params as never[])) as unknown) ?? null;
+            },
+            async all() {
+              const statement = db.query(sql);
+              return {
+                results: (statement.all(...(params as never[])) ??
+                  []) as unknown[],
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+function createOpsEnv(overrides?: Partial<Env>) {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA foreign_keys = ON;");
+
+  for (const migrationName of [
+    "0025_execution_fabric.sql",
+    "0026_execution_canary.sql",
+    "0027_runtime_canary.sql",
+  ]) {
+    const migrationPath = resolve(
+      import.meta.dir,
+      "..",
+      "..",
+      "apps/worker/migrations",
+      migrationName,
+    );
+    sqlite.exec(readFileSync(migrationPath, "utf8"));
+  }
+
+  const env = createWorkerLiveEnv({
+    overrides: {
+      WAITLIST_DB: createSqliteD1Adapter(sqlite),
+      ADMIN_TOKEN: "admin-secret",
+      ...overrides,
+    },
+  });
+
+  return { env, sqlite };
+}
+
+const synthesisFixture = buildRuntimeResearchSynthesis({
+  request: {
+    brief: {
+      briefId: "brief_latest_signal",
+      generatedAt: "2026-03-11T12:00:00.000Z",
+      profile: "custom",
+      title: "Latest signal research",
+      summary:
+        "Reviewed 1 approved source across 1 acquisition request. Most recent coverage: Momentum Alpha in Crypto.",
+      findings: [
+        "Momentum Alpha in Crypto (published 2026-03-11T08:00:00.000Z): Measure momentum across venue fragments and validate liquidity persistence.",
+      ],
+      approvedHosts: ["research.example.com"],
+      requestCount: 1,
+      sourceCount: 1,
+      createdCount: 1,
+      existingCount: 0,
+      citations: [
+        {
+          sourceId: "source_article_momentum",
+          materialDigest: "sha256:source_article_momentum",
+          notes: "published 2026-03-11T08:00:00.000Z",
+        },
+      ],
+      sources: [
+        {
+          sourceId: "source_article_momentum",
+          sourceKind: "article",
+          title: "Momentum Alpha in Crypto",
+          url: "https://research.example.com/posts/momentum-alpha",
+          canonicalUrl: "https://research.example.com/posts/momentum-alpha",
+          authors: ["Ada Researcher"],
+          publishedAt: "2026-03-11T08:00:00.000Z",
+          retrievedAt: "2026-03-11T12:00:00.000Z",
+          venueKeys: ["jupiter"],
+          assetKeys: ["SOL", "USDC"],
+          tags: ["signal", "momentum"],
+          digest: "sha256:source_article_momentum",
+        },
+      ],
+    },
+    strategyKey: "candidate_trend_following_jupiter_sol_usdc",
+    title: "Trend continuation alpha",
+  },
+});
+
+const triageFixture = buildRuntimeResearchCandidateTriage({
+  request: {
+    synthesis: synthesisFixture,
+  },
+});
+
+describe("worker runtime research policy gate route", () => {
+  test("requires admin auth", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/research/policy-gate",
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              synthesis: synthesisFixture,
+              triage: triageFixture,
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({
+        ok: false,
+        error: "auth-required",
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("builds a policy gate artifact and blocks unsupported live promotion", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/research/policy-gate",
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              synthesis: synthesisFixture,
+              triage: triageFixture,
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(200);
+      const payload = await response.json();
+      expect(payload.ok).toBe(true);
+      expect(payload.policyGate.policyGateId).toEqual(expect.any(String));
+      expect(
+        payload.policyGate.gates.find(
+          (gate: { targetMode: string }) => gate.targetMode === "shadow",
+        )?.status,
+      ).toBe("pass");
+      expect(
+        payload.policyGate.gates.find(
+          (gate: { targetMode: string }) => gate.targetMode === "paper",
+        )?.status,
+      ).toBe("blocked");
+      expect(
+        payload.policyGate.gates.find(
+          (gate: { targetMode: string }) => gate.targetMode === "limited_live",
+        )?.status,
+      ).toBe("blocked");
+      expect(String(payload.markdown)).toContain("## Limited Live");
+    } finally {
+      sqlite.close();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #321

## Summary
- add machine-readable policy gate contracts for shadow, paper, limited live, and broad live promotion
- add Worker admin route, local CLI, and manual workflow for evaluating candidate strategy promotion safety
- add unit and Worker route coverage for blocked/approval-gated promotion paths

## Validation
- bun run lint
- bun run typecheck
- bun test tests/unit/runtime_research_policy_gate.test.ts tests/unit/worker_runtime_research_policy_gate_route.test.ts tests/unit/runtime_research_triage.test.ts tests/unit/worker_runtime_research_triage_route.test.ts tests/unit/worker_runtime_internal_routes.test.ts tests/unit/worker_runtime_contracts.test.ts
- cargo test --workspace
