### PR TITLE
Handle missing deployments in post-live workflow

### DIFF
--- a/apps/worker/src/runtime_research_post_live.ts
+++ b/apps/worker/src/runtime_research_post_live.ts
@@ -76,6 +76,16 @@ async function requireRuntimeInternalPayload(
   return result.payload;
 }
 
+async function readOptionalRuntimeInternalPayload(
+  resultPromise: Promise<{ ok: boolean; payload: Record<string, unknown> }>,
+): Promise<Record<string, unknown> | null> {
+  const result = await resultPromise;
+  if (!result.ok) {
+    return null;
+  }
+  return result.payload;
+}
+
 function parseRuntimeAssetRecords(payload: Record<string, unknown>) {
   const raw =
     isRecord(payload.registry) && Array.isArray(payload.registry.assets)
@@ -285,17 +295,18 @@ async function hydratePostLiveContext(input: {
   let pairSymbol = input.request.pairSymbol ?? null;
 
   if (input.request.deploymentId) {
-    const deploymentPayload = await requireRuntimeInternalPayload(
+    const deploymentPayload = await readOptionalRuntimeInternalPayload(
       readRuntimeDeployment(input.env, input.request.deploymentId),
-      "runtime-research-post-live-deployment-read-failed",
     );
-    const parsedDeployment = parseRuntimeDeploymentRecord(
-      deploymentPayload.deployment,
-    );
-    deployment = parsedDeployment;
-    venueKey = venueKey ?? parsedDeployment.venueKey;
-    pairSymbol = pairSymbol ?? parsedDeployment.pair.symbol;
-    assetKey = assetKey ?? parsedDeployment.pair.symbol.split("/", 1)[0];
+    if (deploymentPayload) {
+      const parsedDeployment = parseRuntimeDeploymentRecord(
+        deploymentPayload.deployment,
+      );
+      deployment = parsedDeployment;
+      venueKey = venueKey ?? parsedDeployment.venueKey;
+      pairSymbol = pairSymbol ?? parsedDeployment.pair.symbol;
+      assetKey = assetKey ?? parsedDeployment.pair.symbol.split("/", 1)[0];
+    }
   }
 
   const latestPromotion =
@@ -368,13 +379,15 @@ async function hydratePostLiveContext(input: {
       : null;
 
   const scorecard =
-    input.request.subjectKind === "strategy" && input.request.deploymentId
+    input.request.subjectKind === "strategy" &&
+    input.request.deploymentId &&
+    deployment
       ? await (async () => {
           if (input.request.refreshEvaluation !== false) {
-            await requireRuntimeInternalPayload(
+            const evaluationPayload = await readOptionalRuntimeInternalPayload(
               evaluateRuntimeDeployment({
                 env: input.env,
-                deploymentId: input.request.deploymentId,
+                deploymentId: deployment.deploymentId,
                 body: {
                   trigger: {
                     kind: "operator",
@@ -383,13 +396,17 @@ async function hydratePostLiveContext(input: {
                   },
                 },
               }),
-              "runtime-research-post-live-evaluate-failed",
             );
+            if (!evaluationPayload) {
+              return null;
+            }
           }
-          const payload = await requireRuntimeInternalPayload(
-            readRuntimeScorecard(input.env, input.request.deploymentId),
-            "runtime-research-post-live-scorecard-read-failed",
+          const payload = await readOptionalRuntimeInternalPayload(
+            readRuntimeScorecard(input.env, deployment.deploymentId),
           );
+          if (!payload) {
+            return null;
+          }
           return parseScorecardSnapshot(payload);
         })()
       : null;

--- a/docs/strategy-lab/pilots/trend-following-sol-usdc/post-live.request.json
+++ b/docs/strategy-lab/pilots/trend-following-sol-usdc/post-live.request.json
@@ -2,7 +2,6 @@
   "subjectKind": "strategy",
   "subjectKey": "candidate_trend_following_jupiter_sol_usdc",
   "requestedBy": "codex",
-  "issueNumber": 327,
   "currentState": "limited_live",
   "deploymentId": "dep_trend_following_sol_usdc_limited_live",
   "venueKey": "jupiter",

--- a/tests/unit/runtime_research_post_live.test.ts
+++ b/tests/unit/runtime_research_post_live.test.ts
@@ -171,4 +171,46 @@ describe("runtime research post-live review", () => {
       ),
     ).toBe(true);
   });
+
+  test("fails closed when a strategy deployment is missing its runtime scorecard", () => {
+    const { artifact } = buildRuntimeResearchPostLiveReview({
+      request: {
+        subjectKind: "strategy",
+        subjectKey: "candidate_trend_following_jupiter_sol_usdc",
+        requestedBy: "codex",
+        currentState: "limited_live",
+        deploymentId: "dep_missing_live_strategy",
+        venueKey: "jupiter",
+        assetKey: "SOL",
+        pairSymbol: "SOL/USDC",
+      },
+      context: {
+        venueControl: {
+          schemaVersion: "v1",
+          subjectKind: "venue",
+          subjectKey: "jupiter",
+          liveAllowed: true,
+          killSwitchEnabled: false,
+          updatedAt: "2026-03-11T00:00:00.000Z",
+        },
+        assetControl: {
+          schemaVersion: "v1",
+          subjectKind: "asset",
+          subjectKey: "SOL",
+          liveAllowed: true,
+          killSwitchEnabled: false,
+          updatedAt: "2026-03-11T00:00:00.000Z",
+        },
+      },
+    });
+
+    expect(artifact.status).toBe("blocked");
+    expect(artifact.recommendedAction).toBe("demote");
+    expect(artifact.recommendedTargetState).toBe("paper");
+    expect(
+      artifact.checks.some(
+        (check) => check.checkId === "scorecard" && check.status === "blocked",
+      ),
+    ).toBe(true);
+  });
 });

--- a/tests/unit/worker_runtime_research_post_live_route.test.ts
+++ b/tests/unit/worker_runtime_research_post_live_route.test.ts
@@ -286,4 +286,53 @@ describe("worker runtime research post-live route", () => {
       sqlite.close();
     }
   });
+
+  test("accepts post-live requests under stub mode even when the deployment id is unknown", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      await seedControls(env);
+
+      const response = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/research/post-live",
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              subjectKind: "strategy",
+              subjectKey: "candidate_trend_following_jupiter_sol_usdc",
+              requestedBy: "codex",
+              currentState: "limited_live",
+              deploymentId: "dep_missing_live_strategy",
+              venueKey: "jupiter",
+              assetKey: "SOL",
+              pairSymbol: "SOL/USDC",
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(200);
+      const payload = (await response.json()) as {
+        ok: boolean;
+        artifact: {
+          status: string;
+          recommendedAction: string;
+          postLiveId: string;
+        };
+      };
+      expect(payload.ok).toBe(true);
+      expect(payload.artifact.postLiveId).toBeTruthy();
+      expect(["observe", "revalidate", "demote", "pause"]).toContain(
+        payload.artifact.recommendedAction,
+      );
+    } finally {
+      sqlite.close();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- make post-live hydration fail closed instead of throwing when a tracked deployment has already disappeared from runtime storage
- keep the post-live pilot request free of stale issue references
- add regression coverage for missing-scorecard strategy reviews and the stubbed worker route behavior

## Validation
- export PATH="$HOME/.bun/bin:$PATH"; bun run lint
- export PATH="$HOME/.bun/bin:$PATH"; bun run typecheck
- export PATH="$HOME/.bun/bin:$PATH"; bun test tests/unit/runtime_research_post_live.test.ts tests/unit/worker_runtime_research_post_live_route.test.ts

Refs #327
