### PR TITLE
Unblock same-request strategy-lab curation pilots

### DIFF
--- a/apps/worker/src/runtime_research_curation.ts
+++ b/apps/worker/src/runtime_research_curation.ts
@@ -68,6 +68,36 @@ export type RuntimeResearchCurationWorkflowResult = {
   markdown: string;
 };
 
+export type RuntimeResearchCurationIo = {
+  writeRuntimeResearchSource: typeof writeRuntimeResearchSource;
+  writeRuntimeResearchHypothesis: typeof writeRuntimeResearchHypothesis;
+  writeRuntimeAsset: typeof writeRuntimeAsset;
+  writeRuntimeHistoricalDatasetSnapshot: typeof writeRuntimeHistoricalDatasetSnapshot;
+  writeRuntimeReplayCorpus: typeof writeRuntimeReplayCorpus;
+  writeRuntimeFeatureDefinition: typeof writeRuntimeFeatureDefinition;
+  writeRuntimeRegimeTag: typeof writeRuntimeRegimeTag;
+  writeRuntimeExecutionCostModel: typeof writeRuntimeExecutionCostModel;
+  writeRuntimeExecutionCostObservation: typeof writeRuntimeExecutionCostObservation;
+  writeRuntimeResearchExperiment: typeof writeRuntimeResearchExperiment;
+  runRuntimeBacktest: typeof runRuntimeBacktest;
+  writeRuntimeResearchEvidenceBundle: typeof writeRuntimeResearchEvidenceBundle;
+};
+
+const defaultRuntimeResearchCurationIo: RuntimeResearchCurationIo = {
+  writeRuntimeResearchSource,
+  writeRuntimeResearchHypothesis,
+  writeRuntimeAsset,
+  writeRuntimeHistoricalDatasetSnapshot,
+  writeRuntimeReplayCorpus,
+  writeRuntimeFeatureDefinition,
+  writeRuntimeRegimeTag,
+  writeRuntimeExecutionCostModel,
+  writeRuntimeExecutionCostObservation,
+  writeRuntimeResearchExperiment,
+  runRuntimeBacktest,
+  writeRuntimeResearchEvidenceBundle,
+};
+
 function createdFromResponse(response: RuntimeInternalJsonResult): boolean {
   return response.payload.created === true || response.status === 201;
 }
