### PR TITLE
Normalize runtime curation response records

### DIFF
--- a/apps/worker/src/runtime_research_curation.ts
+++ b/apps/worker/src/runtime_research_curation.ts
@@ -72,6 +72,18 @@ function createdFromResponse(response: RuntimeInternalJsonResult): boolean {
   return response.payload.created === true || response.status === 201;
 }
 
+export function resolvePersistedCollectionRecord<T>(input: {
+  payloadValue: unknown;
+  fallbackValue: T;
+  parseItem: (value: unknown) => T;
+}): T {
+  try {
+    return input.parseItem(input.payloadValue ?? input.fallbackValue);
+  } catch {
+    return input.parseItem(input.fallbackValue);
+  }
+}
+
 async function persistCollection<T>(input: {
   items: T[] | undefined;
   writeItem: (item: T) => Promise<RuntimeInternalJsonResult>;
@@ -95,7 +107,13 @@ async function persistCollection<T>(input: {
       created += 1;
     }
     const payloadValue = input.selectPayloadItem(response.payload);
-    records.push(input.parseItem(payloadValue ?? item));
+    records.push(
+      resolvePersistedCollectionRecord({
+        payloadValue,
+        fallbackValue: item,
+        parseItem: input.parseItem,
+      }),
+    );
   }
 
   return {

--- a/tests/unit/runtime_research_curation.test.ts
+++ b/tests/unit/runtime_research_curation.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { resolvePersistedCollectionRecord } from "../../apps/worker/src/runtime_research_curation";
+import {
+  parseRuntimeAssetRecord,
+  parseRuntimeResearchExperimentRecord,
+} from "../../src/runtime/contracts/autonomous_runtime.js";
+
+function loadFixture<T>(filename: string): T {
+  return JSON.parse(
+    readFileSync(
+      resolve(
+        import.meta.dir,
+        "..",
+        "..",
+        "docs",
+        "runtime-contracts",
+        "fixtures",
+        filename,
+      ),
+      "utf8",
+    ),
+  ) as T;
+}
+
+describe("resolvePersistedCollectionRecord", () => {
+  test("falls back to the original asset when the persisted response uses null optional fields", () => {
+    const asset = loadFixture<Record<string, unknown>>(
+      "runtime.asset_record.valid.v1.json",
+    );
+    const persisted = {
+      ...asset,
+      promotedAt: null,
+      pausedAt: null,
+      deprecatedAt: null,
+    };
+
+    const resolved = resolvePersistedCollectionRecord({
+      payloadValue: persisted,
+      fallbackValue: parseRuntimeAssetRecord(asset),
+      parseItem: parseRuntimeAssetRecord,
+    });
+
+    expect(resolved.assetKey).toBe("SOL");
+    expect(resolved.aliases).toEqual(["WSOL"]);
+  });
+
+  test("falls back to the original experiment when the persisted response adds null citation notes", () => {
+    const experiment = loadFixture<Record<string, unknown>>(
+      "runtime.research_experiment.valid.v1.json",
+    );
+    const sourceCitations = Array.isArray(experiment.sourceCitations)
+      ? experiment.sourceCitations
+      : [];
+    const persisted = {
+      ...experiment,
+      sourceCitations: sourceCitations.map((citation) => ({
+        ...citation,
+        notes: null,
+      })),
+    };
+
+    const resolved = resolvePersistedCollectionRecord({
+      payloadValue: persisted,
+      fallbackValue: parseRuntimeResearchExperimentRecord(experiment),
+      parseItem: parseRuntimeResearchExperimentRecord,
+    });
+
+    expect(resolved.experimentId).toBe("experiment_signal_trend_shadow");
+    expect(resolved.sourceCitations[0]?.sourceId).toBe(
+      "source_paper_microstructure",
+    );
+  });
+});


### PR DESCRIPTION
Part of #326.

## Summary
- make strategy-lab curation tolerate nullable optional fields returned by production runtime writes
- fall back to the original validated request record when the persisted response is noisier than the strict schema
- add regression coverage for nullable asset and experiment response payloads

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun test tests/unit/runtime_research_curation.test.ts tests/unit/worker_runtime_research_curation_route.test.ts`
