### PR TITLE
Implement strategy-lab promotion orchestration

### DIFF
--- a/.github/workflows/strategy-lab-promote.yml
+++ b/.github/workflows/strategy-lab-promote.yml
@@ -1,0 +1,100 @@
+name: Strategy Lab Promote
+
+on:
+  workflow_dispatch:
+    inputs:
+      request_file:
+        description: Repo-relative path to a checked-in strategy-lab promotion request JSON
+        required: true
+      issue_number:
+        description: Optional GitHub issue number to comment with the promotion summary
+        required: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.0"
+
+      - name: Install deps
+        run: bun install
+
+      - name: Check admin credentials
+        env:
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ADMIN_TOKEN:-}" ]; then
+            echo "::error::Missing required secret ADMIN_TOKEN for strategy-lab promotion."
+            exit 1
+          fi
+
+      - name: Build promotion artifact
+        env:
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          REQUEST_FILE: ${{ inputs.request_file }}
+        run: |
+          set -euo pipefail
+          mkdir -p .tmp/strategy-lab-promotion
+
+          bun run strategy-lab:promote \
+            --base-url https://api.trader-ralph.com \
+            --admin-token "${ADMIN_TOKEN}" \
+            --output-dir .tmp/strategy-lab-promotion \
+            --request-file "${REQUEST_FILE}"
+
+          cat .tmp/strategy-lab-promotion/promotion.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload promotion artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: strategy-lab-promotion-${{ github.run_id }}
+          path: .tmp/strategy-lab-promotion
+          if-no-files-found: error
+
+      - name: Comment on issue
+        if: ${{ inputs.issue_number != '' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          set -euo pipefail
+
+          promotion_id="$(jq -r '.promotionId' .tmp/strategy-lab-promotion/promotion.json)"
+          subject_kind="$(jq -r '.subjectKind' .tmp/strategy-lab-promotion/promotion.json)"
+          subject_key="$(jq -r '.subjectKey' .tmp/strategy-lab-promotion/promotion.json)"
+          current_state="$(jq -r '.currentState' .tmp/strategy-lab-promotion/promotion.json)"
+          target_state="$(jq -r '.targetState' .tmp/strategy-lab-promotion/promotion.json)"
+          status="$(jq -r '.status' .tmp/strategy-lab-promotion/promotion.json)"
+          run_url="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
+
+          body="$(cat <<EOF
+          Strategy-lab promotion evaluated.
+
+          - promotionId: \`${promotion_id}\`
+          - subject: \`${subject_kind}:${subject_key}\`
+          - transition: \`${current_state} -> ${target_state}\`
+          - status: \`${status}\`
+          - workflow run: ${run_url}
+          EOF
+          )"
+
+          payload="$(jq -n --arg body "$body" '{body:$body}')"
+          curl -fsS \
+            -X POST \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
+            -d "${payload}" >/dev/null

--- a/apps/worker/migrations/0028_strategy_lab_promotions.sql
+++ b/apps/worker/migrations/0028_strategy_lab_promotions.sql
@@ -1,0 +1,49 @@
+CREATE TABLE IF NOT EXISTS strategy_lab_promotions (
+  promotion_id TEXT PRIMARY KEY,
+  schema_version TEXT NOT NULL DEFAULT 'v1',
+  subject_kind TEXT NOT NULL,
+  subject_key TEXT NOT NULL,
+  current_state TEXT NOT NULL,
+  target_state TEXT NOT NULL,
+  transition_type TEXT NOT NULL,
+  status TEXT NOT NULL,
+  summary TEXT NOT NULL,
+  requested_by TEXT NOT NULL,
+  issue_number INTEGER,
+  pull_request_number INTEGER,
+  deployment_id TEXT,
+  policy_gate_id TEXT,
+  synthesis_id TEXT,
+  triage_id TEXT,
+  implementation_reference_json TEXT,
+  evidence_refs_json TEXT NOT NULL,
+  checks_json TEXT NOT NULL,
+  actions_json TEXT NOT NULL,
+  approvals_json TEXT,
+  metadata_json TEXT,
+  applied_at TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_lab_promotions_subject
+ON strategy_lab_promotions(subject_kind, subject_key, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_lab_promotions_status
+ON strategy_lab_promotions(status, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS strategy_lab_promotion_events (
+  event_id TEXT PRIMARY KEY,
+  promotion_id TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  actor TEXT NOT NULL,
+  from_state TEXT,
+  to_state TEXT,
+  summary TEXT NOT NULL,
+  details_json TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (promotion_id) REFERENCES strategy_lab_promotions(promotion_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_lab_promotion_events_promotion
+ON strategy_lab_promotion_events(promotion_id, created_at ASC);

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,5 +1,6 @@
 import { parseRuntimeResearchBriefRequest } from "../../../src/runtime/research/briefs.js";
 import { parseRuntimeResearchPolicyGateRequest } from "../../../src/runtime/research/policy_gate.js";
+import { parseRuntimeResearchPromotionRequest } from "../../../src/runtime/research/promotion.js";
 import { parseRuntimeResearchSynthesisRequest } from "../../../src/runtime/research/synthesis.js";
 import { parseRuntimeResearchCandidateTriageRequest } from "../../../src/runtime/research/triage.js";
 import { buildAgentQueryResponse } from "./agent_query";
@@ -156,6 +157,10 @@ import {
 } from "./runtime_internal";
 import { runRuntimeResearchBriefWorkflow } from "./runtime_research_briefs";
 import { runRuntimeResearchPolicyGateWorkflow } from "./runtime_research_policy_gate";
+import {
+  listRuntimeResearchPromotionWorkflow,
+  runRuntimeResearchPromotionWorkflow,
+} from "./runtime_research_promotion";
 import { runRuntimeResearchSynthesisWorkflow } from "./runtime_research_synthesis";
 import { runRuntimeResearchCandidateTriageWorkflow } from "./runtime_research_triage";
 import { SolanaRpc } from "./solana_rpc";
@@ -2406,6 +2411,106 @@ const worker = {
                   error instanceof Error
                     ? error.message
                     : "runtime-research-policy-gate-failed",
+              },
+              { status: 400 },
+            ),
+            env,
+          );
+        }
+      }
+
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/admin/ops/runtime/research/promotions"
+      ) {
+        const auth = authorizeAdminRoute(request, env);
+        if (!auth.ok) {
+          return withCors(
+            json({ ok: false, error: auth.error }, { status: auth.status }),
+            env,
+          );
+        }
+        try {
+          const promotionRequest = parseRuntimeResearchPromotionRequest(
+            await request.json(),
+          );
+          const result = await runRuntimeResearchPromotionWorkflow({
+            env,
+            request: promotionRequest,
+          });
+          return withCors(
+            json({
+              ok: true,
+              promotion: result.promotion,
+              event: result.event,
+              markdown: result.markdown,
+            }),
+            env,
+          );
+        } catch (error) {
+          return withCors(
+            json(
+              {
+                ok: false,
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "runtime-research-promotion-failed",
+              },
+              { status: 400 },
+            ),
+            env,
+          );
+        }
+      }
+
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/admin/ops/runtime/research/promotions"
+      ) {
+        const auth = authorizeAdminRoute(request, env);
+        if (!auth.ok) {
+          return withCors(
+            json({ ok: false, error: auth.error }, { status: auth.status }),
+            env,
+          );
+        }
+        try {
+          const limitRaw = Number(url.searchParams.get("limit"));
+          const result = await listRuntimeResearchPromotionWorkflow({
+            env,
+            promotionId: url.searchParams.get("promotionId") ?? undefined,
+            subjectKind:
+              url.searchParams.get("subjectKind") === "strategy" ||
+              url.searchParams.get("subjectKind") === "venue" ||
+              url.searchParams.get("subjectKind") === "asset"
+                ? (url.searchParams.get("subjectKind") as
+                    | "strategy"
+                    | "venue"
+                    | "asset")
+                : undefined,
+            subjectKey: url.searchParams.get("subjectKey") ?? undefined,
+            ...(Number.isFinite(limitRaw) && limitRaw > 0
+              ? { limit: Math.trunc(limitRaw) }
+              : {}),
+          });
+          return withCors(
+            json({
+              ok: true,
+              promotions: result.promotions,
+              ...(result.events ? { events: result.events } : {}),
+            }),
+            env,
+          );
+        } catch (error) {
+          return withCors(
+            json(
+              {
+                ok: false,
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "runtime-research-promotion-list-failed",
               },
               { status: 400 },
             ),

--- a/apps/worker/src/runtime_contracts.ts
+++ b/apps/worker/src/runtime_contracts.ts
@@ -25,6 +25,8 @@ export type {
   RuntimeRiskVerdict,
   RuntimeRunRecord,
   RuntimeRunState,
+  RuntimeStrategyLabPromotionEvent,
+  RuntimeStrategyLabPromotionRecord,
   RuntimeStrategySpec,
   RuntimeVenueCapability,
 } from "../../../src/runtime/contracts/index.js";
@@ -50,6 +52,8 @@ export {
   parseRuntimeResearchSourceRecord,
   parseRuntimeRiskVerdict,
   parseRuntimeRunRecord,
+  parseRuntimeStrategyLabPromotionEvent,
+  parseRuntimeStrategyLabPromotionRecord,
   parseRuntimeStrategySpec,
   parseRuntimeVenueCapability,
   RUNTIME_DEPLOYMENT_STATE_TRANSITIONS,
@@ -76,6 +80,8 @@ export {
   safeParseRuntimeResearchSourceRecord,
   safeParseRuntimeRiskVerdict,
   safeParseRuntimeRunRecord,
+  safeParseRuntimeStrategyLabPromotionEvent,
+  safeParseRuntimeStrategyLabPromotionRecord,
   safeParseRuntimeStrategySpec,
   safeParseRuntimeVenueCapability,
 } from "../../../src/runtime/contracts/index.js";

--- a/apps/worker/src/runtime_research_promotion.ts
+++ b/apps/worker/src/runtime_research_promotion.ts
@@ -1,0 +1,246 @@
+import { parseRuntimeDeploymentRecord } from "../../../src/runtime/contracts/autonomous_runtime.js";
+import type {
+  RuntimeResearchPromotionRequest,
+  RuntimeScorecardGate,
+} from "../../../src/runtime/research/promotion.js";
+import {
+  buildRuntimeResearchPromotion,
+  buildRuntimeResearchPromotionMarkdown,
+} from "../../../src/runtime/research/promotion.js";
+import {
+  applyRuntimeDeploymentControl,
+  evaluateRuntimeDeployment,
+  readRuntimeScorecard,
+  upsertRuntimeDeployment,
+} from "./runtime_internal";
+import {
+  appendStrategyLabPromotionEvent,
+  getStrategyLabPromotion,
+  listStrategyLabPromotionEvents,
+  listStrategyLabPromotions,
+  writeStrategyLabPromotion,
+} from "./strategy_lab_promotion_repository";
+import type { Env } from "./types";
+
+export type RuntimeResearchPromotionWorkflowResult = {
+  promotion: ReturnType<typeof buildRuntimeResearchPromotion>["promotion"];
+  event: ReturnType<typeof buildRuntimeResearchPromotion>["event"];
+  markdown: string;
+};
+
+export async function runRuntimeResearchPromotionWorkflow(input: {
+  env: Env;
+  request: RuntimeResearchPromotionRequest;
+}): Promise<RuntimeResearchPromotionWorkflowResult> {
+  const resolvedRequest = await hydratePromotionRequest(input);
+  const { promotion, event } = buildRuntimeResearchPromotion({
+    request: resolvedRequest,
+  });
+
+  if (promotion.status === "applied") {
+    for (const action of promotion.actions) {
+      if (action.actionType === "record_state_transition") {
+        continue;
+      }
+      await applyPromotionAction({
+        env: input.env,
+        action,
+      });
+    }
+  }
+
+  await writeStrategyLabPromotion(input.env.WAITLIST_DB, promotion);
+  await appendStrategyLabPromotionEvent(input.env.WAITLIST_DB, event);
+
+  return {
+    promotion,
+    event,
+    markdown: buildRuntimeResearchPromotionMarkdown(promotion),
+  };
+}
+
+export async function listRuntimeResearchPromotionWorkflow(input: {
+  env: Env;
+  promotionId?: string;
+  subjectKind?: "strategy" | "venue" | "asset";
+  subjectKey?: string;
+  limit?: number;
+}): Promise<{
+  promotions: Awaited<ReturnType<typeof listStrategyLabPromotions>>;
+  events: Awaited<ReturnType<typeof listStrategyLabPromotionEvents>> | null;
+}> {
+  if (input.promotionId) {
+    const promotion = await getStrategyLabPromotion(
+      input.env.WAITLIST_DB,
+      input.promotionId,
+    );
+    if (!promotion) {
+      return {
+        promotions: [],
+        events: null,
+      };
+    }
+    return {
+      promotions: [promotion],
+      events: await listStrategyLabPromotionEvents(
+        input.env.WAITLIST_DB,
+        input.promotionId,
+      ),
+    };
+  }
+
+  return {
+    promotions: await listStrategyLabPromotions(input.env.WAITLIST_DB, {
+      subjectKind: input.subjectKind,
+      subjectKey: input.subjectKey,
+      limit: input.limit,
+    }),
+    events: null,
+  };
+}
+
+async function hydratePromotionRequest(input: {
+  env: Env;
+  request: RuntimeResearchPromotionRequest;
+}): Promise<RuntimeResearchPromotionRequest> {
+  if (
+    input.request.runtimeScorecard ||
+    !input.request.deployment ||
+    (input.request.targetState !== "paper" &&
+      input.request.targetState !== "limited_live")
+  ) {
+    return input.request;
+  }
+
+  const scorecardResponse = await readRuntimeScorecard(
+    input.env,
+    input.request.deployment.deploymentId,
+  );
+  if (!scorecardResponse.ok) {
+    return input.request;
+  }
+
+  const promotionGates = readScorecardPromotionGates(
+    scorecardResponse.payload.report,
+  );
+  return {
+    ...input.request,
+    runtimeScorecard: {
+      promotionGates,
+    },
+  };
+}
+
+function readScorecardPromotionGates(value: unknown): RuntimeScorecardGate[] {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    !Array.isArray((value as { promotionGates?: unknown[] }).promotionGates)
+  ) {
+    return [];
+  }
+  return ((value as { promotionGates?: unknown[] }).promotionGates ?? []).map(
+    (entry) => {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        return {};
+      }
+      const sourceMode =
+        typeof (entry as { sourceMode?: unknown }).sourceMode === "string"
+          ? String((entry as { sourceMode?: unknown }).sourceMode)
+          : undefined;
+      const targetMode =
+        typeof (entry as { targetMode?: unknown }).targetMode === "string"
+          ? String((entry as { targetMode?: unknown }).targetMode)
+          : undefined;
+      const status =
+        typeof (entry as { status?: unknown }).status === "string"
+          ? String((entry as { status?: unknown }).status)
+          : undefined;
+      return {
+        ...(sourceMode ? { sourceMode } : {}),
+        ...(targetMode ? { targetMode } : {}),
+        ...(status ? { status } : {}),
+      };
+    },
+  );
+}
+
+async function applyPromotionAction(input: {
+  env: Env;
+  action: RuntimeResearchPromotionWorkflowResult["promotion"]["actions"][number];
+}): Promise<void> {
+  const payload =
+    input.action.payload &&
+    typeof input.action.payload === "object" &&
+    !Array.isArray(input.action.payload)
+      ? (input.action.payload as Record<string, unknown>)
+      : {};
+
+  switch (input.action.actionType) {
+    case "upsert_runtime_deployment": {
+      const deployment = parseRuntimeDeploymentRecord(payload.deployment);
+      const response = await upsertRuntimeDeployment(input.env, deployment);
+      if (!response.ok) {
+        throw new Error(
+          String(
+            response.payload.error ??
+              "runtime-research-promotion-upsert-deployment-failed",
+          ),
+        );
+      }
+      return;
+    }
+    case "evaluate_runtime_deployment": {
+      const deploymentId = String(payload.deploymentId ?? "").trim();
+      if (!deploymentId) {
+        throw new Error(
+          "runtime-research-promotion-missing-evaluate-deployment",
+        );
+      }
+      const response = await evaluateRuntimeDeployment({
+        env: input.env,
+        deploymentId,
+        body:
+          payload.body &&
+          typeof payload.body === "object" &&
+          !Array.isArray(payload.body)
+            ? (payload.body as Record<string, unknown>)
+            : {},
+      });
+      if (!response.ok) {
+        throw new Error(
+          String(
+            response.payload.error ??
+              "runtime-research-promotion-evaluate-deployment-failed",
+          ),
+        );
+      }
+      return;
+    }
+    case "apply_runtime_control": {
+      const deploymentId = String(payload.deploymentId ?? "").trim();
+      const action = String(payload.action ?? "").trim();
+      if (!deploymentId || !["pause", "resume", "kill"].includes(action)) {
+        throw new Error("runtime-research-promotion-invalid-runtime-control");
+      }
+      const response = await applyRuntimeDeploymentControl({
+        env: input.env,
+        deploymentId,
+        action: action as "pause" | "resume" | "kill",
+      });
+      if (!response.ok) {
+        throw new Error(
+          String(
+            response.payload.error ??
+              "runtime-research-promotion-runtime-control-failed",
+          ),
+        );
+      }
+      return;
+    }
+    case "record_allowlist_change":
+    case "record_state_transition":
+      return;
+  }
+}

--- a/apps/worker/src/strategy_lab_promotion_repository.ts
+++ b/apps/worker/src/strategy_lab_promotion_repository.ts
@@ -1,0 +1,359 @@
+import {
+  parseRuntimeStrategyLabPromotionEvent,
+  parseRuntimeStrategyLabPromotionRecord,
+  type RuntimeStrategyLabPromotionEvent,
+  type RuntimeStrategyLabPromotionRecord,
+  type RuntimeStrategyLabSubjectKind,
+} from "../../../src/runtime/contracts/autonomous_runtime.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string {
+  return String(value ?? "");
+}
+
+function stringOrNull(value: unknown): string | null {
+  const parsed = String(value ?? "").trim();
+  return parsed ? parsed : null;
+}
+
+function numberOrNull(value: unknown): number | null {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseJsonValue(value: unknown): unknown {
+  if (typeof value !== "string" || !value.trim()) return undefined;
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function stringifyJson(value: unknown): string | null {
+  if (value === undefined) return null;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return null;
+  }
+}
+
+function mapPromotionRow(
+  row: Record<string, unknown>,
+): RuntimeStrategyLabPromotionRecord {
+  const appliedAt = stringOrNull(row.appliedAt);
+  const issueNumber = numberOrNull(row.issueNumber);
+  const pullRequestNumber = numberOrNull(row.pullRequestNumber);
+  const deploymentId = stringOrNull(row.deploymentId);
+  const policyGateId = stringOrNull(row.policyGateId);
+  const synthesisId = stringOrNull(row.synthesisId);
+  const triageId = stringOrNull(row.triageId);
+  const implementationReference = parseJsonValue(row.implementationReference);
+  const evidenceRefs = parseJsonValue(row.evidenceRefs);
+  const checks = parseJsonValue(row.checks);
+  const actions = parseJsonValue(row.actions);
+  const approvals = parseJsonValue(row.approvals);
+  const metadata = parseJsonValue(row.metadata);
+
+  return parseRuntimeStrategyLabPromotionRecord({
+    schemaVersion: stringValue(row.schemaVersion || "v1"),
+    promotionId: stringValue(row.promotionId),
+    subjectKind: stringValue(row.subjectKind),
+    subjectKey: stringValue(row.subjectKey),
+    currentState: stringValue(row.currentState),
+    targetState: stringValue(row.targetState),
+    transitionType: stringValue(row.transitionType),
+    status: stringValue(row.status),
+    summary: stringValue(row.summary),
+    requestedBy: stringValue(row.requestedBy),
+    createdAt: stringValue(row.createdAt),
+    updatedAt: stringValue(row.updatedAt),
+    ...(appliedAt ? { appliedAt } : {}),
+    ...(issueNumber !== null ? { issueNumber } : {}),
+    ...(pullRequestNumber !== null ? { pullRequestNumber } : {}),
+    ...(deploymentId ? { deploymentId } : {}),
+    ...(policyGateId ? { policyGateId } : {}),
+    ...(synthesisId ? { synthesisId } : {}),
+    ...(triageId ? { triageId } : {}),
+    ...(implementationReference ? { implementationReference } : {}),
+    evidenceRefs: Array.isArray(evidenceRefs) ? evidenceRefs : [],
+    checks: Array.isArray(checks) ? checks : [],
+    actions: Array.isArray(actions) ? actions : [],
+    approvals: Array.isArray(approvals) ? approvals : [],
+    ...(isRecord(metadata) ? { metadata } : {}),
+  });
+}
+
+function mapEventRow(
+  row: Record<string, unknown>,
+): RuntimeStrategyLabPromotionEvent {
+  const fromState = stringOrNull(row.fromState);
+  const toState = stringOrNull(row.toState);
+  const details = parseJsonValue(row.details);
+
+  return parseRuntimeStrategyLabPromotionEvent({
+    schemaVersion: stringValue(row.schemaVersion || "v1"),
+    eventId: stringValue(row.eventId),
+    promotionId: stringValue(row.promotionId),
+    eventType: stringValue(row.eventType),
+    actor: stringValue(row.actor),
+    ...(fromState ? { fromState } : {}),
+    ...(toState ? { toState } : {}),
+    summary: stringValue(row.summary),
+    ...(isRecord(details) ? { details } : {}),
+    createdAt: stringValue(row.createdAt),
+  });
+}
+
+export async function writeStrategyLabPromotion(
+  db: D1Database,
+  record: RuntimeStrategyLabPromotionRecord,
+): Promise<RuntimeStrategyLabPromotionRecord> {
+  await db
+    .prepare(
+      `
+      INSERT INTO strategy_lab_promotions (
+        promotion_id,
+        schema_version,
+        subject_kind,
+        subject_key,
+        current_state,
+        target_state,
+        transition_type,
+        status,
+        summary,
+        requested_by,
+        issue_number,
+        pull_request_number,
+        deployment_id,
+        policy_gate_id,
+        synthesis_id,
+        triage_id,
+        implementation_reference_json,
+        evidence_refs_json,
+        checks_json,
+        actions_json,
+        approvals_json,
+        metadata_json,
+        applied_at,
+        created_at,
+        updated_at
+      ) VALUES (
+        ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
+        ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19,
+        ?20, ?21, ?22, ?23, ?24, ?25
+      )
+      ON CONFLICT(promotion_id) DO UPDATE SET
+        subject_kind = excluded.subject_kind,
+        subject_key = excluded.subject_key,
+        current_state = excluded.current_state,
+        target_state = excluded.target_state,
+        transition_type = excluded.transition_type,
+        status = excluded.status,
+        summary = excluded.summary,
+        requested_by = excluded.requested_by,
+        issue_number = excluded.issue_number,
+        pull_request_number = excluded.pull_request_number,
+        deployment_id = excluded.deployment_id,
+        policy_gate_id = excluded.policy_gate_id,
+        synthesis_id = excluded.synthesis_id,
+        triage_id = excluded.triage_id,
+        implementation_reference_json = excluded.implementation_reference_json,
+        evidence_refs_json = excluded.evidence_refs_json,
+        checks_json = excluded.checks_json,
+        actions_json = excluded.actions_json,
+        approvals_json = excluded.approvals_json,
+        metadata_json = excluded.metadata_json,
+        applied_at = excluded.applied_at,
+        updated_at = excluded.updated_at
+      `,
+    )
+    .bind(
+      record.promotionId,
+      record.schemaVersion,
+      record.subjectKind,
+      record.subjectKey,
+      record.currentState,
+      record.targetState,
+      record.transitionType,
+      record.status,
+      record.summary,
+      record.requestedBy,
+      record.issueNumber ?? null,
+      record.pullRequestNumber ?? null,
+      record.deploymentId ?? null,
+      record.policyGateId ?? null,
+      record.synthesisId ?? null,
+      record.triageId ?? null,
+      stringifyJson(record.implementationReference),
+      stringifyJson(record.evidenceRefs) ?? "[]",
+      stringifyJson(record.checks) ?? "[]",
+      stringifyJson(record.actions) ?? "[]",
+      stringifyJson(record.approvals),
+      stringifyJson(record.metadata),
+      record.appliedAt ?? null,
+      record.createdAt,
+      record.updatedAt,
+    )
+    .run();
+  return record;
+}
+
+export async function appendStrategyLabPromotionEvent(
+  db: D1Database,
+  event: RuntimeStrategyLabPromotionEvent,
+): Promise<RuntimeStrategyLabPromotionEvent> {
+  await db
+    .prepare(
+      `
+      INSERT INTO strategy_lab_promotion_events (
+        event_id,
+        promotion_id,
+        event_type,
+        actor,
+        from_state,
+        to_state,
+        summary,
+        details_json,
+        created_at
+      ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+      `,
+    )
+    .bind(
+      event.eventId,
+      event.promotionId,
+      event.eventType,
+      event.actor,
+      event.fromState ?? null,
+      event.toState ?? null,
+      event.summary,
+      stringifyJson(event.details),
+      event.createdAt,
+    )
+    .run();
+  return event;
+}
+
+export async function getStrategyLabPromotion(
+  db: D1Database,
+  promotionId: string,
+): Promise<RuntimeStrategyLabPromotionRecord | null> {
+  const row = (await db
+    .prepare(
+      `
+      SELECT
+        promotion_id AS promotionId,
+        schema_version AS schemaVersion,
+        subject_kind AS subjectKind,
+        subject_key AS subjectKey,
+        current_state AS currentState,
+        target_state AS targetState,
+        transition_type AS transitionType,
+        status,
+        summary,
+        requested_by AS requestedBy,
+        issue_number AS issueNumber,
+        pull_request_number AS pullRequestNumber,
+        deployment_id AS deploymentId,
+        policy_gate_id AS policyGateId,
+        synthesis_id AS synthesisId,
+        triage_id AS triageId,
+        implementation_reference_json AS implementationReference,
+        evidence_refs_json AS evidenceRefs,
+        checks_json AS checks,
+        actions_json AS actions,
+        approvals_json AS approvals,
+        metadata_json AS metadata,
+        applied_at AS appliedAt,
+        created_at AS createdAt,
+        updated_at AS updatedAt
+      FROM strategy_lab_promotions
+      WHERE promotion_id = ?1
+      LIMIT 1
+      `,
+    )
+    .bind(promotionId)
+    .first()) as Record<string, unknown> | null;
+  return row ? mapPromotionRow(row) : null;
+}
+
+export async function listStrategyLabPromotions(
+  db: D1Database,
+  options?: {
+    subjectKind?: RuntimeStrategyLabSubjectKind;
+    subjectKey?: string;
+    limit?: number;
+  },
+): Promise<RuntimeStrategyLabPromotionRecord[]> {
+  const limit = Math.max(1, Math.min(options?.limit ?? 20, 100));
+  const rows = (await db
+    .prepare(
+      `
+      SELECT
+        promotion_id AS promotionId,
+        schema_version AS schemaVersion,
+        subject_kind AS subjectKind,
+        subject_key AS subjectKey,
+        current_state AS currentState,
+        target_state AS targetState,
+        transition_type AS transitionType,
+        status,
+        summary,
+        requested_by AS requestedBy,
+        issue_number AS issueNumber,
+        pull_request_number AS pullRequestNumber,
+        deployment_id AS deploymentId,
+        policy_gate_id AS policyGateId,
+        synthesis_id AS synthesisId,
+        triage_id AS triageId,
+        implementation_reference_json AS implementationReference,
+        evidence_refs_json AS evidenceRefs,
+        checks_json AS checks,
+        actions_json AS actions,
+        approvals_json AS approvals,
+        metadata_json AS metadata,
+        applied_at AS appliedAt,
+        created_at AS createdAt,
+        updated_at AS updatedAt
+      FROM strategy_lab_promotions
+      WHERE (?1 IS NULL OR subject_kind = ?1)
+        AND (?2 IS NULL OR subject_key = ?2)
+      ORDER BY created_at DESC, promotion_id DESC
+      LIMIT ?3
+      `,
+    )
+    .bind(options?.subjectKind ?? null, options?.subjectKey ?? null, limit)
+    .all()) as { results?: Record<string, unknown>[] };
+  return (rows.results ?? []).map(mapPromotionRow);
+}
+
+export async function listStrategyLabPromotionEvents(
+  db: D1Database,
+  promotionId: string,
+): Promise<RuntimeStrategyLabPromotionEvent[]> {
+  const rows = (await db
+    .prepare(
+      `
+      SELECT
+        event_id AS eventId,
+        promotion_id AS promotionId,
+        event_type AS eventType,
+        actor,
+        from_state AS fromState,
+        to_state AS toState,
+        summary,
+        details_json AS details,
+        created_at AS createdAt
+      FROM strategy_lab_promotion_events
+      WHERE promotion_id = ?1
+      ORDER BY created_at ASC, event_id ASC
+      `,
+    )
+    .bind(promotionId)
+    .all()) as { results?: Record<string, unknown>[] };
+  return (rows.results ?? []).map(mapEventRow);
+}

--- a/docs/repository-verification-index.md
+++ b/docs/repository-verification-index.md
@@ -334,6 +334,24 @@ Verify:
 - newly generated strategies cannot auto-promote straight to broad live,
 - the policy gate stays on the Worker admin boundary and consumes repo-owned runtime evidence instead of bypassing contracts.
 
+### 3m. Strategy-lab promotion orchestration verification
+
+For transition orchestration and audit persistence:
+
+```bash
+bun run lint
+bun run typecheck
+bun test tests/unit/runtime_research_promotion.test.ts tests/unit/worker_runtime_research_promotion_route.test.ts tests/unit/worker_execution_migrations.test.ts
+```
+
+Verify:
+
+- every transition persists an auditable promotion record and event,
+- strategy transitions fail closed when deployment state does not match the target mode,
+- missing evidence or approval keeps the transition blocked or approval-gated,
+- rollback and pause transitions remain explicit in the recorded actions,
+- venue and asset readiness transitions use the same route without changing the public Worker API surface.
+
 ### 4. x402 and discovery verification
 
 Portal-side discovery:

--- a/docs/runtime-contracts/fixtures/runtime.strategy_lab_promotion.valid.v1.json
+++ b/docs/runtime-contracts/fixtures/runtime.strategy_lab_promotion.valid.v1.json
@@ -1,0 +1,132 @@
+{
+  "schemaVersion": "v1",
+  "promotionId": "promotion_trend_following_shadow",
+  "subjectKind": "strategy",
+  "subjectKey": "candidate_trend_following_jupiter_sol_usdc",
+  "currentState": "draft",
+  "targetState": "shadow",
+  "transitionType": "promote",
+  "status": "applied",
+  "summary": "promote transition draft -> shadow was applied.",
+  "requestedBy": "codex",
+  "createdAt": "2026-03-12T00:00:00.000Z",
+  "updatedAt": "2026-03-12T00:00:00.000Z",
+  "appliedAt": "2026-03-12T00:00:00.000Z",
+  "issueNumber": 322,
+  "pullRequestNumber": 400,
+  "deploymentId": "dep_candidate_trend_following_jupiter_sol_usdc_shadow",
+  "policyGateId": "policygate_candidate_trend_following_jupiter_sol_usdc",
+  "synthesisId": "synthesis_candidate_trend_following_jupiter_sol_usdc",
+  "triageId": "triage_candidate_trend_following_jupiter_sol_usdc",
+  "implementationReference": {
+    "kind": "pull_request",
+    "ref": "#400",
+    "mergedAt": "2026-03-12T00:00:00.000Z"
+  },
+  "evidenceRefs": [
+    {
+      "kind": "synthesis",
+      "ref": "synthesis_candidate_trend_following_jupiter_sol_usdc"
+    },
+    {
+      "kind": "triage",
+      "ref": "triage_candidate_trend_following_jupiter_sol_usdc"
+    },
+    {
+      "kind": "policy_gate",
+      "ref": "policygate_candidate_trend_following_jupiter_sol_usdc"
+    },
+    {
+      "kind": "implementation_reference",
+      "ref": "#400"
+    }
+  ],
+  "checks": [
+    {
+      "checkId": "allowed-transition",
+      "status": "pass",
+      "observedValue": "draft->shadow",
+      "thresholdValue": "supported",
+      "message": "Transition is part of the strategy-lab strategy state machine."
+    },
+    {
+      "checkId": "policy-gate",
+      "status": "pass",
+      "observedValue": "pass",
+      "thresholdValue": "pass",
+      "message": "Shadow policy gate passed."
+    },
+    {
+      "checkId": "implementation-reference",
+      "status": "pass",
+      "observedValue": "#400",
+      "thresholdValue": "present",
+      "message": "Implementation reference is attached to the transition record."
+    },
+    {
+      "checkId": "deployment-record",
+      "status": "pass",
+      "observedValue": "shadow:shadow",
+      "thresholdValue": "shadow:shadow",
+      "message": "Runtime deployment record is attached for apply-time orchestration."
+    }
+  ],
+  "actions": [
+    {
+      "actionId": "record-state-transition",
+      "actionType": "record_state_transition",
+      "summary": "Persist the strategy-lab transition audit record.",
+      "required": true,
+      "payload": {
+        "subjectKind": "strategy",
+        "subjectKey": "candidate_trend_following_jupiter_sol_usdc",
+        "currentState": "draft",
+        "targetState": "shadow"
+      }
+    },
+    {
+      "actionId": "upsert-runtime-deployment",
+      "actionType": "upsert_runtime_deployment",
+      "summary": "Upsert the runtime deployment into the target execution mode.",
+      "required": true,
+      "payload": {
+        "deployment": {
+          "schemaVersion": "v1",
+          "deploymentId": "dep_candidate_trend_following_jupiter_sol_usdc_shadow",
+          "strategyKey": "candidate_trend_following_jupiter_sol_usdc",
+          "sleeveId": "sleeve_alpha",
+          "ownerUserId": "user_runtime_fixture",
+          "venueKey": "jupiter",
+          "pair": {
+            "symbol": "SOL/USDC",
+            "baseMint": "So11111111111111111111111111111111111111112",
+            "quoteMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "marketType": "spot"
+          },
+          "mode": "shadow",
+          "state": "shadow",
+          "lane": "safe",
+          "createdAt": "2026-03-12T00:00:00.000Z",
+          "updatedAt": "2026-03-12T00:00:00.000Z",
+          "policy": {
+            "maxNotionalUsd": "25",
+            "dailyLossLimitUsd": "10",
+            "maxSlippageBps": 50,
+            "maxConcurrentRuns": 1,
+            "rebalanceToleranceBps": 100
+          },
+          "capital": {
+            "allocatedUsd": "100",
+            "reservedUsd": "5",
+            "availableUsd": "95"
+          },
+          "tags": ["strategy-lab", "shadow"]
+        }
+      }
+    }
+  ],
+  "approvals": [],
+  "metadata": {
+    "source": "strategy-lab"
+  }
+}

--- a/docs/runtime-contracts/fixtures/runtime.strategy_lab_promotion_event.valid.v1.json
+++ b/docs/runtime-contracts/fixtures/runtime.strategy_lab_promotion_event.valid.v1.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "v1",
+  "eventId": "promoevt_trend_following_shadow",
+  "promotionId": "promotion_trend_following_shadow",
+  "eventType": "applied",
+  "actor": "codex",
+  "fromState": "draft",
+  "toState": "shadow",
+  "summary": "promote transition draft -> shadow was applied.",
+  "details": {
+    "status": "applied",
+    "transitionType": "promote",
+    "subjectKind": "strategy",
+    "subjectKey": "candidate_trend_following_jupiter_sol_usdc"
+  },
+  "createdAt": "2026-03-12T00:00:00.000Z"
+}

--- a/docs/runtime-contracts/schema-manifest.v1.json
+++ b/docs/runtime-contracts/schema-manifest.v1.json
@@ -106,6 +106,16 @@
       "name": "strategySpec",
       "schemaId": "https://trader-ralph.com/schemas/runtime/v1/strategy_spec",
       "schemaFile": "docs/runtime-contracts/schemas/runtime.strategy_spec.v1.schema.json"
+    },
+    {
+      "name": "strategyLabPromotion",
+      "schemaId": "https://trader-ralph.com/schemas/runtime/v1/strategy_lab_promotion",
+      "schemaFile": "docs/runtime-contracts/schemas/runtime.strategy_lab_promotion.v1.schema.json"
+    },
+    {
+      "name": "strategyLabPromotionEvent",
+      "schemaId": "https://trader-ralph.com/schemas/runtime/v1/strategy_lab_promotion_event",
+      "schemaFile": "docs/runtime-contracts/schemas/runtime.strategy_lab_promotion_event.v1.schema.json"
     }
   ],
   "rustCodegenHook": {

--- a/docs/runtime-contracts/schemas/runtime.strategy_lab_promotion.v1.schema.json
+++ b/docs/runtime-contracts/schemas/runtime.strategy_lab_promotion.v1.schema.json
@@ -1,0 +1,296 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://trader-ralph.com/schemas/runtime/v1/strategy_lab_promotion",
+  "type": "object",
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "v1"
+    },
+    "promotionId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "subjectKind": {
+      "type": "string",
+      "enum": ["strategy", "venue", "asset"]
+    },
+    "subjectKey": {
+      "type": "string",
+      "minLength": 1
+    },
+    "currentState": {
+      "type": "string",
+      "enum": [
+        "candidate",
+        "draft",
+        "shadow",
+        "paper",
+        "limited_live",
+        "broad_live",
+        "integrated",
+        "shadow_ready",
+        "paper_ready",
+        "limited_live_ready",
+        "broad_live_ready",
+        "paused",
+        "deprecated"
+      ]
+    },
+    "targetState": {
+      "type": "string",
+      "enum": [
+        "candidate",
+        "draft",
+        "shadow",
+        "paper",
+        "limited_live",
+        "broad_live",
+        "integrated",
+        "shadow_ready",
+        "paper_ready",
+        "limited_live_ready",
+        "broad_live_ready",
+        "paused",
+        "deprecated"
+      ]
+    },
+    "transitionType": {
+      "type": "string",
+      "enum": ["promote", "demote", "pause", "resume", "archive"]
+    },
+    "status": {
+      "type": "string",
+      "enum": ["pass", "blocked", "requires_human_approval", "applied"]
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "requestedBy": {
+      "type": "string",
+      "minLength": 1
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+    },
+    "appliedAt": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+    },
+    "issueNumber": {
+      "type": "integer",
+      "exclusiveMinimum": 0,
+      "maximum": 9007199254740991
+    },
+    "pullRequestNumber": {
+      "type": "integer",
+      "exclusiveMinimum": 0,
+      "maximum": 9007199254740991
+    },
+    "deploymentId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "policyGateId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "synthesisId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "triageId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "implementationReference": {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["pull_request", "issue", "commit"]
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "mergedAt": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "revision": {
+          "type": "string",
+          "minLength": 1
+        },
+        "notes": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["kind", "ref"],
+      "additionalProperties": false
+    },
+    "evidenceRefs": {
+      "maxItems": 64,
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "minLength": 1
+          },
+          "ref": {
+            "type": "string",
+            "minLength": 1
+          },
+          "notes": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": ["kind", "ref"],
+        "additionalProperties": false
+      }
+    },
+    "checks": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "checkId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pass",
+              "blocked",
+              "requires_human_approval",
+              "not_applicable"
+            ]
+          },
+          "observedValue": {
+            "type": "string",
+            "minLength": 1
+          },
+          "thresholdValue": {
+            "type": "string",
+            "minLength": 1
+          },
+          "message": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": ["checkId", "status", "message"],
+        "additionalProperties": false
+      }
+    },
+    "actions": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "actionId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "actionType": {
+            "type": "string",
+            "enum": [
+              "record_state_transition",
+              "upsert_runtime_deployment",
+              "evaluate_runtime_deployment",
+              "apply_runtime_control",
+              "record_allowlist_change"
+            ]
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "payload": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {}
+          }
+        },
+        "required": ["actionId", "actionType", "summary", "required"],
+        "additionalProperties": false
+      }
+    },
+    "approvals": {
+      "maxItems": 16,
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "targetMode": {
+            "type": "string",
+            "enum": ["shadow", "paper", "limited_live", "broad_live"]
+          },
+          "approvedBy": {
+            "type": "string",
+            "minLength": 1
+          },
+          "approvedAt": {
+            "type": "string",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+          },
+          "notes": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": ["targetMode", "approvedBy", "approvedAt"],
+        "additionalProperties": false
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {}
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "promotionId",
+    "subjectKind",
+    "subjectKey",
+    "currentState",
+    "targetState",
+    "transitionType",
+    "status",
+    "summary",
+    "requestedBy",
+    "createdAt",
+    "updatedAt",
+    "evidenceRefs",
+    "checks",
+    "actions",
+    "approvals"
+  ],
+  "additionalProperties": false
+}

--- a/docs/runtime-contracts/schemas/runtime.strategy_lab_promotion_event.v1.schema.json
+++ b/docs/runtime-contracts/schemas/runtime.strategy_lab_promotion_event.v1.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://trader-ralph.com/schemas/runtime/v1/strategy_lab_promotion_event",
+  "type": "object",
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "v1"
+    },
+    "eventId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "promotionId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "eventType": {
+      "type": "string",
+      "enum": ["evaluated", "applied"]
+    },
+    "actor": {
+      "type": "string",
+      "minLength": 1
+    },
+    "fromState": {
+      "type": "string",
+      "enum": [
+        "candidate",
+        "draft",
+        "shadow",
+        "paper",
+        "limited_live",
+        "broad_live",
+        "integrated",
+        "shadow_ready",
+        "paper_ready",
+        "limited_live_ready",
+        "broad_live_ready",
+        "paused",
+        "deprecated"
+      ]
+    },
+    "toState": {
+      "type": "string",
+      "enum": [
+        "candidate",
+        "draft",
+        "shadow",
+        "paper",
+        "limited_live",
+        "broad_live",
+        "integrated",
+        "shadow_ready",
+        "paper_ready",
+        "limited_live_ready",
+        "broad_live_ready",
+        "paused",
+        "deprecated"
+      ]
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "details": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {}
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "eventId",
+    "promotionId",
+    "eventType",
+    "actor",
+    "summary",
+    "createdAt"
+  ],
+  "additionalProperties": false
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "strategy-lab:synthesize": "bun run src/bin/strategy_lab_synthesis.ts",
     "strategy-lab:triage": "bun run src/bin/strategy_lab_triage.ts",
     "strategy-lab:policy-gate": "bun run src/bin/strategy_lab_policy_gate.ts",
+    "strategy-lab:promote": "bun run src/bin/strategy_lab_promote.ts",
     "runtime:fly:deploy": "node scripts/runtime_rs/fly_deploy.mjs",
     "runtime:fly:smoke": "node scripts/runtime_rs/fly_smoke.mjs",
     "runner:once": "bun run src/bin/runner.ts once",

--- a/services/runtime-rs/README.md
+++ b/services/runtime-rs/README.md
@@ -239,6 +239,8 @@ Operators should use the Worker as the public control plane:
 - `POST /api/admin/ops/runtime/research/synthesis`
 - `POST /api/admin/ops/runtime/research/triage`
 - `POST /api/admin/ops/runtime/research/policy-gate`
+- `GET /api/admin/ops/runtime/research/promotions`
+- `POST /api/admin/ops/runtime/research/promotions`
 - `POST /api/admin/ops/runtime/deployments/:deploymentId/pause`
 - `POST /api/admin/ops/runtime/deployments/:deploymentId/resume`
 - `POST /api/admin/ops/runtime/deployments/:deploymentId/kill`
@@ -290,6 +292,18 @@ That command writes `.tmp/strategy-lab-policy-gate/policy-gate.json` and
 `.tmp/strategy-lab-policy-gate/policy-gate.md`, including machine-readable
 shadow, paper, limited-live, and broad-live gates, unsafe-pattern detection,
 and explicit human-approval requirements before paper or real-money promotion.
+
+Promotion orchestration turns those gates into auditable transitions:
+
+```bash
+bun run strategy-lab:promote \
+  --request-file .tmp/strategy-lab-promotion/request.json
+```
+
+That command writes `.tmp/strategy-lab-promotion/promotion.json`,
+`.tmp/strategy-lab-promotion/promotion-event.json`, and
+`.tmp/strategy-lab-promotion/promotion.md`, including the transition audit
+record, orchestration actions, and explicit rollback or human-approval status.
 
 The runtime operator surface now includes allocator details for a deployment:
 

--- a/src/bin/strategy_lab_promote.ts
+++ b/src/bin/strategy_lab_promote.ts
@@ -1,0 +1,90 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { parseRuntimeResearchPromotionRequest } from "../runtime/research/promotion.js";
+
+function readArg(flag: string): string | null {
+  const index = process.argv.indexOf(flag);
+  if (index < 0) return null;
+  return process.argv[index + 1] ?? null;
+}
+
+function readJsonFile(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf8")) as unknown;
+}
+
+async function main(): Promise<void> {
+  const baseUrl = readArg("--base-url") ?? "http://127.0.0.1:8888";
+  const outputDir = resolve(
+    readArg("--output-dir") ?? ".tmp/strategy-lab-promotion",
+  );
+  const adminToken =
+    readArg("--admin-token") ?? String(process.env.ADMIN_TOKEN ?? "").trim();
+  if (!adminToken) {
+    throw new Error("missing-admin-token");
+  }
+
+  const requestFile = readArg("--request-file");
+  if (!requestFile) {
+    throw new Error("missing-arg:--request-file");
+  }
+
+  const requestBody = parseRuntimeResearchPromotionRequest(
+    readJsonFile(resolve(requestFile)),
+  );
+
+  const response = await fetch(
+    `${baseUrl.replace(/\/$/, "")}/api/admin/ops/runtime/research/promotions`,
+    {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${adminToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    },
+  );
+  const payload = (await response.json()) as Record<string, unknown>;
+  if (!response.ok || payload.ok !== true) {
+    throw new Error(
+      String(
+        payload.error ?? `runtime-research-promotion-failed:${response.status}`,
+      ),
+    );
+  }
+
+  mkdirSync(outputDir, { recursive: true });
+  const promotionPath = join(outputDir, "promotion.json");
+  const eventPath = join(outputDir, "promotion-event.json");
+  const markdownPath = join(outputDir, "promotion.md");
+  writeFileSync(
+    promotionPath,
+    `${JSON.stringify(payload.promotion, null, 2)}\n`,
+  );
+  writeFileSync(eventPath, `${JSON.stringify(payload.event, null, 2)}\n`);
+  writeFileSync(markdownPath, `${String(payload.markdown ?? "")}\n`);
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        baseUrl,
+        outputDir,
+        promotionPath,
+        eventPath,
+        markdownPath,
+        promotionId:
+          typeof payload.promotion === "object" && payload.promotion
+            ? (payload.promotion as Record<string, unknown>).promotionId
+            : null,
+        status:
+          typeof payload.promotion === "object" && payload.promotion
+            ? (payload.promotion as Record<string, unknown>).status
+            : null,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+await main();

--- a/src/runtime/contracts/autonomous_runtime.ts
+++ b/src/runtime/contracts/autonomous_runtime.ts
@@ -1078,6 +1078,138 @@ export const RuntimeResearchPolicyGateArtifactSchema = VersionedSchema.extend({
   summary: z.array(NON_EMPTY_STRING_SCHEMA).max(16),
 }).strict();
 
+export const RuntimeStrategyLabSubjectKindSchema = z.enum([
+  "strategy",
+  "venue",
+  "asset",
+]);
+
+export const RuntimeStrategyLabStrategyStateSchema = z.enum([
+  "candidate",
+  "draft",
+  "shadow",
+  "paper",
+  "limited_live",
+  "broad_live",
+  "paused",
+  "deprecated",
+]);
+
+export const RuntimeStrategyLabPromotionStateSchema = z.enum([
+  "candidate",
+  "draft",
+  "shadow",
+  "paper",
+  "limited_live",
+  "broad_live",
+  "integrated",
+  "shadow_ready",
+  "paper_ready",
+  "limited_live_ready",
+  "broad_live_ready",
+  "paused",
+  "deprecated",
+]);
+
+export const RuntimeStrategyLabTransitionTypeSchema = z.enum([
+  "promote",
+  "demote",
+  "pause",
+  "resume",
+  "archive",
+]);
+
+export const RuntimeStrategyLabPromotionStatusSchema = z.enum([
+  "pass",
+  "blocked",
+  "requires_human_approval",
+  "applied",
+]);
+
+export const RuntimeStrategyLabImplementationReferenceSchema = z
+  .object({
+    kind: z.enum(["pull_request", "issue", "commit"]),
+    ref: NON_EMPTY_STRING_SCHEMA,
+    mergedAt: ISO_DATETIME_SCHEMA.optional(),
+    revision: NON_EMPTY_STRING_SCHEMA.optional(),
+    notes: NON_EMPTY_STRING_SCHEMA.optional(),
+  })
+  .strict();
+
+export const RuntimeStrategyLabEvidenceRefSchema = z
+  .object({
+    kind: NON_EMPTY_STRING_SCHEMA,
+    ref: NON_EMPTY_STRING_SCHEMA,
+    notes: NON_EMPTY_STRING_SCHEMA.optional(),
+  })
+  .strict();
+
+const RuntimeStrategyLabTransitionCheckSchema = z
+  .object({
+    checkId: NON_EMPTY_STRING_SCHEMA,
+    status: RuntimeResearchPolicyGateStatusSchema,
+    observedValue: NON_EMPTY_STRING_SCHEMA.optional(),
+    thresholdValue: NON_EMPTY_STRING_SCHEMA.optional(),
+    message: NON_EMPTY_STRING_SCHEMA,
+  })
+  .strict();
+
+export const RuntimeStrategyLabActionSchema = z
+  .object({
+    actionId: NON_EMPTY_STRING_SCHEMA,
+    actionType: z.enum([
+      "record_state_transition",
+      "upsert_runtime_deployment",
+      "evaluate_runtime_deployment",
+      "apply_runtime_control",
+      "record_allowlist_change",
+    ]),
+    summary: NON_EMPTY_STRING_SCHEMA,
+    required: z.boolean(),
+    payload: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict();
+
+export const RuntimeStrategyLabPromotionRecordSchema = VersionedSchema.extend({
+  promotionId: NON_EMPTY_STRING_SCHEMA,
+  subjectKind: RuntimeStrategyLabSubjectKindSchema,
+  subjectKey: NON_EMPTY_STRING_SCHEMA,
+  currentState: RuntimeStrategyLabPromotionStateSchema,
+  targetState: RuntimeStrategyLabPromotionStateSchema,
+  transitionType: RuntimeStrategyLabTransitionTypeSchema,
+  status: RuntimeStrategyLabPromotionStatusSchema,
+  summary: NON_EMPTY_STRING_SCHEMA,
+  requestedBy: NON_EMPTY_STRING_SCHEMA,
+  createdAt: ISO_DATETIME_SCHEMA,
+  updatedAt: ISO_DATETIME_SCHEMA,
+  appliedAt: ISO_DATETIME_SCHEMA.optional(),
+  issueNumber: z.number().int().positive().optional(),
+  pullRequestNumber: z.number().int().positive().optional(),
+  deploymentId: NON_EMPTY_STRING_SCHEMA.optional(),
+  policyGateId: NON_EMPTY_STRING_SCHEMA.optional(),
+  synthesisId: NON_EMPTY_STRING_SCHEMA.optional(),
+  triageId: NON_EMPTY_STRING_SCHEMA.optional(),
+  implementationReference:
+    RuntimeStrategyLabImplementationReferenceSchema.optional(),
+  evidenceRefs: z.array(RuntimeStrategyLabEvidenceRefSchema).max(64),
+  checks: z.array(RuntimeStrategyLabTransitionCheckSchema).min(1),
+  actions: z.array(RuntimeStrategyLabActionSchema).min(1),
+  approvals: z.array(RuntimeResearchHumanApprovalRecordSchema).max(16),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+}).strict();
+
+export const RuntimeStrategyLabPromotionEventSchema = VersionedSchema.extend({
+  eventId: NON_EMPTY_STRING_SCHEMA,
+  promotionId: NON_EMPTY_STRING_SCHEMA,
+  eventType: z.enum(["evaluated", "applied"]),
+  actor: NON_EMPTY_STRING_SCHEMA,
+  fromState: RuntimeStrategyLabPromotionStateSchema.optional(),
+  toState: RuntimeStrategyLabPromotionStateSchema.optional(),
+  summary: NON_EMPTY_STRING_SCHEMA,
+  details: z.record(z.string(), z.unknown()).optional(),
+  createdAt: ISO_DATETIME_SCHEMA,
+}).strict();
+
 export const RuntimeExecutionCostModelStatusSchema = z.enum([
   "draft",
   "active",
@@ -1300,6 +1432,36 @@ export type RuntimeResearchHumanApprovalRecord = z.infer<
 export type RuntimeResearchPolicyGateArtifact = z.infer<
   typeof RuntimeResearchPolicyGateArtifactSchema
 >;
+export type RuntimeStrategyLabSubjectKind = z.infer<
+  typeof RuntimeStrategyLabSubjectKindSchema
+>;
+export type RuntimeStrategyLabStrategyState = z.infer<
+  typeof RuntimeStrategyLabStrategyStateSchema
+>;
+export type RuntimeStrategyLabPromotionState = z.infer<
+  typeof RuntimeStrategyLabPromotionStateSchema
+>;
+export type RuntimeStrategyLabTransitionType = z.infer<
+  typeof RuntimeStrategyLabTransitionTypeSchema
+>;
+export type RuntimeStrategyLabPromotionStatus = z.infer<
+  typeof RuntimeStrategyLabPromotionStatusSchema
+>;
+export type RuntimeStrategyLabImplementationReference = z.infer<
+  typeof RuntimeStrategyLabImplementationReferenceSchema
+>;
+export type RuntimeStrategyLabEvidenceRef = z.infer<
+  typeof RuntimeStrategyLabEvidenceRefSchema
+>;
+export type RuntimeStrategyLabAction = z.infer<
+  typeof RuntimeStrategyLabActionSchema
+>;
+export type RuntimeStrategyLabPromotionRecord = z.infer<
+  typeof RuntimeStrategyLabPromotionRecordSchema
+>;
+export type RuntimeStrategyLabPromotionEvent = z.infer<
+  typeof RuntimeStrategyLabPromotionEventSchema
+>;
 
 export const RUNTIME_DEPLOYMENT_STATE_TRANSITIONS = {
   draft: ["shadow", "paper", "live", "archived"],
@@ -1327,6 +1489,48 @@ export const RUNTIME_RUN_STATE_TRANSITIONS = {
   failed: [],
   killed: [],
 } as const satisfies Record<RuntimeRunState, readonly RuntimeRunState[]>;
+
+export const RUNTIME_STRATEGY_LAB_STRATEGY_STATE_TRANSITIONS = {
+  candidate: ["draft", "deprecated"],
+  draft: ["candidate", "shadow", "deprecated"],
+  shadow: ["draft", "paper", "paused", "deprecated"],
+  paper: ["shadow", "limited_live", "paused", "deprecated"],
+  limited_live: ["paper", "broad_live", "paused", "deprecated"],
+  broad_live: ["limited_live", "paused", "deprecated"],
+  paused: ["shadow", "paper", "limited_live", "broad_live", "deprecated"],
+  deprecated: [],
+} as const satisfies Record<
+  RuntimeStrategyLabStrategyState,
+  readonly RuntimeStrategyLabStrategyState[]
+>;
+
+export const RUNTIME_STRATEGY_LAB_READINESS_STATE_TRANSITIONS = {
+  candidate: ["integrated", "deprecated"],
+  integrated: ["candidate", "shadow_ready", "deprecated"],
+  shadow_ready: ["integrated", "paper_ready", "paused", "deprecated"],
+  paper_ready: ["shadow_ready", "limited_live_ready", "paused", "deprecated"],
+  limited_live_ready: [
+    "paper_ready",
+    "broad_live_ready",
+    "paused",
+    "deprecated",
+  ],
+  broad_live_ready: ["limited_live_ready", "paused", "deprecated"],
+  paused: [
+    "shadow_ready",
+    "paper_ready",
+    "limited_live_ready",
+    "broad_live_ready",
+    "deprecated",
+  ],
+  deprecated: [],
+} as const satisfies Record<
+  Exclude<
+    RuntimeStrategyLabPromotionState,
+    "draft" | "shadow" | "paper" | "limited_live" | "broad_live"
+  >,
+  readonly RuntimeStrategyLabPromotionState[]
+>;
 
 export const RUNTIME_PROTOCOL_SCHEMA_REGISTRY = {
   deployment: {
@@ -1440,6 +1644,18 @@ export const RUNTIME_PROTOCOL_SCHEMA_REGISTRY = {
     schemaId: "https://trader-ralph.com/schemas/runtime/v1/strategy_spec",
     outputFile: "runtime.strategy_spec.v1.schema.json",
   },
+  strategyLabPromotion: {
+    schema: RuntimeStrategyLabPromotionRecordSchema,
+    schemaId:
+      "https://trader-ralph.com/schemas/runtime/v1/strategy_lab_promotion",
+    outputFile: "runtime.strategy_lab_promotion.v1.schema.json",
+  },
+  strategyLabPromotionEvent: {
+    schema: RuntimeStrategyLabPromotionEventSchema,
+    schemaId:
+      "https://trader-ralph.com/schemas/runtime/v1/strategy_lab_promotion_event",
+    outputFile: "runtime.strategy_lab_promotion_event.v1.schema.json",
+  },
 } as const;
 
 export function canTransitionRuntimeDeploymentState(
@@ -1459,6 +1675,29 @@ export function canTransitionRuntimeRunState(
   const allowed = RUNTIME_RUN_STATE_TRANSITIONS[
     from
   ] as readonly RuntimeRunState[];
+  return allowed.includes(to);
+}
+
+export function canTransitionRuntimeStrategyLabStrategyState(
+  from: RuntimeStrategyLabStrategyState,
+  to: RuntimeStrategyLabStrategyState,
+): boolean {
+  const allowed = RUNTIME_STRATEGY_LAB_STRATEGY_STATE_TRANSITIONS[
+    from
+  ] as readonly RuntimeStrategyLabStrategyState[];
+  return allowed.includes(to);
+}
+
+export function canTransitionRuntimeStrategyLabReadinessState(
+  from: Exclude<
+    RuntimeStrategyLabPromotionState,
+    "draft" | "shadow" | "paper" | "limited_live" | "broad_live"
+  >,
+  to: RuntimeStrategyLabPromotionState,
+): boolean {
+  const allowed = RUNTIME_STRATEGY_LAB_READINESS_STATE_TRANSITIONS[
+    from
+  ] as readonly RuntimeStrategyLabPromotionState[];
   return allowed.includes(to);
 }
 
@@ -1586,6 +1825,18 @@ export function parseRuntimeResearchPolicyGateArtifact(
   return RuntimeResearchPolicyGateArtifactSchema.parse(input);
 }
 
+export function parseRuntimeStrategyLabPromotionRecord(
+  input: unknown,
+): RuntimeStrategyLabPromotionRecord {
+  return RuntimeStrategyLabPromotionRecordSchema.parse(input);
+}
+
+export function parseRuntimeStrategyLabPromotionEvent(
+  input: unknown,
+): RuntimeStrategyLabPromotionEvent {
+  return RuntimeStrategyLabPromotionEventSchema.parse(input);
+}
+
 export function safeParseRuntimeDeploymentRecord(input: unknown) {
   return RuntimeDeploymentRecordSchema.safeParse(input);
 }
@@ -1672,4 +1923,12 @@ export function safeParseRuntimeAssetRecord(input: unknown) {
 
 export function safeParseRuntimeStrategySpec(input: unknown) {
   return RuntimeStrategySpecSchema.safeParse(input);
+}
+
+export function safeParseRuntimeStrategyLabPromotionRecord(input: unknown) {
+  return RuntimeStrategyLabPromotionRecordSchema.safeParse(input);
+}
+
+export function safeParseRuntimeStrategyLabPromotionEvent(input: unknown) {
+  return RuntimeStrategyLabPromotionEventSchema.safeParse(input);
 }

--- a/src/runtime/research/promotion.ts
+++ b/src/runtime/research/promotion.ts
@@ -1,0 +1,1341 @@
+import { createHash } from "node:crypto";
+import {
+  canTransitionRuntimeStrategyLabReadinessState,
+  canTransitionRuntimeStrategyLabStrategyState,
+  parseRuntimeDeploymentRecord,
+  parseRuntimeResearchPolicyGateArtifact,
+  parseRuntimeStrategyLabPromotionEvent,
+  parseRuntimeStrategyLabPromotionRecord,
+  type RuntimeDeploymentRecord,
+  type RuntimeResearchHumanApprovalRecord,
+  type RuntimeResearchPolicyGateArtifact,
+  type RuntimeResearchPolicyTargetMode,
+  type RuntimeStrategyLabEvidenceRef,
+  type RuntimeStrategyLabPromotionEvent,
+  type RuntimeStrategyLabPromotionRecord,
+  type RuntimeStrategyLabPromotionState,
+  type RuntimeStrategyLabPromotionStatus,
+  type RuntimeStrategyLabStrategyState,
+  type RuntimeStrategyLabSubjectKind,
+  type RuntimeStrategyLabTransitionType,
+} from "../contracts/autonomous_runtime.js";
+import type { RuntimeResearchSynthesisArtifact } from "./synthesis.js";
+import type { RuntimeResearchCandidateTriageArtifact } from "./triage.js";
+
+type RuntimePromotionCheck =
+  RuntimeStrategyLabPromotionRecord["checks"][number];
+type RuntimePromotionAction =
+  RuntimeStrategyLabPromotionRecord["actions"][number];
+
+export type RuntimeScorecardGate = {
+  sourceMode?: string;
+  targetMode?: string;
+  status?: string;
+};
+
+export type RuntimeResearchPromotionRequest = {
+  subjectKind: RuntimeStrategyLabSubjectKind;
+  subjectKey: string;
+  currentState: RuntimeStrategyLabPromotionState;
+  targetState: RuntimeStrategyLabPromotionState;
+  requestedBy: string;
+  issueNumber?: number;
+  pullRequestNumber?: number;
+  evidenceRefs?: RuntimeStrategyLabEvidenceRef[];
+  implementationReference?: {
+    kind: "pull_request" | "issue" | "commit";
+    ref: string;
+    mergedAt?: string;
+    revision?: string;
+    notes?: string;
+  };
+  synthesis?: RuntimeResearchSynthesisArtifact;
+  triage?: RuntimeResearchCandidateTriageArtifact;
+  policyGate?: RuntimeResearchPolicyGateArtifact;
+  approvals?: RuntimeResearchHumanApprovalRecord[];
+  deployment?: RuntimeDeploymentRecord;
+  runtimeScorecard?: {
+    promotionGates?: RuntimeScorecardGate[];
+  };
+  limitedLiveCanaryPassed?: boolean;
+  limitedLiveCanaryRef?: string;
+  limitedLiveSoakPassed?: boolean;
+  limitedLiveSoakRef?: string;
+  applyTransition?: boolean;
+  activateEvaluation?: boolean;
+  metadata?: Record<string, unknown>;
+};
+
+const STRATEGY_STATE_ORDER: RuntimeStrategyLabStrategyState[] = [
+  "candidate",
+  "draft",
+  "shadow",
+  "paper",
+  "limited_live",
+  "broad_live",
+];
+
+const READINESS_STATE_ORDER: Array<
+  Exclude<
+    RuntimeStrategyLabPromotionState,
+    | "draft"
+    | "shadow"
+    | "paper"
+    | "limited_live"
+    | "broad_live"
+    | "paused"
+    | "deprecated"
+  >
+> = [
+  "candidate",
+  "integrated",
+  "shadow_ready",
+  "paper_ready",
+  "limited_live_ready",
+  "broad_live_ready",
+];
+
+const STRATEGY_STATES = new Set<RuntimeStrategyLabPromotionState>([
+  "candidate",
+  "draft",
+  "shadow",
+  "paper",
+  "limited_live",
+  "broad_live",
+  "paused",
+  "deprecated",
+]);
+
+const READINESS_STATES = new Set<RuntimeStrategyLabPromotionState>([
+  "candidate",
+  "integrated",
+  "shadow_ready",
+  "paper_ready",
+  "limited_live_ready",
+  "broad_live_ready",
+  "paused",
+  "deprecated",
+]);
+
+export function parseRuntimeResearchPromotionRequest(
+  input: unknown,
+): RuntimeResearchPromotionRequest {
+  if (!isRecord(input)) {
+    throw new Error("invalid-runtime-research-promotion-request");
+  }
+
+  const subjectKind = readEnum(input.subjectKind, "subjectKind", [
+    "strategy",
+    "venue",
+    "asset",
+  ]) as RuntimeStrategyLabSubjectKind;
+  const currentState = readState(input.currentState, "currentState");
+  const targetState = readState(input.targetState, "targetState");
+  const requestedBy = readRequiredString(input.requestedBy, "requestedBy");
+  const evidenceRefs = Array.isArray(input.evidenceRefs)
+    ? input.evidenceRefs.map(parseEvidenceRef)
+    : [];
+  const approvals = Array.isArray(input.approvals)
+    ? input.approvals.map(parseApproval)
+    : [];
+
+  return {
+    subjectKind,
+    subjectKey: readRequiredString(input.subjectKey, "subjectKey"),
+    currentState,
+    targetState,
+    requestedBy,
+    ...(typeof input.issueNumber === "number" &&
+    Number.isInteger(input.issueNumber)
+      ? { issueNumber: input.issueNumber }
+      : {}),
+    ...(typeof input.pullRequestNumber === "number" &&
+    Number.isInteger(input.pullRequestNumber)
+      ? { pullRequestNumber: input.pullRequestNumber }
+      : {}),
+    ...(evidenceRefs.length > 0 ? { evidenceRefs } : {}),
+    ...(input.implementationReference
+      ? {
+          implementationReference: parseImplementationReference(
+            input.implementationReference,
+          ),
+        }
+      : {}),
+    ...(input.synthesis
+      ? { synthesis: input.synthesis as RuntimeResearchSynthesisArtifact }
+      : {}),
+    ...(input.triage
+      ? { triage: input.triage as RuntimeResearchCandidateTriageArtifact }
+      : {}),
+    ...(input.policyGate
+      ? { policyGate: parseRuntimeResearchPolicyGateArtifact(input.policyGate) }
+      : {}),
+    ...(approvals.length > 0 ? { approvals } : {}),
+    ...(input.deployment
+      ? { deployment: parseRuntimeDeploymentRecord(input.deployment) }
+      : {}),
+    ...(isRecord(input.runtimeScorecard)
+      ? {
+          runtimeScorecard: {
+            promotionGates: Array.isArray(input.runtimeScorecard.promotionGates)
+              ? input.runtimeScorecard.promotionGates.map((gate) =>
+                  parseRuntimeScorecardGate(gate),
+                )
+              : [],
+          },
+        }
+      : {}),
+    ...(typeof input.limitedLiveCanaryPassed === "boolean"
+      ? { limitedLiveCanaryPassed: input.limitedLiveCanaryPassed }
+      : {}),
+    ...(typeof input.limitedLiveCanaryRef === "string" &&
+    input.limitedLiveCanaryRef.trim()
+      ? { limitedLiveCanaryRef: input.limitedLiveCanaryRef.trim() }
+      : {}),
+    ...(typeof input.limitedLiveSoakPassed === "boolean"
+      ? { limitedLiveSoakPassed: input.limitedLiveSoakPassed }
+      : {}),
+    ...(typeof input.limitedLiveSoakRef === "string" &&
+    input.limitedLiveSoakRef.trim()
+      ? { limitedLiveSoakRef: input.limitedLiveSoakRef.trim() }
+      : {}),
+    ...(typeof input.applyTransition === "boolean"
+      ? { applyTransition: input.applyTransition }
+      : {}),
+    ...(typeof input.activateEvaluation === "boolean"
+      ? { activateEvaluation: input.activateEvaluation }
+      : {}),
+    ...(isRecord(input.metadata)
+      ? { metadata: input.metadata as Record<string, unknown> }
+      : {}),
+  };
+}
+
+export function buildRuntimeResearchPromotion(input: {
+  request: RuntimeResearchPromotionRequest;
+}): {
+  promotion: RuntimeStrategyLabPromotionRecord;
+  event: RuntimeStrategyLabPromotionEvent;
+} {
+  const request = input.request;
+  const nowIso = new Date().toISOString();
+  const checks: RuntimePromotionCheck[] = [];
+  const actions: RuntimePromotionAction[] = [
+    action("record-state-transition", "record_state_transition", {
+      summary: "Persist the strategy-lab transition audit record.",
+      required: true,
+      payload: {
+        subjectKind: request.subjectKind,
+        subjectKey: request.subjectKey,
+        currentState: request.currentState,
+        targetState: request.targetState,
+      },
+    }),
+  ];
+  const evidenceRefs = collectEvidenceRefs(request);
+  const approvalMap = new Map(
+    (request.approvals ?? []).map((approval) => [
+      approval.targetMode,
+      approval,
+    ]),
+  );
+
+  const transitionType = classifyTransitionType(
+    request.subjectKind,
+    request.currentState,
+    request.targetState,
+  );
+
+  if (request.subjectKind === "strategy") {
+    buildStrategyChecks({
+      request,
+      checks,
+      actions,
+      evidenceRefs,
+      approvalMap,
+      nowIso,
+    });
+  } else {
+    buildReadinessChecks({
+      request,
+      checks,
+      actions,
+      evidenceRefs,
+      approvalMap,
+    });
+  }
+
+  const status = finalizeStatus(checks, request.applyTransition === true);
+  const summary = buildSummary(request, status, transitionType);
+  const promotionId = `promotion_${hash(
+    JSON.stringify({
+      subjectKind: request.subjectKind,
+      subjectKey: request.subjectKey,
+      currentState: request.currentState,
+      targetState: request.targetState,
+      transitionType,
+      status,
+      issueNumber: request.issueNumber ?? null,
+      pullRequestNumber: request.pullRequestNumber ?? null,
+    }),
+  )}`;
+
+  const promotion = parseRuntimeStrategyLabPromotionRecord({
+    schemaVersion: "v1",
+    promotionId,
+    subjectKind: request.subjectKind,
+    subjectKey: request.subjectKey,
+    currentState: request.currentState,
+    targetState: request.targetState,
+    transitionType,
+    status,
+    summary,
+    requestedBy: request.requestedBy,
+    createdAt: nowIso,
+    updatedAt: nowIso,
+    ...(status === "applied" ? { appliedAt: nowIso } : {}),
+    ...(request.issueNumber ? { issueNumber: request.issueNumber } : {}),
+    ...(request.pullRequestNumber
+      ? { pullRequestNumber: request.pullRequestNumber }
+      : {}),
+    ...(request.deployment
+      ? { deploymentId: request.deployment.deploymentId }
+      : {}),
+    ...(request.policyGate
+      ? { policyGateId: request.policyGate.policyGateId }
+      : {}),
+    ...(request.synthesis
+      ? { synthesisId: request.synthesis.synthesisId }
+      : {}),
+    ...(request.triage ? { triageId: request.triage.triageId } : {}),
+    ...(request.implementationReference
+      ? { implementationReference: request.implementationReference }
+      : {}),
+    evidenceRefs,
+    checks,
+    actions,
+    approvals: Array.from(approvalMap.values()),
+    ...(request.metadata ? { metadata: request.metadata } : {}),
+  });
+
+  const event = parseRuntimeStrategyLabPromotionEvent({
+    schemaVersion: "v1",
+    eventId: `promoevt_${hash(`${promotionId}:${nowIso}:${status}`)}`,
+    promotionId,
+    eventType: status === "applied" ? "applied" : "evaluated",
+    actor: request.requestedBy,
+    fromState: request.currentState,
+    toState: request.targetState,
+    summary,
+    details: {
+      status,
+      transitionType,
+      subjectKind: request.subjectKind,
+      subjectKey: request.subjectKey,
+    },
+    createdAt: nowIso,
+  });
+
+  return { promotion, event };
+}
+
+export function buildRuntimeResearchPromotionMarkdown(
+  promotion: RuntimeStrategyLabPromotionRecord,
+): string {
+  const lines = [
+    `# Strategy-lab transition for ${promotion.subjectKind}:${promotion.subjectKey}`,
+    "",
+    `- Promotion id: ${promotion.promotionId}`,
+    `- Status: ${promotion.status}`,
+    `- Transition: ${promotion.currentState} -> ${promotion.targetState} (${promotion.transitionType})`,
+    `- Requested by: ${promotion.requestedBy}`,
+    `- Created at: ${promotion.createdAt}`,
+    `- Summary: ${promotion.summary}`,
+  ];
+
+  if (promotion.issueNumber) {
+    lines.push(`- Issue: #${promotion.issueNumber}`);
+  }
+  if (promotion.pullRequestNumber) {
+    lines.push(`- PR: #${promotion.pullRequestNumber}`);
+  }
+  if (promotion.deploymentId) {
+    lines.push(`- Deployment: ${promotion.deploymentId}`);
+  }
+
+  lines.push("", "## Evidence", "");
+  if (promotion.evidenceRefs.length === 0) {
+    lines.push("- none");
+  } else {
+    for (const ref of promotion.evidenceRefs) {
+      lines.push(`- ${ref.kind}: ${ref.ref}`);
+    }
+  }
+
+  lines.push("", "## Checks", "");
+  for (const check of promotion.checks) {
+    const observed = check.observedValue
+      ? ` observed=${check.observedValue}`
+      : "";
+    const threshold = check.thresholdValue
+      ? ` threshold=${check.thresholdValue}`
+      : "";
+    lines.push(
+      `- ${check.checkId}: ${check.status}${observed}${threshold} (${check.message})`,
+    );
+  }
+
+  lines.push("", "## Actions", "");
+  for (const action of promotion.actions) {
+    lines.push(
+      `- ${action.actionType}${action.required ? " [required]" : ""}: ${action.summary}`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+function buildStrategyChecks(input: {
+  request: RuntimeResearchPromotionRequest;
+  checks: RuntimePromotionCheck[];
+  actions: RuntimePromotionAction[];
+  evidenceRefs: RuntimeStrategyLabEvidenceRef[];
+  approvalMap: Map<
+    RuntimeResearchPolicyTargetMode,
+    RuntimeResearchHumanApprovalRecord
+  >;
+  nowIso: string;
+}): void {
+  const { request, checks, actions, evidenceRefs } = input;
+  const currentState = asStrategyState(request.currentState);
+  const targetState = asStrategyState(request.targetState);
+  if (!currentState || !targetState) {
+    checks.push(
+      blockedCheck(
+        "strategy-state-family",
+        `${request.currentState}->${request.targetState}`,
+        "strategy-state transition",
+        "Strategy promotions must use the strategy-lifecycle state family.",
+      ),
+    );
+    return;
+  }
+
+  checks.push(
+    canTransitionRuntimeStrategyLabStrategyState(currentState, targetState)
+      ? passCheck(
+          "allowed-transition",
+          `${currentState}->${targetState}`,
+          "supported",
+          "Transition is part of the strategy-lab strategy state machine.",
+        )
+      : blockedCheck(
+          "allowed-transition",
+          `${currentState}->${targetState}`,
+          "supported",
+          "Requested strategy transition is not allowed by the orchestration state machine.",
+        ),
+  );
+
+  if (isRollbackLike(currentState, targetState)) {
+    maybeAddApplyAction({ request, actions });
+    return;
+  }
+
+  if (targetState === "draft") {
+    checks.push(
+      request.synthesis
+        ? passCheck(
+            "candidate-synthesis",
+            request.synthesis.synthesisId,
+            "present",
+            "Candidate draft promotion is backed by a synthesis artifact.",
+          )
+        : blockedCheck(
+            "candidate-synthesis",
+            "missing",
+            "present",
+            "Candidate-to-draft promotion requires a synthesis artifact.",
+          ),
+    );
+    checks.push(
+      request.triage
+        ? passCheck(
+            "candidate-triage",
+            request.triage.triageId,
+            "present",
+            "Candidate draft promotion is backed by a triage artifact.",
+          )
+        : blockedCheck(
+            "candidate-triage",
+            "missing",
+            "present",
+            "Candidate-to-draft promotion requires a triage artifact.",
+          ),
+    );
+    checks.push(
+      request.triage && request.triage.disposition !== "archive"
+        ? passCheck(
+            "candidate-disposition",
+            request.triage.disposition,
+            "promote_to_candidate|review",
+            "Archived candidates cannot progress to draft.",
+          )
+        : blockedCheck(
+            "candidate-disposition",
+            request.triage?.disposition ?? "missing",
+            "promote_to_candidate|review",
+            "Archived or missing triage blocks candidate-to-draft promotion.",
+          ),
+    );
+    return;
+  }
+
+  const policyTarget = toPolicyTarget(targetState);
+  const gate = request.policyGate?.gates.find(
+    (entry) => entry.targetMode === policyTarget,
+  );
+  checks.push(
+    gate?.status === "pass"
+      ? passCheck(
+          "policy-gate",
+          gate.status,
+          "pass",
+          `${formatPolicyTarget(policyTarget)} policy gate passed.`,
+        )
+      : gate?.status === "requires_human_approval"
+        ? approvalCheck(
+            "policy-gate",
+            gate.status,
+            "pass",
+            `${formatPolicyTarget(policyTarget)} policy gate still requires human approval.`,
+          )
+        : blockedCheck(
+            "policy-gate",
+            gate?.status ?? "missing",
+            "pass",
+            `${formatPolicyTarget(policyTarget)} policy gate must pass before promotion.`,
+          ),
+  );
+
+  checks.push(
+    request.implementationReference
+      ? passCheck(
+          "implementation-reference",
+          request.implementationReference.ref,
+          "present",
+          "Implementation reference is attached to the transition record.",
+        )
+      : blockedCheck(
+          "implementation-reference",
+          "missing",
+          "present",
+          "Strategy promotion beyond draft requires a merged implementation reference.",
+        ),
+  );
+
+  if (
+    targetState === "shadow" ||
+    targetState === "paper" ||
+    targetState === "limited_live" ||
+    targetState === "broad_live"
+  ) {
+    checks.push(deploymentRecordCheck(request.deployment, targetState));
+  }
+
+  if (targetState === "paper") {
+    checks.push(
+      scorecardGateCheck(request.runtimeScorecard, "shadow", "paper"),
+    );
+  }
+
+  if (targetState === "limited_live") {
+    checks.push(scorecardGateCheck(request.runtimeScorecard, "paper", "live"));
+    checks.push(
+      hasEvidenceKind(evidenceRefs, "allocator_review")
+        ? passCheck(
+            "allocator-review",
+            "present",
+            "allocator_review",
+            "Allocator review is attached for bounded live promotion.",
+          )
+        : blockedCheck(
+            "allocator-review",
+            "missing",
+            "allocator_review",
+            "Limited-live promotion requires allocator review evidence.",
+          ),
+    );
+    checks.push(
+      hasEvidenceKind(evidenceRefs, "limited_live_canary_plan")
+        ? passCheck(
+            "limited-live-canary-plan",
+            "present",
+            "limited_live_canary_plan",
+            "Bounded canary plan is attached for limited-live promotion.",
+          )
+        : blockedCheck(
+            "limited-live-canary-plan",
+            "missing",
+            "limited_live_canary_plan",
+            "Limited-live promotion requires a bounded canary plan.",
+          ),
+    );
+  }
+
+  if (targetState === "broad_live") {
+    checks.push(
+      request.limitedLiveCanaryPassed
+        ? passCheck(
+            "limited-live-canary",
+            request.limitedLiveCanaryRef ?? "passed",
+            "passed",
+            "Limited-live canary passed for broader rollout.",
+          )
+        : blockedCheck(
+            "limited-live-canary",
+            "missing_or_failed",
+            "passed",
+            "Broad-live promotion requires a successful limited-live canary.",
+          ),
+    );
+    checks.push(
+      request.limitedLiveSoakPassed
+        ? passCheck(
+            "limited-live-soak",
+            request.limitedLiveSoakRef ?? "passed",
+            "passed",
+            "Limited-live soak passed for broader rollout.",
+          )
+        : blockedCheck(
+            "limited-live-soak",
+            "missing_or_failed",
+            "passed",
+            "Broad-live promotion requires a successful limited-live soak.",
+          ),
+    );
+  }
+
+  maybeAddApplyAction({ request, actions });
+  if (
+    request.applyTransition === true &&
+    request.activateEvaluation === true &&
+    request.deployment &&
+    targetState === "shadow"
+  ) {
+    actions.push(
+      action("evaluate-shadow", "evaluate_runtime_deployment", {
+        summary:
+          "Kick off a bounded shadow evaluation after the deployment is upserted.",
+        required: true,
+        payload: {
+          deploymentId: request.deployment.deploymentId,
+          body: {
+            trigger: "strategy-lab-promotion",
+            promotedAt: input.nowIso,
+          },
+        },
+      }),
+    );
+  }
+}
+
+function buildReadinessChecks(input: {
+  request: RuntimeResearchPromotionRequest;
+  checks: RuntimePromotionCheck[];
+  actions: RuntimePromotionAction[];
+  evidenceRefs: RuntimeStrategyLabEvidenceRef[];
+  approvalMap: Map<
+    RuntimeResearchPolicyTargetMode,
+    RuntimeResearchHumanApprovalRecord
+  >;
+}): void {
+  const { request, checks, actions, evidenceRefs, approvalMap } = input;
+  if (
+    !READINESS_STATES.has(request.currentState) ||
+    !READINESS_STATES.has(request.targetState)
+  ) {
+    checks.push(
+      blockedCheck(
+        "readiness-state-family",
+        `${request.currentState}->${request.targetState}`,
+        "readiness-state transition",
+        "Venue and asset promotion must use onboarding readiness states.",
+      ),
+    );
+    return;
+  }
+
+  checks.push(
+    canTransitionRuntimeStrategyLabReadinessState(
+      request.currentState as Exclude<
+        RuntimeStrategyLabPromotionState,
+        "draft" | "shadow" | "paper" | "limited_live" | "broad_live"
+      >,
+      request.targetState,
+    )
+      ? passCheck(
+          "allowed-transition",
+          `${request.currentState}->${request.targetState}`,
+          "supported",
+          "Transition is part of the venue/asset readiness state machine.",
+        )
+      : blockedCheck(
+          "allowed-transition",
+          `${request.currentState}->${request.targetState}`,
+          "supported",
+          "Requested readiness transition is not allowed by the orchestration state machine.",
+        ),
+  );
+
+  if (isRollbackLike(request.currentState, request.targetState)) {
+    return;
+  }
+
+  if (request.targetState === "integrated") {
+    requireEvidenceKind(
+      checks,
+      evidenceRefs,
+      "metadata_draft",
+      "candidate-integrated-metadata",
+    );
+    requireEvidenceKind(
+      checks,
+      evidenceRefs,
+      "mapping_coverage",
+      "candidate-integrated-mappings",
+    );
+    return;
+  }
+
+  if (request.targetState === "shadow_ready") {
+    requireEvidenceKind(
+      checks,
+      evidenceRefs,
+      "replay_fixture",
+      "shadow-ready-replay",
+    );
+    requireEvidenceKind(
+      checks,
+      evidenceRefs,
+      "adapter_validation",
+      "shadow-ready-adapter",
+    );
+    return;
+  }
+
+  if (request.targetState === "paper_ready") {
+    requireEvidenceKind(
+      checks,
+      evidenceRefs,
+      "cost_model_coverage",
+      "paper-ready-cost-model",
+    );
+    requireEvidenceKind(
+      checks,
+      evidenceRefs,
+      "paper_lifecycle_coverage",
+      "paper-ready-paper-lifecycle",
+    );
+    return;
+  }
+
+  if (request.targetState === "limited_live_ready") {
+    requireEvidenceKind(
+      checks,
+      evidenceRefs,
+      "bounded_canary_plan",
+      "limited-live-ready-canary-plan",
+    );
+    requireEvidenceKind(
+      checks,
+      evidenceRefs,
+      "allowlist_change",
+      "limited-live-ready-allowlist",
+    );
+    checks.push(
+      approvalMap.has("limited_live")
+        ? passCheck(
+            "human-approval",
+            approvalMap.get("limited_live")?.approvedBy ?? "present",
+            "recorded",
+            "Limited-live readiness requires explicit human approval.",
+          )
+        : approvalCheck(
+            "human-approval",
+            "missing",
+            "recorded",
+            "Limited-live readiness requires explicit human approval.",
+          ),
+    );
+    actions.push(
+      action("record-allowlist-change", "record_allowlist_change", {
+        summary:
+          "Record the allowlist change needed for bounded live readiness.",
+        required: true,
+      }),
+    );
+    return;
+  }
+
+  if (request.targetState === "broad_live_ready") {
+    checks.push(
+      request.limitedLiveCanaryPassed
+        ? passCheck(
+            "limited-live-canary",
+            request.limitedLiveCanaryRef ?? "passed",
+            "passed",
+            "Limited-live canary evidence is attached for readiness widening.",
+          )
+        : blockedCheck(
+            "limited-live-canary",
+            "missing_or_failed",
+            "passed",
+            "Broad-live readiness requires a successful limited-live canary.",
+          ),
+    );
+    checks.push(
+      request.limitedLiveSoakPassed
+        ? passCheck(
+            "limited-live-soak",
+            request.limitedLiveSoakRef ?? "passed",
+            "passed",
+            "Limited-live soak evidence is attached for readiness widening.",
+          )
+        : blockedCheck(
+            "limited-live-soak",
+            "missing_or_failed",
+            "passed",
+            "Broad-live readiness requires a successful limited-live soak.",
+          ),
+    );
+    checks.push(
+      approvalMap.has("broad_live")
+        ? passCheck(
+            "human-approval",
+            approvalMap.get("broad_live")?.approvedBy ?? "present",
+            "recorded",
+            "Broad-live readiness requires explicit human approval.",
+          )
+        : approvalCheck(
+            "human-approval",
+            "missing",
+            "recorded",
+            "Broad-live readiness requires explicit human approval.",
+          ),
+    );
+  }
+}
+
+function scorecardGateCheck(
+  runtimeScorecard:
+    | RuntimeResearchPromotionRequest["runtimeScorecard"]
+    | undefined,
+  sourceMode: "shadow" | "paper",
+  targetMode: "paper" | "live",
+): RuntimePromotionCheck {
+  const gate = (runtimeScorecard?.promotionGates ?? []).find(
+    (entry) =>
+      entry.sourceMode?.toLowerCase() === sourceMode &&
+      entry.targetMode?.toLowerCase() === targetMode,
+  );
+  return String(gate?.status ?? "").toLowerCase() === "pass"
+    ? passCheck(
+        "runtime-scorecard",
+        `${sourceMode}->${targetMode}:pass`,
+        "pass",
+        "Runtime scorecard cleared the required promotion gate.",
+      )
+    : blockedCheck(
+        "runtime-scorecard",
+        gate?.status ?? "missing",
+        "pass",
+        "Runtime scorecard must clear the required promotion gate before progression.",
+      );
+}
+
+function maybeAddApplyAction(input: {
+  request: RuntimeResearchPromotionRequest;
+  actions: RuntimePromotionAction[];
+}): void {
+  const { request, actions } = input;
+  if (request.applyTransition !== true) {
+    return;
+  }
+
+  if (request.subjectKind !== "strategy") {
+    return;
+  }
+
+  if (request.targetState === "paused") {
+    const deploymentId = request.deployment?.deploymentId ?? request.subjectKey;
+    actions.push(
+      action("pause-runtime-deployment", "apply_runtime_control", {
+        summary: "Pause the runtime deployment for this strategy transition.",
+        required: true,
+        payload: {
+          deploymentId,
+          action: "pause",
+        },
+      }),
+    );
+    return;
+  }
+
+  if (
+    request.deployment &&
+    (request.targetState === "shadow" ||
+      request.targetState === "paper" ||
+      request.targetState === "limited_live")
+  ) {
+    actions.push(
+      action("upsert-runtime-deployment", "upsert_runtime_deployment", {
+        summary:
+          "Upsert the runtime deployment into the target execution mode.",
+        required: true,
+        payload: {
+          deployment: request.deployment,
+        },
+      }),
+    );
+  }
+}
+
+function deploymentRecordCheck(
+  deployment: RuntimeDeploymentRecord | undefined,
+  targetState: RuntimeStrategyLabStrategyState,
+): RuntimePromotionCheck {
+  const expected = expectedDeploymentRecord(targetState);
+  const threshold = `${expected.mode}:${expected.state}`;
+  if (!deployment) {
+    return blockedCheck(
+      "deployment-record",
+      "missing",
+      threshold,
+      "Apply-time promotion requires a runtime deployment record in the target mode.",
+    );
+  }
+
+  const observed = `${deployment.mode}:${deployment.state}`;
+  if (
+    deployment.mode !== expected.mode ||
+    deployment.state !== expected.state
+  ) {
+    return blockedCheck(
+      "deployment-record",
+      observed,
+      threshold,
+      "Runtime deployment record must already reflect the requested target mode and state.",
+    );
+  }
+
+  return passCheck(
+    "deployment-record",
+    observed,
+    threshold,
+    "Runtime deployment record is attached for apply-time orchestration.",
+  );
+}
+
+function requireEvidenceKind(
+  checks: RuntimePromotionCheck[],
+  evidenceRefs: RuntimeStrategyLabEvidenceRef[],
+  kind: string,
+  checkId: string,
+): void {
+  checks.push(
+    hasEvidenceKind(evidenceRefs, kind)
+      ? passCheck(
+          checkId,
+          "present",
+          kind,
+          `Evidence of kind ${kind} is attached to the transition.`,
+        )
+      : blockedCheck(
+          checkId,
+          "missing",
+          kind,
+          `Transition requires evidence of kind ${kind}.`,
+        ),
+  );
+}
+
+function collectEvidenceRefs(
+  request: RuntimeResearchPromotionRequest,
+): RuntimeStrategyLabEvidenceRef[] {
+  const refs = [...(request.evidenceRefs ?? [])];
+  if (request.synthesis) {
+    refs.push({
+      kind: "synthesis",
+      ref: request.synthesis.synthesisId,
+    });
+  }
+  if (request.triage) {
+    refs.push({
+      kind: "triage",
+      ref: request.triage.triageId,
+    });
+  }
+  if (request.policyGate) {
+    refs.push({
+      kind: "policy_gate",
+      ref: request.policyGate.policyGateId,
+    });
+  }
+  if (request.implementationReference) {
+    refs.push({
+      kind: "implementation_reference",
+      ref: request.implementationReference.ref,
+      ...(request.implementationReference.notes
+        ? { notes: request.implementationReference.notes }
+        : {}),
+    });
+  }
+  if (request.runtimeScorecard?.promotionGates?.length) {
+    refs.push({
+      kind: "runtime_scorecard",
+      ref: request.deployment?.deploymentId ?? request.subjectKey,
+    });
+  }
+  if (request.limitedLiveCanaryPassed) {
+    refs.push({
+      kind: "limited_live_canary",
+      ref: request.limitedLiveCanaryRef ?? "passed",
+    });
+  }
+  if (request.limitedLiveSoakPassed) {
+    refs.push({
+      kind: "limited_live_soak",
+      ref: request.limitedLiveSoakRef ?? "passed",
+    });
+  }
+
+  const deduped = new Map<string, RuntimeStrategyLabEvidenceRef>();
+  for (const ref of refs) {
+    deduped.set(`${ref.kind}:${ref.ref}`, ref);
+  }
+  return Array.from(deduped.values());
+}
+
+function finalizeStatus(
+  checks: RuntimePromotionCheck[],
+  applyTransition: boolean,
+): RuntimeStrategyLabPromotionStatus {
+  if (checks.some((check) => check.status === "blocked")) {
+    return "blocked";
+  }
+  if (checks.some((check) => check.status === "requires_human_approval")) {
+    return "requires_human_approval";
+  }
+  return applyTransition ? "applied" : "pass";
+}
+
+function buildSummary(
+  request: RuntimeResearchPromotionRequest,
+  status: RuntimeStrategyLabPromotionStatus,
+  transitionType: RuntimeStrategyLabTransitionType,
+): string {
+  const transition = `${request.currentState} -> ${request.targetState}`;
+  switch (status) {
+    case "applied":
+      return `${transitionType} transition ${transition} was applied.`;
+    case "pass":
+      return `${transitionType} transition ${transition} is eligible and ready to apply.`;
+    case "requires_human_approval":
+      return `${transitionType} transition ${transition} is gated on explicit human approval.`;
+    default:
+      return `${transitionType} transition ${transition} is blocked by orchestration checks.`;
+  }
+}
+
+function classifyTransitionType(
+  subjectKind: RuntimeStrategyLabSubjectKind,
+  currentState: RuntimeStrategyLabPromotionState,
+  targetState: RuntimeStrategyLabPromotionState,
+): RuntimeStrategyLabTransitionType {
+  if (targetState === "paused") return "pause";
+  if (currentState === "paused") return "resume";
+  if (targetState === "deprecated") return "archive";
+
+  const order =
+    subjectKind === "strategy" ? STRATEGY_STATE_ORDER : READINESS_STATE_ORDER;
+  const currentIndex = order.indexOf(currentState as never);
+  const targetIndex = order.indexOf(targetState as never);
+  if (currentIndex >= 0 && targetIndex >= 0 && targetIndex > currentIndex) {
+    return "promote";
+  }
+  return "demote";
+}
+
+function isRollbackLike(
+  currentState: RuntimeStrategyLabPromotionState,
+  targetState: RuntimeStrategyLabPromotionState,
+): boolean {
+  if (targetState === "paused" || targetState === "deprecated") {
+    return true;
+  }
+  if (currentState === "paused") {
+    return false;
+  }
+  const currentStrategyIndex = STRATEGY_STATE_ORDER.indexOf(
+    currentState as RuntimeStrategyLabStrategyState,
+  );
+  const targetStrategyIndex = STRATEGY_STATE_ORDER.indexOf(
+    targetState as RuntimeStrategyLabStrategyState,
+  );
+  if (
+    currentStrategyIndex >= 0 &&
+    targetStrategyIndex >= 0 &&
+    targetStrategyIndex < currentStrategyIndex
+  ) {
+    return true;
+  }
+  const currentReadinessIndex = READINESS_STATE_ORDER.indexOf(
+    currentState as never,
+  );
+  const targetReadinessIndex = READINESS_STATE_ORDER.indexOf(
+    targetState as never,
+  );
+  return (
+    currentReadinessIndex >= 0 &&
+    targetReadinessIndex >= 0 &&
+    targetReadinessIndex < currentReadinessIndex
+  );
+}
+
+function toPolicyTarget(
+  targetState: RuntimeStrategyLabStrategyState,
+): RuntimeResearchPolicyTargetMode {
+  switch (targetState) {
+    case "shadow":
+      return "shadow";
+    case "paper":
+      return "paper";
+    case "limited_live":
+      return "limited_live";
+    case "broad_live":
+      return "broad_live";
+    default:
+      return "shadow";
+  }
+}
+
+function expectedDeploymentRecord(
+  targetState: RuntimeStrategyLabStrategyState,
+): Pick<RuntimeDeploymentRecord, "mode" | "state"> {
+  switch (targetState) {
+    case "shadow":
+      return { mode: "shadow", state: "shadow" };
+    case "paper":
+      return { mode: "paper", state: "paper" };
+    case "limited_live":
+    case "broad_live":
+      return { mode: "live", state: "live" };
+    case "paused":
+      return { mode: "live", state: "paused" };
+    default:
+      return { mode: "shadow", state: "draft" };
+  }
+}
+
+function formatPolicyTarget(target: RuntimeResearchPolicyTargetMode): string {
+  switch (target) {
+    case "limited_live":
+      return "Limited Live";
+    case "broad_live":
+      return "Broad Live";
+    case "paper":
+      return "Paper";
+    default:
+      return "Shadow";
+  }
+}
+
+function hasEvidenceKind(
+  evidenceRefs: RuntimeStrategyLabEvidenceRef[],
+  kind: string,
+): boolean {
+  return evidenceRefs.some((ref) => ref.kind === kind);
+}
+
+function asStrategyState(
+  state: RuntimeStrategyLabPromotionState,
+): RuntimeStrategyLabStrategyState | null {
+  return STRATEGY_STATES.has(state)
+    ? (state as RuntimeStrategyLabStrategyState)
+    : null;
+}
+
+function action(
+  actionId: string,
+  actionType: RuntimePromotionAction["actionType"],
+  input: Omit<RuntimePromotionAction, "actionId" | "actionType">,
+): RuntimePromotionAction {
+  return {
+    actionId,
+    actionType,
+    ...input,
+  };
+}
+
+function passCheck(
+  checkId: string,
+  observedValue: string,
+  thresholdValue: string,
+  message: string,
+): RuntimePromotionCheck {
+  return {
+    checkId,
+    status: "pass",
+    observedValue,
+    thresholdValue,
+    message,
+  };
+}
+
+function blockedCheck(
+  checkId: string,
+  observedValue: string,
+  thresholdValue: string,
+  message: string,
+): RuntimePromotionCheck {
+  return {
+    checkId,
+    status: "blocked",
+    observedValue,
+    thresholdValue,
+    message,
+  };
+}
+
+function approvalCheck(
+  checkId: string,
+  observedValue: string,
+  thresholdValue: string,
+  message: string,
+): RuntimePromotionCheck {
+  return {
+    checkId,
+    status: "requires_human_approval",
+    observedValue,
+    thresholdValue,
+    message,
+  };
+}
+
+function parseEvidenceRef(input: unknown): RuntimeStrategyLabEvidenceRef {
+  if (!isRecord(input)) {
+    throw new Error("invalid-runtime-strategy-lab-evidence-ref");
+  }
+  return {
+    kind: readRequiredString(input.kind, "evidenceRefs.kind"),
+    ref: readRequiredString(input.ref, "evidenceRefs.ref"),
+    ...(typeof input.notes === "string" && input.notes.trim()
+      ? { notes: input.notes.trim() }
+      : {}),
+  };
+}
+
+function parseImplementationReference(
+  input: unknown,
+): RuntimeResearchPromotionRequest["implementationReference"] {
+  if (!isRecord(input)) {
+    throw new Error("invalid-runtime-strategy-lab-implementation-reference");
+  }
+  return {
+    kind: readEnum(input.kind, "implementationReference.kind", [
+      "pull_request",
+      "issue",
+      "commit",
+    ]) as "pull_request" | "issue" | "commit",
+    ref: readRequiredString(input.ref, "implementationReference.ref"),
+    ...(typeof input.mergedAt === "string" && input.mergedAt.trim()
+      ? { mergedAt: input.mergedAt.trim() }
+      : {}),
+    ...(typeof input.revision === "string" && input.revision.trim()
+      ? { revision: input.revision.trim() }
+      : {}),
+    ...(typeof input.notes === "string" && input.notes.trim()
+      ? { notes: input.notes.trim() }
+      : {}),
+  };
+}
+
+function parseApproval(input: unknown): RuntimeResearchHumanApprovalRecord {
+  if (!isRecord(input)) {
+    throw new Error("invalid-runtime-strategy-lab-approval");
+  }
+  return {
+    targetMode: readEnum(input.targetMode, "approvals.targetMode", [
+      "shadow",
+      "paper",
+      "limited_live",
+      "broad_live",
+    ]) as RuntimeResearchPolicyTargetMode,
+    approvedBy: readRequiredString(input.approvedBy, "approvals.approvedBy"),
+    approvedAt: readRequiredString(input.approvedAt, "approvals.approvedAt"),
+    ...(typeof input.notes === "string" && input.notes.trim()
+      ? { notes: input.notes.trim() }
+      : {}),
+  };
+}
+
+function parseRuntimeScorecardGate(input: unknown): RuntimeScorecardGate {
+  if (!isRecord(input)) {
+    return {};
+  }
+  return {
+    ...(typeof input.sourceMode === "string"
+      ? { sourceMode: input.sourceMode }
+      : {}),
+    ...(typeof input.targetMode === "string"
+      ? { targetMode: input.targetMode }
+      : {}),
+    ...(typeof input.status === "string" ? { status: input.status } : {}),
+  };
+}
+
+function readState(
+  value: unknown,
+  field: string,
+): RuntimeStrategyLabPromotionState {
+  return readEnum(value, field, [
+    "candidate",
+    "draft",
+    "shadow",
+    "paper",
+    "limited_live",
+    "broad_live",
+    "integrated",
+    "shadow_ready",
+    "paper_ready",
+    "limited_live_ready",
+    "broad_live_ready",
+    "paused",
+    "deprecated",
+  ]) as RuntimeStrategyLabPromotionState;
+}
+
+function readEnum(value: unknown, field: string, allowed: string[]): string {
+  const parsed = readRequiredString(value, field);
+  if (!allowed.includes(parsed)) {
+    throw new Error(`invalid-runtime-strategy-lab-${field}`);
+  }
+  return parsed;
+}
+
+function readRequiredString(value: unknown, field: string): string {
+  const parsed = String(value ?? "").trim();
+  if (!parsed) {
+    throw new Error(`invalid-runtime-strategy-lab-${field}`);
+  }
+  return parsed;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function hash(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 24);
+}

--- a/tests/unit/runtime_protocol_schema_fixtures.test.ts
+++ b/tests/unit/runtime_protocol_schema_fixtures.test.ts
@@ -148,6 +148,18 @@ describe("runtime protocol schema fixtures", () => {
         "docs/runtime-contracts/fixtures/runtime.strategy_spec.valid.v1.json",
       ),
     ).toBe(true);
+    expect(
+      validate(
+        "docs/runtime-contracts/schemas/runtime.strategy_lab_promotion.v1.schema.json",
+        "docs/runtime-contracts/fixtures/runtime.strategy_lab_promotion.valid.v1.json",
+      ),
+    ).toBe(true);
+    expect(
+      validate(
+        "docs/runtime-contracts/schemas/runtime.strategy_lab_promotion_event.v1.schema.json",
+        "docs/runtime-contracts/fixtures/runtime.strategy_lab_promotion_event.valid.v1.json",
+      ),
+    ).toBe(true);
   });
 
   test("manifest lists every runtime schema file", () => {
@@ -179,6 +191,8 @@ describe("runtime protocol schema fixtures", () => {
       "docs/runtime-contracts/schemas/runtime.venue_capability.v1.schema.json",
       "docs/runtime-contracts/schemas/runtime.asset_record.v1.schema.json",
       "docs/runtime-contracts/schemas/runtime.strategy_spec.v1.schema.json",
+      "docs/runtime-contracts/schemas/runtime.strategy_lab_promotion.v1.schema.json",
+      "docs/runtime-contracts/schemas/runtime.strategy_lab_promotion_event.v1.schema.json",
     ]);
   });
 });

