### PR TITLE
Build operator surfaces for research and promotion control

### DIFF
--- a/apps/portal/app/api/runtime/operator/route.ts
+++ b/apps/portal/app/api/runtime/operator/route.ts
@@ -23,6 +23,32 @@ type RuntimeControls = {
   shadowOnlyReason: string | null;
 };
 
+type StrategyLabResearchSnapshot = {
+  hypotheses: Record<string, unknown>[];
+  sources: Record<string, unknown>[];
+  experiments: Record<string, unknown>[];
+  evidenceBundles: Record<string, unknown>[];
+  reproducibilityBundles: Record<string, unknown>[];
+  error: string | null;
+};
+
+type StrategyLabPromotionSnapshot = {
+  strategy: Record<string, unknown>[];
+  venue: Record<string, unknown>[];
+  asset: Record<string, unknown>[];
+  error: string | null;
+};
+
+type StrategyLabSubjectSnapshot = {
+  subjectKind: "venue" | "asset";
+  subjectKey: string;
+  artifacts: Record<string, unknown>[];
+  controls: Record<string, unknown>[];
+  canaryRuns: Record<string, unknown>[];
+  canaryState: Record<string, unknown> | null;
+  error: string | null;
+};
+
 function parseCsvSet(value: string | undefined): Set<string> {
   return new Set(
     String(value ?? "")
@@ -43,6 +69,13 @@ function readString(value: unknown): string | null {
 
 function readBoolean(value: unknown, fallback: boolean): boolean {
   return typeof value === "boolean" ? value : fallback;
+}
+
+function readRecordArray(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is Record<string, unknown> =>
+    isRecord(entry),
+  );
 }
 
 function normalizeAuthHeader(value: string | null): string | null {
@@ -204,6 +237,201 @@ function normalizeRuntimeSnapshot(payload: Record<string, unknown>) {
   };
 }
 
+function buildQueryPath(
+  path: string,
+  params: Record<string, string | number | null | undefined>,
+): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    const normalized = String(value ?? "").trim();
+    if (!normalized) continue;
+    search.set(key, normalized);
+  }
+  const query = search.toString();
+  return query ? `${path}?${query}` : path;
+}
+
+function inferAssetKey(
+  deployment: RuntimeDeploymentRecord | null,
+): string | null {
+  if (!deployment) return null;
+  const [baseSymbol] = deployment.pair.symbol.split("/");
+  return readString(baseSymbol) ?? null;
+}
+
+function resolveOperatorActor(payload: Record<string, unknown>): string {
+  const user = isRecord(payload.user) ? payload.user : {};
+  return (
+    readString(user.email) ??
+    readString(user.id) ??
+    readString(user.privyUserId) ??
+    "runtime-operator"
+  );
+}
+
+async function loadStrategyLabResearch(
+  deployment: RuntimeDeploymentRecord,
+  adminAuthHeader: string,
+): Promise<StrategyLabResearchSnapshot> {
+  const assetKey = inferAssetKey(deployment);
+  const result = await requestWorkerJson({
+    path: buildQueryPath("/api/admin/ops/runtime/research", {
+      strategyKey: deployment.strategyKey,
+      venueKey: deployment.venueKey,
+      assetKey,
+    }),
+    authHeader: adminAuthHeader,
+  });
+  if (result.status < 200 || result.status >= 300) {
+    return {
+      hypotheses: [],
+      sources: [],
+      experiments: [],
+      evidenceBundles: [],
+      reproducibilityBundles: [],
+      error: readString(result.payload.error) ?? `http-${result.status}`,
+    };
+  }
+  const registry = isRecord(result.payload.registry)
+    ? result.payload.registry
+    : {};
+  return {
+    hypotheses: readRecordArray(registry.hypotheses),
+    sources: readRecordArray(registry.sources),
+    experiments: readRecordArray(registry.experiments),
+    evidenceBundles: readRecordArray(registry.evidenceBundles),
+    reproducibilityBundles: readRecordArray(registry.reproducibilityBundles),
+    error: null,
+  };
+}
+
+async function loadStrategyLabPromotions(
+  deployment: RuntimeDeploymentRecord,
+  adminAuthHeader: string,
+): Promise<StrategyLabPromotionSnapshot> {
+  const assetKey = inferAssetKey(deployment);
+  const [strategyResult, venueResult, assetResult] = await Promise.all([
+    requestWorkerJson({
+      path: buildQueryPath("/api/admin/ops/runtime/research/promotions", {
+        subjectKind: "strategy",
+        subjectKey: deployment.strategyKey,
+        limit: 5,
+      }),
+      authHeader: adminAuthHeader,
+    }),
+    requestWorkerJson({
+      path: buildQueryPath("/api/admin/ops/runtime/research/promotions", {
+        subjectKind: "venue",
+        subjectKey: deployment.venueKey,
+        limit: 5,
+      }),
+      authHeader: adminAuthHeader,
+    }),
+    assetKey
+      ? requestWorkerJson({
+          path: buildQueryPath("/api/admin/ops/runtime/research/promotions", {
+            subjectKind: "asset",
+            subjectKey: assetKey,
+            limit: 5,
+          }),
+          authHeader: adminAuthHeader,
+        })
+      : Promise.resolve({
+          status: 200,
+          payload: { ok: true, promotions: [] },
+        }),
+  ]);
+
+  const errors = [strategyResult, venueResult, assetResult]
+    .filter((result) => result.status < 200 || result.status >= 300)
+    .map(
+      (result) => readString(result.payload.error) ?? `http-${result.status}`,
+    )
+    .filter(Boolean);
+
+  return {
+    strategy:
+      strategyResult.status >= 200 && strategyResult.status < 300
+        ? readRecordArray(strategyResult.payload.promotions)
+        : [],
+    venue:
+      venueResult.status >= 200 && venueResult.status < 300
+        ? readRecordArray(venueResult.payload.promotions)
+        : [],
+    asset:
+      assetResult.status >= 200 && assetResult.status < 300
+        ? readRecordArray(assetResult.payload.promotions)
+        : [],
+    error: errors.length > 0 ? errors.join("; ") : null,
+  };
+}
+
+async function loadStrategyLabSubject(
+  subjectKind: "venue" | "asset",
+  subjectKey: string | null,
+  adminAuthHeader: string,
+): Promise<StrategyLabSubjectSnapshot | null> {
+  if (!subjectKey) return null;
+
+  const [readinessResult, controlsResult, canaryResult] = await Promise.all([
+    requestWorkerJson({
+      path: buildQueryPath("/api/admin/ops/runtime/research/readiness", {
+        subjectKind,
+        subjectKey,
+        limit: 5,
+      }),
+      authHeader: adminAuthHeader,
+    }),
+    requestWorkerJson({
+      path: buildQueryPath("/api/admin/ops/runtime/research/subject-controls", {
+        subjectKind,
+        subjectKey,
+        limit: 5,
+      }),
+      authHeader: adminAuthHeader,
+    }),
+    requestWorkerJson({
+      path: buildQueryPath("/api/admin/ops/runtime/research/readiness/canary", {
+        subjectKind,
+        subjectKey,
+        limit: 5,
+      }),
+      authHeader: adminAuthHeader,
+    }),
+  ]);
+
+  const errors = [readinessResult, controlsResult, canaryResult]
+    .filter((result) => result.status < 200 || result.status >= 300)
+    .map(
+      (result) => readString(result.payload.error) ?? `http-${result.status}`,
+    )
+    .filter(Boolean);
+
+  return {
+    subjectKind,
+    subjectKey,
+    artifacts:
+      readinessResult.status >= 200 && readinessResult.status < 300
+        ? readRecordArray(readinessResult.payload.readinessArtifacts)
+        : [],
+    controls:
+      controlsResult.status >= 200 && controlsResult.status < 300
+        ? readRecordArray(controlsResult.payload.controls)
+        : [],
+    canaryRuns:
+      canaryResult.status >= 200 && canaryResult.status < 300
+        ? readRecordArray(canaryResult.payload.runs)
+        : [],
+    canaryState:
+      canaryResult.status >= 200 &&
+      canaryResult.status < 300 &&
+      isRecord(canaryResult.payload.state)
+        ? canaryResult.payload.state
+        : null,
+    error: errors.length > 0 ? errors.join("; ") : null,
+  };
+}
+
 function firstDeploymentId(
   deployments: RuntimeDeploymentRecord[],
 ): string | null {
@@ -225,6 +453,14 @@ async function loadRuntimeDetail(
       totals: RuntimeLedgerSnapshot["totals"];
     } | null;
     scorecard: Record<string, unknown> | null;
+    lab: {
+      research: StrategyLabResearchSnapshot;
+      promotions: StrategyLabPromotionSnapshot;
+      readiness: {
+        venue: StrategyLabSubjectSnapshot | null;
+        asset: StrategyLabSubjectSnapshot | null;
+      };
+    } | null;
   } | null;
   error: string | null;
 }> {
@@ -241,11 +477,41 @@ async function loadRuntimeDetail(
   const parsedDeployment = isRecord(result.payload.deployment)
     ? safeParseRuntimeDeploymentRecord(result.payload.deployment)
     : null;
+  const deployment = parsedDeployment?.success ? parsedDeployment.data : null;
+  const [research, promotions, venueReadiness, assetReadiness] = deployment
+    ? await Promise.all([
+        loadStrategyLabResearch(deployment, adminAuthHeader),
+        loadStrategyLabPromotions(deployment, adminAuthHeader),
+        loadStrategyLabSubject("venue", deployment.venueKey, adminAuthHeader),
+        loadStrategyLabSubject(
+          "asset",
+          inferAssetKey(deployment),
+          adminAuthHeader,
+        ),
+      ])
+    : await Promise.all([
+        Promise.resolve({
+          hypotheses: [],
+          sources: [],
+          experiments: [],
+          evidenceBundles: [],
+          reproducibilityBundles: [],
+          error: "missing-selected-deployment",
+        }),
+        Promise.resolve({
+          strategy: [],
+          venue: [],
+          asset: [],
+          error: "missing-selected-deployment",
+        }),
+        Promise.resolve(null),
+        Promise.resolve(null),
+      ]);
 
   return {
     detail: {
       deploymentId,
-      deployment: parsedDeployment?.success ? parsedDeployment.data : null,
+      deployment,
       runs: parseRuns(result.payload.runs),
       allocator: isRecord(result.payload.allocator)
         ? result.payload.allocator
@@ -255,6 +521,14 @@ async function loadRuntimeDetail(
       scorecard: isRecord(result.payload.scorecard)
         ? result.payload.scorecard
         : null,
+      lab: {
+        research,
+        promotions,
+        readiness: {
+          venue: venueReadiness,
+          asset: assetReadiness,
+        },
+      },
     },
     error: null,
   };
@@ -352,6 +626,8 @@ export async function POST(request: Request) {
     );
   }
 
+  const operatorActor = resolveOperatorActor(sessionResult.payload);
+
   const adminToken = resolveAdminToken();
   if (!adminToken) {
     return NextResponse.json(
@@ -364,25 +640,102 @@ export async function POST(request: Request) {
   const payload = isRecord(payloadRaw) ? payloadRaw : {};
   const deploymentId = readString(payload.deploymentId);
   const action = readString(payload.action);
-  if (!deploymentId || !action) {
-    return NextResponse.json(
-      { ok: false, error: "invalid-runtime-operator-action" },
-      { status: 400 },
-    );
-  }
-  if (action !== "pause" && action !== "resume" && action !== "kill") {
-    return NextResponse.json(
-      { ok: false, error: "invalid-runtime-operator-action" },
-      { status: 400 },
-    );
+  if (action === "pause" || action === "resume" || action === "kill") {
+    if (!deploymentId) {
+      return NextResponse.json(
+        { ok: false, error: "invalid-runtime-operator-action" },
+        { status: 400 },
+      );
+    }
+
+    const result = await requestWorkerJson({
+      path: `/api/admin/ops/runtime/deployments/${encodeURIComponent(
+        deploymentId,
+      )}/${action}`,
+      method: "POST",
+      authHeader: `Bearer ${adminToken}`,
+    });
+    return NextResponse.json(result.payload, { status: result.status });
   }
 
-  const result = await requestWorkerJson({
-    path: `/api/admin/ops/runtime/deployments/${encodeURIComponent(
-      deploymentId,
-    )}/${action}`,
-    method: "POST",
-    authHeader: `Bearer ${adminToken}`,
-  });
-  return NextResponse.json(result.payload, { status: result.status });
+  if (action === "update_subject_control") {
+    const subjectKind =
+      payload.subjectKind === "venue" || payload.subjectKind === "asset"
+        ? payload.subjectKind
+        : null;
+    const subjectKey = readString(payload.subjectKey);
+    if (!subjectKind || !subjectKey) {
+      return NextResponse.json(
+        { ok: false, error: "invalid-runtime-operator-action" },
+        { status: 400 },
+      );
+    }
+    const result = await requestWorkerJson({
+      path: "/api/admin/ops/runtime/research/subject-controls",
+      method: "POST",
+      authHeader: `Bearer ${adminToken}`,
+      body: {
+        subjectKind,
+        subjectKey,
+        ...(typeof payload.liveAllowed === "boolean"
+          ? { liveAllowed: payload.liveAllowed }
+          : {}),
+        ...(typeof payload.killSwitchEnabled === "boolean"
+          ? { killSwitchEnabled: payload.killSwitchEnabled }
+          : {}),
+        ...(payload.disabledReason === null ||
+        typeof payload.disabledReason === "string"
+          ? { disabledReason: payload.disabledReason ?? null }
+          : {}),
+        updatedBy: operatorActor,
+      },
+    });
+    return NextResponse.json(result.payload, { status: result.status });
+  }
+
+  if (action === "run_readiness_canary") {
+    const subjectKind =
+      payload.subjectKind === "venue" || payload.subjectKind === "asset"
+        ? payload.subjectKind
+        : null;
+    const subjectKey = readString(payload.subjectKey);
+    if (!subjectKind || !subjectKey) {
+      return NextResponse.json(
+        { ok: false, error: "invalid-runtime-operator-action" },
+        { status: 400 },
+      );
+    }
+    const result = await requestWorkerJson({
+      path: "/api/admin/ops/runtime/research/readiness/canary",
+      method: "POST",
+      authHeader: `Bearer ${adminToken}`,
+      body: {
+        subjectKind,
+        subjectKey,
+        requestedBy: operatorActor,
+        triggerSource: "manual",
+        ...(readString(payload.venueKey)
+          ? { venueKey: readString(payload.venueKey) }
+          : {}),
+        ...(readString(payload.assetKey)
+          ? { assetKey: readString(payload.assetKey) }
+          : {}),
+        ...(readString(payload.pairSymbol)
+          ? { pairSymbol: readString(payload.pairSymbol) }
+          : {}),
+        ...(readString(payload.adapterKey)
+          ? { adapterKey: readString(payload.adapterKey) }
+          : {}),
+        ...(readString(payload.targetNotionalUsd)
+          ? { targetNotionalUsd: readString(payload.targetNotionalUsd) }
+          : {}),
+      },
+    });
+    return NextResponse.json(result.payload, { status: result.status });
+  }
+
+  return NextResponse.json(
+    { ok: false, error: "invalid-runtime-operator-action" },
+    { status: 400 },
+  );
 }

--- a/apps/portal/app/api/runtime/operator/route.ts
+++ b/apps/portal/app/api/runtime/operator/route.ts
@@ -78,6 +78,12 @@ function readRecordArray(value: unknown): Record<string, unknown>[] {
   );
 }
 
+function workerPayload(
+  record: Record<string, unknown>,
+): Record<string, unknown> {
+  return record;
+}
+
 function normalizeAuthHeader(value: string | null): string | null {
   const token = String(value ?? "").trim();
   if (!token) return null;
@@ -338,7 +344,7 @@ async function loadStrategyLabPromotions(
         })
       : Promise.resolve({
           status: 200,
-          payload: { ok: true, promotions: [] },
+          payload: workerPayload({ ok: true, promotions: [] }),
         }),
   ]);
 

--- a/apps/portal/app/proof/runtime/page.tsx
+++ b/apps/portal/app/proof/runtime/page.tsx
@@ -2,10 +2,7 @@
 
 import { useState } from "react";
 import { RuntimeOperatorView } from "../../terminal/runtime/runtime-operator-view";
-import type {
-  RuntimeControlAction,
-  RuntimeOperatorApiPayload,
-} from "../../terminal/runtime/types";
+import type { RuntimeOperatorApiPayload } from "../../terminal/runtime/types";
 
 const FIXTURE_TIME = "2026-03-09T14:10:00.000Z";
 const SOL_MINT = "So11111111111111111111111111111111111111112";
@@ -272,6 +269,168 @@ function buildPayload(selectedDeploymentId: string): RuntimeOperatorApiPayload {
           },
         ],
       },
