### PR TITLE
Accept null code revision diffs in runtime backtest reports

### DIFF
--- a/src/runtime/contracts/autonomous_runtime.ts
+++ b/src/runtime/contracts/autonomous_runtime.ts
@@ -6,6 +6,10 @@ export const DEFAULT_RUNTIME_VENUE_KEY = "jupiter" as const;
 
 const ISO_DATETIME_SCHEMA = z.string().datetime({ offset: true });
 const NON_EMPTY_STRING_SCHEMA = z.string().min(1);
+const NULLABLE_OPTIONAL_NON_EMPTY_STRING_SCHEMA = z.preprocess(
+  (value) => (value === null ? undefined : value),
+  NON_EMPTY_STRING_SCHEMA.optional(),
+);
 const PUBKEY_SCHEMA = z.string().min(32).max(64);
 const DECIMAL_STRING_SCHEMA = z
   .string()
@@ -310,7 +314,7 @@ const RuntimeCodeRevisionRefSchema = z
     vcs: NON_EMPTY_STRING_SCHEMA,
     repository: NON_EMPTY_STRING_SCHEMA,
     revision: NON_EMPTY_STRING_SCHEMA,
-    comparedTo: NON_EMPTY_STRING_SCHEMA.optional(),
+    comparedTo: NULLABLE_OPTIONAL_NON_EMPTY_STRING_SCHEMA,
     treeDirty: z.boolean(),
   })
   .strict();

--- a/tests/unit/worker_runtime_contracts.test.ts
+++ b/tests/unit/worker_runtime_contracts.test.ts
@@ -81,6 +81,26 @@ describe("worker runtime contract bridge", () => {
     expect(report.promotionEligible).toBe(true);
   });
 
+  test("worker accepts runtime backtest reports with null comparedTo revisions", () => {
+    const fixture = readJson(
+      "docs/runtime-contracts/fixtures/runtime.backtest_report.valid.v1.json",
+    ) as Record<string, unknown>;
+    const codeRevision =
+      typeof fixture.codeRevision === "object" && fixture.codeRevision !== null
+        ? (fixture.codeRevision as Record<string, unknown>)
+        : {};
+
+    const report = parseRuntimeBacktestReport({
+      ...fixture,
+      codeRevision: {
+        ...codeRevision,
+        comparedTo: null,
+      },
+    });
+
+    expect(report.codeRevision.comparedTo).toBeUndefined();
+  });
+
   test("worker can parse the canonical reproducibility bundle fixture", () => {
     const bundle = parseRuntimeResearchReproducibilityBundleRecord(
       readJson(


### PR DESCRIPTION
## Summary
- accept nullable `codeRevision.comparedTo` values in the shared runtime contract parser
- cover the worker bridge with a regression for production-shaped backtest reports

## Validation
- bun run lint
- bun run typecheck
- bun test tests/unit/worker_runtime_contracts.test.ts tests/unit/runtime_research_curation.test.ts tests/unit/runtime_research_curation_order.test.ts tests/unit/worker_runtime_research_curation_route.test.ts

Fixes #326