### PR TITLE
Fix runtime backtest fixture resolution

### DIFF
--- a/crates/backtesting-engine/src/lib.rs
+++ b/crates/backtesting-engine/src/lib.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    env,
-    fs,
+    env, fs,
     path::{Path, PathBuf},
 };
 
@@ -866,7 +865,10 @@ fn load_replay_fixture(
 fn resolve_fixture_uri(uri: &str) -> Result<PathBuf, BacktestingEngineError> {
     let without_fragment = uri.split('#').next().unwrap_or(uri);
     if let Some(relative) = without_fragment.strip_prefix("repo://") {
-        return Ok(resolve_repo_relative_path(relative, &candidate_repo_roots()));
+        return Ok(resolve_repo_relative_path(
+            relative,
+            &candidate_repo_roots(),
+        ));
     }
     let candidate = PathBuf::from(without_fragment);
     if candidate.is_absolute() {
@@ -1271,13 +1273,10 @@ mod tests {
             "backtesting-engine-resolve-{}",
             OffsetDateTime::now_utc().unix_timestamp_nanos()
         ));
-        let fixture = root.join("services/runtime-rs/fixtures/runtime-feed-replay.sol_usdc.v1.json");
-        fs::create_dir_all(
-            fixture
-                .parent()
-                .expect("fixture parent directory to exist"),
-        )
-        .expect("fixture directory");
+        let fixture =
+            root.join("services/runtime-rs/fixtures/runtime-feed-replay.sol_usdc.v1.json");
+        fs::create_dir_all(fixture.parent().expect("fixture parent directory to exist"))
+            .expect("fixture directory");
         fs::write(&fixture, "{}").expect("fixture file");
 
         let resolved = resolve_repo_relative_path(

--- a/crates/backtesting-engine/src/lib.rs
+++ b/crates/backtesting-engine/src/lib.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
+    env,
     fs,
     path::{Path, PathBuf},
 };
@@ -865,7 +866,7 @@ fn load_replay_fixture(
 fn resolve_fixture_uri(uri: &str) -> Result<PathBuf, BacktestingEngineError> {
     let without_fragment = uri.split('#').next().unwrap_or(uri);
     if let Some(relative) = without_fragment.strip_prefix("repo://") {
-        return Ok(repo_root().join(relative));
+        return Ok(resolve_repo_relative_path(relative, &candidate_repo_roots()));
     }
     let candidate = PathBuf::from(without_fragment);
     if candidate.is_absolute() {
@@ -878,6 +879,30 @@ fn resolve_fixture_uri(uri: &str) -> Result<PathBuf, BacktestingEngineError> {
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn candidate_repo_roots() -> Vec<PathBuf> {
+    let mut candidates = vec![repo_root()];
+    if let Ok(current_dir) = env::current_dir() {
+        if !candidates.iter().any(|candidate| candidate == &current_dir) {
+            candidates.push(current_dir);
+        }
+    }
+    candidates
+}
+
+fn resolve_repo_relative_path(relative: &str, roots: &[PathBuf]) -> PathBuf {
+    for root in roots {
+        let candidate = root.join(relative);
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+    roots
+        .first()
+        .cloned()
+        .unwrap_or_else(PathBuf::new)
+        .join(relative)
 }
 
 fn default_feature_cache_config() -> FeatureCacheConfig {
@@ -1238,6 +1263,31 @@ mod tests {
     fn fixture_uri() -> String {
         "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json"
             .to_string()
+    }
+
+    #[test]
+    fn resolves_repo_fixtures_from_working_directory_when_manifest_root_is_missing() {
+        let root = std::env::temp_dir().join(format!(
+            "backtesting-engine-resolve-{}",
+            OffsetDateTime::now_utc().unix_timestamp_nanos()
+        ));
+        let fixture = root.join("services/runtime-rs/fixtures/runtime-feed-replay.sol_usdc.v1.json");
+        fs::create_dir_all(
+            fixture
+                .parent()
+                .expect("fixture parent directory to exist"),
+        )
+        .expect("fixture directory");
+        fs::write(&fixture, "{}").expect("fixture file");
+
+        let resolved = resolve_repo_relative_path(
+            "services/runtime-rs/fixtures/runtime-feed-replay.sol_usdc.v1.json",
+            &[root.join("missing-root"), root.clone()],
+        );
+
+        assert_eq!(resolved, fixture);
+
+        fs::remove_dir_all(root).expect("cleanup temp fixture directory");
     }
 
     fn experiment() -> RuntimeResearchExperimentRecord {

--- a/docs/strategy-lab/pilots/jup-onboarding/curation.request.json
+++ b/docs/strategy-lab/pilots/jup-onboarding/curation.request.json
@@ -83,39 +83,67 @@
   "datasetSnapshots": [
     {
       "schemaVersion": "v1",
-      "datasetId": "dataset_feed_replay_jup_usdc_market_events",
-      "snapshotId": "snapshot_2026_03_07_seed",
+      "datasetId": "dataset_feature_cache_jup_usdc_market_events",
+      "snapshotId": "snapshot_2026_03_07_backtest",
       "datasetKind": "market_events",
       "normalizationKind": "replay_ready",
       "format": "fixture_json",
-      "retentionClass": "seed",
+      "retentionClass": "research",
       "capturedAt": "2026-03-11T00:00:00Z",
       "coverageStartAt": "2026-03-07T00:00:00Z",
-      "coverageEndAt": "2026-03-07T00:00:05Z",
-      "rowCount": 2,
+      "coverageEndAt": "2026-03-07T00:00:25Z",
+      "rowCount": 6,
       "venueKeys": ["jupiter"],
       "assetKeys": ["JUP", "USDC"],
       "pairSymbols": ["JUP/USDC"],
       "chainKeys": ["solana-mainnet"],
-      "uri": "repo://services/runtime-rs/fixtures/runtime-feed-replay.jup_usdc.v1.json#marketEvents",
-      "contentDigest": "sha256:jup-feed-fixture",
+      "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.jup_usdc.v1.json#marketEvents",
+      "contentDigest": "sha256:jup-feature-fixture",
       "provenance": {
         "acquisitionKind": "research_fixture",
-        "collectedFrom": "services/runtime-rs/fixtures/runtime-feed-replay.jup_usdc.v1.json",
+        "collectedFrom": "services/runtime-rs/fixtures/runtime-feature-cache-replay.jup_usdc.v1.json",
         "provider": "repo-fixture",
         "collectedAt": "2026-03-11T00:00:00Z",
         "generator": "runtime-rs",
-        "generatorRevision": "jup-feed-replay-seed-v1"
+        "generatorRevision": "jup-feature-cache-seed-v1"
       },
-      "tags": ["seed", "deterministic", "replay"]
+      "tags": ["seed", "deterministic", "feature-cache"]
+    },
+    {
+      "schemaVersion": "v1",
+      "datasetId": "dataset_feature_cache_jup_usdc_slot_events",
+      "snapshotId": "snapshot_2026_03_07_backtest",
+      "datasetKind": "slot_events",
+      "normalizationKind": "replay_ready",
+      "format": "fixture_json",
+      "retentionClass": "research",
+      "capturedAt": "2026-03-11T00:00:00Z",
+      "coverageStartAt": "2026-03-07T00:00:23Z",
+      "coverageEndAt": "2026-03-07T00:00:25Z",
+      "rowCount": 3,
+      "venueKeys": ["helius"],
+      "assetKeys": ["JUP", "USDC"],
+      "pairSymbols": ["JUP/USDC"],
+      "chainKeys": ["solana-mainnet"],
+      "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.jup_usdc.v1.json#slotEvents",
+      "contentDigest": "sha256:jup-feature-fixture",
+      "provenance": {
+        "acquisitionKind": "research_fixture",
+        "collectedFrom": "services/runtime-rs/fixtures/runtime-feature-cache-replay.jup_usdc.v1.json",
+        "provider": "repo-fixture",
+        "collectedAt": "2026-03-11T00:00:00Z",
+        "generator": "runtime-rs",
+        "generatorRevision": "jup-feature-cache-seed-v1"
+      },
+      "tags": ["seed", "deterministic", "feature-cache"]
     }
   ],
   "replayCorpora": [
     {
       "schemaVersion": "v1",
-      "corpusId": "replay_corpus_jup_usdc_feed_gateway_seed",
-      "title": "JUP/USDC feed gateway seed replay corpus",
-      "summary": "Deterministic replay corpus for the JUP onboarding pilot.",
+      "corpusId": "replay_corpus_jup_usdc_feature_cache_seed",
+      "title": "JUP/USDC feature-cache replay corpus",
+      "summary": "Deterministic feature-cache replay corpus for the JUP onboarding pilot.",
       "replayKind": "feed_gateway_v1",
       "createdAt": "2026-03-11T00:00:00Z",
       "updatedAt": "2026-03-11T00:00:00Z",
@@ -125,17 +153,24 @@
       "chainKeys": ["solana-mainnet"],
       "datasetSnapshots": [
         {
-          "datasetId": "dataset_feed_replay_jup_usdc_market_events",
-          "snapshotId": "snapshot_2026_03_07_seed",
+          "datasetId": "dataset_feature_cache_jup_usdc_market_events",
+          "snapshotId": "snapshot_2026_03_07_backtest",
           "capturedAt": "2026-03-11T00:00:00Z",
-          "uri": "repo://services/runtime-rs/fixtures/runtime-feed-replay.jup_usdc.v1.json#marketEvents",
-          "contentDigest": "sha256:jup-feed-fixture"
+          "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.jup_usdc.v1.json#marketEvents",
+          "contentDigest": "sha256:jup-feature-fixture"
+        },
+        {
+          "datasetId": "dataset_feature_cache_jup_usdc_slot_events",
+          "snapshotId": "snapshot_2026_03_07_backtest",
+          "capturedAt": "2026-03-11T00:00:00Z",
+          "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.jup_usdc.v1.json#slotEvents",
+          "contentDigest": "sha256:jup-feature-fixture"
         }
       ],
-      "fixtureUri": "repo://services/runtime-rs/fixtures/runtime-feed-replay.jup_usdc.v1.json",
-      "contentDigest": "sha256:jup-feed-fixture",
-      "deterministicSeed": 200,
-      "tags": ["seed", "deterministic", "jup"]
+      "fixtureUri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.jup_usdc.v1.json",
+      "contentDigest": "sha256:jup-feature-fixture",
+      "deterministicSeed": 300,
+      "tags": ["seed", "deterministic", "jup", "feature-cache"]
     }
   ],
   "featureDefinitions": [
@@ -169,8 +204,8 @@
       },
       "datasetSnapshots": [
         {
-          "datasetId": "dataset_feed_replay_jup_usdc_market_events",
-          "snapshotId": "snapshot_2026_03_07_seed",
+          "datasetId": "dataset_feature_cache_jup_usdc_market_events",
+          "snapshotId": "snapshot_2026_03_07_backtest",
           "capturedAt": "2026-03-11T00:00:00Z",
           "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.jup_usdc.v1.json#marketEvents",
           "contentDigest": "sha256:jup-feature-fixture"
@@ -207,8 +242,8 @@
       },
       "datasetSnapshots": [
         {
-          "datasetId": "dataset_feed_replay_jup_usdc_market_events",
-          "snapshotId": "snapshot_2026_03_07_seed",
+          "datasetId": "dataset_feature_cache_jup_usdc_market_events",
+          "snapshotId": "snapshot_2026_03_07_backtest",
           "capturedAt": "2026-03-11T00:00:00Z",
           "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.jup_usdc.v1.json#marketEvents",
           "contentDigest": "sha256:jup-feature-fixture"
@@ -260,11 +295,18 @@
       },
       "datasetSnapshots": [
         {
-          "datasetId": "dataset_feed_replay_jup_usdc_market_events",
-          "snapshotId": "snapshot_2026_03_07_seed",
+          "datasetId": "dataset_feature_cache_jup_usdc_market_events",
+          "snapshotId": "snapshot_2026_03_07_backtest",
           "capturedAt": "2026-03-11T00:00:00Z",
-          "uri": "repo://services/runtime-rs/fixtures/runtime-feed-replay.jup_usdc.v1.json#marketEvents",
-          "contentDigest": "sha256:jup-feed-fixture"
+          "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.jup_usdc.v1.json#marketEvents",
+          "contentDigest": "sha256:jup-feature-fixture"
+        },
+        {
+          "datasetId": "dataset_feature_cache_jup_usdc_slot_events",
+          "snapshotId": "snapshot_2026_03_07_backtest",
+          "capturedAt": "2026-03-11T00:00:00Z",
+          "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.jup_usdc.v1.json#slotEvents",
+          "contentDigest": "sha256:jup-feature-fixture"
         }
       ],
       "createdAt": "2026-03-11T00:00:00Z",
@@ -326,11 +368,18 @@
       },
       "datasetSnapshots": [
         {
-          "datasetId": "dataset_feed_replay_jup_usdc_market_events",
-          "snapshotId": "snapshot_2026_03_07_seed",
+          "datasetId": "dataset_feature_cache_jup_usdc_market_events",
+          "snapshotId": "snapshot_2026_03_07_backtest",
           "capturedAt": "2026-03-11T00:00:00Z",
-          "uri": "repo://services/runtime-rs/fixtures/runtime-feed-replay.jup_usdc.v1.json#marketEvents",
-          "contentDigest": "sha256:jup-feed-fixture"
+          "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.jup_usdc.v1.json#marketEvents",
+          "contentDigest": "sha256:jup-feature-fixture"
+        },
+        {
+          "datasetId": "dataset_feature_cache_jup_usdc_slot_events",
+          "snapshotId": "snapshot_2026_03_07_backtest",
+          "capturedAt": "2026-03-11T00:00:00Z",
+          "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.jup_usdc.v1.json#slotEvents",
+          "contentDigest": "sha256:jup-feature-fixture"
         }
       ],
       "artifacts": [
@@ -373,11 +422,18 @@
       },
       "datasetSnapshots": [
         {
-          "datasetId": "dataset_feed_replay_jup_usdc_market_events",
-          "snapshotId": "snapshot_2026_03_07_seed",
+          "datasetId": "dataset_feature_cache_jup_usdc_market_events",
+          "snapshotId": "snapshot_2026_03_07_backtest",
           "capturedAt": "2026-03-11T00:00:00Z",
-          "uri": "repo://services/runtime-rs/fixtures/runtime-feed-replay.jup_usdc.v1.json#marketEvents",
-          "contentDigest": "sha256:jup-feed-fixture"
+          "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.jup_usdc.v1.json#marketEvents",
+          "contentDigest": "sha256:jup-feature-fixture"
+        },
+        {
+          "datasetId": "dataset_feature_cache_jup_usdc_slot_events",
+          "snapshotId": "snapshot_2026_03_07_backtest",
+          "capturedAt": "2026-03-11T00:00:00Z",
+          "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.jup_usdc.v1.json#slotEvents",
+          "contentDigest": "sha256:jup-feature-fixture"
         }
       ],
       "artifacts": [
@@ -404,7 +460,7 @@
     {
       "reportId": "backtest_jup_usdc_onboarding",
       "experimentId": "experiment_jup_usdc_onboarding",
-      "replayCorpusId": "replay_corpus_jup_usdc_feed_gateway_seed",
+      "replayCorpusId": "replay_corpus_jup_usdc_feature_cache_seed",
       "venueKey": "jupiter",
       "pairSymbol": "JUP/USDC",
       "marketType": "spot",

--- a/docs/strategy-lab/pilots/trend-following-sol-usdc/curation.request.json
+++ b/docs/strategy-lab/pilots/trend-following-sol-usdc/curation.request.json
@@ -46,6 +46,99 @@
       "tags": ["pilot", "candidate", "trend_following"]
     }
   ],
+  "datasetSnapshots": [
+    {
+      "schemaVersion": "v1",
+      "datasetId": "dataset_feature_cache_sol_usdc_market_events",
+      "snapshotId": "snapshot_2026_03_07_backtest",
+      "datasetKind": "market_events",
+      "normalizationKind": "replay_ready",
+      "format": "fixture_json",
+      "retentionClass": "research",
+      "capturedAt": "2026-03-10T00:00:00.000Z",
+      "coverageStartAt": "2026-03-07T00:00:00Z",
+      "coverageEndAt": "2026-03-07T00:00:25Z",
+      "rowCount": 6,
+      "venueKeys": ["jupiter"],
+      "assetKeys": ["SOL", "USDC"],
+      "pairSymbols": ["SOL/USDC"],
+      "chainKeys": ["solana-mainnet"],
+      "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json#marketEvents",
+      "contentDigest": "sha256:feature-cache",
+      "provenance": {
+        "acquisitionKind": "research_fixture",
+        "collectedFrom": "services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json",
+        "provider": "repo-fixture",
+        "collectedAt": "2026-03-10T00:00:00.000Z",
+        "generator": "strategy-lab",
+        "generatorRevision": "trend-following-sol-usdc-seed"
+      },
+      "tags": ["pilot", "feature-cache"]
+    },
+    {
+      "schemaVersion": "v1",
+      "datasetId": "dataset_feature_cache_sol_usdc_slot_events",
+      "snapshotId": "snapshot_2026_03_07_backtest",
+      "datasetKind": "slot_events",
+      "normalizationKind": "replay_ready",
+      "format": "fixture_json",
+      "retentionClass": "research",
+      "capturedAt": "2026-03-10T00:00:00.000Z",
+      "coverageStartAt": "2026-03-07T00:00:23Z",
+      "coverageEndAt": "2026-03-07T00:00:25Z",
+      "rowCount": 3,
+      "venueKeys": ["helius"],
+      "assetKeys": ["SOL", "USDC"],
+      "pairSymbols": ["SOL/USDC"],
+      "chainKeys": ["solana-mainnet"],
+      "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json#slotEvents",
+      "contentDigest": "sha256:feature-cache",
+      "provenance": {
+        "acquisitionKind": "research_fixture",
+        "collectedFrom": "services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json",
+        "provider": "repo-fixture",
+        "collectedAt": "2026-03-10T00:00:00.000Z",
+        "generator": "strategy-lab",
+        "generatorRevision": "trend-following-sol-usdc-seed"
+      },
+      "tags": ["pilot", "feature-cache"]
+    }
+  ],
+  "replayCorpora": [
+    {
+      "schemaVersion": "v1",
+      "corpusId": "replay_corpus_sol_usdc_feature_cache_seed",
+      "title": "SOL/USDC feature-cache replay corpus",
+      "summary": "Deterministic feature-cache replay corpus for the trend-following pilot.",
+      "replayKind": "feed_gateway_v1",
+      "createdAt": "2026-03-10T00:00:00.000Z",
+      "updatedAt": "2026-03-10T00:00:00.000Z",
+      "venueKeys": ["jupiter", "helius"],
+      "assetKeys": ["SOL", "USDC"],
+      "pairSymbols": ["SOL/USDC"],
+      "chainKeys": ["solana-mainnet"],
+      "datasetSnapshots": [
+        {
+          "datasetId": "dataset_feature_cache_sol_usdc_market_events",
+          "snapshotId": "snapshot_2026_03_07_backtest",
+          "capturedAt": "2026-03-10T00:00:00.000Z",
+          "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json#marketEvents",
+          "contentDigest": "sha256:feature-cache"
+        },
+        {
+          "datasetId": "dataset_feature_cache_sol_usdc_slot_events",
+          "snapshotId": "snapshot_2026_03_07_backtest",
+          "capturedAt": "2026-03-10T00:00:00.000Z",
+          "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json#slotEvents",
+          "contentDigest": "sha256:feature-cache"
+        }
+      ],
+      "fixtureUri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json",
+      "contentDigest": "sha256:feature-cache",
+      "deterministicSeed": 300,
+      "tags": ["pilot", "feature-cache", "deterministic"]
+    }
+  ],
   "experiments": [
     {
       "schemaVersion": "v1",
@@ -73,11 +166,18 @@
       },
       "datasetSnapshots": [
         {
-          "datasetId": "dataset_feed_replay_sol_usdc_market_events",
-          "snapshotId": "snapshot_2026_03_07_seed",
+          "datasetId": "dataset_feature_cache_sol_usdc_market_events",
+          "snapshotId": "snapshot_2026_03_07_backtest",
           "capturedAt": "2026-03-10T00:00:00.000Z",
           "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json#marketEvents",
-          "contentDigest": "sha256:fixture"
+          "contentDigest": "sha256:feature-cache"
+        },
+        {
+          "datasetId": "dataset_feature_cache_sol_usdc_slot_events",
+          "snapshotId": "snapshot_2026_03_07_backtest",
+          "capturedAt": "2026-03-10T00:00:00.000Z",
+          "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json#slotEvents",
+          "contentDigest": "sha256:feature-cache"
         }
       ],
       "artifacts": [
@@ -120,11 +220,18 @@
       },
       "datasetSnapshots": [
         {
-          "datasetId": "dataset_feed_replay_sol_usdc_market_events",
-          "snapshotId": "snapshot_2026_03_07_seed",
+          "datasetId": "dataset_feature_cache_sol_usdc_market_events",
+          "snapshotId": "snapshot_2026_03_07_backtest",
           "capturedAt": "2026-03-10T00:00:00.000Z",
           "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json#marketEvents",
-          "contentDigest": "sha256:fixture"
+          "contentDigest": "sha256:feature-cache"
+        },
+        {
+          "datasetId": "dataset_feature_cache_sol_usdc_slot_events",
+          "snapshotId": "snapshot_2026_03_07_backtest",
+          "capturedAt": "2026-03-10T00:00:00.000Z",
+          "uri": "repo://services/runtime-rs/fixtures/runtime-feature-cache-replay.sol_usdc.v1.json#slotEvents",
+          "contentDigest": "sha256:feature-cache"
         }
       ],
       "artifacts": [
@@ -158,7 +265,7 @@
     {
       "reportId": "backtest_trend_following_sol_usdc_pilot",
       "experimentId": "experiment_trend_following_sol_usdc_pilot",
-      "replayCorpusId": "replay_corpus_sol_usdc_feed_gateway_seed",
+      "replayCorpusId": "replay_corpus_sol_usdc_feature_cache_seed",
       "venueKey": "jupiter",
       "pairSymbol": "SOL/USDC",
       "marketType": "spot",


### PR DESCRIPTION
## Summary
- make `repo://` replay fixtures resolve from the runtime working directory when the Fly image does not ship the compile-time crate path
- repoint both pilot curation requests at the richer checked-in feature-cache replay corpora so their walk-forward backtests have enough observations
- keep the bounded pilot flow aligned with the runtime’s real backtest contract in production

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun test tests/unit/runtime_research_curation.test.ts tests/unit/runtime_research_curation_order.test.ts tests/unit/worker_runtime_research_curation_route.test.ts`
- `cargo test -p backtesting-engine`
- schema-parse both pilot curation requests with `parseRuntimeResearchCurationRequest`

Refs #326