+      lab: {
+        research: {
+          hypotheses: [
+            {
+              hypothesisId: "hyp_trend_following_sol",
+              strategyKey: "trend_following",
+              title: "Trend following on SOL/USDC",
+              thesis:
+                "Momentum persistence remains durable during healthy liquidity regimes.",
+              status: "candidate",
+              createdAt: FIXTURE_TIME,
+              updatedAt: FIXTURE_TIME,
+            },
+          ],
+          sources: [
+            {
+              sourceId: "src_trend_following_paper",
+              sourceKind: "paper",
+              title: "Interpretable momentum signal study",
+              canonicalUrl: "https://research.example.com/momentum",
+              retrievedAt: FIXTURE_TIME,
+              publishedAt: FIXTURE_TIME,
+            },
+          ],
+          experiments: [
+            {
+              experimentId: "exp_trend_following_sol",
+              status: "completed",
+              summary:
+                "Walk-forward replay beat flat cash and held significance across volatile windows.",
+              updatedAt: FIXTURE_TIME,
+              completedAt: FIXTURE_TIME,
+            },
+          ],
+          evidenceBundles: [
+            {
+              evidenceBundleId: "bundle_trend_following_shadow",
+              status: "approved",
+              promotionTarget: "paper",
+              summary:
+                "Shadow and paper bundle includes backtest, replay, and reconciliation artifacts.",
+            },
+          ],
+          reproducibilityBundles: [
+            {
+              reproducibilityBundleId: "repro_trend_following_shadow",
+              summary:
+                "Backtest rerun matched the stored report within configured tolerances.",
+              updatedAt: FIXTURE_TIME,
+              latestVerification: {
+                status: "pass",
+              },
+            },
+          ],
+          error: null,
+        },
+        promotions: {
+          strategy: [
+            {
+              promotionId: "promotion_strategy_shadow",
+              currentState: "draft",
+              targetState: "shadow",
+              status: "applied",
+              summary:
+                "Candidate implementation merged and activated in shadow.",
+              requestedBy: "operator@example.com",
+              updatedAt: FIXTURE_TIME,
+            },
+          ],
+          venue: [
+            {
+              promotionId: "promotion_venue_limited_live",
+              currentState: "paper_ready",
+              targetState: "limited_live_ready",
+              status: "requires_human_approval",
+              summary:
+                "Venue readiness cleared all automated checks and awaits approval.",
+              requestedBy: "operator@example.com",
+              updatedAt: FIXTURE_TIME,
+            },
+          ],
+          asset: [
+            {
+              promotionId: "promotion_asset_limited_live",
+              currentState: "paper_ready",
+              targetState: "limited_live_ready",
+              status: "pass",
+              summary:
+                "Asset controls, cost drift, and bounded canary are all within guardrails.",
+              requestedBy: "operator@example.com",
+              updatedAt: FIXTURE_TIME,
+            },
+          ],
+          error: null,
+        },
+        readiness: {
+          venue: {
+            subjectKind: "venue",
+            subjectKey: "jupiter",
+            artifacts: [
+              {
+                readinessId: "readiness_jupiter",
+                targetState: "limited_live_ready",
+                status: "pass",
+                summary:
+                  "Venue readiness checks passed with a bounded canary plan.",
+                canaryRunId: "readycanary_jupiter_sol",
+              },
+            ],
+            controls: [
+              {
+                liveAllowed: true,
+                killSwitchEnabled: false,
+                updatedAt: FIXTURE_TIME,
+              },
+            ],
+            canaryRuns: [
+              {
+                runId: "readycanary_jupiter_sol",
+                status: "success",
+                updatedAt: FIXTURE_TIME,
+              },
+            ],
+            canaryState: {
+              updatedAt: FIXTURE_TIME,
+            },
+            error: null,
+          },
+          asset: {
+            subjectKind: "asset",
+            subjectKey: "SOL",
+            artifacts: [
+              {
+                readinessId: "readiness_sol",
+                targetState: "limited_live_ready",
+                status: "pass",
+                summary:
+                  "Asset readiness checks passed with live controls staged.",
+                canaryRunId: "readycanary_sol",
+              },
+            ],
+            controls: [
+              {
+                liveAllowed: true,
+                killSwitchEnabled: false,
+                updatedAt: FIXTURE_TIME,
+              },
+            ],
+            canaryRuns: [
+              {
+                runId: "readycanary_sol",
+                status: "success",
+                updatedAt: FIXTURE_TIME,
+              },
+            ],
+            canaryState: {
+              updatedAt: FIXTURE_TIME,
+            },
+            error: null,
+          },
+        },
+      },
     },
     detailError: null,
   };
