### PR TITLE
Generalize execution intents beyond swap-only routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,4 +43,5 @@
 
 - Before pushing a branch, make sure CI-impacting workflow and env changes are included in the same PR.
 - Before merging each PR into `main`, confirm required checks are green.
+- If the repo owner or operator explicitly authorizes merge in-thread, OpenAI or Codex review with no blocking findings can satisfy the final review gate without a separate human GitHub review.
 - Do not manually remap `dev` custom domains outside CI unless production is degraded and an emergency fix is required.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -59,6 +59,9 @@ Take an issue only when all of the following are true:
 
 When a run starts, add `agent-running`. When the PR is ready for review, remove
 `agent-running` and add `human-review`.
+The `human-review` label marks the merge gate. It can be cleared either by a
+human GitHub review or by an explicitly authorized agent merge after OpenAI or
+Codex review reports no blocking findings and all required checks are green.
 
 ## Branching and PR Rules
 
@@ -171,16 +174,17 @@ the target state transition:
 ## Approval Posture
 
 - This repo is operated in a high-trust mode for engineering execution.
-- Human review is still mandatory before merge.
-- Stop at `human-review`; do not auto-merge unless the repo policy changes in a
-  later issue.
+- Human GitHub review is preferred, but it is not mandatory when the repo owner
+  or operator explicitly authorizes agent merge in-thread.
+- An agent may merge from `human-review` when OpenAI or Codex review reports no
+  blocking findings and all required checks are green.
 - Prefer reversible changes and call out any deployment or rollout risk in the
   PR summary.
 
 Money-state approval boundaries:
 
 - Merging a PR does not authorize real-money promotion by itself.
-- `shadow` may begin only after human-reviewed code merge.
+- `shadow` may begin only after a merged PR.
 - `paper` requires explicit operator approval.
 - `limited_live` requires explicit human approval, allowlist changes, kill
   controls, and bounded canary notes.

--- a/apps/worker/src/execution/receipt_assembler.ts
+++ b/apps/worker/src/execution/receipt_assembler.ts
@@ -2,6 +2,7 @@ import type {
   ExecutionAttemptRecord,
   ExecutionReceiptRecord,
   ExecutionRequestRecord,
+  JsonObject,
 } from "./repository";
 
 export type CanonicalExecutionReceiptV1 = {
@@ -32,6 +33,26 @@ export type CanonicalExecutionReceiptV1 = {
     state: string;
     at: string;
   }>;
+  intent?: {
+    family: string;
+    marketType?: string;
+    venueKey?: string;
+    instrumentId?: string;
+    inputMint?: string;
+    outputMint?: string;
+    outcomeId?: string;
+    referenceId?: string;
+    side?: string;
+    settlementMint?: string;
+    borrowLegCount?: number;
+  };
+  lifecycle?: {
+    orderState?: string;
+    fillState?: string;
+    positionState?: string;
+    settlementState?: string;
+    notes?: string[];
+  };
   immutability?: {
     hashAlgorithm: string;
     receivedTxHash: string;
@@ -44,6 +65,94 @@ function toOutcomeStatus(status: string): "finalized" | "failed" | "expired" {
   if (status === "expired") return "expired";
   if (status === "landed" || status === "finalized") return "finalized";
   return "failed";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return normalized ? normalized : null;
+}
+
+function readNumber(value: unknown): number | null {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function readStringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  const normalized = value
+    .map((entry) => readString(entry))
+    .filter((entry): entry is string => Boolean(entry));
+  return normalized.length > 0 ? normalized : null;
+}
+
+function readIntentSummary(
+  metadata: JsonObject | null,
+): CanonicalExecutionReceiptV1["intent"] | undefined {
+  const record = isRecord(metadata?.intent) ? metadata?.intent : null;
+  if (!record) return undefined;
+  const family = readString(record.family);
+  if (!family) return undefined;
+  return {
+    family,
+    ...(readString(record.marketType)
+      ? { marketType: readString(record.marketType) as string }
+      : {}),
+    ...(readString(record.venueKey)
+      ? { venueKey: readString(record.venueKey) as string }
+      : {}),
+    ...(readString(record.instrumentId)
+      ? { instrumentId: readString(record.instrumentId) as string }
+      : {}),
+    ...(readString(record.inputMint)
+      ? { inputMint: readString(record.inputMint) as string }
+      : {}),
+    ...(readString(record.outputMint)
+      ? { outputMint: readString(record.outputMint) as string }
+      : {}),
+    ...(readString(record.outcomeId)
+      ? { outcomeId: readString(record.outcomeId) as string }
+      : {}),
+    ...(readString(record.referenceId)
+      ? { referenceId: readString(record.referenceId) as string }
+      : {}),
+    ...(readString(record.side)
+      ? { side: readString(record.side) as string }
+      : {}),
+    ...(readString(record.settlementMint)
+      ? { settlementMint: readString(record.settlementMint) as string }
+      : {}),
+    ...(readNumber(record.borrowLegCount) !== null
+      ? { borrowLegCount: readNumber(record.borrowLegCount) as number }
+      : {}),
+  };
+}
+
+function readLifecycleSummary(
+  receipt: JsonObject | null,
+): CanonicalExecutionReceiptV1["lifecycle"] | undefined {
+  const record = isRecord(receipt?.lifecycle) ? receipt?.lifecycle : null;
+  if (!record) return undefined;
+  const notes = readStringArray(record.notes);
+  const lifecycle = {
+    ...(readString(record.orderState)
+      ? { orderState: readString(record.orderState) as string }
+      : {}),
+    ...(readString(record.fillState)
+      ? { fillState: readString(record.fillState) as string }
+      : {}),
+    ...(readString(record.positionState)
+      ? { positionState: readString(record.positionState) as string }
+      : {}),
+    ...(readString(record.settlementState)
+      ? { settlementState: readString(record.settlementState) as string }
+      : {}),
+    ...(notes ? { notes } : {}),
+  };
+  return Object.keys(lifecycle).length > 0 ? lifecycle : undefined;
 }
 
 export function canonicalExecutionReceiptStorageKey(requestId: string): string {
@@ -101,6 +210,12 @@ export function assembleCanonicalExecutionReceiptV1(input: {
       state: attempt.status,
       at: attempt.completedAt ?? attempt.startedAt,
     })),
+    ...(readIntentSummary(input.request.metadata)
+      ? { intent: readIntentSummary(input.request.metadata) }
+      : {}),
+    ...(readLifecycleSummary(input.receipt.receipt)
+      ? { lifecycle: readLifecycleSummary(input.receipt.receipt) }
+      : {}),
     ...(input.immutability ? { immutability: input.immutability } : {}),
   };
 }

--- a/apps/worker/src/execution/router.ts
+++ b/apps/worker/src/execution/router.ts
@@ -1,6 +1,7 @@
 import {
   requireRuntimeVenueCapability,
   runtimeVenueSupportsAdapter,
+  runtimeVenueSupportsIntentFamily,
   runtimeVenueSupportsMode,
 } from "../../../../src/runtime/venues/catalog.js";
 import { TRADING_TOKEN_BY_MINT } from "../defaults";
@@ -10,7 +11,12 @@ import { executeHeliusSenderSwap } from "./helius_sender_executor";
 import { executeJitoBundleSwap } from "./jito_bundle_executor";
 import { executeJupiterSwap } from "./jupiter_executor";
 import { executeMagicBlockEphemeralRollupSwap } from "./magicblock_ephemeral_rollup_executor";
