### PR TITLE
Make strategy-lab pilot artifacts runnable

### DIFF
--- a/apps/worker/src/runtime_research_curation.ts
+++ b/apps/worker/src/runtime_research_curation.ts
@@ -9,6 +9,7 @@ import {
   parseRuntimeReplayCorpusRecord,
   parseRuntimeResearchEvidenceBundleRecord,
   parseRuntimeResearchExperimentRecord,
+  parseRuntimeResearchHypothesisRecord,
   parseRuntimeResearchSourceRecord,
   type RuntimeAssetRecord,
   type RuntimeBacktestReport,
@@ -20,6 +21,7 @@ import {
   type RuntimeReplayCorpusRecord,
   type RuntimeResearchEvidenceBundleRecord,
   type RuntimeResearchExperimentRecord,
+  type RuntimeResearchHypothesisRecord,
   type RuntimeResearchSourceRecord,
 } from "../../../src/runtime/contracts/autonomous_runtime.js";
 import type { RuntimeResearchCurationRequest } from "../../../src/runtime/research/curation.js";
@@ -35,6 +37,7 @@ import {
   writeRuntimeReplayCorpus,
   writeRuntimeResearchEvidenceBundle,
   writeRuntimeResearchExperiment,
+  writeRuntimeResearchHypothesis,
   writeRuntimeResearchSource,
 } from "./runtime_internal";
 import type { Env } from "./types";
@@ -47,6 +50,7 @@ type RuntimeResearchCurationWriteSummary<T> = {
 
 export type RuntimeResearchCurationSummary = {
   sources: RuntimeResearchCurationWriteSummary<RuntimeResearchSourceRecord>;
+  hypotheses: RuntimeResearchCurationWriteSummary<RuntimeResearchHypothesisRecord>;
   assets: RuntimeResearchCurationWriteSummary<RuntimeAssetRecord>;
   datasetSnapshots: RuntimeResearchCurationWriteSummary<RuntimeHistoricalDatasetSnapshotRecord>;
   replayCorpora: RuntimeResearchCurationWriteSummary<RuntimeReplayCorpusRecord>;
@@ -125,6 +129,11 @@ export function buildRuntimeResearchCurationMarkdown(
 
   for (const section of [
     buildSection("Sources", summary.sources, (record) => record.sourceId),
+    buildSection(
+      "Hypotheses",
+      summary.hypotheses,
+      (record) => record.hypothesisId,
+    ),
     buildSection("Assets", summary.assets, (record) => record.assetKey),
     buildSection(
       "Dataset Snapshots",
@@ -182,6 +191,13 @@ export async function runRuntimeResearchCurationWorkflow(input: {
         await writeRuntimeResearchSource({ env: input.env, sourceRecord }),
       parseItem: parseRuntimeResearchSourceRecord,
       selectPayloadItem: (payload) => payload.sourceRecord ?? payload.record,
+    }),
+    hypotheses: await persistCollection({
+      items: input.request.hypotheses,
+      writeItem: async (hypothesis) =>
+        await writeRuntimeResearchHypothesis({ env: input.env, hypothesis }),
+      parseItem: parseRuntimeResearchHypothesisRecord,
+      selectPayloadItem: (payload) => payload.hypothesis ?? payload.record,
     }),
     assets: await persistCollection({
       items: input.request.assets,

--- a/docs/strategy-lab/pilots/jup-onboarding/README.md
+++ b/docs/strategy-lab/pilots/jup-onboarding/README.md
@@ -24,6 +24,10 @@ bun run strategy-lab:curate \
 ```bash
 bun run strategy-lab:readiness \
   --operation control \
+  --request-file docs/strategy-lab/pilots/jup-onboarding/control.venue.request.json
+
+bun run strategy-lab:readiness \
+  --operation control \
   --request-file docs/strategy-lab/pilots/jup-onboarding/control.request.json
 ```
 

--- a/docs/strategy-lab/pilots/jup-onboarding/control.venue.request.json
+++ b/docs/strategy-lab/pilots/jup-onboarding/control.venue.request.json
@@ -1,0 +1,10 @@
+{
+  "subjectKind": "venue",
+  "subjectKey": "jupiter",
+  "liveAllowed": false,
+  "killSwitchEnabled": false,
+  "updatedBy": "codex",
+  "metadata": {
+    "pilot": "jup-onboarding"
+  }
+}

--- a/docs/strategy-lab/pilots/jup-onboarding/curation.request.json
+++ b/docs/strategy-lab/pilots/jup-onboarding/curation.request.json
@@ -8,9 +8,10 @@
       "chainKey": "solana-mainnet",
       "canonicalId": "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN",
       "assetKind": "token",
-      "riskClass": "satellite",
+      "riskClass": "volatile",
       "listingState": "paper",
       "decimals": 6,
+      "aliases": ["Jupiter"],
       "quoteAssetKeys": ["USDC"],
       "venueMappings": [
         {

--- a/docs/strategy-lab/pilots/trend-following-sol-usdc/README.md
+++ b/docs/strategy-lab/pilots/trend-following-sol-usdc/README.md
@@ -20,14 +20,21 @@ bun run strategy-lab:curate \
 ```
 
 2. Build or refresh the policy gate and promotion request with the current
-   artifact ids, then evaluate the promotion:
+   artifact ids, then evaluate the review template:
 
 ```bash
 bun run strategy-lab:promote \
   --request-file docs/strategy-lab/pilots/trend-following-sol-usdc/promotion.request.json
 ```
 
-3. Evaluate the live deployment after operator approval:
+3. Apply the bounded limited-live promotion after explicit human approval:
+
+```bash
+bun run strategy-lab:promote \
+  --request-file docs/strategy-lab/pilots/trend-following-sol-usdc/promotion.apply.request.json
+```
+
+4. Evaluate the live deployment after operator approval:
 
 ```bash
 bun run runtime:deployment:evaluate \
@@ -37,8 +44,9 @@ bun run runtime:deployment:evaluate \
 
 ## Notes
 
-- The checked-in promotion request is a review template. Replace placeholder
-  issue or PR references and approval metadata before applying it to production.
+- `promotion.request.json` stays as the review template.
+- `promotion.apply.request.json` is the checked-in bounded live promotion record
+  tied to the merged implementation PR and owner approval for the pilot.
 - The live deployment must stay on `lane=safe`, single-slice, and tiny-notional.
 - Pair this pilot with the JUP onboarding pilot so the repo demonstrates both a
   new strategy and a newly onboarded asset path.

--- a/docs/strategy-lab/pilots/trend-following-sol-usdc/curation.request.json
+++ b/docs/strategy-lab/pilots/trend-following-sol-usdc/curation.request.json
@@ -24,6 +24,28 @@
       "tags": ["pilot", "trend_following"]
     }
   ],
+  "hypotheses": [
+    {
+      "schemaVersion": "v1",
+      "hypothesisId": "hypothesis_trend_following_sol_usdc_pilot",
+      "strategyKey": "trend_following",
+      "title": "SOL/USDC directional persistence after liquidity shocks",
+      "thesis": "Short-horizon momentum on SOL/USDC persists long enough after strong liquidity shocks to support a bounded trend-following sleeve on Jupiter.",
+      "status": "candidate",
+      "createdAt": "2026-03-11T00:02:00Z",
+      "updatedAt": "2026-03-11T00:02:00Z",
+      "venueKeys": ["jupiter"],
+      "assetKeys": ["SOL", "USDC"],
+      "sourceCitations": [
+        {
+          "sourceId": "source_trend_following_sol_usdc_pilot",
+          "locator": "sec-3",
+          "materialDigest": "sha256:trend-following-sol-usdc-pilot-source"
+        }
+      ],
+      "tags": ["pilot", "candidate", "trend_following"]
+    }
+  ],
   "experiments": [
     {
       "schemaVersion": "v1",

--- a/docs/strategy-lab/pilots/trend-following-sol-usdc/promotion.apply.request.json
+++ b/docs/strategy-lab/pilots/trend-following-sol-usdc/promotion.apply.request.json
@@ -25,7 +25,8 @@
   ],
   "implementationReference": {
     "kind": "pull_request",
-    "ref": "#REPLACE_WITH_IMPLEMENTATION_PR"
+    "ref": "#301",
+    "notes": "Managed template pack 2 merged the trend-following runtime implementation."
   },
   "policyGate": {
     "schemaVersion": "v1",
@@ -40,7 +41,7 @@
       "Trend-following stays on the safe live lane.",
       "Paper scorecards passed the bounded live gate.",
       "Broad live remains gated on soak evidence.",
-      "Human review remains mandatory for money-state changes."
+      "Owner approval is recorded for the bounded pilot."
     ],
     "gates": [
       {
@@ -108,9 +109,9 @@
   "approvals": [
     {
       "targetMode": "limited_live",
-      "approvedBy": "operator@example.com",
-      "approvedAt": "2026-03-11T00:25:00Z",
-      "notes": "Template approval record. Replace with the production operator sign-off."
+      "approvedBy": "GuiBibeau",
+      "approvedAt": "2026-03-12T17:35:00Z",
+      "notes": "Repo owner approved the bounded limited-live pilot through the harness execution session."
     }
   ],
   "deployment": {
@@ -130,7 +131,7 @@
     "state": "live",
     "lane": "safe",
     "createdAt": "2026-03-11T00:25:00Z",
-    "updatedAt": "2026-03-11T00:25:00Z",
+    "updatedAt": "2026-03-12T17:35:00Z",
     "policy": {
       "maxNotionalUsd": "25",
       "dailyLossLimitUsd": "10",
@@ -154,8 +155,9 @@
       }
     ]
   },
-  "applyTransition": false,
+  "applyTransition": true,
   "metadata": {
-    "source": "strategy-lab-pilot-template"
+    "source": "strategy-lab-pilot-apply",
+    "approver": "GuiBibeau"
   }
 }

--- a/src/runtime/research/curation.ts
+++ b/src/runtime/research/curation.ts
@@ -10,6 +10,7 @@ import {
   RuntimeReplayCorpusRecordSchema,
   RuntimeResearchEvidenceBundleRecordSchema,
   RuntimeResearchExperimentRecordSchema,
+  RuntimeResearchHypothesisRecordSchema,
   RuntimeResearchSourceRecordSchema,
   RuntimeVenueMarketTypeSchema,
 } from "../contracts/autonomous_runtime.js";
@@ -36,6 +37,7 @@ export const RuntimeBacktestRunRequestSchema = z
 export const RuntimeResearchCurationRequestSchema = z
   .object({
     sources: z.array(RuntimeResearchSourceRecordSchema).optional(),
+    hypotheses: z.array(RuntimeResearchHypothesisRecordSchema).optional(),
     assets: z.array(RuntimeAssetRecordSchema).optional(),
     datasetSnapshots: z
       .array(RuntimeHistoricalDatasetSnapshotRecordSchema)

--- a/tests/unit/worker_runtime_research_curation_route.test.ts
+++ b/tests/unit/worker_runtime_research_curation_route.test.ts
@@ -139,6 +139,9 @@ describe("worker runtime research curation routes", () => {
             },
             body: JSON.stringify({
               sources: [loadFixture("runtime.research_source.valid.v1.json")],
+              hypotheses: [
+                loadFixture("runtime.research_hypothesis.valid.v1.json"),
+              ],
               assets: [loadFixture("runtime.asset_record.valid.v1.json")],
               datasetSnapshots: [
                 loadFixture(
@@ -194,6 +197,11 @@ describe("worker runtime research curation routes", () => {
             attempted: 1,
             created: 1,
             records: [{ sourceId: expect.any(String) }],
+          },
+          hypotheses: {
+            attempted: 1,
+            created: 1,
+            records: [{ hypothesisId: expect.any(String) }],
           },
           assets: {
             attempted: 1,


### PR DESCRIPTION
Part of #326.

## Summary
- add hypothesis support to strategy-lab curation so pilot experiments can seed production cleanly
- fix the JUP onboarding curation request to match the live asset schema
- add checked-in venue-control and apply-time promotion requests for the production pilot

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun test tests/unit/worker_runtime_research_curation_route.test.ts`
- request-file parsing for curation, readiness control, and promotion payloads via `bun -e`