@@ -281,8 +440,7 @@ export default function RuntimeProofPage() {
   const [selectedDeploymentId, setSelectedDeploymentId] = useState<string>(
     DEPLOYMENTS[0].deploymentId,
   );
-  const [actionPending, setActionPending] =
-    useState<RuntimeControlAction | null>(null);
+  const [actionPending, setActionPending] = useState<string | null>(null);
   const [payload, setPayload] = useState<RuntimeOperatorApiPayload>(() =>
     buildPayload(DEPLOYMENTS[0].deploymentId),
   );
@@ -313,6 +471,26 @@ export default function RuntimeProofPage() {
           if (action === "pause") updateDeploymentState("paused");
           if (action === "resume") updateDeploymentState("live");
           if (action === "kill") updateDeploymentState("killed");
+          window.setTimeout(() => setActionPending(null), 50);
+        }}
+        onSubjectControl={(input) => {
+          setActionPending(
+            `subject-control:${input.subjectKind}:${input.subjectKey}:${
+              input.killSwitchEnabled === true
+                ? "kill-on"
+                : input.killSwitchEnabled === false
+                  ? "kill-off"
+                  : input.liveAllowed === true
+                    ? "live-on"
+                    : "live-off"
+            }`,
+          );
+          window.setTimeout(() => setActionPending(null), 50);
+        }}
+        onReadinessCanary={(input) => {
+          setActionPending(
+            `readiness-canary:${input.subjectKind}:${input.subjectKey}`,
+          );
           window.setTimeout(() => setActionPending(null), 50);
         }}
       />

--- a/apps/portal/app/terminal/runtime/runtime-operator-client.tsx
+++ b/apps/portal/app/terminal/runtime/runtime-operator-client.tsx
@@ -3,7 +3,12 @@
 import { usePrivy } from "@privy-io/react-auth";
 import { useEffect, useState, useTransition } from "react";
 import { RuntimeOperatorView } from "./runtime-operator-view";