--- a/tests/unit/runtime_research_promotion.test.ts
+++ b/tests/unit/runtime_research_promotion.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseRuntimeAssetRecord,
+  parseRuntimeDeploymentRecord,
+} from "../../src/runtime/contracts/autonomous_runtime.js";
+import { buildRuntimeResearchPolicyGate } from "../../src/runtime/research/policy_gate.js";
+import {
+  buildRuntimeResearchPromotion,
+  parseRuntimeResearchPromotionRequest,
+} from "../../src/runtime/research/promotion.js";
+import { buildRuntimeResearchSynthesis } from "../../src/runtime/research/synthesis.js";
+import { buildRuntimeResearchCandidateTriage } from "../../src/runtime/research/triage.js";
+
+const briefFixture = {
+  briefId: "brief_latest_signal",
+  generatedAt: "2026-03-11T12:00:00.000Z",
+  profile: "custom",
+  title: "Latest signal research",
+  summary:
+    "Reviewed 1 approved source across 1 acquisition request. Most recent coverage: Momentum Alpha in Crypto.",
+  findings: [
+    "Momentum Alpha in Crypto (published 2026-03-11T08:00:00.000Z): Measure momentum across venue fragments and validate liquidity persistence.",
+  ],
+  approvedHosts: ["research.example.com"],
+  requestCount: 1,
+  sourceCount: 1,
+  createdCount: 1,
+  existingCount: 0,
+  citations: [
+    {
+      sourceId: "source_article_momentum",
+      materialDigest: "sha256:source_article_momentum",
+      notes: "published 2026-03-11T08:00:00.000Z",
+    },
+  ],
+  sources: [
+    {
+      sourceId: "source_article_momentum",
+      sourceKind: "article",
+      title: "Momentum Alpha in Crypto",
+      url: "https://research.example.com/posts/momentum-alpha",
+      canonicalUrl: "https://research.example.com/posts/momentum-alpha",
+      authors: ["Ada Researcher"],
+      publishedAt: "2026-03-11T08:00:00.000Z",
+      retrievedAt: "2026-03-11T12:00:00.000Z",
+      venueKeys: ["jupiter"],
+      assetKeys: ["SOL", "USDC"],
+      tags: ["signal", "momentum"],
+      digest: "sha256:source_article_momentum",
+    },
+  ],
+} as const;
+
+function buildCandidateArtifacts() {
+  const synthesis = buildRuntimeResearchSynthesis({
+    request: {
+      brief: briefFixture,
+      strategyKey: "candidate_trend_following_jupiter_sol_usdc",
+      title: "Trend continuation alpha",
+    },
+  });
+  const triage = buildRuntimeResearchCandidateTriage({
+    request: {
+      synthesis,
+    },
+  });
+  return { synthesis, triage };
+}
+
+function buildAssetRecord(assetKey: "SOL" | "USDC") {
+  const isSol = assetKey === "SOL";
+  const nativeId = isSol
+    ? "So11111111111111111111111111111111111111112"
+    : "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+  return parseRuntimeAssetRecord({
+    schemaVersion: "v1",
+    assetKey,
+    displayName: isSol ? "Solana" : "USD Coin",
+    symbol: assetKey,
+    chainKey: "solana-mainnet",
+    canonicalId: nativeId,
+    assetKind: isSol ? "native" : "stablecoin",
+    riskClass: "core",
+    listingState: "live",
+    decimals: isSol ? 9 : 6,
+    aliases: isSol ? ["WSOL"] : ["USD Coin"],
+    quoteAssetKeys: ["USDC"],
+    venueMappings: [
+      {
+        venueKey: "jupiter",
+        nativeId,
+        venueSymbol: assetKey,
+        decimals: isSol ? 9 : 6,
+        listingState: "live",
+        quoteAssetKeys: ["USDC"],
+        priceDecimals: 6,
+        sizeDecimals: isSol ? 9 : 6,
+        minNotionalUsd: "0.01",
+      },
+    ],
+    createdAt: "2026-03-11T12:00:00.000Z",
+    updatedAt: "2026-03-11T12:00:00.000Z",
+    promotedAt: "2026-03-11T12:00:00.000Z",
+    tags: ["asset-registry"],
+  });
+}
+
+function buildShadowDeployment(strategyKey: string) {
+  return parseRuntimeDeploymentRecord({
+    schemaVersion: "v1",
+    deploymentId: `dep_${strategyKey}_shadow`,
+    strategyKey,
+    sleeveId: "sleeve_alpha",
+    ownerUserId: "user_runtime_fixture",
+    venueKey: "jupiter",
+    pair: {
+      symbol: "SOL/USDC",
+      baseMint: "So11111111111111111111111111111111111111112",
+      quoteMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    },
+    mode: "shadow",
+    state: "shadow",
+    lane: "safe",
+    createdAt: "2026-03-11T12:00:00.000Z",
+    updatedAt: "2026-03-11T12:00:00.000Z",
+    policy: {
+      maxNotionalUsd: "25",
+      dailyLossLimitUsd: "10",
+      maxSlippageBps: 50,
+      maxConcurrentRuns: 1,
+      rebalanceToleranceBps: 100,
+    },
+    capital: {
+      allocatedUsd: "100",
+      reservedUsd: "5",
+      availableUsd: "95",
+    },
+    tags: ["strategy-lab", "shadow"],
+  });
+}
+
+describe("runtime research promotion", () => {
+  test("parses a promotion request", () => {
+    const { synthesis, triage } = buildCandidateArtifacts();
+    const request = parseRuntimeResearchPromotionRequest({
+      subjectKind: "strategy",
+      subjectKey: synthesis.strategySpecDraft.strategyKey,
+      currentState: "candidate",
+      targetState: "draft",
+      requestedBy: "codex",
+      synthesis,
+      triage,
+    });
+
+    expect(request.subjectKind).toBe("strategy");
+    expect(request.targetState).toBe("draft");
+  });
+
+  test("promotes candidate strategies into draft with synthesis and triage evidence", () => {
+    const { synthesis, triage } = buildCandidateArtifacts();
+    const result = buildRuntimeResearchPromotion({
+      request: {
+        subjectKind: "strategy",
+        subjectKey: synthesis.strategySpecDraft.strategyKey,
+        currentState: "candidate",
+        targetState: "draft",
+        requestedBy: "codex",
+        synthesis,
+        triage,
+      },
+    });
+
+    expect(result.promotion.status).toBe("pass");
+    expect(result.promotion.transitionType).toBe("promote");
+    expect(
+      result.promotion.checks.every((check) => check.status === "pass"),
+    ).toBe(true);
+  });
+
+  test("blocks draft to shadow when the policy gate and implementation reference are missing", () => {
+    const { synthesis } = buildCandidateArtifacts();
+    const result = buildRuntimeResearchPromotion({
+      request: {
+        subjectKind: "strategy",
+        subjectKey: synthesis.strategySpecDraft.strategyKey,
+        currentState: "draft",
+        targetState: "shadow",
+        requestedBy: "codex",
+      },
+    });
+
+    expect(result.promotion.status).toBe("blocked");
+    expect(
+      result.promotion.checks.some((check) => check.checkId === "policy-gate"),
+    ).toBe(true);
+    expect(
+      result.promotion.checks.some(
+        (check) => check.checkId === "implementation-reference",
+      ),
+    ).toBe(true);
+  });
+
+  test("applies draft to shadow when the shadow gate passes and a deployment is provided", () => {
+    const { synthesis, triage } = buildCandidateArtifacts();
+    const policyGate = buildRuntimeResearchPolicyGate({
+      request: {
+        synthesis,
+        triage,
+        assetRecords: [buildAssetRecord("SOL"), buildAssetRecord("USDC")],
+      },
+    });
+    const deployment = buildShadowDeployment(
+      synthesis.strategySpecDraft.strategyKey,
+    );
+
+    const result = buildRuntimeResearchPromotion({
+      request: {
+        subjectKind: "strategy",
+        subjectKey: synthesis.strategySpecDraft.strategyKey,
+        currentState: "draft",
+        targetState: "shadow",
+        requestedBy: "codex",
+        policyGate,
+        implementationReference: {
+          kind: "pull_request",
+          ref: "#348",
+          mergedAt: "2026-03-12T05:00:00.000Z",
+        },
+        deployment,
+        applyTransition: true,
+        activateEvaluation: true,
+      },
+    });
+
+    expect(result.promotion.status).toBe("applied");
+    expect(
+      result.promotion.actions.some(
+        (action) => action.actionType === "upsert_runtime_deployment",
+      ),
+    ).toBe(true);
+    expect(
+      result.promotion.actions.some(
+        (action) => action.actionType === "evaluate_runtime_deployment",
+      ),
+    ).toBe(true);
+  });
+
+  test("blocks shadow promotion when the deployment record does not match the target mode", () => {
+    const { synthesis, triage } = buildCandidateArtifacts();
+    const policyGate = buildRuntimeResearchPolicyGate({
+      request: {
+        synthesis,
+        triage,
+        assetRecords: [buildAssetRecord("SOL"), buildAssetRecord("USDC")],
+      },
+    });
+    const deployment = parseRuntimeDeploymentRecord({
+      ...buildShadowDeployment(synthesis.strategySpecDraft.strategyKey),
+      deploymentId: `dep_${synthesis.strategySpecDraft.strategyKey}_paper`,
+      mode: "paper",
+      state: "paper",
+    });
+
+    const result = buildRuntimeResearchPromotion({
+      request: {
+        subjectKind: "strategy",
+        subjectKey: synthesis.strategySpecDraft.strategyKey,
+        currentState: "draft",
+        targetState: "shadow",
+        requestedBy: "codex",
+        policyGate,
+        implementationReference: {
+          kind: "pull_request",
+          ref: "#349",
+          mergedAt: "2026-03-12T05:00:00.000Z",
+        },
+        deployment,
+        applyTransition: true,
+      },
+    });
+
+    expect(result.promotion.status).toBe("blocked");
+    expect(
+      result.promotion.checks.find(
+        (check) => check.checkId === "deployment-record",
+      ),
+    ).toMatchObject({
+      status: "blocked",
+      observedValue: "paper:paper",
+      thresholdValue: "shadow:shadow",
+    });
+  });
+
+  test("requires human approval before limited-live readiness for assets", () => {
+    const result = buildRuntimeResearchPromotion({
+      request: {
+        subjectKind: "asset",
+        subjectKey: "SOL",
+        currentState: "paper_ready",
+        targetState: "limited_live_ready",
+        requestedBy: "codex",
+        evidenceRefs: [
+          { kind: "bounded_canary_plan", ref: "canary_plan_sol" },
+          { kind: "allowlist_change", ref: "allowlist_sol" },
+        ],
+      },
+    });
+
+    expect(result.promotion.status).toBe("requires_human_approval");
+    expect(
+      result.promotion.actions.some(
+        (action) => action.actionType === "record_allowlist_change",
+      ),
+    ).toBe(true);
+  });
+});