@@ -201,33 +231,35 @@ export function buildRuntimeResearchCurationMarkdown(
 export async function runRuntimeResearchCurationWorkflow(input: {
   env: Env;
   request: RuntimeResearchCurationRequest;
+  io?: RuntimeResearchCurationIo;
 }): Promise<RuntimeResearchCurationWorkflowResult> {
+  const io = input.io ?? defaultRuntimeResearchCurationIo;
   const summary: RuntimeResearchCurationSummary = {
     sources: await persistCollection({
       items: input.request.sources,
       writeItem: async (sourceRecord) =>
-        await writeRuntimeResearchSource({ env: input.env, sourceRecord }),
+        await io.writeRuntimeResearchSource({ env: input.env, sourceRecord }),
       parseItem: parseRuntimeResearchSourceRecord,
       selectPayloadItem: (payload) => payload.sourceRecord ?? payload.record,
     }),
     hypotheses: await persistCollection({
       items: input.request.hypotheses,
       writeItem: async (hypothesis) =>
-        await writeRuntimeResearchHypothesis({ env: input.env, hypothesis }),
+        await io.writeRuntimeResearchHypothesis({ env: input.env, hypothesis }),
       parseItem: parseRuntimeResearchHypothesisRecord,
       selectPayloadItem: (payload) => payload.hypothesis ?? payload.record,
     }),
     assets: await persistCollection({
       items: input.request.assets,
       writeItem: async (asset) =>
-        await writeRuntimeAsset({ env: input.env, asset }),
+        await io.writeRuntimeAsset({ env: input.env, asset }),
       parseItem: parseRuntimeAssetRecord,
       selectPayloadItem: (payload) => payload.asset ?? payload.record,
     }),
     datasetSnapshots: await persistCollection({
       items: input.request.datasetSnapshots,
       writeItem: async (datasetSnapshot) =>
-        await writeRuntimeHistoricalDatasetSnapshot({
+        await io.writeRuntimeHistoricalDatasetSnapshot({
           env: input.env,
           datasetSnapshot,
         }),
@@ -237,14 +269,14 @@ export async function runRuntimeResearchCurationWorkflow(input: {
     replayCorpora: await persistCollection({
       items: input.request.replayCorpora,
       writeItem: async (replayCorpus) =>
-        await writeRuntimeReplayCorpus({ env: input.env, replayCorpus }),
+        await io.writeRuntimeReplayCorpus({ env: input.env, replayCorpus }),
       parseItem: parseRuntimeReplayCorpusRecord,
       selectPayloadItem: (payload) => payload.replayCorpus ?? payload.record,
     }),
     featureDefinitions: await persistCollection({
       items: input.request.featureDefinitions,
       writeItem: async (featureDefinition) =>
-        await writeRuntimeFeatureDefinition({
+        await io.writeRuntimeFeatureDefinition({
           env: input.env,
           featureDefinition,
         }),
@@ -255,14 +287,14 @@ export async function runRuntimeResearchCurationWorkflow(input: {
     regimeTags: await persistCollection({
       items: input.request.regimeTags,
       writeItem: async (regimeTag) =>
-        await writeRuntimeRegimeTag({ env: input.env, regimeTag }),
+        await io.writeRuntimeRegimeTag({ env: input.env, regimeTag }),
       parseItem: parseRuntimeRegimeTagRecord,
       selectPayloadItem: (payload) => payload.regimeTag ?? payload.record,
     }),
     costModels: await persistCollection({
       items: input.request.costModels,
       writeItem: async (costModel) =>
-        await writeRuntimeExecutionCostModel({
+        await io.writeRuntimeExecutionCostModel({
           env: input.env,
           costModel,
         }),
@@ -272,7 +304,7 @@ export async function runRuntimeResearchCurationWorkflow(input: {
     costObservations: await persistCollection({
       items: input.request.costObservations,
       writeItem: async (costObservation) =>
-        await writeRuntimeExecutionCostObservation({
+        await io.writeRuntimeExecutionCostObservation({
           env: input.env,
           costObservation,
         }),
@@ -282,26 +314,28 @@ export async function runRuntimeResearchCurationWorkflow(input: {
     experiments: await persistCollection({
       items: input.request.experiments,
       writeItem: async (experiment) =>
-        await writeRuntimeResearchExperiment({ env: input.env, experiment }),
+        await io.writeRuntimeResearchExperiment({ env: input.env, experiment }),
       parseItem: parseRuntimeResearchExperimentRecord,
       selectPayloadItem: (payload) => payload.experiment ?? payload.record,
     }),
+    backtests: await persistCollection({
+      items: input.request.backtests,
+      writeItem: async (payload) =>
+        await io.runRuntimeBacktest({ env: input.env, payload }),
+      parseItem: parseRuntimeBacktestReport,
+      selectPayloadItem: (payload) => payload.report ?? payload.record,
+    }),
+    // Backtests must be persisted before evidence bundles so same-request
+    // promotions can reference freshly created runtime-backtest artifacts.
     evidenceBundles: await persistCollection({
       items: input.request.evidenceBundles,
       writeItem: async (evidenceBundle) =>
-        await writeRuntimeResearchEvidenceBundle({
+        await io.writeRuntimeResearchEvidenceBundle({
           env: input.env,
           evidenceBundle,
         }),
       parseItem: parseRuntimeResearchEvidenceBundleRecord,
       selectPayloadItem: (payload) => payload.evidenceBundle ?? payload.record,
-    }),
-    backtests: await persistCollection({
-      items: input.request.backtests,
-      writeItem: async (payload) =>
-        await runRuntimeBacktest({ env: input.env, payload }),
-      parseItem: parseRuntimeBacktestReport,
-      selectPayloadItem: (payload) => payload.report ?? payload.record,
     }),
   };
 

--- a/docs/strategy-lab/pilots/jup-onboarding/curation.request.json
+++ b/docs/strategy-lab/pilots/jup-onboarding/curation.request.json
@@ -1,4 +1,51 @@
 {
+  "sources": [
+    {
+      "schemaVersion": "v1",
+      "sourceId": "source_jup_usdc_onboarding_pilot",
+      "sourceKind": "article",
+      "title": "Operational checklist for JUP/USDC bounded onboarding",
+      "url": "https://example.com/research/jup-usdc-onboarding-checklist",
+      "canonicalUrl": "https://example.com/research/jup-usdc-onboarding-checklist",
+      "authors": ["Ralph Ops"],
+      "publishedAt": "2026-03-10T00:00:00Z",
+      "retrievedAt": "2026-03-11T00:00:00Z",
+      "contentDigest": "sha256:jup-onboarding-source",
+      "provenance": {
+        "acquisitionKind": "manual_url",
+        "collectedFrom": "https://example.com/research/jup-usdc-onboarding-checklist",
+        "hostname": "example.com",
+        "publisher": "Example Research",
+        "firstSeenAt": "2026-03-11T00:00:00Z",
+        "lastSeenAt": "2026-03-11T00:00:00Z"
+      },
+      "venueKeys": ["jupiter"],
+      "assetKeys": ["JUP", "USDC"],
+      "tags": ["pilot", "asset-onboarding"]
+    }
+  ],
+  "hypotheses": [
+    {
+      "schemaVersion": "v1",
+      "hypothesisId": "hypothesis_jup_usdc_onboarding",
+      "strategyKey": "dca",
+      "title": "Bounded DCA flow remains safe for JUP onboarding",
+      "thesis": "A tiny-notional DCA sleeve on JUP/USDC can be onboarded safely when replay, readiness, and cost controls remain inside the bounded paper thresholds.",
+      "status": "candidate",
+      "createdAt": "2026-03-11T00:05:00Z",
+      "updatedAt": "2026-03-11T00:05:00Z",
+      "venueKeys": ["jupiter"],
+      "assetKeys": ["JUP", "USDC"],
+      "sourceCitations": [
+        {
+          "sourceId": "source_jup_usdc_onboarding_pilot",
+          "locator": "ops-checklist",
+          "materialDigest": "sha256:jup-onboarding-source"
+        }
+      ],
+      "tags": ["pilot", "candidate", "asset-onboarding"]
+    }
+  ],
   "assets": [
     {
       "schemaVersion": "v1",
@@ -264,7 +311,13 @@
       "completedAt": "2026-03-11T00:15:00Z",
       "venueKeys": ["jupiter"],
       "assetKeys": ["JUP", "USDC"],
-      "sourceCitations": [],
+      "sourceCitations": [
+        {
+          "sourceId": "source_jup_usdc_onboarding_pilot",
+          "locator": "ops-checklist",
+          "materialDigest": "sha256:jup-onboarding-source"
+        }
+      ],
       "codeRevision": {
         "vcs": "git",
         "repository": "github.com/GuiBibeau/serious-trader-ralph",
@@ -305,7 +358,13 @@
       "updatedAt": "2026-03-11T00:20:00Z",
       "venueKeys": ["jupiter"],
       "assetKeys": ["JUP", "USDC"],
-      "sourceCitations": [],
+      "sourceCitations": [
+        {
+          "sourceId": "source_jup_usdc_onboarding_pilot",
+          "locator": "ops-checklist",
+          "materialDigest": "sha256:jup-onboarding-source"
+        }
+      ],
       "codeRevision": {
         "vcs": "git",
         "repository": "github.com/GuiBibeau/serious-trader-ralph",
@@ -322,6 +381,13 @@
         }
       ],
       "artifacts": [
+        {
+          "artifactId": "backtest-report",
+          "kind": "backtest-report",
+          "uri": "runtime-backtest://backtest_jup_usdc_onboarding",
+          "contentDigest": "sha256:jup-onboarding-backtest",
+          "createdAt": "2026-03-11T00:20:00Z"
+        },
         {
           "artifactId": "jup-onboarding-proof",
           "kind": "proof-bundle",

--- a/docs/strategy-lab/pilots/trend-following-sol-usdc/curation.request.json
+++ b/docs/strategy-lab/pilots/trend-following-sol-usdc/curation.request.json
@@ -129,6 +129,13 @@
       ],
       "artifacts": [
         {
+          "artifactId": "backtest-report",
+          "kind": "backtest-report",
+          "uri": "runtime-backtest://backtest_trend_following_sol_usdc_pilot",
+          "contentDigest": "sha256:trend-following-sol-usdc-backtest",
+          "createdAt": "2026-03-11T00:15:00Z"
+        },
+        {
           "artifactId": "trend-following-sol-usdc-proof",
           "kind": "proof-bundle",
           "uri": "repo://docs/strategy-lab/pilots/trend-following-sol-usdc/README.md",

--- a/tests/unit/runtime_research_curation_order.test.ts
+++ b/tests/unit/runtime_research_curation_order.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  type RuntimeResearchCurationIo,
+  runRuntimeResearchCurationWorkflow,
+} from "../../apps/worker/src/runtime_research_curation";
+import { parseRuntimeResearchCurationRequest } from "../../src/runtime/research/curation.js";
+
+const callOrder: string[] = [];
+
+function loadFixture<T>(filename: string): T {
+  return JSON.parse(
+    readFileSync(
+      resolve(
+        import.meta.dir,
+        "..",
+        "..",
+        "docs",
+        "runtime-contracts",
+        "fixtures",
+        filename,
+      ),
+      "utf8",
+    ),
+  ) as T;
+}
+
+function writeResult(
+  key: string,
+  value: unknown,
+): Promise<{
+  ok: true;
+  status: number;
+  payload: Record<string, unknown>;
+}> {
+  return Promise.resolve({
+    ok: true,
+    status: 201,
+    payload: {
+      created: true,
+      [key]: value,
+    },
+  });
+}
+
+const io: RuntimeResearchCurationIo = {
+  writeRuntimeResearchSource: mock(async ({ sourceRecord }) => {
+    callOrder.push("source");
+    return await writeResult("sourceRecord", sourceRecord);
+  }),
+  writeRuntimeResearchHypothesis: mock(async ({ hypothesis }) => {
+    callOrder.push("hypothesis");
+    return await writeResult("hypothesis", hypothesis);
+  }),
+  writeRuntimeAsset: mock(async ({ asset }) => {
+    callOrder.push("asset");
+    return await writeResult("asset", asset);
+  }),
+  writeRuntimeHistoricalDatasetSnapshot: mock(async ({ datasetSnapshot }) => {
+    callOrder.push("datasetSnapshot");
+    return await writeResult("datasetSnapshot", datasetSnapshot);
+  }),
+  writeRuntimeReplayCorpus: mock(async ({ replayCorpus }) => {
+    callOrder.push("replayCorpus");
+    return await writeResult("replayCorpus", replayCorpus);
+  }),
+  writeRuntimeFeatureDefinition: mock(async ({ featureDefinition }) => {
+    callOrder.push("featureDefinition");
+    return await writeResult("featureDefinition", featureDefinition);
+  }),
+  writeRuntimeRegimeTag: mock(async ({ regimeTag }) => {
+    callOrder.push("regimeTag");
+    return await writeResult("regimeTag", regimeTag);
+  }),
+  writeRuntimeExecutionCostModel: mock(async ({ costModel }) => {
+    callOrder.push("costModel");
+    return await writeResult("costModel", costModel);
+  }),
+  writeRuntimeExecutionCostObservation: mock(async ({ costObservation }) => {
+    callOrder.push("costObservation");
+    return await writeResult("costObservation", costObservation);
+  }),
+  writeRuntimeResearchExperiment: mock(async ({ experiment }) => {
+    callOrder.push("experiment");
+    return await writeResult("experiment", experiment);
+  }),
+  runRuntimeBacktest: mock(async ({ payload }) => {
+    callOrder.push("backtest");
+    const fixture = loadFixture<Record<string, unknown>>(
+      "runtime.backtest_report.valid.v1.json",
+    );
+    const config =
+      typeof fixture.config === "object" && fixture.config !== null
+        ? (fixture.config as Record<string, unknown>)
+        : {};
+    const report = {
+      ...fixture,
+      reportId: payload.reportId ?? "backtest_report_seed",
+      experimentId: payload.experimentId,
+      config: {
+        ...config,
+        replayCorpusId: payload.replayCorpusId,
+        venueKey: payload.venueKey,
+        pairSymbol: payload.pairSymbol,
+        marketType: payload.marketType,
+        windowMode: payload.windowMode,
+        trainingWindowObservations: payload.trainingWindowObservations,
+        testingWindowObservations: payload.testingWindowObservations,
+        stepObservations: payload.stepObservations,
+        purgeObservations: payload.purgeObservations,
+        baselineStrategies: payload.baselineStrategies,
+      },
+    };
+    return await writeResult("report", report);
+  }),
+  writeRuntimeResearchEvidenceBundle: mock(async ({ evidenceBundle }) => {
+    callOrder.push("evidenceBundle");
+    return await writeResult("evidenceBundle", evidenceBundle);
+  }),
+};
+
+describe("runRuntimeResearchCurationWorkflow", () => {
+  beforeEach(() => {
+    callOrder.length = 0;
+    for (const fn of Object.values(io)) {
+      fn.mockClear();
+    }
+  });
+
+  test("runs backtests before persisting evidence bundles in same-request curation", async () => {
+    const request = parseRuntimeResearchCurationRequest(
+      JSON.parse(
+        readFileSync(
+          resolve(
+            import.meta.dir,
+            "..",
+            "..",
+            "docs",
+            "strategy-lab",
+            "pilots",
+            "trend-following-sol-usdc",
+            "curation.request.json",
+          ),
+          "utf8",
+        ),
+      ),
+    );
+
+    const result = await runRuntimeResearchCurationWorkflow({
+      env: {} as never,
+      request,
+      io,
+    });
+
+    expect(result.summary.backtests.created).toBe(1);
+    expect(result.summary.evidenceBundles.created).toBe(1);
+    expect(callOrder.indexOf("backtest")).toBeGreaterThan(
+      callOrder.indexOf("experiment"),
+    );
+    expect(callOrder.indexOf("evidenceBundle")).toBeGreaterThan(
+      callOrder.indexOf("backtest"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- run strategy-lab backtests before evidence bundle writes in the worker curation workflow
- make the JUP onboarding pilot a complete research path with a source, hypothesis, and backtest-linked paper evidence bundle
- attach runtime-backtest artifacts to both pilot evidence bundles and add a regression test for curation ordering

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun test tests/unit/runtime_research_curation.test.ts tests/unit/runtime_research_curation_order.test.ts tests/unit/worker_runtime_research_curation_route.test.ts`
- schema-parse both pilot curation requests with `parseRuntimeResearchCurationRequest`

Refs #326