-import type { RuntimeControlAction, RuntimeOperatorApiPayload } from "./types";
+import type {
+  RuntimeControlAction,
+  RuntimeOperatorApiPayload,
+  RuntimeOperatorReadinessCanaryInput,
+  RuntimeOperatorSubjectControlInput,
+} from "./types";
 
 async function readJson<T>(response: Response): Promise<T | null> {
   return (await response.json().catch(() => null)) as T | null;
@@ -37,8 +42,7 @@ export function RuntimeOperatorClient() {
     null,
   );
   const [error, setError] = useState<string | null>(null);
-  const [actionPending, setActionPending] =
-    useState<RuntimeControlAction | null>(null);
+  const [actionPending, setActionPending] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
   async function loadOperatorView(deploymentId?: string) {
@@ -56,17 +60,17 @@ export function RuntimeOperatorClient() {
     setError(null);
   }
 
-  async function runControl(action: RuntimeControlAction) {
-    const deploymentId = payload?.selectedDeploymentId;
-    if (!deploymentId) return;
-
+  async function runOperatorAction(
+    requestBody: Record<string, unknown>,
+    actionKey: string,
+  ) {
     const token = await getAccessToken();
     if (!token) {
       setError("operator-auth-token-unavailable");
       return;
     }
 
-    setActionPending(action);
+    setActionPending(actionKey);
     try {
       const response = await fetch("/api/runtime/operator", {
         method: "POST",
@@ -74,20 +78,62 @@ export function RuntimeOperatorClient() {
           authorization: `Bearer ${token}`,
           "content-type": "application/json",
         },
-        body: JSON.stringify({
-          deploymentId,
-          action,
-        }),
+        body: JSON.stringify(requestBody),
       });
-      const body = await readJson<{ ok?: boolean; error?: string }>(response);
-      if (!response.ok || body?.ok === false) {
-        setError(body?.error ?? `http-${response.status}`);
+      const responseBody = await readJson<{ ok?: boolean; error?: string }>(
+        response,
+      );
+      if (!response.ok || responseBody?.ok === false) {
+        setError(responseBody?.error ?? `http-${response.status}`);
         return;
       }
-      await loadOperatorView(deploymentId);
+      await loadOperatorView(payload?.selectedDeploymentId ?? undefined);
     } finally {
       setActionPending(null);
     }
+  }
+
+  async function runControl(action: RuntimeControlAction) {
+    const deploymentId = payload?.selectedDeploymentId;
+    if (!deploymentId) return;
+    await runOperatorAction(
+      {
+        deploymentId,
+        action,
+      },
+      action,
+    );
+  }
+
+  async function runSubjectControl(input: RuntimeOperatorSubjectControlInput) {
+    const actionKey = `subject-control:${input.subjectKind}:${input.subjectKey}:${
+      input.killSwitchEnabled === true
+        ? "kill-on"
+        : input.killSwitchEnabled === false
+          ? "kill-off"
+          : input.liveAllowed === true
+            ? "live-on"
+            : "live-off"
+    }`;
+    await runOperatorAction(
+      {
+        action: "update_subject_control",
+        ...input,
+      },
+      actionKey,
+    );
+  }
+
+  async function runReadinessCanary(
+    input: RuntimeOperatorReadinessCanaryInput,
+  ) {
+    await runOperatorAction(
+      {
+        action: "run_readiness_canary",
+        ...input,
+      },
+      `readiness-canary:${input.subjectKind}:${input.subjectKey}`,
+    );
   }
 
   useEffect(() => {
@@ -166,6 +212,28 @@ export function RuntimeOperatorClient() {
               cause instanceof Error
                 ? cause.message
                 : "runtime-operator-control-failed",
+            );
+          });
+        });
+      }}
+      onSubjectControl={(input) => {
+        startTransition(() => {
+          void runSubjectControl(input).catch((cause) => {
+            setError(
+              cause instanceof Error
+                ? cause.message
+                : "runtime-operator-subject-control-failed",
+            );
+          });
+        });
+      }}
+      onReadinessCanary={(input) => {
+        startTransition(() => {
+          void runReadinessCanary(input).catch((cause) => {
+            setError(
+              cause instanceof Error
+                ? cause.message
+                : "runtime-operator-readiness-canary-failed",
             );
           });
         });

--- a/apps/portal/app/terminal/runtime/runtime-operator-view.tsx
+++ b/apps/portal/app/terminal/runtime/runtime-operator-view.tsx
@@ -6,7 +6,9 @@ import type {
   RuntimeControlAction,
   RuntimeOperatorApiPayload,
   RuntimeOperatorDetail,
+  RuntimeOperatorReadinessCanaryInput,
   RuntimeOperatorSnapshot,
+  RuntimeOperatorSubjectControlInput,
 } from "./types";
 
 type RuntimeOperatorViewProps = {
@@ -14,10 +16,12 @@ type RuntimeOperatorViewProps = {
   loading: boolean;
   error: string | null;
   payload: RuntimeOperatorApiPayload | null;
-  actionPending: RuntimeControlAction | null;
+  actionPending: string | null;
   onRefresh?: () => void;
   onSelectDeployment?: (deploymentId: string) => void;
   onControl?: (action: RuntimeControlAction) => void;
+  onSubjectControl?: (input: RuntimeOperatorSubjectControlInput) => void;
+  onReadinessCanary?: (input: RuntimeOperatorReadinessCanaryInput) => void;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -62,6 +66,38 @@ function summaryItem(label: string, value: string) {
       </p>
       <p className="mt-2 text-sm font-medium text-ink">{value}</p>
     </div>
+  );
+}
+
+function buildSubjectActionKey(
+  input: RuntimeOperatorSubjectControlInput,
+): string {
+  return `subject-control:${input.subjectKind}:${input.subjectKey}:${
+    input.killSwitchEnabled === true
+      ? "kill-on"
+      : input.killSwitchEnabled === false
+        ? "kill-off"
+        : input.liveAllowed === true
+          ? "live-on"
+          : "live-off"
+  }`;
+}
+
+function buildReadinessCanaryActionKey(
+  input: RuntimeOperatorReadinessCanaryInput,
+): string {
+  return `readiness-canary:${input.subjectKind}:${input.subjectKey}`;
+}
+
+function renderBadge(status: string, label?: string) {
+  return (
+    <span
+      className={`inline-flex rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.24em] ${statusClasses(
+        status,
+      )}`}
+    >
+      {(label ?? status).replaceAll("_", " ")}
+    </span>
   );
 }
 
@@ -522,6 +558,504 @@ function renderAllocator(detail: RuntimeOperatorDetail | null) {
   );
 }
 
+function renderResearchProvenance(detail: RuntimeOperatorDetail | null) {
+  const research = isRecord(detail?.lab?.research)
+    ? detail?.lab?.research
+    : null;
+  if (!research) {
+    return (
+      <div className="rounded border border-dashed border-border p-4 text-sm text-muted">
+        Research provenance is not available yet.
+      </div>
+    );
+  }
+
+  const hypotheses = readRecordArray(research.hypotheses);
+  const sources = readRecordArray(research.sources);
+  const experiments = readRecordArray(research.experiments);
+  const evidenceBundles = readRecordArray(research.evidenceBundles);
+  const reproducibilityBundles = readRecordArray(
+    research.reproducibilityBundles,
+  );
+  const hypothesis = hypotheses[0] ?? null;
+  const source = sources[0] ?? null;
+  const experiment = experiments[0] ?? null;
+  const evidenceBundle = evidenceBundles[0] ?? null;
+  const reproducibilityBundle = reproducibilityBundles[0] ?? null;
+  const latestVerification = isRecord(reproducibilityBundle?.latestVerification)
+    ? reproducibilityBundle.latestVerification
+    : null;
+
+  return (
+    <div className="space-y-4">
+      {research.error ? (
+        <div className="rounded border border-amber-500/40 bg-amber-500/10 p-4 text-sm text-amber-200">
+          {readString(research.error)}
+        </div>
+      ) : null}
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+        {summaryItem("Hypotheses", String(hypotheses.length))}
+        {summaryItem("Sources", String(sources.length))}
+        {summaryItem("Experiments", String(experiments.length))}
+        {summaryItem("Evidence bundles", String(evidenceBundles.length))}
+        {summaryItem("Repro bundles", String(reproducibilityBundles.length))}
+      </div>
+      <div className="grid gap-3 lg:grid-cols-2 xl:grid-cols-3">
+        <article className="rounded border border-border bg-surface/80 p-4">
+          <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+            Latest hypothesis
+          </p>
+          {hypothesis ? (
+            <>
+              <h3 className="mt-2 text-sm font-medium text-ink">
+                {readString(hypothesis.title) ??
+                  readString(hypothesis.hypothesisId) ??
+                  "untitled hypothesis"}
+              </h3>
+              <p className="mt-2 text-sm text-muted">
+                {readString(hypothesis.thesis) ?? "No thesis captured."}
+              </p>
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                {renderBadge(readString(hypothesis.status) ?? "candidate")}
+                <span className="text-xs text-muted">
+                  {readString(hypothesis.updatedAt) ??
+                    readString(hypothesis.createdAt) ??
+                    "n/a"}
+                </span>
+              </div>
+            </>
+          ) : (
+            <p className="mt-3 text-sm text-muted">No hypotheses recorded.</p>
+          )}
+        </article>
+        <article className="rounded border border-border bg-surface/80 p-4">
+          <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+            Latest source
+          </p>
+          {source ? (
+            <>
+              <h3 className="mt-2 text-sm font-medium text-ink">
+                {readString(source.title) ??
+                  readString(source.sourceId) ??
+                  "untitled source"}
+              </h3>
+              <p className="mt-2 text-sm text-muted">
+                {readString(source.sourceKind) ?? "unknown"} ·{" "}
+                {readString(source.canonicalUrl) ??
+                  readString(source.url) ??
+                  "no url"}
+              </p>
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                {renderBadge("pass", readString(source.sourceKind) ?? "source")}
+                <span className="text-xs text-muted">
+                  {readString(source.publishedAt) ??
+                    readString(source.retrievedAt) ??
+                    "n/a"}
+                </span>
+              </div>
+            </>
+          ) : (
+            <p className="mt-3 text-sm text-muted">
+              No research sources recorded.
+            </p>
+          )}
+        </article>
+        <article className="rounded border border-border bg-surface/80 p-4">
+          <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+            Latest experiment
+          </p>
+          {experiment ? (
+            <>
+              <h3 className="mt-2 text-sm font-medium text-ink">
+                {readString(experiment.experimentId) ?? "experiment"}
+              </h3>
+              <p className="mt-2 text-sm text-muted">
+                {readString(experiment.summary) ??
+                  "No experiment summary available."}
+              </p>
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                {renderBadge(readString(experiment.status) ?? "candidate")}
+                <span className="text-xs text-muted">
+                  {readString(experiment.completedAt) ??
+                    readString(experiment.updatedAt) ??
+                    "n/a"}
+                </span>
+              </div>
+            </>
+          ) : (
+            <p className="mt-3 text-sm text-muted">No experiments recorded.</p>
+          )}
+        </article>
+        <article className="rounded border border-border bg-surface/80 p-4">
+          <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+            Evidence bundle
+          </p>
+          {evidenceBundle ? (
+            <>
+              <h3 className="mt-2 text-sm font-medium text-ink">
+                {readString(evidenceBundle.evidenceBundleId) ??
+                  "evidence bundle"}
+              </h3>
+              <p className="mt-2 text-sm text-muted">
+                {readString(evidenceBundle.summary) ??
+                  "No evidence summary available."}
+              </p>
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                {renderBadge(readString(evidenceBundle.status) ?? "candidate")}
+                <span className="text-xs text-muted">
+                  {readString(evidenceBundle.promotionTarget) ?? "n/a"}
+                </span>
+              </div>
+            </>
+          ) : (
+            <p className="mt-3 text-sm text-muted">
+              No evidence bundles recorded.
+            </p>
+          )}
+        </article>
+        <article className="rounded border border-border bg-surface/80 p-4">
+          <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+            Reproducibility
+          </p>
+          {reproducibilityBundle ? (
+            <>
+              <h3 className="mt-2 text-sm font-medium text-ink">
+                {readString(reproducibilityBundle.reproducibilityBundleId) ??
+                  "reproducibility bundle"}
+              </h3>
+              <p className="mt-2 text-sm text-muted">
+                {readString(reproducibilityBundle.summary) ??
+                  "No reproducibility summary available."}
+              </p>
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                {renderBadge(
+                  readString(latestVerification?.status) ?? "pass",
+                  readString(latestVerification?.status) ?? "verified",
+                )}
+                <span className="text-xs text-muted">
+                  {readString(reproducibilityBundle.updatedAt) ?? "n/a"}
+                </span>
+              </div>
+            </>
+          ) : (
+            <p className="mt-3 text-sm text-muted">
+              No reproducibility bundles recorded.
+            </p>
+          )}
+        </article>
+      </div>
+    </div>
+  );
+}
+
+function renderPromotionTimeline(detail: RuntimeOperatorDetail | null) {
+  const promotions = isRecord(detail?.lab?.promotions)
+    ? detail?.lab?.promotions
+    : null;
+  const scorecard = isRecord(detail?.scorecard) ? detail.scorecard : null;
+  const strategyPromotions = promotions
+    ? readRecordArray(promotions.strategy)
+    : [];
+  const venuePromotions = promotions ? readRecordArray(promotions.venue) : [];
+  const assetPromotions = promotions ? readRecordArray(promotions.asset) : [];
+  const promotionGates = Array.isArray(scorecard?.promotionGates)
+    ? scorecard.promotionGates
+    : [];
+  if (!promotions && promotionGates.length === 0) {
+    return (
+      <div className="rounded border border-dashed border-border p-4 text-sm text-muted">
+        Promotion evidence not available yet.
+      </div>
+    );
+  }
+
+  const groups = [
+    { label: "Strategy lifecycle", items: strategyPromotions },
+    { label: "Venue readiness", items: venuePromotions },
+    { label: "Asset readiness", items: assetPromotions },
+  ];
+
+  return (
+    <div className="space-y-4">
+      {promotions?.error ? (
+        <div className="rounded border border-amber-500/40 bg-amber-500/10 p-4 text-sm text-amber-200">
+          {readString(promotions.error)}
+        </div>
+      ) : null}
+      {promotionGates.length > 0 ? (
+        <div className="grid gap-3 md:grid-cols-2">
+          {promotionGates.map((gate) => {
+            const record = isRecord(gate) ? gate : {};
+            const targetMode = readString(record.targetMode) ?? "unknown";
+            const status = readString(record.status) ?? "unknown";
+            const summary =
+              readString(record.summary) ?? "No gate summary available.";
+            return (
+              <article
+                key={`${targetMode}:${status}:${summary}`}
+                className="rounded border border-border bg-surface/80 p-4"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                      Runtime gate
+                    </p>
+                    <h3 className="mt-2 text-sm font-medium text-ink">
+                      target {targetMode}
+                    </h3>
+                  </div>
+                  {renderBadge(status)}
+                </div>
+                <p className="mt-3 text-sm text-muted">{summary}</p>
+              </article>
+            );
+          })}
+        </div>
+      ) : null}
+      <div className="grid gap-3 lg:grid-cols-3">
+        {groups.map((group) => (
+          <article
+            key={group.label}
+            className="rounded border border-border bg-surface/80 p-4"
+          >
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                  {group.label}
+                </p>
+                <h3 className="mt-2 text-sm font-medium text-ink">
+                  {group.items.length} records
+                </h3>
+              </div>
+            </div>
+            <div className="mt-3 space-y-3">
+              {group.items.length === 0 ? (
+                <p className="text-sm text-muted">No promotion records yet.</p>
+              ) : (
+                group.items.slice(0, 3).map((promotion, index) => {
+                  const record = isRecord(promotion) ? promotion : {};
+                  const status = readString(record.status) ?? "candidate";
+                  return (
+                    <div
+                      key={`${readString(record.promotionId) ?? group.label}:${index}`}
+                      className="rounded border border-border bg-paper/70 p-3"
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <p className="text-sm font-medium text-ink">
+                          {readString(record.currentState) ?? "current"} to{" "}
+                          {readString(record.targetState) ?? "target"}
+                        </p>
+                        {renderBadge(status)}
+                      </div>
+                      <p className="mt-2 text-xs text-muted">
+                        {readString(record.summary) ??
+                          "No promotion summary available."}
+                      </p>
+                      <p className="mt-2 text-xs text-muted">
+                        {readString(record.requestedBy) ?? "n/a"} ·{" "}
+                        {readString(record.updatedAt) ??
+                          readString(record.createdAt) ??
+                          "n/a"}
+                      </p>
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function renderReadinessControls(
+  detail: RuntimeOperatorDetail | null,
+  actionPending: string | null,
+  onSubjectControl?: (input: RuntimeOperatorSubjectControlInput) => void,
+  onReadinessCanary?: (input: RuntimeOperatorReadinessCanaryInput) => void,
+) {
+  const deployment = detail?.deployment ?? null;
+  const readiness = isRecord(detail?.lab?.readiness)
+    ? detail?.lab?.readiness
+    : null;
+  const subjects = [
+    isRecord(readiness?.venue) ? readiness.venue : null,
+    isRecord(readiness?.asset) ? readiness.asset : null,
+  ].filter((entry): entry is Record<string, unknown> => entry !== null);
+
+  if (!deployment || subjects.length === 0) {
+    return (
+      <div className="rounded border border-dashed border-border p-4 text-sm text-muted">
+        Venue and asset readiness controls are not available yet.
+      </div>
+    );
+  }
+
+  const assetKey =
+    deployment.pair.symbol.split("/")[0] ?? deployment.pair.baseMint;
+
+  return (
+    <div className="grid gap-4 xl:grid-cols-2">
+      {subjects.map((subject) => {
+        const subjectKind =
+          readString(subject.subjectKind) === "asset" ? "asset" : "venue";
+        const subjectKey = readString(subject.subjectKey) ?? "unknown";
+        const controls = readRecordArray(subject.controls);
+        const artifacts = readRecordArray(subject.artifacts);
+        const canaryRuns = readRecordArray(subject.canaryRuns);
+        const canaryState = isRecord(subject.canaryState)
+          ? subject.canaryState
+          : null;
+        const control = controls[0] ?? null;
+        const latestArtifact = artifacts[0] ?? null;
+        const latestCanary = canaryRuns[0] ?? null;
+        const liveAllowed = readBoolean(control?.liveAllowed, false);
+        const killSwitchEnabled = readBoolean(
+          control?.killSwitchEnabled,
+          false,
+        );
+        const liveToggleInput: RuntimeOperatorSubjectControlInput = {
+          subjectKind,
+          subjectKey,
+          liveAllowed: !liveAllowed,
+          disabledReason: liveAllowed ? "operator-disabled" : null,
+        };
+        const killToggleInput: RuntimeOperatorSubjectControlInput = {
+          subjectKind,
+          subjectKey,
+          killSwitchEnabled: !killSwitchEnabled,
+          disabledReason: killSwitchEnabled ? null : "operator-kill-switch",
+        };
+        const canaryInput: RuntimeOperatorReadinessCanaryInput = {
+          subjectKind,
+          subjectKey,
+          venueKey: deployment.venueKey,
+          assetKey,
+          pairSymbol: deployment.pair.symbol,
+          targetNotionalUsd: "5.00",
+        };
+        const liveTogglePending =
+          actionPending === buildSubjectActionKey(liveToggleInput);
+        const killTogglePending =
+          actionPending === buildSubjectActionKey(killToggleInput);
+        const canaryPending =
+          actionPending === buildReadinessCanaryActionKey(canaryInput);
+
+        return (
+          <article
+            key={`${subjectKind}:${subjectKey}`}
+            className="rounded border border-border bg-surface/80 p-4"
+          >
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                  {subjectKind} readiness
+                </p>
+                <h3 className="mt-2 text-sm font-medium text-ink">
+                  {subjectKey}
+                </h3>
+              </div>
+              {renderBadge(
+                readString(latestArtifact?.status) ??
+                  readString(latestCanary?.status) ??
+                  "candidate",
+              )}
+            </div>
+            {readString(subject.error) ? (
+              <div className="mt-3 rounded border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-200">
+                {readString(subject.error)}
+              </div>
+            ) : null}
+            <div className="mt-3 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+              {summaryItem(
+                "Live allowed",
+                liveAllowed ? "enabled" : "disabled",
+              )}
+              {summaryItem(
+                "Kill switch",
+                killSwitchEnabled ? "engaged" : "clear",
+              )}
+              {summaryItem(
+                "Readiness",
+                readString(latestArtifact?.targetState) ?? "n/a",
+              )}
+              {summaryItem(
+                "Latest canary",
+                readString(latestCanary?.status) ?? "not run",
+              )}
+            </div>
+            <div className="mt-4 grid gap-3 md:grid-cols-[1.1fr_0.9fr]">
+              <div className="rounded border border-border bg-paper/70 p-3">
+                <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                  Evidence
+                </p>
+                <p className="mt-2 text-sm text-muted">
+                  {readString(latestArtifact?.summary) ??
+                    "No readiness artifact summary available."}
+                </p>
+                <div className="mt-3 grid gap-2 text-xs text-muted">
+                  <p>
+                    canary{" "}
+                    {readString(latestArtifact?.canaryRunId) ??
+                      readString(latestCanary?.runId) ??
+                      "n/a"}
+                  </p>
+                  <p>
+                    control{" "}
+                    {readString(control?.updatedAt) ??
+                      readString(canaryState?.updatedAt) ??
+                      "n/a"}
+                  </p>
+                </div>
+              </div>
+              <div className="rounded border border-border bg-paper/70 p-3">
+                <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                  Controls
+                </p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <button
+                    className={BTN_SECONDARY}
+                    type="button"
+                    onClick={() => onSubjectControl?.(liveToggleInput)}
+                    disabled={!onSubjectControl}
+                  >
+                    {liveTogglePending
+                      ? "Updating..."
+                      : liveAllowed
+                        ? "Disable live"
+                        : "Allow live"}
+                  </button>
+                  <button
+                    className={BTN_SECONDARY}
+                    type="button"
+                    onClick={() => onSubjectControl?.(killToggleInput)}
+                    disabled={!onSubjectControl}
+                  >
+                    {killTogglePending
+                      ? "Updating..."
+                      : killSwitchEnabled
+                        ? "Clear kill switch"
+                        : "Engage kill switch"}
+                  </button>
+                  <button
+                    className={BTN_PRIMARY}
+                    type="button"
+                    onClick={() => onReadinessCanary?.(canaryInput)}
+                    disabled={!onReadinessCanary}
+                  >
+                    {canaryPending ? "Running canary..." : "Run canary"}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}
+
 export function RuntimeOperatorView({
   authenticated,
   loading,
@@ -531,6 +1065,8 @@ export function RuntimeOperatorView({
   onRefresh,
   onSelectDeployment,
   onControl,
+  onSubjectControl,
+  onReadinessCanary,
 }: RuntimeOperatorViewProps) {
   const runtime = payload?.runtime ?? null;
   const detail = payload?.detail ?? null;
@@ -571,11 +1107,11 @@ export function RuntimeOperatorView({
               Runtime operator
             </p>
             <h1 className="mt-3 text-2xl font-semibold tracking-tight text-ink">
-              Runtime deployments, runs, and live controls
+              Runtime deployments, research evidence, and promotion control
             </h1>
             <p className="mt-3 text-sm text-muted">
-              Auth-gated view of runtime health, rollout state, scorecards,
-              positions, and deployment controls.
+              Auth-gated view of runtime health, research provenance, readiness,
+              scorecards, and bounded live controls.
             </p>
           </div>
           <div className="flex gap-3">
@@ -696,6 +1232,18 @@ export function RuntimeOperatorView({
           </section>
 
           <section className="card p-5">
+            <div className="mb-4">
+              <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                Research provenance
+              </p>
+              <h2 className="mt-2 text-lg font-semibold text-ink">
+                Latest hypotheses, sources, experiments, and evidence bundles
+              </h2>
+            </div>
+            {renderResearchProvenance(detail)}
+          </section>
+
+          <section className="card p-5">
             <div className="flex flex-wrap items-start justify-between gap-4">
               <div>
                 <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
@@ -746,6 +1294,23 @@ export function RuntimeOperatorView({
           <section className="card p-5">
             <div className="mb-4">
               <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                Readiness controls
+              </p>
+              <h2 className="mt-2 text-lg font-semibold text-ink">
+                Venue and asset promotion guardrails
+              </h2>
+            </div>
+            {renderReadinessControls(
+              detail,
+              actionPending,
+              onSubjectControl,
+              onReadinessCanary,
+            )}
+          </section>
+
+          <section className="card p-5">
+            <div className="mb-4">
+              <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
                 Capital coordination
               </p>
               <h2 className="mt-2 text-lg font-semibold text-ink">
@@ -782,7 +1347,19 @@ export function RuntimeOperatorView({
           <section className="card p-5">
             <div className="mb-4">
               <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
-                Promotion evidence
+                Strategy-lab promotion state
+              </p>
+              <h2 className="mt-2 text-lg font-semibold text-ink">
+                Lifecycle transitions, approvals, and rollout status
+              </h2>
+            </div>
+            {renderPromotionTimeline(detail)}
+          </section>
+
+          <section className="card p-5">
+            <div className="mb-4">
+              <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                Runtime scorecards
               </p>
               <h2 className="mt-2 text-lg font-semibold text-ink">
                 Scorecards and rollout gates

--- a/apps/portal/app/terminal/runtime/runtime-operator-view.tsx
+++ b/apps/portal/app/terminal/runtime/runtime-operator-view.tsx
@@ -37,6 +37,13 @@ function readBoolean(value: unknown, fallback: boolean): boolean {
   return typeof value === "boolean" ? value : fallback;
 }
 
+function readRecordArray(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is Record<string, unknown> =>
+    isRecord(entry),
+  );
+}
+
 function statusClasses(status: string | null): string {
   switch (status) {
     case "healthy":
@@ -876,13 +883,10 @@ function renderReadinessControls(
   onReadinessCanary?: (input: RuntimeOperatorReadinessCanaryInput) => void,
 ) {
   const deployment = detail?.deployment ?? null;
-  const readiness = isRecord(detail?.lab?.readiness)
-    ? detail?.lab?.readiness
-    : null;
-  const subjects = [
-    isRecord(readiness?.venue) ? readiness.venue : null,
-    isRecord(readiness?.asset) ? readiness.asset : null,
-  ].filter((entry): entry is Record<string, unknown> => entry !== null);
+  const readiness = detail?.lab?.readiness ?? null;
+  const subjects = [readiness?.venue, readiness?.asset].filter(
+    (entry): entry is NonNullable<typeof entry> => entry !== null,
+  );
 
   if (!deployment || subjects.length === 0) {
     return (

--- a/apps/portal/app/terminal/runtime/types.ts
+++ b/apps/portal/app/terminal/runtime/types.ts
@@ -5,6 +5,25 @@ import type {
 } from "../../../lib/runtime-contracts";
 
 export type RuntimeControlAction = "pause" | "resume" | "kill";
+export type RuntimeSubjectKind = "venue" | "asset";
+
+export type RuntimeOperatorSubjectControlInput = {
+  subjectKind: RuntimeSubjectKind;
+  subjectKey: string;
+  liveAllowed?: boolean;
+  killSwitchEnabled?: boolean;
+  disabledReason?: string | null;
+};
+
+export type RuntimeOperatorReadinessCanaryInput = {
+  subjectKind: RuntimeSubjectKind;
+  subjectKey: string;
+  venueKey?: string;
+  assetKey?: string;
+  pairSymbol?: string;
+  adapterKey?: string;
+  targetNotionalUsd?: string;
+};
 
 export type RuntimeOperatorControls = {
   enabled: boolean;
@@ -36,6 +55,42 @@ export type RuntimeOperatorDetail = {
     totals: RuntimeLedgerSnapshot["totals"];
   } | null;
   scorecard: Record<string, unknown> | null;
+  lab: {
+    research: {
+      hypotheses: Record<string, unknown>[];
+      sources: Record<string, unknown>[];
+      experiments: Record<string, unknown>[];
+      evidenceBundles: Record<string, unknown>[];
+      reproducibilityBundles: Record<string, unknown>[];
+      error: string | null;
+    };
+    promotions: {
+      strategy: Record<string, unknown>[];
+      venue: Record<string, unknown>[];
+      asset: Record<string, unknown>[];
+      error: string | null;
+    };
+    readiness: {
+      venue: {
+        subjectKind: RuntimeSubjectKind;
+        subjectKey: string;
+        artifacts: Record<string, unknown>[];
+        controls: Record<string, unknown>[];
+        canaryRuns: Record<string, unknown>[];
+        canaryState: Record<string, unknown> | null;
+        error: string | null;
+      } | null;
+      asset: {
+        subjectKind: RuntimeSubjectKind;
+        subjectKey: string;
+        artifacts: Record<string, unknown>[];
+        controls: Record<string, unknown>[];
+        canaryRuns: Record<string, unknown>[];
+        canaryState: Record<string, unknown> | null;
+        error: string | null;
+      } | null;
+    };
+  } | null;
 };
 
 export type RuntimeOperatorApiPayload = {

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -158,6 +158,7 @@ import {
   readRuntimeDeploymentRuns,
   readRuntimePnlSummary,
   readRuntimePositionSnapshot,
+  readRuntimeResearchRegistry,
   readRuntimeScorecard,
 } from "./runtime_internal";
 import { runRuntimeResearchBriefWorkflow } from "./runtime_research_briefs";
@@ -2247,6 +2248,43 @@ const worker = {
                   error instanceof Error
                     ? error.message
                     : "ops-control-reset-failed",
+              },
+              { status: 503 },
+            ),
+            env,
+          );
+        }
+      }
+
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/admin/ops/runtime/research"
+      ) {
+        const auth = authorizeAdminRoute(request, env);
+        if (!auth.ok) {
+          return withCors(
+            json({ ok: false, error: auth.error }, { status: auth.status }),
+            env,
+          );
+        }
+        try {
+          const result = await readRuntimeResearchRegistry({
+            env,
+            strategyKey: url.searchParams.get("strategyKey") ?? undefined,
+            venueKey: url.searchParams.get("venueKey") ?? undefined,
+            assetKey: url.searchParams.get("assetKey") ?? undefined,
+            sourceId: url.searchParams.get("sourceId") ?? undefined,
+          });
+          return withCors(json(result.payload, { status: result.status }), env);
+        } catch (error) {
+          return withCors(
+            json(
+              {
+                ok: false,
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "runtime-research-registry-read-failed",
               },
               { status: 503 },
             ),

--- a/tests/browser/harness-proof.spec.ts
+++ b/tests/browser/harness-proof.spec.ts
@@ -176,6 +176,11 @@ test("runtime operator proof shows deployment detail and control affordances", a
   await expect(
     page.getByRole("heading", { name: /Runtime deployments/i }),
   ).toBeVisible();
+  await expect(
+    page.getByRole("heading", {
+      name: /Latest hypotheses, sources, experiments, and evidence bundles/i,
+    }),
+  ).toBeVisible();
   await captureCheckpoint(page, "runtime-operator-home.png");
 
   await page.getByRole("button", { name: /mean_reversion/i }).click();
@@ -183,6 +188,9 @@ test("runtime operator proof shows deployment detail and control affordances", a
     page.getByRole("heading", {
       name: "deployment_mean_reversion_paper",
     }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Run canary" }).first(),
   ).toBeVisible();
 
   await page.getByRole("button", { name: "Pause" }).click();

--- a/tests/unit/portal_runtime_operator_route.test.ts
+++ b/tests/unit/portal_runtime_operator_route.test.ts
@@ -281,6 +281,181 @@ describe("portal runtime operator route", () => {
           },
         );
       }
+      if (
+        url.includes(
+          "/api/admin/ops/runtime/research?strategyKey=dca&venueKey=jupiter&assetKey=SOL",
+        )
+      ) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            registry: {
+              hypotheses: [
+                {
+                  hypothesisId: "hyp_runtime",
+                  title: "Runtime momentum hypothesis",
+                },
+              ],
+              sources: [{ sourceId: "src_runtime", title: "Paper" }],
+              experiments: [{ experimentId: "exp_runtime" }],
+              evidenceBundles: [{ evidenceBundleId: "bundle_runtime" }],
+              reproducibilityBundles: [
+                { reproducibilityBundleId: "repro_runtime" },
+              ],
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (
+        url.includes(
+          "/api/admin/ops/runtime/research/promotions?subjectKind=strategy&subjectKey=dca&limit=5",
+        )
+      ) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            promotions: [{ promotionId: "promo_strategy_dca" }],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (
+        url.includes(
+          "/api/admin/ops/runtime/research/promotions?subjectKind=venue&subjectKey=jupiter&limit=5",
+        )
+      ) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            promotions: [{ promotionId: "promo_venue_jupiter" }],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (
+        url.includes(
+          "/api/admin/ops/runtime/research/promotions?subjectKind=asset&subjectKey=SOL&limit=5",
+        )
+      ) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            promotions: [{ promotionId: "promo_asset_sol" }],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (
+        url.includes(
+          "/api/admin/ops/runtime/research/readiness?subjectKind=venue&subjectKey=jupiter&limit=5",
+        )
+      ) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            readinessArtifacts: [{ readinessId: "ready_venue_jupiter" }],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (
+        url.includes(
+          "/api/admin/ops/runtime/research/readiness?subjectKind=asset&subjectKey=SOL&limit=5",
+        )
+      ) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            readinessArtifacts: [{ readinessId: "ready_asset_sol" }],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (
+        url.includes(
+          "/api/admin/ops/runtime/research/subject-controls?subjectKind=venue&subjectKey=jupiter&limit=5",
+        )
+      ) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            controls: [{ subjectKey: "jupiter", liveAllowed: true }],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (
+        url.includes(
+          "/api/admin/ops/runtime/research/subject-controls?subjectKind=asset&subjectKey=SOL&limit=5",
+        )
+      ) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            controls: [{ subjectKey: "SOL", liveAllowed: true }],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (
+        url.includes(
+          "/api/admin/ops/runtime/research/readiness/canary?subjectKind=venue&subjectKey=jupiter&limit=5",
+        )
+      ) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            runs: [{ runId: "canary_venue_jupiter", status: "success" }],
+            state: { updatedAt: FIXTURE_TIME },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (
+        url.includes(
+          "/api/admin/ops/runtime/research/readiness/canary?subjectKind=asset&subjectKey=SOL&limit=5",
+        )
+      ) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            runs: [{ runId: "canary_asset_sol", status: "success" }],
+            state: { updatedAt: FIXTURE_TIME },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
       throw new Error(`unexpected fetch ${url}`);
     }) as typeof fetch;
 
@@ -325,13 +500,31 @@ describe("portal runtime operator route", () => {
             reservedUsd: "5.00",
           },
         },
+        lab: {
+          research: {
+            hypotheses: [{ hypothesisId: "hyp_runtime" }],
+          },
+          promotions: {
+            strategy: [{ promotionId: "promo_strategy_dca" }],
+          },
+          readiness: {
+            venue: {
+              subjectKey: "jupiter",
+            },
+            asset: {
+              subjectKey: "SOL",
+            },
+          },
+        },
       },
     });
-    expect(seenAuthHeaders).toEqual([
-      "Bearer user-token",
-      "Bearer operator-admin",
-      "Bearer operator-admin",
-    ]);
+    expect(seenAuthHeaders[0]).toBe("Bearer user-token");
+    expect(seenAuthHeaders.slice(1)).toHaveLength(12);
+    expect(
+      seenAuthHeaders
+        .slice(1)
+        .every((value) => value === "Bearer operator-admin"),
+    ).toBe(true);
   });
 
   test("forwards runtime deployment control actions", async () => {
@@ -390,6 +583,147 @@ describe("portal runtime operator route", () => {
     await expect(response.json()).resolves.toMatchObject({
       ok: true,
       action: "pause",
+    });
+  });
+
+  test("forwards subject control actions with operator identity", async () => {
+    process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
+    process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";
+    process.env.RUNTIME_OPERATOR_USER_ALLOWLIST = "u_1";
+
+    let capturedBody = "";
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url = String(input);
+      if (url.endsWith("/api/me")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            user: { id: "u_1", email: "operator@example.com" },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (url.endsWith("/api/admin/ops/runtime/research/subject-controls")) {
+        capturedBody = String(init?.body ?? "");
+        return new Response(
+          JSON.stringify({ ok: true, control: { subjectKey: "SOL" } }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const response = await POST(
+      new Request("https://www.trader-ralph.com/api/runtime/operator", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer user-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          action: "update_subject_control",
+          subjectKind: "asset",
+          subjectKey: "SOL",
+          liveAllowed: false,
+          disabledReason: "operator-disabled",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(JSON.parse(capturedBody)).toMatchObject({
+      subjectKind: "asset",
+      subjectKey: "SOL",
+      liveAllowed: false,
+      disabledReason: "operator-disabled",
+      updatedBy: "operator@example.com",
+    });
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      control: {
+        subjectKey: "SOL",
+      },
+    });
+  });
+
+  test("forwards readiness canary actions with operator identity", async () => {
+    process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
+    process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";
+    process.env.RUNTIME_OPERATOR_USER_ALLOWLIST = "u_1";
+
+    let capturedBody = "";
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url = String(input);
+      if (url.endsWith("/api/me")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            user: { id: "u_1", email: "operator@example.com" },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (url.endsWith("/api/admin/ops/runtime/research/readiness/canary")) {
+        capturedBody = String(init?.body ?? "");
+        return new Response(
+          JSON.stringify({ ok: true, run: { runId: "readycanary_sol" } }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const response = await POST(
+      new Request("https://www.trader-ralph.com/api/runtime/operator", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer user-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          action: "run_readiness_canary",
+          subjectKind: "asset",
+          subjectKey: "SOL",
+          venueKey: "jupiter",
+          assetKey: "SOL",
+          pairSymbol: "SOL/USDC",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(JSON.parse(capturedBody)).toMatchObject({
+      subjectKind: "asset",
+      subjectKey: "SOL",
+      venueKey: "jupiter",
+      assetKey: "SOL",
+      pairSymbol: "SOL/USDC",
+      requestedBy: "operator@example.com",
+      triggerSource: "manual",
+    });
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      run: {
+        runId: "readycanary_sol",
+      },
     });
   });
 });

--- a/tests/unit/worker_runtime_research_registry_route.test.ts
+++ b/tests/unit/worker_runtime_research_registry_route.test.ts
@@ -1,0 +1,135 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Env } from "../../apps/worker/src/types";
+import {
+  createExecutionContextStub,
+  createWorkerLiveEnv,
+} from "../integration/_worker_live_test_utils";
+
+const worker = (await import("../../apps/worker/src/index")).default;
+
+function createSqliteD1Adapter(db: Database): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          return {
+            async run() {
+              const statement = db.query(sql);
+              const result = statement.run(...(params as never[])) as {
+                changes?: number;
+              };
+              return {
+                meta: {
+                  changes:
+                    typeof result.changes === "number" ? result.changes : 0,
+                },
+              };
+            },
+            async first() {
+              const statement = db.query(sql);
+              return (statement.get(...(params as never[])) as unknown) ?? null;
+            },
+            async all() {
+              const statement = db.query(sql);
+              return {
+                results: (statement.all(...(params as never[])) ??
+                  []) as unknown[],
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+function createOpsEnv(overrides?: Partial<Env>) {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA foreign_keys = ON;");
+
+  for (const migrationName of [
+    "0025_execution_fabric.sql",
+    "0026_execution_canary.sql",
+    "0027_runtime_canary.sql",
+  ]) {
+    const migrationPath = resolve(
+      import.meta.dir,
+      "..",
+      "..",
+      "apps/worker/migrations",
+      migrationName,
+    );
+    sqlite.exec(readFileSync(migrationPath, "utf8"));
+  }
+
+  const env = createWorkerLiveEnv({
+    overrides: {
+      WAITLIST_DB: createSqliteD1Adapter(sqlite),
+      ADMIN_TOKEN: "admin-secret",
+      ...overrides,
+    },
+  });
+
+  return { env, sqlite };
+}
+
+describe("worker runtime research registry route", () => {
+  test("requires admin auth", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/admin/ops/runtime/research"),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({
+        ok: false,
+        error: "auth-required",
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("returns the filtered research registry through the admin route", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/research?strategyKey=dca&venueKey=jupiter&assetKey=SOL",
+          {
+            headers: {
+              authorization: "Bearer admin-secret",
+            },
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        ok: true,
+        filters: {
+          strategyKey: "dca",
+          venueKey: "jupiter",
+          assetKey: "SOL",
+        },
+        registry: {
+          hypotheses: expect.any(Array),
+          sources: expect.any(Array),
+          experiments: expect.any(Array),
+          evidenceBundles: expect.any(Array),
+          reproducibilityBundles: expect.any(Array),
+        },
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- extend the runtime operator API to aggregate research, promotion, readiness, control, and canary artifacts through the Worker admin boundary
- add operator surface sections for research provenance, strategy-lab promotion state, and venue/asset readiness controls
- add portal route coverage for the new strategy-lab reads/writes and update the runtime proof page/browser proof expectations

## Validation
- `~/.bun/bin/bun run lint`
- `~/.bun/bin/bun x tsc --noEmit --pretty false`
- `~/.bun/bin/bun test tests/unit/portal_runtime_operator_route.test.ts`
- `cargo test --workspace`

## Notes
- local `harness:proof` is currently blocked on this machine by the Bun/Playwright toolchain (`bunx`/Playwright config preflight), so browser proof is deferred to CI for this PR
- `harness:up` is also locally blocked by Wrangler local migration setup in this environment; the app changes themselves are covered by unit/type/runtime tests and CI will exercise preview/browser lanes