-import type { ExecuteSwapInput, ExecuteSwapResult } from "./types";
+import type {
+  ExecuteIntentInput,
+  ExecuteSwapInput,
+  ExecuteSwapResult,
+  ExecutionIntentFamily,
+} from "./types";
 
 export type ExecutionAdapterFn = (
   input: ExecuteSwapInput,
@@ -20,15 +26,20 @@ export type ExecutionAdapterRegistration = {
   adapterKey: string;
   venueKey: string;
   supportedModes: RuntimeMode[];
+  supportedIntentFamilies: ExecutionIntentFamily[];
   adapter: ExecutionAdapterFn;
 };
 
 type RegisterExecutionAdapterOptions = {
   venueKey?: string;
   supportedModes?: RuntimeMode[];
+  supportedIntentFamilies?: ExecutionIntentFamily[];
 };
 
 const DEFAULT_SUPPORTED_MODES: RuntimeMode[] = ["shadow", "paper", "live"];
+const DEFAULT_SUPPORTED_INTENT_FAMILIES: ExecutionIntentFamily[] = [
+  "spot_swap",
+];
 
 const ADAPTERS = new Map<string, ExecutionAdapterRegistration>([
   [
@@ -37,6 +48,7 @@ const ADAPTERS = new Map<string, ExecutionAdapterRegistration>([
       adapterKey: "jupiter",
       venueKey: "jupiter",
       supportedModes: ["shadow", "paper", "live"],
+      supportedIntentFamilies: ["spot_swap"],
       adapter: executeJupiterSwap,
     },
   ],
@@ -46,6 +58,7 @@ const ADAPTERS = new Map<string, ExecutionAdapterRegistration>([
       adapterKey: "helius_sender",
       venueKey: "jupiter",
       supportedModes: ["live"],
+      supportedIntentFamilies: ["spot_swap"],
       adapter: executeHeliusSenderSwap,
     },
   ],
@@ -55,6 +68,7 @@ const ADAPTERS = new Map<string, ExecutionAdapterRegistration>([
       adapterKey: "jito_bundle",
       venueKey: "jupiter",
       supportedModes: ["live"],
+      supportedIntentFamilies: ["spot_swap"],
       adapter: executeJitoBundleSwap,
     },
   ],
@@ -64,6 +78,7 @@ const ADAPTERS = new Map<string, ExecutionAdapterRegistration>([
       adapterKey: "magicblock_ephemeral_rollup",
       venueKey: "magicblock",
       supportedModes: ["shadow", "paper"],
+      supportedIntentFamilies: ["spot_swap"],
       adapter: executeMagicBlockEphemeralRollupSwap,
     },
   ],
@@ -84,6 +99,9 @@ export function registerExecutionAdapter(
     supportedModes: options?.supportedModes
       ? [...options.supportedModes]
       : [...DEFAULT_SUPPORTED_MODES],
+    supportedIntentFamilies: options?.supportedIntentFamilies
+      ? [...options.supportedIntentFamilies]
+      : [...DEFAULT_SUPPORTED_INTENT_FAMILIES],
     adapter,
   });
 }
@@ -139,9 +157,17 @@ async function enforceStrategyLabSubjectControls(input: {
   }
 }
 
-export async function executeSwapViaRouter(
-  input: ExecuteSwapInput,
-): Promise<ExecuteSwapResult> {
+async function resolveExecutionAdapterForIntent(input: {
+  env: ExecuteIntentInput["env"];
+  execution: ExecuteIntentInput["execution"];
+  venueKey: string;
+  runtimeMode?: RuntimeMode;
+  requireVenueRouting?: boolean;
+  subjectControlBypassReason?: ExecuteIntentInput["subjectControlBypassReason"];
+  intentFamily: ExecutionIntentFamily;
+  inputMint?: string;
+  outputMint?: string;
+}): Promise<ExecutionAdapterRegistration> {
   const adapterName =
     (input.execution?.adapter ?? "jupiter").trim() || "jupiter";
   const venueKey = String(input.venueKey ?? "").trim();
@@ -174,6 +200,11 @@ export async function executeSwapViaRouter(
         `runtime-venue-adapter-not-supported:${venueKey}:${adapterName}`,
       );
     }
+    if (!runtimeVenueSupportsIntentFamily(capability, input.intentFamily)) {
+      throw new Error(
+        `runtime-venue-intent-family-not-supported:${venueKey}:${input.intentFamily}`,
+      );
+    }
     if (runtimeMode && !runtimeVenueSupportsMode(capability, runtimeMode)) {
       throw new Error(
         `runtime-venue-mode-not-supported:${venueKey}:${runtimeMode}`,
@@ -183,8 +214,8 @@ export async function executeSwapViaRouter(
       await enforceStrategyLabSubjectControls({
         db: input.env.WAITLIST_DB,
         venueKey,
-        inputMint: input.quoteResponse?.inputMint,
-        outputMint: input.quoteResponse?.outputMint,
+        inputMint: input.inputMint,
+        outputMint: input.outputMint,
         bypassReason: input.subjectControlBypassReason,
       });
     }
@@ -194,5 +225,70 @@ export async function executeSwapViaRouter(
       `execution-adapter-mode-unsupported:${adapterName}:${runtimeMode}`,
     );
   }
-  return await registration.adapter(input);
+  if (!registration.supportedIntentFamilies.includes(input.intentFamily)) {
+    throw new Error(
+      `execution-adapter-intent-not-supported:${adapterName}:${input.intentFamily}`,
+    );
+  }
+  return registration;
+}
+
+export async function executeIntentViaRouter(
+  input: ExecuteIntentInput,
+): Promise<ExecuteSwapResult> {
+  const venueKey = String(input.venueKey ?? input.intent.venueKey ?? "").trim();
+  const registration = await resolveExecutionAdapterForIntent({
+    env: input.env,
+    execution: input.execution,
+    venueKey,
+    runtimeMode: input.runtimeMode,
+    requireVenueRouting: input.requireVenueRouting,
+    subjectControlBypassReason: input.subjectControlBypassReason,
+    intentFamily: input.intent.family,
+    inputMint:
+      input.intent.family === "spot_swap" ? input.intent.inputMint : undefined,
+    outputMint:
+      input.intent.family === "spot_swap" ? input.intent.outputMint : undefined,
+  });
+
+  if (input.intent.family !== "spot_swap") {
+    throw new Error(
+      `execution-intent-family-not-implemented:${input.intent.family}:${registration.adapterKey}`,
+    );
+  }
+
+  return await registration.adapter({
+    env: input.env,
+    venueKey,
+    runtimeMode: input.runtimeMode,
+    requireVenueRouting: input.requireVenueRouting,
+    subjectControlBypassReason: input.subjectControlBypassReason,
+    execution: input.execution,
+    policy: input.policy,
+    rpc: input.rpc,
+    jupiter: input.jupiter,
+    quoteResponse: input.quoteResponse,
+    userPublicKey: input.userPublicKey,
+    privyWalletId: input.privyWalletId,
+    log: input.log,
+    guardEnabled: input.guardEnabled,
+  });
+}
+
+export async function executeSwapViaRouter(
+  input: ExecuteSwapInput,
+): Promise<ExecuteSwapResult> {
+  return await executeIntentViaRouter({
+    ...input,
+    intent: {
+      family: "spot_swap",
+      wallet: input.userPublicKey,
+      venueKey: input.venueKey,
+      marketType: "spot",
+      inputMint: String(input.quoteResponse?.inputMint ?? ""),
+      outputMint: String(input.quoteResponse?.outputMint ?? ""),
+      amountAtomic: String(input.quoteResponse?.inAmount ?? ""),
+      slippageBps: input.policy.slippageBps,
+    },
+  });
 }

--- a/apps/worker/src/execution/submit_contract.ts
+++ b/apps/worker/src/execution/submit_contract.ts
@@ -1,11 +1,185 @@
 import type { ExecutionLane, ExecutionMode, JsonObject } from "./repository";
+import type { ExecutionIntentFamily } from "./types";
 
 const BASE58_RE = /^[1-9A-HJ-NP-Za-km-z]+$/;
 const BASE64_RE = /^[A-Za-z0-9+/=]+$/;
-const SCHEMA_VERSION = "v1";
+const POSITIVE_ATOMIC_RE = /^[1-9][0-9]*$/;
+const SCHEMA_VERSION_V1 = "v1";
+const SCHEMA_VERSION_V2 = "v2";
+
+export type ExecSubmitOptions = {
+  simulateOnly?: boolean;
+  requireSimulation?: boolean;
+  dryRun?: boolean;
+  priorityMicroLamports?: number;
+  commitment?: "processed" | "confirmed" | "finalized";
+  orderType?: "market" | "limit" | "trigger";
+  timeInForce?: "gtc" | "ioc" | "fok";
+  reduceOnly?: boolean;
+  postOnly?: boolean;
+  quantityMode?: "base" | "quote" | "notional";
+  limitPriceAtomic?: string;
+  triggerPriceAtomic?: string;
+  takeProfitPriceAtomic?: string;
+  stopLossPriceAtomic?: string;
+};
+
+export type ExecSubmitPrivyExecuteV1 = {
+  intentType: "swap";
+  wallet: string;
+  swap: {
+    inputMint: string;
+    outputMint: string;
+    amountAtomic: string;
+    slippageBps: number;
+  };
+  options?: ExecSubmitOptions;
+};
+
+export type ExecSubmitPrivySpotSwapIntentV2 = {
+  family: "spot_swap";
+  venueKey?: string;
+  marketType: "spot";
+  inputMint: string;
+  outputMint: string;
+  amountAtomic: string;
+  slippageBps: number;
+};
+
+export type ExecSubmitPrivyConditionalSpotOrderIntentV2 = {
+  family: "conditional_spot_order";
+  venueKey: string;
+  marketType: "spot";
+  instrumentId: string;
+  side: "buy" | "sell";
+  quantityAtomic: string;
+};
+
+export type ExecSubmitPrivyClobOrderIntentV2 = {
+  family: "clob_order";
+  venueKey: string;
+  marketType: "spot" | "perp";
+  instrumentId: string;
+  side: "buy" | "sell";
+  quantityAtomic: string;
+};
+
+export type ExecSubmitPrivyPerpOrderIntentV2 = {
+  family: "perp_order";
+  venueKey: string;
+  marketType: "perp";
+  instrumentId: string;
+  side: "long" | "short" | "close_long" | "close_short";
+  quantityAtomic: string;
+  collateralAtomic?: string;
+};
+
+export type ExecSubmitPrivyPredictionOrderIntentV2 = {
+  family: "prediction_order";
+  venueKey: string;
+  marketType: "prediction";
+  instrumentId: string;
+  outcomeId: string;
+  side: "buy_yes" | "buy_no" | "sell_yes" | "sell_no";
+  quantityAtomic: string;
+};
+
+export type ExecSubmitPrivyFlashLegV2 = {
+  provider: string;
+  mint: string;
+  amountAtomic: string;
+};
+
+export type ExecSubmitPrivyFlashAtomicIntentV2 = {
+  family: "flash_atomic";
+  venueKey: string;
+  marketType: "spot";
+  referenceId: string;
+  borrowLegs: ExecSubmitPrivyFlashLegV2[];
+  settlementMint: string;
+};
+
+export type ExecSubmitPrivyIntentV2 =
+  | ExecSubmitPrivySpotSwapIntentV2
+  | ExecSubmitPrivyConditionalSpotOrderIntentV2
+  | ExecSubmitPrivyClobOrderIntentV2
+  | ExecSubmitPrivyPerpOrderIntentV2
+  | ExecSubmitPrivyPredictionOrderIntentV2
+  | ExecSubmitPrivyFlashAtomicIntentV2;
+
+export type ExecSubmitPrivyExecuteV2 = {
+  wallet: string;
+  intent: ExecSubmitPrivyIntentV2;
+  options?: ExecSubmitOptions;
+};
+
+export type ExecSubmitRequestV1 = {
+  schemaVersion: "v1";
+  mode: ExecutionMode;
+  lane: ExecutionLane;
+  metadata?: {
+    source?: string;
+    reason?: string;
+    clientRequestId?: string;
+  };
+  relaySigned?: {
+    encoding: "base64";
+    signedTransaction: string;
+  };
+  privyExecute?: ExecSubmitPrivyExecuteV1;
+};
+
+export type ExecSubmitRequestV2 = {
+  schemaVersion: "v2";
+  mode: ExecutionMode;
+  lane: ExecutionLane;
+  metadata?: {
+    source?: string;
+    reason?: string;
+    clientRequestId?: string;
+  };
+  relaySigned?: {
+    encoding: "base64";
+    signedTransaction: string;
+  };
+  privyExecute?: ExecSubmitPrivyExecuteV2;
+};
+
+export type ExecSubmitRequest = ExecSubmitRequestV1 | ExecSubmitRequestV2;
+
+export type ExecSubmitSpotSwapCompat = {
+  wallet: string;
+  venueKey?: string;
+  swap: {
+    inputMint: string;
+    outputMint: string;
+    amountAtomic: string;
+    slippageBps: number;
+  };
+  options?: ExecSubmitOptions;
+};
+
+export type ExecSubmitPayloadParseResult =
+  | {
+      ok: true;
+      value: ExecSubmitRequest;
+      metadataForStorage: JsonObject | null;
+    }
+  | { ok: false; error: "invalid-request" };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function assertAllowedKeys(
+  value: Record<string, unknown>,
+  allowedKeys: readonly string[],
+): boolean {
+  const allowed = new Set(allowedKeys);
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) return false;
+  }
+  return true;
 }
 
 function parseBoundedString(
@@ -41,9 +215,8 @@ function parseMetadata(value: unknown): {
 } | null {
   if (value === undefined) return {};
   if (!isRecord(value)) return null;
-  const allowedKeys = new Set(["source", "reason", "clientRequestId"]);
-  for (const key of Object.keys(value)) {
-    if (!allowedKeys.has(key)) return null;
+  if (!assertAllowedKeys(value, ["source", "reason", "clientRequestId"])) {
+    return null;
   }
 
   const source = parseBoundedString(value.source, 1, 80);
@@ -66,9 +239,8 @@ function parseRelaySigned(
   value: unknown,
 ): { encoding: "base64"; signedTransaction: string } | null {
   if (!isRecord(value)) return null;
-  const allowedKeys = new Set(["encoding", "signedTransaction"]);
-  for (const key of Object.keys(value)) {
-    if (!allowedKeys.has(key)) return null;
+  if (!assertAllowedKeys(value, ["encoding", "signedTransaction"])) {
+    return null;
   }
 
   if (String(value.encoding ?? "") !== "base64") return null;
@@ -87,112 +259,96 @@ function parseRelaySigned(
   };
 }
 
-function parsePrivyExecute(value: unknown): {
-  intentType: "swap";
-  wallet: string;
-  swap: {
-    inputMint: string;
-    outputMint: string;
-    amountAtomic: string;
-    slippageBps: number;
-  };
-  options?: {
-    simulateOnly?: boolean;
-    requireSimulation?: boolean;
-    dryRun?: boolean;
-    priorityMicroLamports?: number;
-    commitment?: "processed" | "confirmed" | "finalized";
-    orderType?: "market" | "limit" | "trigger";
-    timeInForce?: "gtc" | "ioc" | "fok";
-    reduceOnly?: boolean;
-    postOnly?: boolean;
-    quantityMode?: "base" | "quote" | "notional";
-    limitPriceAtomic?: string;
-    triggerPriceAtomic?: string;
-    takeProfitPriceAtomic?: string;
-    stopLossPriceAtomic?: string;
-  };
-} | null {
+function parsePubkey(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  if (
+    normalized.length < 32 ||
+    normalized.length > 64 ||
+    !BASE58_RE.test(normalized)
+  ) {
+    return null;
+  }
+  return normalized;
+}
+
+function parsePositiveAtomicString(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return POSITIVE_ATOMIC_RE.test(normalized) ? normalized : null;
+}
+
+function parseVenueKey(value: unknown): string | null {
+  return parseBoundedString(value, 1, 64);
+}
+
+function parseInstrumentId(value: unknown): string | null {
+  return parseBoundedString(value, 1, 160);
+}
+
+function parseExecutionIntentFamily(
+  value: unknown,
+): ExecutionIntentFamily | null {
+  const normalized = String(value ?? "").trim();
+  if (normalized === "spot_swap") return "spot_swap";
+  if (normalized === "conditional_spot_order") {
+    return "conditional_spot_order";
+  }
+  if (normalized === "clob_order") return "clob_order";
+  if (normalized === "perp_order") return "perp_order";
+  if (normalized === "prediction_order") return "prediction_order";
+  if (normalized === "flash_atomic") return "flash_atomic";
+  return null;
+}
+
+function parseMarketType(
+  value: unknown,
+): "spot" | "perp" | "prediction" | null {
+  const normalized = String(value ?? "").trim();
+  if (normalized === "spot") return "spot";
+  if (normalized === "perp") return "perp";
+  if (normalized === "prediction") return "prediction";
+  return null;
+}
+
+function parseCommonOptions(value: unknown): ExecSubmitOptions | null {
+  if (value === undefined) return {};
   if (!isRecord(value)) return null;
-  const allowedKeys = new Set(["intentType", "wallet", "swap", "options"]);
-  for (const key of Object.keys(value)) {
-    if (!allowedKeys.has(key)) return null;
-  }
-
-  if (String(value.intentType ?? "") !== "swap") return null;
-  const wallet = String(value.wallet ?? "").trim();
-  if (wallet.length < 32 || wallet.length > 64 || !BASE58_RE.test(wallet)) {
-    return null;
-  }
-
-  if (!isRecord(value.swap)) return null;
-  const swapAllowedKeys = new Set([
-    "inputMint",
-    "outputMint",
-    "amountAtomic",
-    "slippageBps",
-  ]);
-  for (const key of Object.keys(value.swap)) {
-    if (!swapAllowedKeys.has(key)) return null;
-  }
-
-  const inputMint = String(value.swap.inputMint ?? "").trim();
-  const outputMint = String(value.swap.outputMint ?? "").trim();
-  const amountAtomic = String(value.swap.amountAtomic ?? "").trim();
-  const slippageBps = Number(value.swap.slippageBps);
   if (
-    inputMint.length < 32 ||
-    inputMint.length > 64 ||
-    !BASE58_RE.test(inputMint) ||
-    outputMint.length < 32 ||
-    outputMint.length > 64 ||
-    !BASE58_RE.test(outputMint) ||
-    !/^[1-9][0-9]*$/.test(amountAtomic) ||
-    !Number.isInteger(slippageBps) ||
-    slippageBps < 1 ||
-    slippageBps > 5_000
-  ) {
-    return null;
-  }
-
-  if (value.options !== undefined && !isRecord(value.options)) return null;
-  const options = isRecord(value.options) ? value.options : {};
-  const optionKeys = new Set([
-    "simulateOnly",
-    "requireSimulation",
-    "dryRun",
-    "priorityMicroLamports",
-    "commitment",
-    "orderType",
-    "timeInForce",
-    "reduceOnly",
-    "postOnly",
-    "quantityMode",
-    "limitPriceAtomic",
-    "triggerPriceAtomic",
-    "takeProfitPriceAtomic",
-    "stopLossPriceAtomic",
-  ]);
-  for (const key of Object.keys(options)) {
-    if (!optionKeys.has(key)) return null;
-  }
-  if (
-    options.simulateOnly !== undefined &&
-    typeof options.simulateOnly !== "boolean"
+    !assertAllowedKeys(value, [
+      "simulateOnly",
+      "requireSimulation",
+      "dryRun",
+      "priorityMicroLamports",
+      "commitment",
+      "orderType",
+      "timeInForce",
+      "reduceOnly",
+      "postOnly",
+      "quantityMode",
+      "limitPriceAtomic",
+      "triggerPriceAtomic",
+      "takeProfitPriceAtomic",
+      "stopLossPriceAtomic",
+    ])
   ) {
     return null;
   }
   if (
-    options.requireSimulation !== undefined &&
-    typeof options.requireSimulation !== "boolean"
+    value.simulateOnly !== undefined &&
+    typeof value.simulateOnly !== "boolean"
   ) {
     return null;
   }
-  if (options.dryRun !== undefined && typeof options.dryRun !== "boolean") {
+  if (
+    value.requireSimulation !== undefined &&
+    typeof value.requireSimulation !== "boolean"
+  ) {
     return null;
   }
-  if (options.priorityMicroLamports !== undefined) {
-    const priorityMicroLamports = Number(options.priorityMicroLamports);
+  if (value.dryRun !== undefined && typeof value.dryRun !== "boolean") {
+    return null;
+  }
+  if (value.priorityMicroLamports !== undefined) {
+    const priorityMicroLamports = Number(value.priorityMicroLamports);
     if (
       !Number.isInteger(priorityMicroLamports) ||
       priorityMicroLamports < 0 ||
@@ -202,70 +358,156 @@ function parsePrivyExecute(value: unknown): {
     }
   }
   if (
-    options.commitment !== undefined &&
-    options.commitment !== "processed" &&
-    options.commitment !== "confirmed" &&
-    options.commitment !== "finalized"
+    value.commitment !== undefined &&
+    value.commitment !== "processed" &&
+    value.commitment !== "confirmed" &&
+    value.commitment !== "finalized"
   ) {
     return null;
   }
   if (
-    options.orderType !== undefined &&
-    options.orderType !== "market" &&
-    options.orderType !== "limit" &&
-    options.orderType !== "trigger"
+    value.orderType !== undefined &&
+    value.orderType !== "market" &&
+    value.orderType !== "limit" &&
+    value.orderType !== "trigger"
   ) {
     return null;
   }
   if (
-    options.timeInForce !== undefined &&
-    options.timeInForce !== "gtc" &&
-    options.timeInForce !== "ioc" &&
-    options.timeInForce !== "fok"
+    value.timeInForce !== undefined &&
+    value.timeInForce !== "gtc" &&
+    value.timeInForce !== "ioc" &&
+    value.timeInForce !== "fok"
+  ) {
+    return null;
+  }
+  if (value.reduceOnly !== undefined && typeof value.reduceOnly !== "boolean") {
+    return null;
+  }
+  if (value.postOnly !== undefined && typeof value.postOnly !== "boolean") {
+    return null;
+  }
+  if (
+    value.quantityMode !== undefined &&
+    value.quantityMode !== "base" &&
+    value.quantityMode !== "quote" &&
+    value.quantityMode !== "notional"
   ) {
     return null;
   }
   if (
-    options.reduceOnly !== undefined &&
-    typeof options.reduceOnly !== "boolean"
-  ) {
-    return null;
-  }
-  if (options.postOnly !== undefined && typeof options.postOnly !== "boolean") {
-    return null;
-  }
-  if (
-    options.quantityMode !== undefined &&
-    options.quantityMode !== "base" &&
-    options.quantityMode !== "quote" &&
-    options.quantityMode !== "notional"
+    value.limitPriceAtomic !== undefined &&
+    parsePositiveAtomicString(value.limitPriceAtomic) === null
   ) {
     return null;
   }
   if (
-    options.limitPriceAtomic !== undefined &&
-    !/^[1-9][0-9]*$/.test(String(options.limitPriceAtomic))
+    value.triggerPriceAtomic !== undefined &&
+    parsePositiveAtomicString(value.triggerPriceAtomic) === null
   ) {
     return null;
   }
   if (
-    options.triggerPriceAtomic !== undefined &&
-    !/^[1-9][0-9]*$/.test(String(options.triggerPriceAtomic))
+    value.takeProfitPriceAtomic !== undefined &&
+    parsePositiveAtomicString(value.takeProfitPriceAtomic) === null
   ) {
     return null;
   }
   if (
-    options.takeProfitPriceAtomic !== undefined &&
-    !/^[1-9][0-9]*$/.test(String(options.takeProfitPriceAtomic))
+    value.stopLossPriceAtomic !== undefined &&
+    parsePositiveAtomicString(value.stopLossPriceAtomic) === null
   ) {
     return null;
   }
+
+  return {
+    ...(value.simulateOnly !== undefined
+      ? { simulateOnly: value.simulateOnly as boolean }
+      : {}),
+    ...(value.requireSimulation !== undefined
+      ? { requireSimulation: value.requireSimulation as boolean }
+      : {}),
+    ...(value.dryRun !== undefined ? { dryRun: value.dryRun as boolean } : {}),
+    ...(value.priorityMicroLamports !== undefined
+      ? { priorityMicroLamports: Number(value.priorityMicroLamports) }
+      : {}),
+    ...(value.commitment !== undefined
+      ? {
+          commitment: value.commitment as
+            | "processed"
+            | "confirmed"
+            | "finalized",
+        }
+      : {}),
+    ...(value.orderType !== undefined
+      ? {
+          orderType: value.orderType as "market" | "limit" | "trigger",
+        }
+      : {}),
+    ...(value.timeInForce !== undefined
+      ? { timeInForce: value.timeInForce as "gtc" | "ioc" | "fok" }
+      : {}),
+    ...(value.reduceOnly !== undefined
+      ? { reduceOnly: value.reduceOnly as boolean }
+      : {}),
+    ...(value.postOnly !== undefined
+      ? { postOnly: value.postOnly as boolean }
+      : {}),
+    ...(value.quantityMode !== undefined
+      ? {
+          quantityMode: value.quantityMode as "base" | "quote" | "notional",
+        }
+      : {}),
+    ...(value.limitPriceAtomic !== undefined
+      ? { limitPriceAtomic: String(value.limitPriceAtomic) }
+      : {}),
+    ...(value.triggerPriceAtomic !== undefined
+      ? { triggerPriceAtomic: String(value.triggerPriceAtomic) }
+      : {}),
+    ...(value.takeProfitPriceAtomic !== undefined
+      ? { takeProfitPriceAtomic: String(value.takeProfitPriceAtomic) }
+      : {}),
+    ...(value.stopLossPriceAtomic !== undefined
+      ? { stopLossPriceAtomic: String(value.stopLossPriceAtomic) }
+      : {}),
+  };
+}
+
+function parsePrivyExecuteV1(value: unknown): ExecSubmitPrivyExecuteV1 | null {
+  if (!isRecord(value)) return null;
+  if (!assertAllowedKeys(value, ["intentType", "wallet", "swap", "options"])) {
+    return null;
+  }
+  if (String(value.intentType ?? "") !== "swap") return null;
+  const wallet = parsePubkey(value.wallet);
+  if (!wallet) return null;
+  if (!isRecord(value.swap)) return null;
   if (
-    options.stopLossPriceAtomic !== undefined &&
-    !/^[1-9][0-9]*$/.test(String(options.stopLossPriceAtomic))
+    !assertAllowedKeys(value.swap, [
+      "inputMint",
+      "outputMint",
+      "amountAtomic",
+      "slippageBps",
+    ])
   ) {
     return null;
   }
+  const inputMint = parsePubkey(value.swap.inputMint);
+  const outputMint = parsePubkey(value.swap.outputMint);
+  const amountAtomic = parsePositiveAtomicString(value.swap.amountAtomic);
+  const slippageBps = Number(value.swap.slippageBps);
+  if (
+    !inputMint ||
+    !outputMint ||
+    !amountAtomic ||
+    !Number.isInteger(slippageBps) ||
+    slippageBps < 1 ||
+    slippageBps > 5_000
+  ) {
+    return null;
+  }
+  const options = parseCommonOptions(value.options);
+  if (options === null) return null;
 
   return {
     intentType: "swap",
@@ -276,153 +518,348 @@ function parsePrivyExecute(value: unknown): {
       amountAtomic,
       slippageBps,
     },
-    ...(Object.keys(options).length > 0
-      ? {
-          options: {
-            ...(options.simulateOnly !== undefined
-              ? { simulateOnly: options.simulateOnly as boolean }
-              : {}),
-            ...(options.requireSimulation !== undefined
-              ? { requireSimulation: options.requireSimulation as boolean }
-              : {}),
-            ...(options.dryRun !== undefined
-              ? { dryRun: options.dryRun as boolean }
-              : {}),
-            ...(options.priorityMicroLamports !== undefined
-              ? {
-                  priorityMicroLamports: Number(options.priorityMicroLamports),
-                }
-              : {}),
-            ...(options.commitment !== undefined
-              ? {
-                  commitment: options.commitment as
-                    | "processed"
-                    | "confirmed"
-                    | "finalized",
-                }
-              : {}),
-            ...(options.orderType !== undefined
-              ? {
-                  orderType: options.orderType as
-                    | "market"
-                    | "limit"
-                    | "trigger",
-                }
-              : {}),
-            ...(options.timeInForce !== undefined
-              ? {
-                  timeInForce: options.timeInForce as "gtc" | "ioc" | "fok",
-                }
-              : {}),
-            ...(options.reduceOnly !== undefined
-              ? { reduceOnly: options.reduceOnly as boolean }
-              : {}),
-            ...(options.postOnly !== undefined
-              ? { postOnly: options.postOnly as boolean }
-              : {}),
-            ...(options.quantityMode !== undefined
-              ? {
-                  quantityMode: options.quantityMode as
-                    | "base"
-                    | "quote"
-                    | "notional",
-                }
-              : {}),
-            ...(options.limitPriceAtomic !== undefined
-              ? { limitPriceAtomic: String(options.limitPriceAtomic) }
-              : {}),
-            ...(options.triggerPriceAtomic !== undefined
-              ? { triggerPriceAtomic: String(options.triggerPriceAtomic) }
-              : {}),
-            ...(options.takeProfitPriceAtomic !== undefined
-              ? { takeProfitPriceAtomic: String(options.takeProfitPriceAtomic) }
-              : {}),
-            ...(options.stopLossPriceAtomic !== undefined
-              ? { stopLossPriceAtomic: String(options.stopLossPriceAtomic) }
-              : {}),
-          },
-        }
-      : {}),
+    ...(Object.keys(options).length > 0 ? { options } : {}),
   };
 }
 
-export type ExecSubmitRequestV1 = {
-  schemaVersion: "v1";
-  mode: ExecutionMode;
-  lane: ExecutionLane;
-  metadata?: {
+function parseConditionalSide(value: unknown): "buy" | "sell" | null {
+  const normalized = String(value ?? "").trim();
+  if (normalized === "buy") return "buy";
+  if (normalized === "sell") return "sell";
+  return null;
+}
+
+function parsePerpSide(
+  value: unknown,
+): "long" | "short" | "close_long" | "close_short" | null {
+  const normalized = String(value ?? "").trim();
+  if (normalized === "long") return "long";
+  if (normalized === "short") return "short";
+  if (normalized === "close_long") return "close_long";
+  if (normalized === "close_short") return "close_short";
+  return null;
+}
+
+function parsePredictionSide(
+  value: unknown,
+): "buy_yes" | "buy_no" | "sell_yes" | "sell_no" | null {
+  const normalized = String(value ?? "").trim();
+  if (normalized === "buy_yes") return "buy_yes";
+  if (normalized === "buy_no") return "buy_no";
+  if (normalized === "sell_yes") return "sell_yes";
+  if (normalized === "sell_no") return "sell_no";
+  return null;
+}
+
+function parseFlashLeg(value: unknown): ExecSubmitPrivyFlashLegV2 | null {
+  if (!isRecord(value)) return null;
+  if (!assertAllowedKeys(value, ["provider", "mint", "amountAtomic"])) {
+    return null;
+  }
+  const provider = parseBoundedString(value.provider, 1, 80);
+  const mint = parsePubkey(value.mint);
+  const amountAtomic = parsePositiveAtomicString(value.amountAtomic);
+  if (!provider || !mint || !amountAtomic) return null;
+  return {
+    provider,
+    mint,
+    amountAtomic,
+  };
+}
+
+function parsePrivyIntentV2(
+  value: unknown,
+  options: ExecSubmitOptions,
+): ExecSubmitPrivyIntentV2 | null {
+  if (!isRecord(value)) return null;
+  const family = parseExecutionIntentFamily(value.family);
+  if (!family) return null;
+
+  switch (family) {
+    case "spot_swap": {
+      if (
+        !assertAllowedKeys(value, [
+          "family",
+          "venueKey",
+          "marketType",
+          "inputMint",
+          "outputMint",
+          "amountAtomic",
+          "slippageBps",
+        ])
+      ) {
+        return null;
+      }
+      const venueKey =
+        value.venueKey !== undefined
+          ? parseVenueKey(value.venueKey)
+          : undefined;
+      const marketType =
+        value.marketType === undefined
+          ? "spot"
+          : parseMarketType(value.marketType);
+      const inputMint = parsePubkey(value.inputMint);
+      const outputMint = parsePubkey(value.outputMint);
+      const amountAtomic = parsePositiveAtomicString(value.amountAtomic);
+      const slippageBps = Number(value.slippageBps);
+      if (
+        marketType !== "spot" ||
+        (value.venueKey !== undefined && !venueKey) ||
+        !inputMint ||
+        !outputMint ||
+        !amountAtomic ||
+        !Number.isInteger(slippageBps) ||
+        slippageBps < 1 ||
+        slippageBps > 5_000
+      ) {
+        return null;
+      }
+      return {
+        family,
+        ...(venueKey ? { venueKey } : {}),
+        marketType: "spot",
+        inputMint,
+        outputMint,
+        amountAtomic,
+        slippageBps,
+      };
+    }
+    case "conditional_spot_order": {
+      if (
+        !assertAllowedKeys(value, [
+          "family",
+          "venueKey",
+          "marketType",
+          "instrumentId",
+          "side",
+          "quantityAtomic",
+        ])
+      ) {
+        return null;
+      }
+      const venueKey = parseVenueKey(value.venueKey);
+      const marketType =
+        value.marketType === undefined
+          ? "spot"
+          : parseMarketType(value.marketType);
+      const instrumentId = parseInstrumentId(value.instrumentId);
+      const side = parseConditionalSide(value.side);
+      const quantityAtomic = parsePositiveAtomicString(value.quantityAtomic);
+      const hasConditionalPricing =
+        Boolean(options.limitPriceAtomic) ||
+        Boolean(options.triggerPriceAtomic) ||
+        Boolean(options.takeProfitPriceAtomic) ||
+        Boolean(options.stopLossPriceAtomic);
+      if (
+        !venueKey ||
+        marketType !== "spot" ||
+        !instrumentId ||
+        !side ||
+        !quantityAtomic ||
+        !hasConditionalPricing
+      ) {
+        return null;
+      }
+      return {
+        family,
+        venueKey,
+        marketType: "spot",
+        instrumentId,
+        side,
+        quantityAtomic,
+      };
+    }
+    case "clob_order": {
+      if (
+        !assertAllowedKeys(value, [
+          "family",
+          "venueKey",
+          "marketType",
+          "instrumentId",
+          "side",
+          "quantityAtomic",
+        ])
+      ) {
+        return null;
+      }
+      const venueKey = parseVenueKey(value.venueKey);
+      const marketType = parseMarketType(value.marketType);
+      const instrumentId = parseInstrumentId(value.instrumentId);
+      const side = parseConditionalSide(value.side);
+      const quantityAtomic = parsePositiveAtomicString(value.quantityAtomic);
+      if (
+        !venueKey ||
+        (marketType !== "spot" && marketType !== "perp") ||
+        !instrumentId ||
+        !side ||
+        !quantityAtomic
+      ) {
+        return null;
+      }
+      return {
+        family,
+        venueKey,
+        marketType,
+        instrumentId,
+        side,
+        quantityAtomic,
+      };
+    }
+    case "perp_order": {
+      if (
+        !assertAllowedKeys(value, [
+          "family",
+          "venueKey",
+          "marketType",
+          "instrumentId",
+          "side",
+          "quantityAtomic",
+          "collateralAtomic",
+        ])
+      ) {
+        return null;
+      }
+      const venueKey = parseVenueKey(value.venueKey);
+      const marketType = parseMarketType(value.marketType);
+      const instrumentId = parseInstrumentId(value.instrumentId);
+      const side = parsePerpSide(value.side);
+      const quantityAtomic = parsePositiveAtomicString(value.quantityAtomic);
+      const collateralAtomic =
+        value.collateralAtomic !== undefined
+          ? parsePositiveAtomicString(value.collateralAtomic)
+          : undefined;
+      if (
+        !venueKey ||
+        marketType !== "perp" ||
+        !instrumentId ||
+        !side ||
+        !quantityAtomic ||
+        (value.collateralAtomic !== undefined && !collateralAtomic)
+      ) {
+        return null;
+      }
+      return {
+        family,
+        venueKey,
+        marketType: "perp",
+        instrumentId,
+        side,
+        quantityAtomic,
+        ...(collateralAtomic ? { collateralAtomic } : {}),
+      };
+    }
+    case "prediction_order": {
+      if (
+        !assertAllowedKeys(value, [
+          "family",
+          "venueKey",
+          "marketType",
+          "instrumentId",
+          "outcomeId",
+          "side",
+          "quantityAtomic",
+        ])
+      ) {
+        return null;
+      }
+      const venueKey = parseVenueKey(value.venueKey);
+      const marketType = parseMarketType(value.marketType);
+      const instrumentId = parseInstrumentId(value.instrumentId);
+      const outcomeId = parseInstrumentId(value.outcomeId);
+      const side = parsePredictionSide(value.side);
+      const quantityAtomic = parsePositiveAtomicString(value.quantityAtomic);
+      if (
+        !venueKey ||
+        marketType !== "prediction" ||
+        !instrumentId ||
+        !outcomeId ||
+        !side ||
+        !quantityAtomic
+      ) {
+        return null;
+      }
+      return {
+        family,
+        venueKey,
+        marketType: "prediction",
+        instrumentId,
+        outcomeId,
+        side,
+        quantityAtomic,
+      };
+    }
+    case "flash_atomic": {
+      if (
+        !assertAllowedKeys(value, [
+          "family",
+          "venueKey",
+          "marketType",
+          "referenceId",
+          "borrowLegs",
+          "settlementMint",
+        ])
+      ) {
+        return null;
+      }
+      const venueKey = parseVenueKey(value.venueKey);
+      const marketType =
+        value.marketType === undefined
+          ? "spot"
+          : parseMarketType(value.marketType);
+      const referenceId = parseInstrumentId(value.referenceId);
+      const settlementMint = parsePubkey(value.settlementMint);
+      const borrowLegs = Array.isArray(value.borrowLegs)
+        ? value.borrowLegs.map((entry) => parseFlashLeg(entry))
+        : null;
+      if (
+        !venueKey ||
+        marketType !== "spot" ||
+        !referenceId ||
+        !settlementMint ||
+        !borrowLegs ||
+        borrowLegs.length < 1 ||
+        borrowLegs.some((entry) => entry === null)
+      ) {
+        return null;
+      }
+      return {
+        family,
+        venueKey,
+        marketType: "spot",
+        referenceId,
+        borrowLegs: borrowLegs as ExecSubmitPrivyFlashLegV2[],
+        settlementMint,
+      };
+    }
+  }
+}
+
+function parsePrivyExecuteV2(value: unknown): ExecSubmitPrivyExecuteV2 | null {
+  if (!isRecord(value)) return null;
+  if (!assertAllowedKeys(value, ["wallet", "intent", "options"])) return null;
+  const wallet = parsePubkey(value.wallet);
+  if (!wallet) return null;
+  const options = parseCommonOptions(value.options);
+  if (options === null) return null;
+  const intent = parsePrivyIntentV2(value.intent, options);
+  if (!intent) return null;
+  return {
+    wallet,
+    intent,
+    ...(Object.keys(options).length > 0 ? { options } : {}),
+  };
+}
+
+function parseSubmitPayloadV1(
+  value: Record<string, unknown>,
+  mode: ExecutionMode,
+  lane: ExecutionLane,
+  metadata: {
     source?: string;
     reason?: string;
     clientRequestId?: string;
-  };
-  relaySigned?: {
-    encoding: "base64";
-    signedTransaction: string;
-  };
-  privyExecute?: {
-    intentType: "swap";
-    wallet: string;
-    swap: {
-      inputMint: string;
-      outputMint: string;
-      amountAtomic: string;
-      slippageBps: number;
-    };
-    options?: {
-      simulateOnly?: boolean;
-      requireSimulation?: boolean;
-      dryRun?: boolean;
-      priorityMicroLamports?: number;
-      commitment?: "processed" | "confirmed" | "finalized";
-      orderType?: "market" | "limit" | "trigger";
-      timeInForce?: "gtc" | "ioc" | "fok";
-      reduceOnly?: boolean;
-      postOnly?: boolean;
-      quantityMode?: "base" | "quote" | "notional";
-      limitPriceAtomic?: string;
-      triggerPriceAtomic?: string;
-      takeProfitPriceAtomic?: string;
-      stopLossPriceAtomic?: string;
-    };
-  };
-};
-
-export type ExecSubmitPayloadParseResult =
-  | {
-      ok: true;
-      value: ExecSubmitRequestV1;
-      metadataForStorage: JsonObject | null;
-    }
-  | { ok: false; error: "invalid-request" };
-
-export function parseExecSubmitPayload(
-  value: unknown,
+  },
 ): ExecSubmitPayloadParseResult {
-  if (!isRecord(value)) return { ok: false, error: "invalid-request" };
-  const allowedTopLevel = new Set([
-    "schemaVersion",
-    "mode",
-    "lane",
-    "metadata",
-    "relaySigned",
-    "privyExecute",
-  ]);
-  for (const key of Object.keys(value)) {
-    if (!allowedTopLevel.has(key)) {
-      return { ok: false, error: "invalid-request" };
-    }
-  }
-
-  if (String(value.schemaVersion ?? "") !== SCHEMA_VERSION) {
-    return { ok: false, error: "invalid-request" };
-  }
-  const mode = parseMode(value.mode);
-  const lane = parseLane(value.lane);
-  if (!mode || !lane) return { ok: false, error: "invalid-request" };
-
-  const metadata = parseMetadata(value.metadata);
-  if (metadata === null) return { ok: false, error: "invalid-request" };
-
   if (mode === "relay_signed") {
     const relaySigned = parseRelaySigned(value.relaySigned);
     if (!relaySigned || value.privyExecute !== undefined) {
@@ -431,35 +868,239 @@ export function parseExecSubmitPayload(
     return {
       ok: true,
       value: {
-        schemaVersion: "v1",
+        schemaVersion: SCHEMA_VERSION_V1,
         mode,
         lane,
-        ...(metadata && Object.keys(metadata).length > 0 ? { metadata } : {}),
+        ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
         relaySigned,
       },
       metadataForStorage:
-        metadata && Object.keys(metadata).length > 0
+        Object.keys(metadata).length > 0
           ? ({ ...metadata } as JsonObject)
           : null,
     };
   }
 
-  const privyExecute = parsePrivyExecute(value.privyExecute);
+  const privyExecute = parsePrivyExecuteV1(value.privyExecute);
   if (!privyExecute || value.relaySigned !== undefined) {
     return { ok: false, error: "invalid-request" };
   }
   return {
     ok: true,
     value: {
-      schemaVersion: "v1",
+      schemaVersion: SCHEMA_VERSION_V1,
       mode,
       lane,
-      ...(metadata && Object.keys(metadata).length > 0 ? { metadata } : {}),
+      ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
       privyExecute,
     },
     metadataForStorage:
-      metadata && Object.keys(metadata).length > 0
-        ? ({ ...metadata } as JsonObject)
-        : null,
+      Object.keys(metadata).length > 0 ? ({ ...metadata } as JsonObject) : null,
   };
+}
+
+function parseSubmitPayloadV2(
+  value: Record<string, unknown>,
+  mode: ExecutionMode,
+  lane: ExecutionLane,
+  metadata: {
+    source?: string;
+    reason?: string;
+    clientRequestId?: string;
+  },
+): ExecSubmitPayloadParseResult {
+  if (mode === "relay_signed") {
+    const relaySigned = parseRelaySigned(value.relaySigned);
+    if (!relaySigned || value.privyExecute !== undefined) {
+      return { ok: false, error: "invalid-request" };
+    }
+    return {
+      ok: true,
+      value: {
+        schemaVersion: SCHEMA_VERSION_V2,
+        mode,
+        lane,
+        ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+        relaySigned,
+      },
+      metadataForStorage:
+        Object.keys(metadata).length > 0
+          ? ({ ...metadata } as JsonObject)
+          : null,
+    };
+  }
+
+  const privyExecute = parsePrivyExecuteV2(value.privyExecute);
+  if (!privyExecute || value.relaySigned !== undefined) {
+    return { ok: false, error: "invalid-request" };
+  }
+  return {
+    ok: true,
+    value: {
+      schemaVersion: SCHEMA_VERSION_V2,
+      mode,
+      lane,
+      ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+      privyExecute,
+    },
+    metadataForStorage:
+      Object.keys(metadata).length > 0 ? ({ ...metadata } as JsonObject) : null,
+  };
+}
+
+export function resolveExecSubmitIntentFamily(
+  value: ExecSubmitRequest,
+): ExecutionIntentFamily | null {
+  if (value.mode !== "privy_execute") return null;
+  if (value.schemaVersion === SCHEMA_VERSION_V1) return "spot_swap";
+  return value.privyExecute?.intent.family ?? null;
+}
+
+export function resolveExecSubmitSpotSwap(
+  value: ExecSubmitRequest,
+): ExecSubmitSpotSwapCompat | null {
+  if (value.mode !== "privy_execute") return null;
+  if (value.schemaVersion === SCHEMA_VERSION_V1) {
+    const privyExecute = value.privyExecute;
+    if (!privyExecute) return null;
+    return {
+      wallet: privyExecute.wallet,
+      swap: { ...privyExecute.swap },
+      ...(privyExecute.options ? { options: { ...privyExecute.options } } : {}),
+    };
+  }
+
+  const privyExecute = value.privyExecute;
+  if (!privyExecute || privyExecute.intent.family !== "spot_swap") {
+    return null;
+  }
+  return {
+    wallet: privyExecute.wallet,
+    ...(privyExecute.intent.venueKey
+      ? { venueKey: privyExecute.intent.venueKey }
+      : {}),
+    swap: {
+      inputMint: privyExecute.intent.inputMint,
+      outputMint: privyExecute.intent.outputMint,
+      amountAtomic: privyExecute.intent.amountAtomic,
+      slippageBps: privyExecute.intent.slippageBps,
+    },
+    ...(privyExecute.options ? { options: { ...privyExecute.options } } : {}),
+  };
+}
+
+export function toExecSubmitRequestV1Compat(
+  value: ExecSubmitRequest,
+): ExecSubmitRequestV1 | null {
+  if (value.mode === "relay_signed") {
+    if (!value.relaySigned) return null;
+    return {
+      schemaVersion: SCHEMA_VERSION_V1,
+      mode: value.mode,
+      lane: value.lane,
+      ...(value.metadata ? { metadata: { ...value.metadata } } : {}),
+      relaySigned: { ...value.relaySigned },
+    };
+  }
+
+  const spotSwap = resolveExecSubmitSpotSwap(value);
+  if (!spotSwap) return null;
+  return {
+    schemaVersion: SCHEMA_VERSION_V1,
+    mode: "privy_execute",
+    lane: value.lane,
+    ...(value.metadata ? { metadata: { ...value.metadata } } : {}),
+    privyExecute: {
+      intentType: "swap",
+      wallet: spotSwap.wallet,
+      swap: { ...spotSwap.swap },
+      ...(spotSwap.options ? { options: { ...spotSwap.options } } : {}),
+    },
+  };
+}
+
+export function buildExecSubmitIntentSummary(
+  value: ExecSubmitRequest,
+): JsonObject | null {
+  if (value.mode !== "privy_execute") return null;
+  if (value.schemaVersion === SCHEMA_VERSION_V1) {
+    const compat = resolveExecSubmitSpotSwap(value);
+    if (!compat) return null;
+    return {
+      family: "spot_swap",
+      marketType: "spot",
+      inputMint: compat.swap.inputMint,
+      outputMint: compat.swap.outputMint,
+    };
+  }
+
+  const intent = value.privyExecute?.intent;
+  if (!intent) return null;
+  switch (intent.family) {
+    case "spot_swap":
+      return {
+        family: intent.family,
+        marketType: intent.marketType,
+        ...(intent.venueKey ? { venueKey: intent.venueKey } : {}),
+        inputMint: intent.inputMint,
+        outputMint: intent.outputMint,
+      };
+    case "conditional_spot_order":
+    case "clob_order":
+    case "perp_order":
+    case "prediction_order":
+      return {
+        family: intent.family,
+        marketType: intent.marketType,
+        venueKey: intent.venueKey,
+        instrumentId: intent.instrumentId,
+        ...(intent.side ? { side: intent.side } : {}),
+        ...(intent.family === "prediction_order"
+          ? { outcomeId: intent.outcomeId }
+          : {}),
+      };
+    case "flash_atomic":
+      return {
+        family: intent.family,
+        marketType: intent.marketType,
+        venueKey: intent.venueKey,
+        referenceId: intent.referenceId,
+        settlementMint: intent.settlementMint,
+        borrowLegCount: intent.borrowLegs.length,
+      };
+  }
+}
+
+export function parseExecSubmitPayload(
+  value: unknown,
+): ExecSubmitPayloadParseResult {
+  if (!isRecord(value)) return { ok: false, error: "invalid-request" };
+  if (
+    !assertAllowedKeys(value, [
+      "schemaVersion",
+      "mode",
+      "lane",
+      "metadata",
+      "relaySigned",
+      "privyExecute",
+    ])
+  ) {
+    return { ok: false, error: "invalid-request" };
+  }
+
+  const mode = parseMode(value.mode);
+  const lane = parseLane(value.lane);
+  const metadata = parseMetadata(value.metadata);
+  if (!mode || !lane || metadata === null) {
+    return { ok: false, error: "invalid-request" };
+  }
+
+  const schemaVersion = String(value.schemaVersion ?? "").trim();
+  if (schemaVersion === SCHEMA_VERSION_V1) {
+    return parseSubmitPayloadV1(value, mode, lane, metadata);
+  }
+  if (schemaVersion === SCHEMA_VERSION_V2) {
+    return parseSubmitPayloadV2(value, mode, lane, metadata);
+  }
+  return { ok: false, error: "invalid-request" };
 }

--- a/apps/worker/src/execution/types.ts
+++ b/apps/worker/src/execution/types.ts
@@ -10,6 +10,99 @@ export type ExecutionLogFn = (
   meta?: Record<string, unknown>,
 ) => void;
 
+export type ExecutionIntentFamily =
+  | "spot_swap"
+  | "conditional_spot_order"
+  | "clob_order"
+  | "perp_order"
+  | "prediction_order"
+  | "flash_atomic";
+
+export type ExecutionIntentLifecycleSnapshot = {
+  orderState?:
+    | "accepted"
+    | "open"
+    | "partially_filled"
+    | "filled"
+    | "cancel_requested"
+    | "cancelled"
+    | "expired"
+    | "rejected";
+  fillState?: "pending" | "partial" | "filled" | "settled" | "failed";
+  positionState?:
+    | "flat"
+    | "opening"
+    | "open"
+    | "closing"
+    | "closed"
+    | "liquidating"
+    | "liquidated";
+  settlementState?:
+    | "pending"
+    | "landed"
+    | "confirmed"
+    | "finalized"
+    | "redeemed"
+    | "failed";
+  notes?: string[];
+};
+
+export type SpotSwapExecutionIntent = {
+  family: "spot_swap";
+  wallet: string;
+  venueKey?: string;
+  marketType: "spot";
+  inputMint: string;
+  outputMint: string;
+  amountAtomic: string;
+  slippageBps: number;
+  lifecycle?: ExecutionIntentLifecycleSnapshot;
+};
+
+export type NonSwapExecutionIntent = {
+  family: Exclude<ExecutionIntentFamily, "spot_swap">;
+  wallet: string;
+  venueKey: string;
+  marketType: "spot" | "perp" | "prediction";
+  instrumentId: string;
+  side?: string;
+  quantityAtomic?: string;
+  referenceId?: string;
+  params?: Record<string, unknown> | null;
+  lifecycle?: ExecutionIntentLifecycleSnapshot;
+};
+
+export type ExecutionRouterIntent =
+  | SpotSwapExecutionIntent
+  | NonSwapExecutionIntent;
+
+type ExecuteIntentInputBase = {
+  env: Env;
+  venueKey?: string;
+  runtimeMode?: RuntimeMode;
+  requireVenueRouting?: boolean;
+  subjectControlBypassReason?: "strategy_lab_readiness_canary";
+  execution?: ExecutionConfig;
+  policy: NormalizedPolicy;
+  rpc: SolanaRpc;
+  jupiter: JupiterClient;
+  log: ExecutionLogFn;
+  guardEnabled?: () => Promise<void>;
+  privyWalletId?: string;
+};
+
+export type ExecuteIntentInput =
+  | (ExecuteIntentInputBase & {
+      intent: SpotSwapExecutionIntent;
+      quoteResponse: JupiterQuoteResponse;
+      userPublicKey: string;
+    })
+  | (ExecuteIntentInputBase & {
+      intent: NonSwapExecutionIntent;
+      quoteResponse?: never;
+      userPublicKey?: string;
+    });
+
 export type ExecuteSwapInput = {
   env: Env;
   venueKey?: string;

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -78,7 +78,10 @@ import {
   upsertExecutionReceiptIdempotent,
 } from "./execution/repository";
 import { evaluateExecutionRolloutGate } from "./execution/rollout_gate";
-import { executeSwapViaRouter } from "./execution/router";
+import {
+  executeSwapViaRouter,
+  resolveExecutionAdapterRegistration,
+} from "./execution/router";
 import {
   buildExecSubmitIntentSummary,
   parseExecSubmitPayload,
@@ -1398,6 +1401,25 @@ const worker = {
             env,
           );
         }
+        if (parsed.value.schemaVersion === "v2" && spotSwap?.venueKey) {
+          const resolvedAdapter = resolveExecutionAdapterRegistration(
+            laneResolution.adapter,
+          );
+          if (
+            !resolvedAdapter ||
+            resolvedAdapter.venueKey !== spotSwap.venueKey
+          ) {
+            return withCors(
+              execErrorResponse({
+                code: "invalid-request",
+                details: {
+                  reason: `unsupported-venue-route:${spotSwap.venueKey}:${laneResolution.adapter}`,
+                },
+              }),
+              env,
+            );
+          }
+        }
 
         const submitPolicy = await evaluateExecutionSubmitPolicy({
           env,
@@ -1700,6 +1722,7 @@ const worker = {
 
             const result = await executeSwapViaRouter({
               env,
+              venueKey: spotSwap?.venueKey,
               execution,
               policy,
               rpc,

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -79,7 +79,13 @@ import {
 } from "./execution/repository";
 import { evaluateExecutionRolloutGate } from "./execution/rollout_gate";
 import { executeSwapViaRouter } from "./execution/router";
-import { parseExecSubmitPayload } from "./execution/submit_contract";
+import {
+  buildExecSubmitIntentSummary,
+  parseExecSubmitPayload,
+  resolveExecSubmitIntentFamily,
+  resolveExecSubmitSpotSwap,
+  toExecSubmitRequestV1Compat,
+} from "./execution/submit_contract";
 import {
   type ExperienceLevel,
   evaluateOnboarding,
@@ -1097,6 +1103,10 @@ const worker = {
             env,
           );
         }
+        const compatRequest = toExecSubmitRequestV1Compat(parsed.value);
+        const intentFamily = resolveExecSubmitIntentFamily(parsed.value);
+        const spotSwap = resolveExecSubmitSpotSwap(parsed.value);
+        const intentSummary = buildExecSubmitIntentSummary(parsed.value);
 
         const idempotencyKey = readIdempotencyKey(request);
         if (!idempotencyKey) {
@@ -1286,6 +1296,7 @@ const worker = {
             request: abuseCheck.metadata,
           },
           laneResolution: laneResolution.metadata,
+          ...(intentSummary ? { intent: intentSummary } : {}),
           actor: {
             type: actorType,
             id: actorId,
@@ -1359,9 +1370,38 @@ const worker = {
           };
         }
 
+        if (parsed.value.mode === "privy_execute" && !compatRequest) {
+          return withCors(
+            execErrorResponse({
+              code: "invalid-request",
+              details: {
+                reason: intentFamily
+                  ? `unsupported-intent-family:${intentFamily}`
+                  : "unsupported-intent-family",
+              },
+            }),
+            env,
+          );
+        }
+        if (
+          parsed.value.schemaVersion === "v2" &&
+          spotSwap?.venueKey &&
+          spotSwap.venueKey !== "jupiter"
+        ) {
+          return withCors(
+            execErrorResponse({
+              code: "invalid-request",
+              details: {
+                reason: `unsupported-venue-key:${spotSwap.venueKey}`,
+              },
+            }),
+            env,
+          );
+        }
+
         const submitPolicy = await evaluateExecutionSubmitPolicy({
           env,
-          request: parsed.value,
+          request: compatRequest as NonNullable<typeof compatRequest>,
           lane: laneResolution.lane,
           actorType,
         });
@@ -1518,8 +1558,21 @@ const worker = {
           shouldSyncExecutePrivySubmit(env) &&
           privyActorContext
         ) {
-          const swap = parsed.value.privyExecute.swap;
-          const options = parsed.value.privyExecute.options ?? {};
+          if (!spotSwap) {
+            return withCors(
+              execErrorResponse({
+                code: "invalid-request",
+                details: {
+                  reason: intentFamily
+                    ? `unsupported-intent-family:${intentFamily}`
+                    : "unsupported-intent-family",
+                },
+              }),
+              env,
+            );
+          }
+          const swap = spotSwap.swap;
+          const options = spotSwap.options ?? {};
           const requestedRequireSimulation =
             typeof options.requireSimulation === "boolean"
               ? options.requireSimulation
@@ -1706,6 +1759,15 @@ const worker = {
                 route: laneResolution.adapter,
                 resultStatus: result.status,
                 outcome: terminalStatus,
+                lifecycle: {
+                  settlementState:
+                    result.status === "finalized"
+                      ? "finalized"
+                      : result.status === "confirmed"
+                        ? "confirmed"
+                        : "landed",
+                  notes: ["spot_swap"],
+                },
                 quality: qualityMetadata,
                 quote: {
                   inputMint: swap.inputMint,
@@ -1776,6 +1838,10 @@ const worker = {
                 mode: parsed.value.mode,
                 route: laneResolution.adapter,
                 outcome: terminalStatus,
+                lifecycle: {
+                  settlementState: "failed",
+                  notes: [statusReason],
+                },
                 quality: qualityMetadata,
               },
               readyAt: failedAt,
@@ -1887,6 +1953,12 @@ const worker = {
         const relayImmutability = readRelayImmutabilitySnapshot(
           latest.request.metadata,
         );
+        const intentSummary = isRecord(latest.request.metadata?.intent)
+          ? latest.request.metadata.intent
+          : null;
+        const lifecycleSummary = isRecord(latest.receipt?.receipt?.lifecycle)
+          ? latest.receipt?.receipt?.lifecycle
+          : null;
         return withCors(
           json({
             ok: true,
@@ -1925,6 +1997,8 @@ const worker = {
               state: attempt.status,
               at: attempt.completedAt ?? attempt.startedAt,
             })),
+            ...(intentSummary ? { intent: intentSummary } : {}),
+            ...(lifecycleSummary ? { lifecycle: lifecycleSummary } : {}),
           }),
           env,
         );

--- a/docs/execution/fixtures/submit.invalid.perp-missing-market-type.v2.json
+++ b/docs/execution/fixtures/submit.invalid.perp-missing-market-type.v2.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "v2",
+  "mode": "privy_execute",
+  "lane": "protected",
+  "privyExecute": {
+    "wallet": "11111111111111111111111111111111",
+    "intent": {
+      "family": "perp_order",
+      "venueKey": "drift",
+      "instrumentId": "SOL-PERP",
+      "side": "long",
+      "quantityAtomic": "1000000"
+    }
+  }
+}

--- a/docs/execution/fixtures/submit.privy_execute.perp_order.valid.v2.json
+++ b/docs/execution/fixtures/submit.privy_execute.perp_order.valid.v2.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "v2",
+  "mode": "privy_execute",
+  "lane": "protected",
+  "metadata": {
+    "source": "terminal-ui",
+    "reason": "bounded-perp-order"
+  },
+  "privyExecute": {
+    "wallet": "11111111111111111111111111111111",
+    "intent": {
+      "family": "perp_order",
+      "venueKey": "drift",
+      "marketType": "perp",
+      "instrumentId": "SOL-PERP",
+      "side": "long",
+      "quantityAtomic": "1000000",
+      "collateralAtomic": "250000"
+    },
+    "options": {
+      "orderType": "limit",
+      "limitPriceAtomic": "155000000",
+      "reduceOnly": false,
+      "timeInForce": "gtc"
+    }
+  }
+}

--- a/docs/execution/fixtures/submit.privy_execute.spot_swap.valid.v2.json
+++ b/docs/execution/fixtures/submit.privy_execute.spot_swap.valid.v2.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": "v2",
+  "mode": "privy_execute",
+  "lane": "safe",
+  "metadata": {
+    "source": "terminal-ui",
+    "reason": "manual-spot-swap"
+  },
+  "privyExecute": {
+    "wallet": "11111111111111111111111111111111",
+    "intent": {
+      "family": "spot_swap",
+      "venueKey": "jupiter",
+      "marketType": "spot",
+      "inputMint": "So11111111111111111111111111111111111111112",
+      "outputMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "amountAtomic": "1500000",
+      "slippageBps": 30
+    },
+    "options": {
+      "requireSimulation": true,
+      "commitment": "confirmed"
+    }
+  }
+}

--- a/docs/execution/schemas/exec.receipt.response.v1.schema.json
+++ b/docs/execution/schemas/exec.receipt.response.v1.schema.json
@@ -127,6 +127,38 @@
               "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T"
             }
           }
+        },
+        "intent": {
+          "type": "object",
+          "required": ["family"],
+          "additionalProperties": false,
+          "properties": {
+            "family": { "type": "string", "minLength": 1 },
+            "marketType": { "type": "string", "minLength": 1 },
+            "venueKey": { "type": "string", "minLength": 1 },
+            "instrumentId": { "type": "string", "minLength": 1 },
+            "inputMint": { "type": "string", "minLength": 1 },
+            "outputMint": { "type": "string", "minLength": 1 },
+            "outcomeId": { "type": "string", "minLength": 1 },
+            "referenceId": { "type": "string", "minLength": 1 },
+            "side": { "type": "string", "minLength": 1 },
+            "settlementMint": { "type": "string", "minLength": 1 },
+            "borrowLegCount": { "type": "integer", "minimum": 1 }
+          }
+        },
+        "lifecycle": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "orderState": { "type": "string", "minLength": 1 },
+            "fillState": { "type": "string", "minLength": 1 },
+            "positionState": { "type": "string", "minLength": 1 },
+            "settlementState": { "type": "string", "minLength": 1 },
+            "notes": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            }
+          }
         }
       }
     }

--- a/docs/execution/schemas/exec.status.response.v1.schema.json
+++ b/docs/execution/schemas/exec.status.response.v1.schema.json
@@ -101,6 +101,38 @@
           "at": { "type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T" }
         }
       }
+    },
+    "intent": {
+      "type": "object",
+      "required": ["family"],
+      "additionalProperties": false,
+      "properties": {
+        "family": { "type": "string", "minLength": 1 },
+        "marketType": { "type": "string", "minLength": 1 },
+        "venueKey": { "type": "string", "minLength": 1 },
+        "instrumentId": { "type": "string", "minLength": 1 },
+        "inputMint": { "type": "string", "minLength": 1 },
+        "outputMint": { "type": "string", "minLength": 1 },
+        "outcomeId": { "type": "string", "minLength": 1 },
+        "referenceId": { "type": "string", "minLength": 1 },
+        "side": { "type": "string", "minLength": 1 },
+        "settlementMint": { "type": "string", "minLength": 1 },
+        "borrowLegCount": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "lifecycle": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "orderState": { "type": "string", "minLength": 1 },
+        "fillState": { "type": "string", "minLength": 1 },
+        "positionState": { "type": "string", "minLength": 1 },
+        "settlementState": { "type": "string", "minLength": 1 },
+        "notes": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
     }
   }
 }

--- a/docs/execution/schemas/exec.submit.request.v2.schema.json
+++ b/docs/execution/schemas/exec.submit.request.v2.schema.json
@@ -1,0 +1,356 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://trader-ralph.com/schemas/exec.submit.request.v2.schema.json",
+  "title": "ExecSubmitRequestV2",
+  "type": "object",
+  "required": ["schemaVersion", "mode", "lane"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": { "const": "v2" },
+    "mode": { "type": "string", "enum": ["relay_signed", "privy_execute"] },
+    "lane": { "type": "string", "enum": ["fast", "protected", "safe"] },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "source": { "type": "string", "minLength": 1, "maxLength": 80 },
+        "reason": { "type": "string", "minLength": 1, "maxLength": 240 },
+        "clientRequestId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 120
+        }
+      }
+    },
+    "relaySigned": {
+      "type": "object",
+      "required": ["encoding", "signedTransaction"],
+      "additionalProperties": false,
+      "properties": {
+        "encoding": { "const": "base64" },
+        "signedTransaction": {
+          "type": "string",
+          "minLength": 16,
+          "pattern": "^[A-Za-z0-9+/=]+$"
+        }
+      }
+    },
+    "privyExecute": {
+      "type": "object",
+      "required": ["wallet", "intent"],
+      "additionalProperties": false,
+      "properties": {
+        "wallet": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64,
+          "pattern": "^[1-9A-HJ-NP-Za-km-z]+$"
+        },
+        "intent": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "family",
+                "marketType",
+                "inputMint",
+                "outputMint",
+                "amountAtomic",
+                "slippageBps"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "family": { "const": "spot_swap" },
+                "venueKey": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 64
+                },
+                "marketType": { "const": "spot" },
+                "inputMint": {
+                  "type": "string",
+                  "minLength": 32,
+                  "maxLength": 64,
+                  "pattern": "^[1-9A-HJ-NP-Za-km-z]+$"
+                },
+                "outputMint": {
+                  "type": "string",
+                  "minLength": 32,
+                  "maxLength": 64,
+                  "pattern": "^[1-9A-HJ-NP-Za-km-z]+$"
+                },
+                "amountAtomic": {
+                  "type": "string",
+                  "pattern": "^[1-9][0-9]*$"
+                },
+                "slippageBps": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 5000
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "family",
+                "venueKey",
+                "marketType",
+                "instrumentId",
+                "side",
+                "quantityAtomic"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "family": { "const": "conditional_spot_order" },
+                "venueKey": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 64
+                },
+                "marketType": { "const": "spot" },
+                "instrumentId": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 160
+                },
+                "side": { "type": "string", "enum": ["buy", "sell"] },
+                "quantityAtomic": {
+                  "type": "string",
+                  "pattern": "^[1-9][0-9]*$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "family",
+                "venueKey",
+                "marketType",
+                "instrumentId",
+                "side",
+                "quantityAtomic"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "family": { "const": "clob_order" },
+                "venueKey": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 64
+                },
+                "marketType": { "type": "string", "enum": ["spot", "perp"] },
+                "instrumentId": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 160
+                },
+                "side": { "type": "string", "enum": ["buy", "sell"] },
+                "quantityAtomic": {
+                  "type": "string",
+                  "pattern": "^[1-9][0-9]*$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "family",
+                "venueKey",
+                "marketType",
+                "instrumentId",
+                "side",
+                "quantityAtomic"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "family": { "const": "perp_order" },
+                "venueKey": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 64
+                },
+                "marketType": { "const": "perp" },
+                "instrumentId": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 160
+                },
+                "side": {
+                  "type": "string",
+                  "enum": ["long", "short", "close_long", "close_short"]
+                },
+                "quantityAtomic": {
+                  "type": "string",
+                  "pattern": "^[1-9][0-9]*$"
+                },
+                "collateralAtomic": {
+                  "type": "string",
+                  "pattern": "^[1-9][0-9]*$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "family",
+                "venueKey",
+                "marketType",
+                "instrumentId",
+                "outcomeId",
+                "side",
+                "quantityAtomic"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "family": { "const": "prediction_order" },
+                "venueKey": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 64
+                },
+                "marketType": { "const": "prediction" },
+                "instrumentId": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 160
+                },
+                "outcomeId": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 160
+                },
+                "side": {
+                  "type": "string",
+                  "enum": ["buy_yes", "buy_no", "sell_yes", "sell_no"]
+                },
+                "quantityAtomic": {
+                  "type": "string",
+                  "pattern": "^[1-9][0-9]*$"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "family",
+                "venueKey",
+                "marketType",
+                "referenceId",
+                "borrowLegs",
+                "settlementMint"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "family": { "const": "flash_atomic" },
+                "venueKey": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 64
+                },
+                "marketType": { "const": "spot" },
+                "referenceId": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 160
+                },
+                "borrowLegs": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "object",
+                    "required": ["provider", "mint", "amountAtomic"],
+                    "additionalProperties": false,
+                    "properties": {
+                      "provider": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 80
+                      },
+                      "mint": {
+                        "type": "string",
+                        "minLength": 32,
+                        "maxLength": 64,
+                        "pattern": "^[1-9A-HJ-NP-Za-km-z]+$"
+                      },
+                      "amountAtomic": {
+                        "type": "string",
+                        "pattern": "^[1-9][0-9]*$"
+                      }
+                    }
+                  }
+                },
+                "settlementMint": {
+                  "type": "string",
+                  "minLength": 32,
+                  "maxLength": 64,
+                  "pattern": "^[1-9A-HJ-NP-Za-km-z]+$"
+                }
+              }
+            }
+          ]
+        },
+        "options": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "simulateOnly": { "type": "boolean" },
+            "requireSimulation": { "type": "boolean" },
+            "dryRun": { "type": "boolean" },
+            "priorityMicroLamports": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2000000
+            },
+            "commitment": {
+              "type": "string",
+              "enum": ["processed", "confirmed", "finalized"]
+            },
+            "orderType": {
+              "type": "string",
+              "enum": ["market", "limit", "trigger"]
+            },
+            "timeInForce": {
+              "type": "string",
+              "enum": ["gtc", "ioc", "fok"]
+            },
+            "reduceOnly": { "type": "boolean" },
+            "postOnly": { "type": "boolean" },
+            "quantityMode": {
+              "type": "string",
+              "enum": ["base", "quote", "notional"]
+            },
+            "limitPriceAtomic": {
+              "type": "string",
+              "pattern": "^[1-9][0-9]*$"
+            },
+            "triggerPriceAtomic": {
+              "type": "string",
+              "pattern": "^[1-9][0-9]*$"
+            },
+            "takeProfitPriceAtomic": {
+              "type": "string",
+              "pattern": "^[1-9][0-9]*$"
+            },
+            "stopLossPriceAtomic": {
+              "type": "string",
+              "pattern": "^[1-9][0-9]*$"
+            }
+          }
+        }
+      }
+    }
+  },
+  "oneOf": [
+    {
+      "properties": { "mode": { "const": "relay_signed" } },
+      "required": ["mode", "relaySigned"],
+      "not": { "required": ["privyExecute"] }
+    },
+    {
+      "properties": { "mode": { "const": "privy_execute" } },
+      "required": ["mode", "privyExecute"],
+      "not": { "required": ["relaySigned"] }
+    }
+  ]
+}