--- a/tests/unit/worker_execution_migrations.test.ts
+++ b/tests/unit/worker_execution_migrations.test.ts
@@ -11,6 +11,7 @@ function withExecutionSchema(run: (db: Database) => void): void {
       "0025_execution_fabric.sql",
       "0026_execution_canary.sql",
       "0027_runtime_canary.sql",
+      "0028_strategy_lab_promotions.sql",
     ]) {
       const migrationPath = resolve(
         import.meta.dir,
@@ -101,7 +102,9 @@ describe("worker execution schema migration", () => {
               'execution_canary_state',
               'execution_canary_runs',
               'runtime_canary_state',
-              'runtime_canary_runs'
+              'runtime_canary_runs',
+              'strategy_lab_promotions',
+              'strategy_lab_promotion_events'
             )
           ORDER BY name
           `,
@@ -117,6 +120,8 @@ describe("worker execution schema migration", () => {
         "execution_status_events",
         "runtime_canary_runs",
         "runtime_canary_state",
+        "strategy_lab_promotion_events",
+        "strategy_lab_promotions",
       ]);
     });
   });

--- a/tests/unit/worker_runtime_contracts.test.ts
+++ b/tests/unit/worker_runtime_contracts.test.ts
@@ -12,6 +12,8 @@ import {
   parseRuntimeRegimeTagRecord,
   parseRuntimeReplayCorpusRecord,
   parseRuntimeResearchReproducibilityBundleRecord,
+  parseRuntimeStrategyLabPromotionEvent,
+  parseRuntimeStrategyLabPromotionRecord,
   parseRuntimeStrategySpec,
   parseRuntimeVenueCapability,
   RUNTIME_PROTOCOL_SCHEMA_REGISTRY,
@@ -46,6 +48,8 @@ describe("worker runtime contract bridge", () => {
       "venueCapability",
       "assetRecord",
       "strategySpec",
+      "strategyLabPromotion",
+      "strategyLabPromotionEvent",
     ]);
   });
 
@@ -91,6 +95,23 @@ describe("worker runtime contract bridge", () => {
 
     expect(strategySpec.strategyKey).toBe("trend_following");
     expect(strategySpec.pluginKey).toBe("builtin::trend_following");
+  });
+
+  test("worker can parse the canonical strategy-lab promotion fixtures", () => {
+    const promotion = parseRuntimeStrategyLabPromotionRecord(
+      readJson(
+        "docs/runtime-contracts/fixtures/runtime.strategy_lab_promotion.valid.v1.json",
+      ),
+    );
+    const event = parseRuntimeStrategyLabPromotionEvent(
+      readJson(
+        "docs/runtime-contracts/fixtures/runtime.strategy_lab_promotion_event.valid.v1.json",
+      ),
+    );
+
+    expect(promotion.targetState).toBe("shadow");
+    expect(promotion.actions[1]?.actionType).toBe("upsert_runtime_deployment");
+    expect(event.eventType).toBe("applied");
   });
 
   test("worker can parse the canonical venue capability fixture", () => {

--- a/tests/unit/worker_runtime_research_promotion_route.test.ts
+++ b/tests/unit/worker_runtime_research_promotion_route.test.ts
@@ -1,0 +1,356 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Env } from "../../apps/worker/src/types";
+import { parseRuntimeAssetRecord } from "../../src/runtime/contracts/autonomous_runtime.js";
+import { buildRuntimeResearchPolicyGate } from "../../src/runtime/research/policy_gate.js";
+import { buildRuntimeResearchSynthesis } from "../../src/runtime/research/synthesis.js";
+import { buildRuntimeResearchCandidateTriage } from "../../src/runtime/research/triage.js";
+import {
+  createExecutionContextStub,
+  createWorkerLiveEnv,
+} from "../integration/_worker_live_test_utils";
+
+const worker = (await import("../../apps/worker/src/index")).default;
+
+function createSqliteD1Adapter(db: Database): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          return {
+            async run() {
+              const statement = db.query(sql);
+              const result = statement.run(...(params as never[])) as {
+                changes?: number;
+              };
+              return {
+                meta: {
+                  changes:
+                    typeof result.changes === "number" ? result.changes : 0,
+                },
+              };
+            },
+            async first() {
+              const statement = db.query(sql);
+              return (statement.get(...(params as never[])) as unknown) ?? null;
+            },
+            async all() {
+              const statement = db.query(sql);
+              return {
+                results: (statement.all(...(params as never[])) ??
+                  []) as unknown[],
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+function createOpsEnv(overrides?: Partial<Env>) {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA foreign_keys = ON;");
+
+  for (const migrationName of [
+    "0025_execution_fabric.sql",
+    "0026_execution_canary.sql",
+    "0027_runtime_canary.sql",
+    "0028_strategy_lab_promotions.sql",
+  ]) {
+    const migrationPath = resolve(
+      import.meta.dir,
+      "..",
+      "..",
+      "apps/worker/migrations",
+      migrationName,
+    );
+    sqlite.exec(readFileSync(migrationPath, "utf8"));
+  }
+
+  const env = createWorkerLiveEnv({
+    overrides: {
+      WAITLIST_DB: createSqliteD1Adapter(sqlite),
+      ADMIN_TOKEN: "admin-secret",
+      RUNTIME_INTERNAL_STUB_MODE: "1",
+      RUNTIME_INTERNAL_SERVICE_TOKEN: "runtime-secret",
+      ...overrides,
+    },
+  });
+
+  return { env, sqlite };
+}
+
+const briefFixture = {
+  briefId: "brief_latest_signal",
+  generatedAt: "2026-03-11T12:00:00.000Z",
+  profile: "custom",
+  title: "Latest signal research",
+  summary:
+    "Reviewed 1 approved source across 1 acquisition request. Most recent coverage: Momentum Alpha in Crypto.",
+  findings: [
+    "Momentum Alpha in Crypto (published 2026-03-11T08:00:00.000Z): Measure momentum across venue fragments and validate liquidity persistence.",
+  ],
+  approvedHosts: ["research.example.com"],
+  requestCount: 1,
+  sourceCount: 1,
+  createdCount: 1,
+  existingCount: 0,
+  citations: [
+    {
+      sourceId: "source_article_momentum",
+      materialDigest: "sha256:source_article_momentum",
+      notes: "published 2026-03-11T08:00:00.000Z",
+    },
+  ],
+  sources: [
+    {
+      sourceId: "source_article_momentum",
+      sourceKind: "article",
+      title: "Momentum Alpha in Crypto",
+      url: "https://research.example.com/posts/momentum-alpha",
+      canonicalUrl: "https://research.example.com/posts/momentum-alpha",
+      authors: ["Ada Researcher"],
+      publishedAt: "2026-03-11T08:00:00.000Z",
+      retrievedAt: "2026-03-11T12:00:00.000Z",
+      venueKeys: ["jupiter"],
+      assetKeys: ["SOL", "USDC"],
+      tags: ["signal", "momentum"],
+      digest: "sha256:source_article_momentum",
+    },
+  ],
+} as const;
+
+function buildAssetRecord(assetKey: "SOL" | "USDC") {
+  const isSol = assetKey === "SOL";
+  const nativeId = isSol
+    ? "So11111111111111111111111111111111111111112"
+    : "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+  return parseRuntimeAssetRecord({
+    schemaVersion: "v1",
+    assetKey,
+    displayName: isSol ? "Solana" : "USD Coin",
+    symbol: assetKey,
+    chainKey: "solana-mainnet",
+    canonicalId: nativeId,
+    assetKind: isSol ? "native" : "stablecoin",
+    riskClass: "core",
+    listingState: "live",
+    decimals: isSol ? 9 : 6,
+    aliases: isSol ? ["WSOL"] : ["USD Coin"],
+    quoteAssetKeys: ["USDC"],
+    venueMappings: [
+      {
+        venueKey: "jupiter",
+        nativeId,
+        venueSymbol: assetKey,
+        decimals: isSol ? 9 : 6,
+        listingState: "live",
+        quoteAssetKeys: ["USDC"],
+        priceDecimals: 6,
+        sizeDecimals: isSol ? 9 : 6,
+        minNotionalUsd: "0.01",
+      },
+    ],
+    createdAt: "2026-03-11T12:00:00.000Z",
+    updatedAt: "2026-03-11T12:00:00.000Z",
+    promotedAt: "2026-03-11T12:00:00.000Z",
+    tags: ["asset-registry"],
+  });
+}
+
+const synthesisFixture = buildRuntimeResearchSynthesis({
+  request: {
+    brief: briefFixture,
+    strategyKey: "candidate_trend_following_jupiter_sol_usdc",
+    title: "Trend continuation alpha",
+  },
+});
+
+const triageFixture = buildRuntimeResearchCandidateTriage({
+  request: {
+    synthesis: synthesisFixture,
+  },
+});
+
+const policyGateFixture = buildRuntimeResearchPolicyGate({
+  request: {
+    synthesis: synthesisFixture,
+    triage: triageFixture,
+    assetRecords: [buildAssetRecord("SOL"), buildAssetRecord("USDC")],
+  },
+});
+
+function buildShadowDeployment() {
+  return {
+    schemaVersion: "v1",
+    deploymentId: `dep_${synthesisFixture.strategySpecDraft.strategyKey}_shadow`,
+    strategyKey: synthesisFixture.strategySpecDraft.strategyKey,
+    sleeveId: "sleeve_alpha",
+    ownerUserId: "user_runtime_fixture",
+    venueKey: "jupiter",
+    pair: {
+      symbol: "SOL/USDC",
+      baseMint: "So11111111111111111111111111111111111111112",
+      quoteMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    },
+    mode: "shadow",
+    state: "shadow",
+    lane: "safe",
+    createdAt: "2026-03-11T12:00:00.000Z",
+    updatedAt: "2026-03-11T12:00:00.000Z",
+    policy: {
+      maxNotionalUsd: "25",
+      dailyLossLimitUsd: "10",
+      maxSlippageBps: 50,
+      maxConcurrentRuns: 1,
+      rebalanceToleranceBps: 100,
+    },
+    capital: {
+      allocatedUsd: "100",
+      reservedUsd: "5",
+      availableUsd: "95",
+    },
+    tags: ["strategy-lab", "shadow"],
+  };
+}
+
+describe("worker runtime research promotion route", () => {
+  test("requires admin auth", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/research/promotions",
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              subjectKind: "strategy",
+              subjectKey: synthesisFixture.strategySpecDraft.strategyKey,
+              currentState: "draft",
+              targetState: "shadow",
+              requestedBy: "codex",
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({
+        ok: false,
+        error: "auth-required",
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("applies and persists a strategy promotion workflow", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/research/promotions",
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              subjectKind: "strategy",
+              subjectKey: synthesisFixture.strategySpecDraft.strategyKey,
+              currentState: "draft",
+              targetState: "shadow",
+              requestedBy: "codex",
+              issueNumber: 322,
+              pullRequestNumber: 400,
+              synthesis: synthesisFixture,
+              triage: triageFixture,
+              policyGate: policyGateFixture,
+              implementationReference: {
+                kind: "pull_request",
+                ref: "#400",
+                mergedAt: "2026-03-12T00:00:00.000Z",
+              },
+              deployment: buildShadowDeployment(),
+              applyTransition: true,
+              activateEvaluation: true,
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(200);
+      const payload = await response.json();
+      expect(payload).toMatchObject({
+        ok: true,
+        promotion: {
+          status: "applied",
+          currentState: "draft",
+          targetState: "shadow",
+          transitionType: "promote",
+          issueNumber: 322,
+          pullRequestNumber: 400,
+          deploymentId: `dep_${synthesisFixture.strategySpecDraft.strategyKey}_shadow`,
+        },
+        event: {
+          eventType: "applied",
+        },
+        markdown: expect.stringContaining("## Actions"),
+      });
+
+      const promotionId = String(payload.promotion.promotionId);
+      const listingResponse = await worker.fetch(
+        new Request(
+          `http://localhost/api/admin/ops/runtime/research/promotions?promotionId=${promotionId}`,
+          {
+            method: "GET",
+            headers: {
+              authorization: "Bearer admin-secret",
+            },
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(listingResponse.status).toBe(200);
+      expect(await listingResponse.json()).toMatchObject({
+        ok: true,
+        promotions: [
+          {
+            promotionId,
+            status: "applied",
+          },
+        ],
+        events: [
+          {
+            promotionId,
+            eventType: "applied",
+          },
+        ],
+      });
+
+      const promotionCount = sqlite
+        .query("SELECT COUNT(*) AS count FROM strategy_lab_promotions")
+        .get() as { count: number };
+      const eventCount = sqlite
+        .query("SELECT COUNT(*) AS count FROM strategy_lab_promotion_events")
+        .get() as { count: number };
+      expect(promotionCount.count).toBe(1);
+      expect(eventCount.count).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #322

## Summary
- add strategy-lab promotion records, events, orchestration builder, and worker admin routes
- add promotion CLI/workflow, schema artifacts, and runtime contract bridge updates
- cover promotion persistence, route behavior, migrations, and shared schema fixtures

## Validation
- bun run lint
- bun run typecheck
- bun test tests/unit/runtime_protocol_contracts.test.ts tests/unit/runtime_protocol_schema_fixtures.test.ts tests/unit/worker_runtime_contracts.test.ts tests/unit/runtime_research_promotion.test.ts tests/unit/worker_runtime_research_promotion_route.test.ts tests/unit/worker_execution_migrations.test.ts