--- a/src/runtime/contracts/autonomous_runtime.ts
+++ b/src/runtime/contracts/autonomous_runtime.ts
@@ -523,11 +523,17 @@ export const RuntimeResearchEvidenceBundleRecordSchema = VersionedSchema.extend(
   },
 ).strict();
 
-export const RuntimeVenueMarketTypeSchema = z.enum(["spot", "perp", "options"]);
+export const RuntimeVenueMarketTypeSchema = z.enum([
+  "spot",
+  "perp",
+  "options",
+  "prediction",
+]);
 
 export const RuntimeVenueOrderTypeSchema = z.enum([
   "market",
   "limit",
+  "trigger",
   "auction",
   "twap",
 ]);
@@ -548,6 +554,39 @@ export const RuntimeVenueSettlementBehaviorSchema = z.enum([
   "orderbook_atomic",
   "orderbook_partial",
 ]);
+
+export const RuntimeExecutionIntentFamilySchema = z.enum([
+  "spot_swap",
+  "conditional_spot_order",
+  "clob_order",
+  "perp_order",
+  "prediction_order",
+  "flash_atomic",
+]);
+
+export const RuntimeVenueSettlementModelSchema = z.enum([
+  "atomic_swap",
+  "resting_order",
+  "position_account",
+  "tokenized_outcome",
+  "flash_loan_atomic",
+]);
+
+export const RuntimeVenueOracleRequirementSchema = z.enum([
+  "pyth",
+  "switchboard",
+  "venue_reference",
+  "none",
+]);
+
+const RuntimeVenueLifecycleCapabilitySchema = z
+  .object({
+    supportsOrderLifecycle: z.boolean(),
+    supportsPositionLifecycle: z.boolean(),
+    requiresExternalOracle: z.boolean(),
+    settlementModel: RuntimeVenueSettlementModelSchema,
+  })
+  .strict();
 
 const RuntimeBacktestConfigSchema = z
   .object({
@@ -906,12 +945,18 @@ export const RuntimeVenueCapabilitySchema = VersionedSchema.extend({
   adapterKeys: z.array(NON_EMPTY_STRING_SCHEMA).min(1),
   marketTypes: z.array(RuntimeVenueMarketTypeSchema).min(1),
   orderTypes: z.array(RuntimeVenueOrderTypeSchema).min(1),
+  intentFamilies: z.array(RuntimeExecutionIntentFamilySchema).min(1).optional(),
   authModel: RuntimeVenueAuthModelSchema,
   feeModel: RuntimeVenueFeeModelSchema,
   precision: RuntimeVenuePrecisionSchema,
   sizeLimits: RuntimeVenueSizeLimitsSchema,
   latencyProfile: RuntimeVenueLatencyProfileSchema,
   settlementBehavior: RuntimeVenueSettlementBehaviorSchema,
+  lifecycle: RuntimeVenueLifecycleCapabilitySchema.optional(),
+  oracleRequirements: z
+    .array(RuntimeVenueOracleRequirementSchema)
+    .min(1)
+    .optional(),
   supportedModes: z.array(RuntimeModeSchema).min(1),
   onboardingState: RuntimeOnboardingStateSchema,
   notes: NON_EMPTY_STRING_SCHEMA.optional(),
@@ -1529,10 +1574,22 @@ export type RuntimeVenueMarketType = z.infer<
   typeof RuntimeVenueMarketTypeSchema
 >;
 export type RuntimeVenueOrderType = z.infer<typeof RuntimeVenueOrderTypeSchema>;
+export type RuntimeExecutionIntentFamily = z.infer<
+  typeof RuntimeExecutionIntentFamilySchema
+>;
 export type RuntimeVenueAuthModel = z.infer<typeof RuntimeVenueAuthModelSchema>;
 export type RuntimeVenueFeeModel = z.infer<typeof RuntimeVenueFeeModelSchema>;
 export type RuntimeVenueSettlementBehavior = z.infer<
   typeof RuntimeVenueSettlementBehaviorSchema
+>;
+export type RuntimeVenueSettlementModel = z.infer<
+  typeof RuntimeVenueSettlementModelSchema
+>;
+export type RuntimeVenueOracleRequirement = z.infer<
+  typeof RuntimeVenueOracleRequirementSchema
+>;
+export type RuntimeVenueLifecycleCapability = z.infer<
+  typeof RuntimeVenueLifecycleCapabilitySchema
 >;
 export type RuntimeVenueCapability = z.infer<
   typeof RuntimeVenueCapabilitySchema

--- a/src/runtime/venues/catalog.ts
+++ b/src/runtime/venues/catalog.ts
@@ -1,4 +1,5 @@
 import type {
+  RuntimeExecutionIntentFamily,
   RuntimeMode,
   RuntimeVenueCapability,
 } from "../contracts/index.js";
@@ -10,7 +11,8 @@ const BUILTIN_RUNTIME_VENUE_CAPABILITIES = [
     displayName: "Jupiter",
     adapterKeys: ["jupiter", "helius_sender", "jito_bundle"],
     marketTypes: ["spot"],
-    orderTypes: ["market"],
+    orderTypes: ["market", "limit", "trigger"],
+    intentFamilies: ["spot_swap", "conditional_spot_order"],
     authModel: "privy_solana_wallet",
     feeModel: "venue_quote_inclusive",
     precision: {
@@ -28,6 +30,13 @@ const BUILTIN_RUNTIME_VENUE_CAPABILITIES = [
       expectedSettlementMs: 5000,
     },
     settlementBehavior: "swap_atomic",
+    lifecycle: {
+      supportsOrderLifecycle: true,
+      supportsPositionLifecycle: false,
+      requiresExternalOracle: false,
+      settlementModel: "atomic_swap",
+    },
+    oracleRequirements: ["venue_reference"],
     supportedModes: ["shadow", "paper", "live"],
     onboardingState: "broad_live_ready",
     notes:
@@ -40,6 +49,7 @@ const BUILTIN_RUNTIME_VENUE_CAPABILITIES = [
     adapterKeys: ["magicblock_ephemeral_rollup"],
     marketTypes: ["spot"],
     orderTypes: ["market"],
+    intentFamilies: ["spot_swap"],
     authModel: "privy_solana_wallet",
     feeModel: "fixed_bps",
     precision: {
@@ -57,6 +67,13 @@ const BUILTIN_RUNTIME_VENUE_CAPABILITIES = [
       expectedSettlementMs: 3000,
     },
     settlementBehavior: "swap_atomic",
+    lifecycle: {
+      supportsOrderLifecycle: false,
+      supportsPositionLifecycle: false,
+      requiresExternalOracle: false,
+      settlementModel: "atomic_swap",
+    },
+    oracleRequirements: ["none"],
     supportedModes: ["shadow", "paper"],
     onboardingState: "paper_ready",
     notes:
@@ -69,6 +86,7 @@ const BUILTIN_RUNTIME_VENUE_CAPABILITIES = [
     adapterKeys: ["phoenix_orderbook"],
     marketTypes: ["spot"],
     orderTypes: ["market", "limit"],
+    intentFamilies: ["clob_order"],
     authModel: "privy_solana_wallet",
     feeModel: "maker_taker_bps",
     precision: {
@@ -86,6 +104,13 @@ const BUILTIN_RUNTIME_VENUE_CAPABILITIES = [
       expectedSettlementMs: 4000,
     },
     settlementBehavior: "orderbook_atomic",
+    lifecycle: {
+      supportsOrderLifecycle: true,
+      supportsPositionLifecycle: false,
+      requiresExternalOracle: false,
+      settlementModel: "resting_order",
+    },
+    oracleRequirements: ["venue_reference"],
     supportedModes: ["shadow", "paper"],
     onboardingState: "candidate",
     notes:
@@ -106,10 +131,17 @@ export function listRuntimeVenueCapabilities(): RuntimeVenueCapability[] {
     adapterKeys: [...capability.adapterKeys],
     marketTypes: [...capability.marketTypes],
     orderTypes: [...capability.orderTypes],
+    ...(capability.intentFamilies
+      ? { intentFamilies: [...capability.intentFamilies] }
+      : {}),
     supportedModes: [...capability.supportedModes],
     precision: { ...capability.precision },
     sizeLimits: { ...capability.sizeLimits },
     latencyProfile: { ...capability.latencyProfile },
+    ...(capability.lifecycle ? { lifecycle: { ...capability.lifecycle } } : {}),
+    ...(capability.oracleRequirements
+      ? { oracleRequirements: [...capability.oracleRequirements] }
+      : {}),
   }));
 }
 
@@ -141,4 +173,15 @@ export function runtimeVenueSupportsAdapter(
   adapterKey: string,
 ): boolean {
   return capability.adapterKeys.includes(adapterKey);
+}
+
+export function runtimeVenueSupportsIntentFamily(
+  capability: RuntimeVenueCapability,
+  intentFamily: RuntimeExecutionIntentFamily,
+): boolean {
+  const configured = capability.intentFamilies;
+  if (!configured || configured.length < 1) {
+    return intentFamily === "spot_swap";
+  }
+  return configured.includes(intentFamily);
 }

--- a/tests/unit/execution_contract_v1_schemas.test.ts
+++ b/tests/unit/execution_contract_v1_schemas.test.ts
@@ -57,6 +57,28 @@ describe("execution contract v1 schemas", () => {
     ).toBe(false);
   });
 
+  test("submit request v2 validates spot and non-swap family fixtures", () => {
+    const schema = "docs/execution/schemas/exec.submit.request.v2.schema.json";
+    expect(
+      validate(
+        schema,
+        "docs/execution/fixtures/submit.privy_execute.spot_swap.valid.v2.json",
+      ),
+    ).toBe(true);
+    expect(
+      validate(
+        schema,
+        "docs/execution/fixtures/submit.privy_execute.perp_order.valid.v2.json",
+      ),
+    ).toBe(true);
+    expect(
+      validate(
+        schema,
+        "docs/execution/fixtures/submit.invalid.perp-missing-market-type.v2.json",
+      ),
+    ).toBe(false);
+  });
+
   test("submit response fixture validates", () => {
     expect(
       validate(

--- a/tests/unit/worker_exec_submit_contract_privy.test.ts
+++ b/tests/unit/worker_exec_submit_contract_privy.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { parseExecSubmitPayload } from "../../apps/worker/src/execution/submit_contract";
+import {
+  buildExecSubmitIntentSummary,
+  parseExecSubmitPayload,
+  resolveExecSubmitIntentFamily,
+  resolveExecSubmitSpotSwap,
+  toExecSubmitRequestV1Compat,
+} from "../../apps/worker/src/execution/submit_contract";
 
 const VALID_PRIVY_SUBMIT = {
   schemaVersion: "v1",
@@ -76,6 +82,130 @@ describe("exec submit contract: privy_execute", () => {
     expect(parsed.value.privyExecute?.options?.triggerPriceAtomic).toBe(
       "950000",
     );
+  });
+
+  test("parses a v2 spot_swap payload and exposes swap compatibility helpers", () => {
+    const parsed = parseExecSubmitPayload({
+      schemaVersion: "v2",
+      mode: "privy_execute",
+      lane: "safe",
+      metadata: {
+        source: "terminal-ui",
+      },
+      privyExecute: {
+        wallet: "11111111111111111111111111111111",
+        intent: {
+          family: "spot_swap",
+          venueKey: "jupiter",
+          marketType: "spot",
+          inputMint: "So11111111111111111111111111111111111111112",
+          outputMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          amountAtomic: "2500000",
+          slippageBps: 35,
+        },
+        options: {
+          commitment: "confirmed",
+          requireSimulation: true,
+        },
+      },
+    });
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(resolveExecSubmitIntentFamily(parsed.value)).toBe("spot_swap");
+    expect(resolveExecSubmitSpotSwap(parsed.value)?.swap.amountAtomic).toBe(
+      "2500000",
+    );
+    expect(toExecSubmitRequestV1Compat(parsed.value)?.schemaVersion).toBe("v1");
+    expect(buildExecSubmitIntentSummary(parsed.value)).toEqual({
+      family: "spot_swap",
+      marketType: "spot",
+      venueKey: "jupiter",
+      inputMint: "So11111111111111111111111111111111111111112",
+      outputMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    });
+  });
+
+  test("parses a non-swap v2 intent family without forcing swap compatibility", () => {
+    const parsed = parseExecSubmitPayload({
+      schemaVersion: "v2",
+      mode: "privy_execute",
+      lane: "protected",
+      privyExecute: {
+        wallet: "11111111111111111111111111111111",
+        intent: {
+          family: "perp_order",
+          venueKey: "drift",
+          marketType: "perp",
+          instrumentId: "SOL-PERP",
+          side: "long",
+          quantityAtomic: "1000000",
+          collateralAtomic: "250000",
+        },
+        options: {
+          orderType: "limit",
+          limitPriceAtomic: "155000000",
+          reduceOnly: false,
+        },
+      },
+    });
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(resolveExecSubmitIntentFamily(parsed.value)).toBe("perp_order");
+    expect(resolveExecSubmitSpotSwap(parsed.value)).toBeNull();
+    expect(toExecSubmitRequestV1Compat(parsed.value)).toBeNull();
+    expect(buildExecSubmitIntentSummary(parsed.value)).toEqual({
+      family: "perp_order",
+      marketType: "perp",
+      venueKey: "drift",
+      instrumentId: "SOL-PERP",
+      side: "long",
+    });
+  });
+
+  test("rejects malformed v2 family payloads deterministically", () => {
+    const missingConditionalPricing = parseExecSubmitPayload({
+      schemaVersion: "v2",
+      mode: "privy_execute",
+      lane: "protected",
+      privyExecute: {
+        wallet: "11111111111111111111111111111111",
+        intent: {
+          family: "conditional_spot_order",
+          venueKey: "jupiter",
+          marketType: "spot",
+          instrumentId: "SOL/USDC",
+          side: "buy",
+          quantityAtomic: "1000000",
+        },
+      },
+    });
+    expect(missingConditionalPricing).toEqual({
+      ok: false,
+      error: "invalid-request",
+    });
+
+    const invalidPredictionMarket = parseExecSubmitPayload({
+      schemaVersion: "v2",
+      mode: "privy_execute",
+      lane: "protected",
+      privyExecute: {
+        wallet: "11111111111111111111111111111111",
+        intent: {
+          family: "prediction_order",
+          venueKey: "dflow",
+          marketType: "prediction",
+          instrumentId: "election-2026",
+          side: "buy_yes",
+          quantityAtomic: "1000000",
+        },
+      },
+    });
+    expect(invalidPredictionMarket).toEqual({
+      ok: false,
+      error: "invalid-request",
+    });
   });
 
   test("rejects invalid privy_execute payloads deterministically", () => {

--- a/tests/unit/worker_execution_receipt_assembler.test.ts
+++ b/tests/unit/worker_execution_receipt_assembler.test.ts
@@ -19,7 +19,15 @@ describe("execution receipt assembler", () => {
         lane: "fast",
         status: "landed",
         statusReason: null,
-        metadata: null,
+        metadata: {
+          intent: {
+            family: "perp_order",
+            marketType: "perp",
+            venueKey: "drift",
+            instrumentId: "SOL-PERP",
+            side: "long",
+          },
+        },
         receivedAt: "2026-03-03T00:00:00.000Z",
         validatedAt: "2026-03-03T00:00:01.000Z",
         terminalAt: "2026-03-03T00:00:03.000Z",
@@ -37,7 +45,14 @@ describe("execution receipt assembler", () => {
         slot: 123,
         errorCode: null,
         errorMessage: null,
-        receipt: null,
+        receipt: {
+          lifecycle: {
+            orderState: "filled",
+            positionState: "open",
+            settlementState: "landed",
+            notes: ["paper-fill"],
+          },
+        },
         readyAt: "2026-03-03T00:00:04.000Z",
         createdAt: "2026-03-03T00:00:04.000Z",
         updatedAt: "2026-03-03T00:00:04.000Z",
@@ -73,6 +88,9 @@ describe("execution receipt assembler", () => {
     expect(receipt.trace.dispatchedAt).toBe("2026-03-03T00:00:02.000Z");
     expect(receipt.trace.landedAt).toBe("2026-03-03T00:00:04.000Z");
     expect(receipt.attempts.length).toBe(1);
+    expect(receipt.intent?.family).toBe("perp_order");
+    expect(receipt.lifecycle?.positionState).toBe("open");
+    expect(receipt.lifecycle?.notes).toEqual(["paper-fill"]);
     expect(receipt.immutability?.hashAlgorithm).toBe("sha256");
   });
 

--- a/tests/unit/worker_execution_router.test.ts
+++ b/tests/unit/worker_execution_router.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import {
+  executeIntentViaRouter,
   executeSwapViaRouter,
   registerExecutionAdapter,
 } from "../../apps/worker/src/execution/router";
@@ -151,12 +152,12 @@ describe("worker execution router", () => {
     ).rejects.toThrow(/magicblock-ephemeral-rollup-url-missing/);
   });
 
-  test("custom execution adapters can be registered for new venues", async () => {
+  test("custom execution adapters can be registered for new intent families", async () => {
     registerExecutionAdapter(
       "phoenix_orderbook",
       async (input) => ({
         status: "simulated",
-        signature: "sig-phoenix",
+        signature: "sig-phoenix-clob",
         usedQuote: input.quoteResponse,
         refreshed: false,
         lastValidBlockHeight: 42,
@@ -164,29 +165,95 @@ describe("worker execution router", () => {
       {
         venueKey: "phoenix",
         supportedModes: ["shadow", "paper"],
+        supportedIntentFamilies: ["clob_order"],
       },
     );
 
-    const result = await executeSwapViaRouter({
-      env: {} as never,
-      venueKey: "phoenix",
-      runtimeMode: "paper",
-      execution: { adapter: "phoenix_orderbook" },
-      policy: normalizePolicy({}),
-      rpc: {} as never,
-      jupiter: {} as never,
-      quoteResponse: {
-        inputMint: "A",
-        outputMint: "B",
-        inAmount: "1",
-        outAmount: "2",
-      },
-      userPublicKey: "11111111111111111111111111111111",
-      log: () => {},
-    });
+    await expect(
+      executeIntentViaRouter({
+        env: {} as never,
+        venueKey: "phoenix",
+        runtimeMode: "paper",
+        execution: { adapter: "phoenix_orderbook" },
+        policy: normalizePolicy({}),
+        rpc: {} as never,
+        jupiter: {} as never,
+        intent: {
+          family: "clob_order",
+          wallet: "11111111111111111111111111111111",
+          venueKey: "phoenix",
+          marketType: "spot",
+          instrumentId: "SOL/USDC",
+          side: "buy",
+          quantityAtomic: "1",
+        },
+        log: () => {},
+      }),
+    ).rejects.toThrow(/execution-intent-family-not-implemented/);
+  });
 
-    expect(result.status).toBe("simulated");
-    expect(result.signature).toBe("sig-phoenix");
+  test("fails closed when a venue advertises an intent family but the adapter does not implement it", async () => {
+    await expect(
+      executeIntentViaRouter({
+        env: {} as never,
+        venueKey: "jupiter",
+        runtimeMode: "paper",
+        execution: { adapter: "jupiter" },
+        policy: normalizePolicy({}),
+        rpc: {} as never,
+        jupiter: {} as never,
+        intent: {
+          family: "conditional_spot_order",
+          wallet: "11111111111111111111111111111111",
+          venueKey: "jupiter",
+          marketType: "spot",
+          instrumentId: "SOL/USDC",
+          side: "buy",
+          quantityAtomic: "1",
+        },
+        log: () => {},
+      }),
+    ).rejects.toThrow(/execution-adapter-intent-not-supported/);
+  });
+
+  test("fails closed when the runtime venue does not support the requested intent family", async () => {
+    registerExecutionAdapter(
+      "phoenix_orderbook",
+      async (input) => ({
+        status: "simulated",
+        signature: "sig-phoenix-clob",
+        usedQuote: input.quoteResponse,
+        refreshed: false,
+        lastValidBlockHeight: 42,
+      }),
+      {
+        venueKey: "phoenix",
+        supportedModes: ["shadow", "paper"],
+        supportedIntentFamilies: ["clob_order"],
+      },
+    );
+
+    await expect(
+      executeIntentViaRouter({
+        env: {} as never,
+        venueKey: "phoenix",
+        runtimeMode: "paper",
+        execution: { adapter: "phoenix_orderbook" },
+        policy: normalizePolicy({}),
+        rpc: {} as never,
+        jupiter: {} as never,
+        intent: {
+          family: "perp_order",
+          wallet: "11111111111111111111111111111111",
+          venueKey: "phoenix",
+          marketType: "perp",
+          instrumentId: "SOL-PERP",
+          side: "long",
+          quantityAtomic: "1",
+        },
+        log: () => {},
+      }),
+    ).rejects.toThrow(/runtime-venue-intent-family-not-supported/);
   });
 
   test("fails closed when a venue adapter does not match the runtime venue", async () => {

--- a/tests/unit/worker_x402_exec_submit_route.test.ts
+++ b/tests/unit/worker_x402_exec_submit_route.test.ts
@@ -829,6 +829,61 @@ describe("worker x402 exec submit scaffold route", () => {
     }
   });
 
+  test("fails closed when a v2 spot swap venue key does not match the resolved lane adapter", async () => {
+    const { env, sqlite } = createExecSubmitEnv({
+      EXEC_LANE_SAFE_ADAPTER: "magicblock_ephemeral_rollup",
+    });
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/x402/exec/submit", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer mock-token",
+            "idempotency-key": "idem-privy-v2-jupiter-mismatch-1",
+          },
+          body: JSON.stringify({
+            schemaVersion: "v2",
+            mode: "privy_execute",
+            lane: "safe",
+            privyExecute: {
+              wallet: "11111111111111111111111111111111",
+              intent: {
+                family: "spot_swap",
+                venueKey: "jupiter",
+                marketType: "spot",
+                inputMint: SOL_MINT,
+                outputMint: MAINNET_USDC_MINT,
+                amountAtomic: "1000000",
+                slippageBps: 50,
+              },
+            },
+          }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(execErrorCode(body)).toBe("invalid-request");
+      expect(execErrorReason(body)).toBe(
+        "unsupported-venue-route:jupiter:magicblock_ephemeral_rollup",
+      );
+
+      const countRow = sqlite
+        .query(
+          "SELECT COUNT(*) as count FROM execution_requests WHERE idempotency_key = ?1",
+        )
+        .get("idem-privy-v2-jupiter-mismatch-1") as
+        | { count?: number }
+        | undefined;
+      expect(countRow?.count).toBe(0);
+    } finally {
+      sqlite.close();
+    }
+  });
+
   test("denies privy_execute submit when trusted rollout segment is disabled", async () => {
     const { env, sqlite } = createExecSubmitEnv({
       EXEC_ROLLOUT_TRUSTED_ENABLED: "0",

--- a/tests/unit/worker_x402_exec_submit_route.test.ts
+++ b/tests/unit/worker_x402_exec_submit_route.test.ts
@@ -739,6 +739,96 @@ describe("worker x402 exec submit scaffold route", () => {
     }
   });
 
+  test("rejects syntactically valid v2 non-swap intents until the adapter path exists", async () => {
+    const { env, sqlite } = createExecSubmitEnv();
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/x402/exec/submit", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer mock-token",
+            "idempotency-key": "idem-privy-v2-perp-1",
+          },
+          body: JSON.stringify({
+            schemaVersion: "v2",
+            mode: "privy_execute",
+            lane: "protected",
+            privyExecute: {
+              wallet: "11111111111111111111111111111111",
+              intent: {
+                family: "perp_order",
+                venueKey: "drift",
+                marketType: "perp",
+                instrumentId: "SOL-PERP",
+                side: "long",
+                quantityAtomic: "1000000",
+                collateralAtomic: "250000",
+              },
+              options: {
+                orderType: "limit",
+                limitPriceAtomic: "155000000",
+              },
+            },
+          }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(execErrorCode(body)).toBe("invalid-request");
+      expect(execErrorReason(body)).toBe(
+        "unsupported-intent-family:perp_order",
+      );
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("rejects v2 spot swaps that request an unsupported venue key on the public submit path", async () => {
+    const { env, sqlite } = createExecSubmitEnv();
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/x402/exec/submit", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer mock-token",
+            "idempotency-key": "idem-privy-v2-phoenix-1",
+          },
+          body: JSON.stringify({
+            schemaVersion: "v2",
+            mode: "privy_execute",
+            lane: "safe",
+            privyExecute: {
+              wallet: "11111111111111111111111111111111",
+              intent: {
+                family: "spot_swap",
+                venueKey: "phoenix",
+                marketType: "spot",
+                inputMint: SOL_MINT,
+                outputMint: MAINNET_USDC_MINT,
+                amountAtomic: "1000000",
+                slippageBps: 50,
+              },
+            },
+          }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(execErrorCode(body)).toBe("invalid-request");
+      expect(execErrorReason(body)).toBe("unsupported-venue-key:phoenix");
+    } finally {
+      sqlite.close();
+    }
+  });
+
   test("denies privy_execute submit when trusted rollout segment is disabled", async () => {
     const { env, sqlite } = createExecSubmitEnv({
       EXEC_ROLLOUT_TRUSTED_ENABLED: "0",


### PR DESCRIPTION
Fixes #362

## Summary
- add a versioned `v2` execution submit contract that can express spot swap, conditional spot order, CLOB order, perp order, prediction order, and flash-atomic intent families while preserving `v1`
- add a generic execution-intent router and intent-family-aware venue or adapter capability checks without breaking the current swap executor path
- extend execution status and canonical receipt contracts with optional intent and lifecycle summaries, plus runtime venue capability metadata for intent families, lifecycle support, and oracle requirements

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun test tests/unit/worker_exec_submit_contract_privy.test.ts tests/unit/worker_execution_router.test.ts tests/unit/worker_execution_receipt_assembler.test.ts tests/unit/worker_x402_exec_submit_route.test.ts tests/unit/execution_contract_v1_schemas.test.ts`

## Proof Bundle
- Change summary: the Worker now understands a broader versioned submit contract, but still fails closed for non-swap families until venue-specific adapters land
- Validation results: all commands above passed locally
- Preview or local URLs: not applicable for this contract or worker-only slice
- Browser artifacts: not applicable
- Benchmark delta: not applicable
- Risk notes and follow-ups:
  - the public submit path still only permits bounded Jupiter swap execution and explicitly rejects `v2` non-swap families
  - `v2` swap requests that name a non-Jupiter venue key are rejected to avoid silent rerouting
  - downstream venue issues should remain blocked on merge of this substrate PR
