### PR TITLE
Add Jupiter Trigger conditional spot order execution

### DIFF
--- a/apps/portal/app/execution-client.ts
+++ b/apps/portal/app/execution-client.ts
@@ -32,42 +32,76 @@ export type ExecutionErrorCode =
   | "not-ready"
   | "unknown";
 
-export type ExecutionSubmitPayload = {
-  schemaVersion: "v1";
-  mode: "relay_signed" | "privy_execute";
-  lane: "fast" | "protected" | "safe";
-  metadata?: Record<string, unknown>;
-  relaySigned?: {
-    signedTransaction: string;
-    encoding?: string;
-  };
-  privyExecute?: {
-    intentType: "swap";
-    wallet: string;
-    swap: {
-      inputMint: string;
-      outputMint: string;
-      amountAtomic: string;
-      slippageBps: number;
+export type ExecutionSubmitPayload =
+  | {
+      schemaVersion: "v1";
+      mode: "relay_signed" | "privy_execute";
+      lane: "fast" | "protected" | "safe";
+      metadata?: Record<string, unknown>;
+      relaySigned?: {
+        signedTransaction: string;
+        encoding?: string;
+      };
+      privyExecute?: {
+        intentType: "swap";
+        wallet: string;
+        swap: {
+          inputMint: string;
+          outputMint: string;
+          amountAtomic: string;
+          slippageBps: number;
+        };
+        options?: {
+          commitment?: "processed" | "confirmed" | "finalized";
+          simulateOnly?: boolean;
+          requireSimulation?: boolean;
+          dryRun?: boolean;
+          priorityMicroLamports?: number;
+          orderType?: "market" | "limit" | "trigger";
+          timeInForce?: "gtc" | "ioc" | "fok";
+          reduceOnly?: boolean;
+          postOnly?: boolean;
+          quantityMode?: "base" | "quote" | "notional";
+          limitPriceAtomic?: string;
+          triggerPriceAtomic?: string;
+          takeProfitPriceAtomic?: string;
+          stopLossPriceAtomic?: string;
+        };
+      };
+    }
+  | {
+      schemaVersion: "v2";
+      mode: "privy_execute";
+      lane: "fast" | "protected" | "safe";
+      metadata?: Record<string, unknown>;
+      privyExecute: {
+        wallet: string;
+        intent: {
+          family: "conditional_spot_order";
+          venueKey: "jupiter";
+          marketType: "spot";
+          instrumentId: string;
+          side: "buy" | "sell";
+          quantityAtomic: string;
+        };
+        options?: {
+          commitment?: "processed" | "confirmed" | "finalized";
+          simulateOnly?: boolean;
+          requireSimulation?: boolean;
+          dryRun?: boolean;
+          priorityMicroLamports?: number;
+          orderType?: "market" | "limit" | "trigger";
+          timeInForce?: "gtc" | "ioc" | "fok";
+          reduceOnly?: boolean;
+          postOnly?: boolean;
+          quantityMode?: "base" | "quote" | "notional";
+          limitPriceAtomic?: string;
+          triggerPriceAtomic?: string;
+          takeProfitPriceAtomic?: string;
+          stopLossPriceAtomic?: string;
+        };
+      };
     };
-    options?: {
-      commitment?: "processed" | "confirmed" | "finalized";
-      simulateOnly?: boolean;
-      requireSimulation?: boolean;
-      dryRun?: boolean;
-      priorityMicroLamports?: number;
-      orderType?: "market" | "limit" | "trigger";
-      timeInForce?: "gtc" | "ioc" | "fok";
-      reduceOnly?: boolean;
-      postOnly?: boolean;
-      quantityMode?: "base" | "quote" | "notional";
-      limitPriceAtomic?: string;
-      triggerPriceAtomic?: string;
-      takeProfitPriceAtomic?: string;
-      stopLossPriceAtomic?: string;
-    };
-  };
-};
 
 export type ExecutionSubmitAck = {
   requestId: string;
@@ -103,6 +137,46 @@ export type ExecutionTerminalResult = {
   receiptId: string | null;
   provider: string | null;
   networkFeeLamports: string | null;
+};
+
+export type ExecutionOpenOrderSnapshot = {
+  requestId: string;
+  requestStatus: string;
+  terminal: boolean;
+  receivedAt: string | null;
+  updatedAt: string | null;
+  terminalAt: string | null;
+  pairId: string | null;
+  direction: "buy" | "sell" | null;
+  source: string | null;
+  reason: string | null;
+  orderType: "limit" | "trigger" | null;
+  timeInForce: "gtc" | "ioc" | "fok" | null;
+  lane: "fast" | "protected" | "safe" | null;
+  simulationPreference: "auto" | "always" | "never" | null;
+  priorityLevel: "normal" | "high" | "urgent" | null;
+  priorityMicroLamports: number | null;
+  slippageBps: number | null;
+  inputMint: string | null;
+  outputMint: string | null;
+  amountAtomic: string | null;
+  remainingAmountAtomic: string | null;
+  takingAmountAtomic: string | null;
+  filledInputAtomic: string | null;
+  filledOutputAtomic: string | null;
+  limitPriceAtomic: string | null;
+  triggerPriceAtomic: string | null;
+  provider: string | null;
+  signature: string | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+  status: string | null;
+  lifecycle: {
+    orderState?: string;
+    fillState?: string;
+    settlementState?: string;
+    notes?: string[];
+  } | null;
 };
 
 export type ExecutionTransportRequest = {
@@ -401,6 +475,126 @@ function parseReceiptSnapshot(payload: unknown): ExecutionReceiptSnapshot {
   };
 }
 
+function parseStringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  const normalized = value
+    .map((entry) => parseOptionalString(entry))
+    .filter((entry): entry is string => entry !== null);
+  return normalized.length > 0 ? normalized : null;
+}
+
+function parseOptionalString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function parseOptionalInt(value: unknown): number | null {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return null;
+  return Math.floor(parsed);
+}
+
+function parseOpenOrderSnapshot(
+  value: unknown,
+): ExecutionOpenOrderSnapshot | null {
+  if (!isRecord(value)) return null;
+  const requestId = parseOptionalString(value.requestId);
+  const requestStatus = parseOptionalString(value.requestStatus);
+  if (!requestId || !requestStatus) return null;
+  const lifecycleRaw = isRecord(value.lifecycle) ? value.lifecycle : null;
+  return {
+    requestId,
+    requestStatus,
+    terminal: value.terminal === true,
+    receivedAt: parseOptionalString(value.receivedAt),
+    updatedAt: parseOptionalString(value.updatedAt),
+    terminalAt: parseOptionalString(value.terminalAt),
+    pairId: parseOptionalString(value.pairId),
+    direction:
+      value.direction === "buy" || value.direction === "sell"
+        ? value.direction
+        : null,
+    source: parseOptionalString(value.source),
+    reason: parseOptionalString(value.reason),
+    orderType:
+      value.orderType === "limit" || value.orderType === "trigger"
+        ? value.orderType
+        : null,
+    timeInForce:
+      value.timeInForce === "gtc" ||
+      value.timeInForce === "ioc" ||
+      value.timeInForce === "fok"
+        ? value.timeInForce
+        : null,
+    lane:
+      value.lane === "fast" ||
+      value.lane === "protected" ||
+      value.lane === "safe"
+        ? value.lane
+        : null,
+    simulationPreference:
+      value.simulationPreference === "auto" ||
+      value.simulationPreference === "always" ||
+      value.simulationPreference === "never"
+        ? value.simulationPreference
+        : null,
+    priorityLevel:
+      value.priorityLevel === "normal" ||
+      value.priorityLevel === "high" ||
+      value.priorityLevel === "urgent"
+        ? value.priorityLevel
+        : null,
+    priorityMicroLamports: parseOptionalInt(value.priorityMicroLamports),
+    slippageBps: parseOptionalInt(value.slippageBps),
+    inputMint: parseOptionalString(value.inputMint),
+    outputMint: parseOptionalString(value.outputMint),
+    amountAtomic: parseOptionalAtomicString(value.amountAtomic),
+    remainingAmountAtomic: parseOptionalAtomicString(
+      value.remainingAmountAtomic,
+    ),
+    takingAmountAtomic: parseOptionalAtomicString(value.takingAmountAtomic),
+    filledInputAtomic: parseOptionalAtomicString(value.filledInputAtomic),
+    filledOutputAtomic: parseOptionalAtomicString(value.filledOutputAtomic),
+    limitPriceAtomic: parseOptionalAtomicString(value.limitPriceAtomic),
+    triggerPriceAtomic: parseOptionalAtomicString(value.triggerPriceAtomic),
+    provider: parseOptionalString(value.provider),
+    signature: parseOptionalString(value.signature),
+    errorCode: parseOptionalString(value.errorCode),
+    errorMessage: parseOptionalString(value.errorMessage),
+    status: parseOptionalString(value.status),
+    lifecycle: lifecycleRaw
+      ? {
+          orderState: parseOptionalString(lifecycleRaw.orderState) ?? undefined,
+          fillState: parseOptionalString(lifecycleRaw.fillState) ?? undefined,
+          settlementState:
+            parseOptionalString(lifecycleRaw.settlementState) ?? undefined,
+          notes: parseStringArray(lifecycleRaw.notes) ?? undefined,
+        }
+      : null,
+  };
+}
+
+function parseOpenOrdersSnapshot(
+  payload: unknown,
+): ExecutionOpenOrderSnapshot[] {
+  if (!isRecord(payload) || payload.ok !== true) {
+    throw new ExecutionClientError({
+      message: "invalid-terminal-open-orders-response",
+      code: "unknown",
+      status: 500,
+      retryable: false,
+      data: payload,
+    });
+  }
+  const orders = Array.isArray(payload.orders)
+    ? payload.orders
+        .map((entry) => parseOpenOrderSnapshot(entry))
+        .filter((entry): entry is ExecutionOpenOrderSnapshot => entry !== null)
+    : [];
+  return orders;
+}
+
 function isExecutionSuccessStatus(status: string | null): boolean {
   if (!status) return false;
   const normalized = status.trim().toLowerCase();
@@ -627,6 +821,31 @@ export function createExecutionClient(options: ExecutionClientOptions) {
     return parseReceiptSnapshot(response);
   }
 
+  async function listOpenOrders(
+    options?: RequestOptions,
+  ): Promise<ExecutionOpenOrderSnapshot[]> {
+    const response = await requestJson({
+      path: "/api/terminal/open-orders",
+      method: "GET",
+      signal: options?.signal,
+      headers: options?.headers,
+    });
+    return parseOpenOrdersSnapshot(response);
+  }
+
+  async function cancelOpenOrder(
+    requestId: string,
+    options?: RequestOptions,
+  ): Promise<ExecutionStatusSnapshot> {
+    const response = await requestJson({
+      path: `/api/terminal/open-orders/${encodeURIComponent(requestId)}/cancel`,
+      method: "POST",
+      signal: options?.signal,
+      headers: options?.headers,
+    });
+    return parseStatusSnapshot(response);
+  }
+
   async function waitForTerminalReceipt(input: {
     requestId: string;
     signal?: AbortSignal;
@@ -721,6 +940,8 @@ export function createExecutionClient(options: ExecutionClientOptions) {
     submit,
     status,
     receipt,
+    listOpenOrders,
+    cancelOpenOrder,
     waitForTerminalReceipt,
   };
 }

--- a/apps/portal/app/terminal/components/open-orders.ts
+++ b/apps/portal/app/terminal/components/open-orders.ts
@@ -74,7 +74,13 @@ export type OpenOrderRow = QueuedTerminalOrder & {
 };
 
 const ORDER_PRICE_DECIMALS = 6;
-const SUPPORTED_PAIR_SET = new Set(SUPPORTED_PAIRS.map((pair) => pair.id));
+const SUPPORTED_PAIR_SET = new Set<string>(
+  SUPPORTED_PAIRS.map((pair) => pair.id),
+);
+
+function isSupportedPairId(value: string): value is PairId {
+  return SUPPORTED_PAIR_SET.has(value);
+}
 
 export function formatOrderAmountUi(value: number): string {
   if (!Number.isFinite(value) || value <= 0) return "";
@@ -138,8 +144,8 @@ export function mapTerminalOpenOrderSnapshot(
   snapshot: TerminalOpenOrderSnapshot,
 ): OpenOrderRow | null {
   const pairId =
-    snapshot.pairId && SUPPORTED_PAIR_SET.has(snapshot.pairId)
-      ? (snapshot.pairId as PairId)
+    snapshot.pairId && isSupportedPairId(snapshot.pairId)
+      ? snapshot.pairId
       : null;
   if (!pairId || !snapshot.direction || !snapshot.orderType || !snapshot.lane) {
     return null;

--- a/apps/portal/app/terminal/components/open-orders.ts
+++ b/apps/portal/app/terminal/components/open-orders.ts
@@ -1,17 +1,80 @@
+import { type PairId, SUPPORTED_PAIRS, TOKEN_BY_MINT } from "./trade-pairs";
 import type { QueuedTerminalOrder } from "./trade-ticket-modal";
 
 export type OpenOrderStatus =
   | "pending"
   | "working"
   | "partial"
+  | "filled"
   | "failed"
-  | "cancelled";
+  | "cancelled"
+  | "expired";
+
+export type TerminalOpenOrderSnapshot = {
+  requestId: string;
+  requestStatus: string;
+  terminal: boolean;
+  receivedAt: string | null;
+  updatedAt: string | null;
+  terminalAt: string | null;
+  pairId: string | null;
+  direction: "buy" | "sell" | null;
+  source: string | null;
+  reason: string | null;
+  orderType: "limit" | "trigger" | null;
+  timeInForce: "gtc" | "ioc" | "fok" | null;
+  lane: "fast" | "protected" | "safe" | null;
+  simulationPreference: "auto" | "always" | "never" | null;
+  priorityLevel: "normal" | "high" | "urgent" | null;
+  priorityMicroLamports: number | null;
+  slippageBps: number | null;
+  inputMint: string | null;
+  outputMint: string | null;
+  amountAtomic: string | null;
+  remainingAmountAtomic: string | null;
+  takingAmountAtomic: string | null;
+  filledInputAtomic: string | null;
+  filledOutputAtomic: string | null;
+  limitPriceAtomic: string | null;
+  triggerPriceAtomic: string | null;
+  provider: string | null;
+  signature: string | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+  status: string | null;
+  lifecycle: {
+    orderState?: string;
+    fillState?: string;
+    settlementState?: string;
+    notes?: string[];
+  } | null;
+};
 
 export type OpenOrderRow = QueuedTerminalOrder & {
+  requestId?: string | null;
   status: OpenOrderStatus;
   initialAmountUi: string;
   lastError: string | null;
+  terminal?: boolean;
+  provider?: string | null;
+  signature?: string | null;
+  errorCode?: string | null;
+  errorMessage?: string | null;
+  receivedAtIso?: string | null;
+  updatedAtIso?: string | null;
+  terminalAtIso?: string | null;
+  inputMint?: string | null;
+  outputMint?: string | null;
+  amountAtomic?: string | null;
+  remainingAmountAtomic?: string | null;
+  takingAmountAtomic?: string | null;
+  filledInputAtomic?: string | null;
+  filledOutputAtomic?: string | null;
+  lifecycle?: TerminalOpenOrderSnapshot["lifecycle"];
 };
+
+const ORDER_PRICE_DECIMALS = 6;
+const SUPPORTED_PAIR_SET = new Set(SUPPORTED_PAIRS.map((pair) => pair.id));
 
 export function formatOrderAmountUi(value: number): string {
   if (!Number.isFinite(value) || value <= 0) return "";
@@ -22,6 +85,122 @@ export function parseOrderAmountUi(value: string): number | null {
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed <= 0) return null;
   return parsed;
+}
+
+function formatAtomicUi(
+  atomicRaw: string | null,
+  decimals: number,
+  maxFractionDigits = 6,
+): string {
+  if (!atomicRaw || !/^\d+$/.test(atomicRaw)) return "";
+  try {
+    const amount = BigInt(atomicRaw);
+    const scale = BigInt(10) ** BigInt(Math.max(0, decimals));
+    const whole = amount / scale;
+    const fraction = (amount % scale).toString().padStart(decimals, "0");
+    if (decimals === 0) return whole.toString();
+    const shown = fraction.slice(0, Math.min(decimals, maxFractionDigits));
+    const trimmed = shown.replace(/0+$/, "");
+    return trimmed ? `${whole.toString()}.${trimmed}` : whole.toString();
+  } catch {
+    return "";
+  }
+}
+
+function parseTimestampMs(value: string | null): number {
+  if (!value) return Date.now();
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+function normalizeOpenOrderStatus(value: string | null): OpenOrderStatus {
+  switch ((value ?? "").trim().toLowerCase()) {
+    case "pending":
+      return "pending";
+    case "working":
+      return "working";
+    case "partial":
+      return "partial";
+    case "filled":
+      return "filled";
+    case "failed":
+      return "failed";
+    case "cancelled":
+      return "cancelled";
+    case "expired":
+      return "expired";
+    default:
+      return "working";
+  }
+}
+
+export function mapTerminalOpenOrderSnapshot(
+  snapshot: TerminalOpenOrderSnapshot,
+): OpenOrderRow | null {
+  const pairId =
+    snapshot.pairId && SUPPORTED_PAIR_SET.has(snapshot.pairId)
+      ? (snapshot.pairId as PairId)
+      : null;
+  if (!pairId || !snapshot.direction || !snapshot.orderType || !snapshot.lane) {
+    return null;
+  }
+  const inputToken = snapshot.inputMint
+    ? TOKEN_BY_MINT[snapshot.inputMint]
+    : null;
+  const amountUi = formatAtomicUi(
+    snapshot.amountAtomic,
+    inputToken?.decimals ?? 0,
+  );
+  const remainingAmountUi =
+    formatAtomicUi(snapshot.remainingAmountAtomic, inputToken?.decimals ?? 0) ||
+    amountUi;
+  const createdAt = parseTimestampMs(snapshot.receivedAt);
+  const updatedAt = parseTimestampMs(snapshot.updatedAt ?? snapshot.receivedAt);
+  return {
+    id: snapshot.requestId,
+    requestId: snapshot.requestId,
+    createdAt,
+    updatedAt,
+    pairId,
+    direction: snapshot.direction,
+    source: snapshot.source ?? "TERMINAL",
+    reason: snapshot.reason ?? "Conditional order",
+    orderType: snapshot.orderType,
+    timeInForce: snapshot.timeInForce ?? "gtc",
+    amountUi,
+    remainingAmountUi,
+    slippageBps: snapshot.slippageBps ?? 50,
+    lane: snapshot.lane,
+    simulationPreference: snapshot.simulationPreference ?? "auto",
+    priorityLevel: snapshot.priorityLevel ?? "normal",
+    limitPriceUi:
+      snapshot.orderType === "limit"
+        ? formatAtomicUi(snapshot.limitPriceAtomic, ORDER_PRICE_DECIMALS)
+        : null,
+    triggerPriceUi:
+      snapshot.orderType === "trigger"
+        ? formatAtomicUi(snapshot.triggerPriceAtomic, ORDER_PRICE_DECIMALS)
+        : null,
+    status: normalizeOpenOrderStatus(snapshot.status),
+    initialAmountUi: amountUi,
+    lastError: snapshot.errorMessage ?? null,
+    terminal: snapshot.terminal,
+    provider: snapshot.provider,
+    signature: snapshot.signature,
+    errorCode: snapshot.errorCode,
+    errorMessage: snapshot.errorMessage,
+    receivedAtIso: snapshot.receivedAt,
+    updatedAtIso: snapshot.updatedAt,
+    terminalAtIso: snapshot.terminalAt,
+    inputMint: snapshot.inputMint,
+    outputMint: snapshot.outputMint,
+    amountAtomic: snapshot.amountAtomic,
+    remainingAmountAtomic: snapshot.remainingAmountAtomic,
+    takingAmountAtomic: snapshot.takingAmountAtomic,
+    filledInputAtomic: snapshot.filledInputAtomic,
+    filledOutputAtomic: snapshot.filledOutputAtomic,
+    lifecycle: snapshot.lifecycle,
+  };
 }
 
 export function queueOpenOrder(

--- a/apps/portal/app/terminal/components/trade-ticket-modal.tsx
+++ b/apps/portal/app/terminal/components/trade-ticket-modal.tsx
@@ -44,7 +44,7 @@ type TradeTicketModalProps = {
   getAccessToken: () => Promise<string | null>;
   onClose: () => void;
   onTradeComplete?: (trade: TradeTicketCompletion) => void;
-  onOrderQueued?: (order: QueuedTerminalOrder) => void;
+  onOrderQueued?: (requestId: string) => void;
 };
 
 type TradeTicketHotkeyBindings = {
@@ -267,6 +267,7 @@ const EMPTY_QUOTE: QuoteState = {
 export function validateOrderConfig(input: {
   orderType: OrderType;
   timeInForce: TimeInForce;
+  lane: ExecutionLane;
   reduceOnly: boolean;
   postOnly: boolean;
   quantityMode: QuantityMode;
@@ -288,13 +289,37 @@ export function validateOrderConfig(input: {
     errors.push("Trigger orders require a trigger price.");
   }
   if (
+    (input.orderType === "limit" || input.orderType === "trigger") &&
+    input.lane !== "safe"
+  ) {
+    errors.push("Limit and trigger orders currently require the safe lane.");
+  }
+  if (
+    (input.orderType === "limit" || input.orderType === "trigger") &&
+    input.timeInForce !== "gtc"
+  ) {
+    errors.push("Trigger-backed spot orders currently require GTC.");
+  }
+  if (
     input.postOnly &&
     (input.timeInForce === "ioc" || input.timeInForce === "fok")
   ) {
     errors.push("Post-only cannot be combined with IOC or FOK.");
   }
+  if (
+    (input.orderType === "limit" || input.orderType === "trigger") &&
+    input.postOnly
+  ) {
+    errors.push("Post-only is not supported for Trigger-backed spot orders.");
+  }
   if (input.orderType === "market" && input.postOnly) {
     errors.push("Post-only is only valid for limit or trigger orders.");
+  }
+  if (
+    (input.orderType === "limit" || input.orderType === "trigger") &&
+    input.reduceOnly
+  ) {
+    errors.push("Reduce-only is not supported for Trigger-backed spot orders.");
   }
   if (
     input.bracketEnabled &&
@@ -327,6 +352,12 @@ export function validateOrderConfig(input: {
     errors.push(
       "Reduce-only market orders currently require quote quantity mode.",
     );
+  }
+  if (
+    (input.orderType === "limit" || input.orderType === "trigger") &&
+    input.bracketEnabled
+  ) {
+    errors.push("Bracket TP/SL is not wired yet for Trigger-backed orders.");
   }
   return errors;
 }
@@ -578,6 +609,7 @@ export function TradeTicketModal({
       validateOrderConfig({
         orderType,
         timeInForce,
+        lane: executionLane,
         reduceOnly,
         postOnly,
         quantityMode,
@@ -591,6 +623,7 @@ export function TradeTicketModal({
     [
       amountAtomicForValidation,
       bracketEnabled,
+      executionLane,
       limitPriceAtomic,
       orderType,
       postOnly,
@@ -815,46 +848,82 @@ export function TradeTicketModal({
     };
 
     if (orderType === "limit" || orderType === "trigger") {
-      if (!onOrderQueued) {
+      setSubmitStatus("submitting");
+      setSubmitMessage(null);
+      try {
+        executeAbortRef.current?.abort();
+        continueExecutionOnUnmountRef.current = false;
+        const controller = new AbortController();
+        executeAbortRef.current = controller;
+        dismissExecuteToast();
+
+        const token = await getAccessToken();
+        if (!token) throw new Error("missing-access-token");
+
+        const executionClient = createExecutionClient({
+          authToken: token,
+          pollIntervalMs: EXEC_POLL_INTERVAL_MS,
+          pollTimeoutMs: EXEC_POLL_TIMEOUT_MS,
+        });
+        const idempotencyKey = newExecutionIdempotencyKey("trade");
+        const submitAck = await executionClient.submit(
+          {
+            schemaVersion: "v2",
+            mode: "privy_execute",
+            lane: executionLane,
+            metadata: {
+              source: intent.source,
+              reason: `${intent.reason} • ${orderType}/${timeInForce}/${quantityMode} • ${executionLane}/${simulationPreference}/${priorityLevel}`,
+              clientRequestId: idempotencyKey,
+            },
+            privyExecute: {
+              wallet: walletAddress,
+              intent: {
+                family: "conditional_spot_order",
+                venueKey: "jupiter",
+                marketType: "spot",
+                instrumentId: intent.pairId,
+                side: intent.direction,
+                quantityAtomic: quote.inAmountAtomic,
+              },
+              options,
+            },
+          },
+          {
+            idempotencyKey,
+            signal: controller.signal,
+          },
+        );
+
+        if (submitAck.terminal) {
+          throw new Error(`conditional-order-${submitAck.state}`);
+        }
+
+        closeModal();
+        onOrderQueued?.(submitAck.requestId);
+        toast.success(`${orderType.toUpperCase()} order submitted`, {
+          description: `${intent.pairId} • ${amountUi.trim()} ${intent.inputSymbol}`,
+          position: "bottom-right",
+          duration: 3500,
+        });
+        return;
+      } catch (error) {
+        const message = describeExecutionClientError(
+          error,
+          "conditional-order-submit-failed",
+        );
+        if (!mountedRef.current || !openRef.current) {
+          toast.error("Conditional order submit failed", {
+            description: message,
+            position: "bottom-right",
+            duration: 7000,
+          });
+          return;
+        }
         setSubmitStatus("error");
-        setSubmitMessage("open-orders-panel-unavailable");
+        setSubmitMessage(message);
         return;
       }
-      const amountForOrder = amountUi.trim();
-      if (!amountForOrder) {
-        setSubmitStatus("error");
-        setSubmitMessage("order-amount-required");
-        return;
-      }
-      const now = Date.now();
-      onOrderQueued({
-        id: crypto.randomUUID(),
-        createdAt: now,
-        updatedAt: now,
-        pairId: intent.pairId,
-        direction: intent.direction,
-        source: intent.source,
-        reason: intent.reason,
-        orderType,
-        timeInForce,
-        amountUi: amountForOrder,
-        remainingAmountUi: amountForOrder,
-        slippageBps: boundedSlippageBps,
-        lane: executionLane,
-        simulationPreference,
-        priorityLevel,
-        limitPriceUi:
-          orderType === "limit" ? limitPriceUi.trim() || null : null,
-        triggerPriceUi:
-          orderType === "trigger" ? triggerPriceUi.trim() || null : null,
-      });
-      closeModal();
-      toast.success(`${orderType.toUpperCase()} order queued`, {
-        description: `${intent.pairId} • ${amountForOrder} ${intent.inputSymbol}`,
-        position: "bottom-right",
-        duration: 3500,
-      });
-      return;
     }
     setSubmitStatus("submitting");
     setSubmitMessage(null);
@@ -995,7 +1064,6 @@ export function TradeTicketModal({
     getAccessToken,
     intent,
     limitPriceAtomic,
-    limitPriceUi,
     onOrderQueued,
     onTradeComplete,
     orderType,
@@ -1020,7 +1088,6 @@ export function TradeTicketModal({
     takeProfitPriceAtomic,
     timeInForce,
     triggerPriceAtomic,
-    triggerPriceUi,
     walletAddress,
   ]);
 

--- a/apps/portal/app/terminal/page.tsx
+++ b/apps/portal/app/terminal/page.tsx
@@ -6,6 +6,11 @@ import { useRouter } from "next/navigation";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "../cn";
 import {
+  createExecutionClient,
+  describeExecutionClientError,
+  type ExecutionOpenOrderSnapshot,
+} from "../execution-client";
+import {
   type AccountWallet,
   apiFetchJson,
   type BalanceResponse,
@@ -49,14 +54,9 @@ import { MacroOilWidget } from "./components/macro-oil-widget";
 import { MacroRadarWidget } from "./components/macro-radar-widget";
 import { MacroStablecoinWidget } from "./components/macro-stablecoin-widget";
 import {
-  amendOpenOrder as applyAmendOpenOrder,
-  cancelAllOpenOrders as applyCancelAllOpenOrders,
-  cancelOpenOrder as applyCancelOpenOrder,
-  executeOpenOrderSlice,
+  mapTerminalOpenOrderSnapshot,
   type OpenOrderRow,
   type OpenOrderStatus,
-  promotePendingOrders,
-  queueOpenOrder,
 } from "./components/open-orders";
 import { buildOrderbookLadder } from "./components/orderbook-ladder";
 import {
@@ -95,12 +95,10 @@ import {
   getPairConfig,
   type PairId,
   SUPPORTED_PAIRS,
+  TOKEN_BY_MINT,
   TOKEN_CONFIGS,
 } from "./components/trade-pairs";
-import type {
-  QueuedTerminalOrder,
-  TradeTicketCompletion,
-} from "./components/trade-ticket-modal";
+import type { TradeTicketCompletion } from "./components/trade-ticket-modal";
 import {
   countMissingTradeTicks,
   filterTradeTicks,
@@ -306,6 +304,107 @@ function formatAtomicTokenBalance(
   }
 }
 
+function isSupportedPairId(value: string): value is PairId {
+  return SUPPORTED_PAIRS.some((pair) => pair.id === value);
+}
+
+function buildConditionalOrderExecutionEntry(
+  snapshot: ExecutionOpenOrderSnapshot,
+): ExecutionActivityRow | null {
+  if (
+    !snapshot.requestId ||
+    !snapshot.pairId ||
+    !isSupportedPairId(snapshot.pairId)
+  ) {
+    return null;
+  }
+  if (snapshot.direction !== "buy" && snapshot.direction !== "sell") {
+    return null;
+  }
+  const pair = getPairConfig(snapshot.pairId);
+  const fallbackInputToken =
+    snapshot.direction === "buy"
+      ? TOKEN_CONFIGS[pair.quoteSymbol]
+      : TOKEN_CONFIGS[pair.baseSymbol];
+  const fallbackOutputToken =
+    snapshot.direction === "buy"
+      ? TOKEN_CONFIGS[pair.baseSymbol]
+      : TOKEN_CONFIGS[pair.quoteSymbol];
+  const inputToken =
+    (snapshot.inputMint ? TOKEN_BY_MINT[snapshot.inputMint] : null) ??
+    fallbackInputToken;
+  const outputToken =
+    (snapshot.outputMint ? TOKEN_BY_MINT[snapshot.outputMint] : null) ??
+    fallbackOutputToken;
+  const inputFilledUi = Number(
+    formatAtomicTokenBalance(
+      snapshot.filledInputAtomic,
+      inputToken.decimals,
+      9,
+    ),
+  );
+  const outputFilledUi = Number(
+    formatAtomicTokenBalance(
+      snapshot.filledOutputAtomic,
+      outputToken.decimals,
+      9,
+    ),
+  );
+  const baseFilledUi =
+    snapshot.direction === "buy" ? outputFilledUi : inputFilledUi;
+  const quoteFilledUi =
+    snapshot.direction === "buy" ? inputFilledUi : outputFilledUi;
+  if (
+    (!Number.isFinite(baseFilledUi) || baseFilledUi <= 0) &&
+    (!Number.isFinite(quoteFilledUi) || quoteFilledUi <= 0)
+  ) {
+    return null;
+  }
+  const fillPrice =
+    Number.isFinite(baseFilledUi) && baseFilledUi > 0
+      ? quoteFilledUi / baseFilledUi
+      : null;
+  const tsRaw = Date.parse(
+    snapshot.terminalAt ?? snapshot.updatedAt ?? snapshot.receivedAt ?? "",
+  );
+  return {
+    id: `conditional-${snapshot.requestId}`,
+    ts: Number.isFinite(tsRaw) ? tsRaw : Date.now(),
+    requestId: snapshot.requestId,
+    receiptId: null,
+    pairId: snapshot.pairId,
+    direction: snapshot.direction,
+    leg: `${inputToken.symbol} -> ${outputToken.symbol}`,
+    lane: snapshot.lane ?? "safe",
+    baseFilledUi,
+    quoteFilledUi,
+    fillPrice,
+    feeUi: null,
+    feeSymbol: null,
+    status: snapshot.status ?? snapshot.requestStatus,
+    provider: snapshot.provider,
+    signature: snapshot.signature,
+    qualitySummary: `lane ${snapshot.lane ?? "safe"} • sim ${snapshot.simulationPreference ?? "auto"} • slip ${snapshot.slippageBps ?? 50} bps • prio ${snapshot.priorityLevel ?? "normal"}`,
+  };
+}
+
+function mergeExecutionActivityRows(
+  current: readonly ExecutionActivityRow[],
+  incoming: readonly ExecutionActivityRow[],
+): ExecutionActivityRow[] {
+  if (incoming.length === 0) return [...current];
+  const byRequestId = new Map<string, ExecutionActivityRow>();
+  for (const entry of current) {
+    byRequestId.set(entry.requestId, entry);
+  }
+  for (const entry of incoming) {
+    byRequestId.set(entry.requestId, entry);
+  }
+  return Array.from(byRequestId.values())
+    .sort((a, b) => b.ts - a.ts)
+    .slice(0, 250);
+}
+
 function parseAccountWallet(payload: unknown): AccountWallet | null {
   if (!isRecord(payload)) return null;
   const signerType = String(payload.signerType ?? "").trim();
@@ -353,18 +452,6 @@ function isTypingTarget(target: EventTarget | null): boolean {
   if (target.isContentEditable) return true;
   const tag = target.tagName;
   return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
-}
-
-function parseOpenOrderExecutionMarker(reason: string): {
-  orderId: string;
-  fraction: 0.5 | 1;
-} | null {
-  const match = reason.match(/\[order:([A-Za-z0-9_-]+);fraction:(0\.5|1)\]/);
-  if (!match) return null;
-  const orderId = match[1] ?? "";
-  const fraction = match[2] === "0.5" ? 0.5 : 1;
-  if (!orderId) return null;
-  return { orderId, fraction };
 }
 
 const ACCOUNT_RISK_THRESHOLDS = resolveAccountRiskThresholds();
@@ -1029,6 +1116,46 @@ function ControlRoom() {
     setLadderPrefill(null);
   }, []);
 
+  const refreshOpenOrders = useCallback(async (): Promise<void> => {
+    if (!authenticated) {
+      setOpenOrders([]);
+      return;
+    }
+    const token = await getAccessToken();
+    if (!token) {
+      setOpenOrders([]);
+      return;
+    }
+    try {
+      const executionClient = createExecutionClient({
+        authToken: token,
+      });
+      const snapshots = await executionClient.listOpenOrders();
+      const rows = snapshots
+        .map((snapshot) => mapTerminalOpenOrderSnapshot(snapshot))
+        .filter((row): row is OpenOrderRow => row !== null)
+        .filter((row) => row.terminal !== true);
+      setOpenOrders(rows);
+
+      const terminalEntries = snapshots
+        .filter((snapshot) => snapshot.terminal)
+        .map((snapshot) => buildConditionalOrderExecutionEntry(snapshot))
+        .filter((entry): entry is ExecutionActivityRow => entry !== null);
+      if (terminalEntries.length > 0) {
+        setRecentExecutions((current) =>
+          mergeExecutionActivityRows(current, terminalEntries),
+        );
+      }
+    } catch (error) {
+      setMessage(
+        describeExecutionClientError(
+          error,
+          "conditional-orders-refresh-failed",
+        ),
+      );
+    }
+  }, [authenticated, getAccessToken]);
+
   const openTradeTicket = useCallback(
     (intent: TradeIntent): void => {
       if (!hasWallet) {
@@ -1041,103 +1168,61 @@ function ControlRoom() {
     [hasWallet],
   );
 
-  const handleOrderQueued = useCallback((order: QueuedTerminalOrder): void => {
-    setOpenOrders((current) => queueOpenOrder(current, order));
-  }, []);
+  const handleOrderQueued = useCallback(
+    (_requestId: string): void => {
+      void refreshOpenOrders();
+    },
+    [refreshOpenOrders],
+  );
 
-  const cancelOpenOrder = useCallback((orderId: string): void => {
-    setOpenOrders((current) =>
-      applyCancelOpenOrder(current, orderId, Date.now()),
-    );
-  }, []);
+  const cancelOpenOrder = useCallback(
+    (requestId: string): void => {
+      void (async () => {
+        try {
+          const token = await getAccessToken();
+          if (!token) throw new Error("missing-access-token");
+          const executionClient = createExecutionClient({
+            authToken: token,
+          });
+          await executionClient.cancelOpenOrder(requestId);
+          await refreshOpenOrders();
+        } catch (error) {
+          setMessage(
+            describeExecutionClientError(
+              error,
+              "conditional-order-cancel-failed",
+            ),
+          );
+        }
+      })();
+    },
+    [getAccessToken, refreshOpenOrders],
+  );
 
   const cancelAllOpenOrders = useCallback((): void => {
     if (openOrders.length === 0) return;
-    setOpenOrders((current) => applyCancelAllOpenOrders(current, Date.now()));
-  }, [openOrders.length]);
-
-  const amendOpenOrder = useCallback(
-    (orderId: string): void => {
-      const target = openOrders.find((order) => order.id === orderId);
-      if (!target) return;
-
-      const amountRaw = window.prompt(
-        "Amend remaining amount",
-        target.remainingAmountUi,
-      );
-      if (amountRaw === null) return;
-      const nextPriceRaw =
-        target.orderType === "limit"
-          ? window.prompt("Amend limit price", target.limitPriceUi ?? "")
-          : window.prompt("Amend trigger price", target.triggerPriceUi ?? "");
-      if (nextPriceRaw === null) return;
-      setOpenOrders(
-        (current) =>
-          applyAmendOpenOrder({
-            current,
-            orderId,
-            amountUi: amountRaw,
-            priceUi: nextPriceRaw,
-            now: Date.now(),
-          }).next,
-      );
-    },
-    [openOrders],
-  );
-
-  const executeOpenOrder = useCallback(
-    (input: { orderId: string; fraction: 0.5 | 1 }): void => {
-      const target = openOrders.find((order) => order.id === input.orderId);
-      if (!target) return;
-      const execution = executeOpenOrderSlice({
-        current: openOrders,
-        orderId: input.orderId,
-        fraction: input.fraction,
-        now: Date.now(),
-      });
-      if (!execution.ok) {
-        setOpenOrders(execution.next);
-        return;
+    void (async () => {
+      try {
+        const token = await getAccessToken();
+        if (!token) throw new Error("missing-access-token");
+        const executionClient = createExecutionClient({
+          authToken: token,
+        });
+        for (const order of openOrders) {
+          const requestId = order.requestId ?? order.id;
+          await executionClient.cancelOpenOrder(requestId);
+        }
+        await refreshOpenOrders();
+      } catch (error) {
+        setMessage(
+          describeExecutionClientError(
+            error,
+            "conditional-order-cancel-failed",
+          ),
+        );
       }
-
-      const now = Date.now();
-      openTradeTicket(
-        createTradeIntent(
-          target.direction,
-          "OPEN_ORDERS_PANEL",
-          target.pairId,
-          {
-            reason: `${target.orderType.toUpperCase()} order manual execution [order:${target.id};fraction:${input.fraction}]`,
-            amountUi: execution.executeAmountUi,
-            slippageBps: target.slippageBps,
-          },
-        ),
-      );
-
-      setOpenOrders((current) =>
-        current.map((order) =>
-          order.id === input.orderId
-            ? {
-                ...order,
-                status: "working",
-                updatedAt: now,
-                lastError: null,
-              }
-            : order,
-        ),
-      );
-    },
-    [openOrders, openTradeTicket],
-  );
-
-  useEffect(() => {
-    if (openOrders.length === 0) return;
-    const timer = window.setInterval(() => {
-      const now = Date.now();
-      setOpenOrders((current) => promotePendingOrders(current, now));
-    }, 1000);
-    return () => window.clearInterval(timer);
-  }, [openOrders.length]);
+    })();
+  }, [getAccessToken, openOrders, refreshOpenOrders]);
 
   const handleLadderPrefill = useCallback((nextPrefill: LadderPrefill) => {
     setLadderPrefill((current) => {
@@ -1239,7 +1324,8 @@ function ControlRoom() {
 
   const triggerRefresh = useCallback(() => {
     void refresh();
-  }, [refresh]);
+    void refreshOpenOrders();
+  }, [refresh, refreshOpenOrders]);
 
   useEffect(() => {
     const focusHotkeyActions: Array<{
@@ -1373,18 +1459,6 @@ function ControlRoom() {
   const handleTradeComplete = useCallback(
     (trade: TradeTicketCompletion): void => {
       applyOptimisticTradeBalances(trade);
-      const openOrderExecution = parseOpenOrderExecutionMarker(trade.reason);
-      if (openOrderExecution) {
-        setOpenOrders(
-          (current) =>
-            executeOpenOrderSlice({
-              current,
-              orderId: openOrderExecution.orderId,
-              fraction: openOrderExecution.fraction,
-              now: Date.now(),
-            }).next,
-        );
-      }
       setRecentExecutions((current) => {
         const entry: ExecutionActivityRow = {
           id: crypto.randomUUID(),
@@ -1419,6 +1493,18 @@ function ControlRoom() {
     }, 15_000);
     return () => window.clearInterval(timer);
   }, [wallet, refreshWalletBalances]);
+
+  useEffect(() => {
+    if (!authenticated || !wallet) {
+      setOpenOrders([]);
+      return;
+    }
+    void refreshOpenOrders();
+    const timer = window.setInterval(() => {
+      void refreshOpenOrders();
+    }, 2500);
+    return () => window.clearInterval(timer);
+  }, [authenticated, refreshOpenOrders, wallet]);
 
   const {
     setWalletBalances: setGlobalWalletBalances,
@@ -1899,8 +1985,6 @@ function ControlRoom() {
                         onQuickAction={openTradeTicket}
                         onCancelOrder={cancelOpenOrder}
                         onCancelAllOrders={cancelAllOpenOrders}
-                        onAmendOrder={amendOpenOrder}
-                        onExecuteOrder={executeOpenOrder}
                       />
                     </div>
                   ) : null}
@@ -2761,8 +2845,6 @@ const PositionsOrdersFillsPanel = memo(
     onQuickAction: (intent: TradeIntent) => void;
     onCancelOrder: (orderId: string) => void;
     onCancelAllOrders: () => void;
-    onAmendOrder: (orderId: string) => void;
-    onExecuteOrder: (input: { orderId: string; fraction: 0.5 | 1 }) => void;
   }) {
     const {
       entries,
@@ -2774,8 +2856,6 @@ const PositionsOrdersFillsPanel = memo(
       onQuickAction,
       onCancelOrder,
       onCancelAllOrders,
-      onAmendOrder,
-      onExecuteOrder,
     } = props;
     const markByPair = useMemo(
       () =>
@@ -2885,6 +2965,12 @@ const PositionsOrdersFillsPanel = memo(
         return "border-emerald-500/40 bg-emerald-500/10 text-emerald-300";
       }
       if (status === "partial") {
+        return "border-amber-500/40 bg-amber-500/10 text-amber-300";
+      }
+      if (status === "filled") {
+        return "border-emerald-500/40 bg-emerald-500/10 text-emerald-300";
+      }
+      if (status === "expired") {
         return "border-amber-500/40 bg-amber-500/10 text-amber-300";
       }
       if (status === "cancelled") {
@@ -3036,6 +3122,11 @@ const PositionsOrdersFillsPanel = memo(
                           : `TRG ${order.triggerPriceUi ?? "--"}`}{" "}
                         • {order.timeInForce.toUpperCase()}
                       </p>
+                      {order.requestId ? (
+                        <p className="text-[10px] text-muted">
+                          Request {shortExecutionId(order.requestId)}
+                        </p>
+                      ) : null}
                     </div>
                     <span
                       className={cn(
@@ -3056,61 +3147,38 @@ const PositionsOrdersFillsPanel = memo(
                       className={cn(
                         BTN_SECONDARY,
                         "h-6 rounded px-2 text-[10px] uppercase tracking-wider",
-                        (!tradingEnabled ||
-                          order.status === "cancelled" ||
-                          order.status === "failed") &&
-                          "opacity-60 pointer-events-none",
+                        !order.requestId && "opacity-60 pointer-events-none",
                       )}
                       onClick={() =>
-                        onExecuteOrder({ orderId: order.id, fraction: 0.5 })
+                        order.requestId ? openInspector(order.requestId) : null
                       }
                       type="button"
-                      disabled={
-                        !tradingEnabled ||
-                        order.status === "cancelled" ||
-                        order.status === "failed"
-                      }
+                      disabled={!order.requestId}
                     >
-                      Exec 50%
+                      Inspect
                     </button>
                     <button
                       className={cn(
                         BTN_SECONDARY,
                         "h-6 rounded px-2 text-[10px] uppercase tracking-wider",
                         (!tradingEnabled ||
+                          order.terminal === true ||
                           order.status === "cancelled" ||
-                          order.status === "failed") &&
+                          order.status === "failed" ||
+                          order.status === "filled" ||
+                          order.status === "expired") &&
                           "opacity-60 pointer-events-none",
                       )}
-                      onClick={() =>
-                        onExecuteOrder({ orderId: order.id, fraction: 1 })
-                      }
+                      onClick={() => onCancelOrder(order.requestId ?? order.id)}
                       type="button"
                       disabled={
                         !tradingEnabled ||
+                        order.terminal === true ||
                         order.status === "cancelled" ||
-                        order.status === "failed"
+                        order.status === "failed" ||
+                        order.status === "filled" ||
+                        order.status === "expired"
                       }
-                    >
-                      Execute all
-                    </button>
-                    <button
-                      className={cn(
-                        BTN_SECONDARY,
-                        "h-6 rounded px-2 text-[10px] uppercase tracking-wider",
-                      )}
-                      onClick={() => onAmendOrder(order.id)}
-                      type="button"
-                    >
-                      Amend
-                    </button>
-                    <button
-                      className={cn(
-                        BTN_SECONDARY,
-                        "h-6 rounded px-2 text-[10px] uppercase tracking-wider",
-                      )}
-                      onClick={() => onCancelOrder(order.id)}
-                      type="button"
                     >
                       Cancel
                     </button>

--- a/apps/worker/src/execution/jupiter_trigger.ts
+++ b/apps/worker/src/execution/jupiter_trigger.ts
@@ -1,0 +1,442 @@
+import { SUPPORTED_TRADING_PAIRS, TRADING_TOKEN_BY_MINT } from "../defaults";
+import type {
+  JupiterTriggerCondition,
+  JupiterTriggerOrderRecord,
+} from "../jupiter";
+import type {
+  ExecutionIntentLifecycleSnapshot,
+  NonSwapExecutionIntent,
+} from "./types";
+
+export const JUPITER_TRIGGER_PRICE_DECIMALS = 6;
+
+export type JupiterConditionalOrderType = "limit" | "trigger";
+
+export type ResolvedJupiterConditionalSpotOrder = {
+  venueKey: "jupiter";
+  instrumentId: string;
+  side: "buy" | "sell";
+  orderType: JupiterConditionalOrderType;
+  timeInForce: "gtc";
+  quantityAtomic: string;
+  priceAtomic: string;
+  inputMint: string;
+  outputMint: string;
+  makingAmount: string;
+  takingAmount: string;
+  triggerCondition: JupiterTriggerCondition;
+};
+
+export type JupiterTriggerTerminalReason =
+  | "filled"
+  | "cancelled"
+  | "expired"
+  | null;
+
+export type JupiterTrackedTriggerOrder = {
+  maker: string;
+  order: string;
+  requestId?: string | null;
+  instrumentId?: string | null;
+  side?: string | null;
+  orderType?: string | null;
+  inputMint?: string | null;
+  outputMint?: string | null;
+  makingAmount?: string | null;
+  takingAmount?: string | null;
+};
+
+export type JupiterTriggerLifecycleSummary = {
+  lifecycle: ExecutionIntentLifecycleSnapshot;
+  terminalReason: JupiterTriggerTerminalReason;
+  filledInputAtomic: string;
+  filledOutputAtomic: string;
+  signature: string | null;
+};
+
+function readString(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return normalized ? normalized : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readBoolean(value: unknown): boolean | null {
+  if (typeof value === "boolean") return value;
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "true" || normalized === "1" || normalized === "on") {
+    return true;
+  }
+  if (normalized === "false" || normalized === "0" || normalized === "off") {
+    return false;
+  }
+  return null;
+}
+
+function readPositiveBigInt(value: unknown): bigint | null {
+  const normalized = readString(value);
+  if (!normalized) return null;
+  try {
+    const parsed = BigInt(normalized);
+    return parsed > 0n ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function readOptionalBigInt(value: unknown): bigint | null {
+  const normalized = readString(value);
+  if (!normalized) return null;
+  try {
+    const parsed = BigInt(normalized);
+    return parsed >= 0n ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function getPairByInstrumentId(instrumentId: string) {
+  return (
+    SUPPORTED_TRADING_PAIRS.find((pair) => pair.id === instrumentId) ?? null
+  );
+}
+
+function pow10(exp: number): bigint {
+  return 10n ** BigInt(Math.max(0, Math.floor(exp)));
+}
+
+function divFloor(numerator: bigint, denominator: bigint): bigint {
+  if (denominator <= 0n) {
+    throw new Error("invalid-jupiter-trigger-denominator");
+  }
+  return numerator / denominator;
+}
+
+export function resolveJupiterConditionalSpotOrder(
+  intent: NonSwapExecutionIntent,
+): ResolvedJupiterConditionalSpotOrder {
+  if (intent.family !== "conditional_spot_order") {
+    throw new Error("invalid-jupiter-trigger-intent-family");
+  }
+  if (intent.venueKey !== "jupiter") {
+    throw new Error("invalid-jupiter-trigger-venue");
+  }
+  const pair = getPairByInstrumentId(intent.instrumentId);
+  if (!pair) {
+    throw new Error(
+      `unsupported-jupiter-trigger-instrument:${intent.instrumentId}`,
+    );
+  }
+  const params = intent.params ?? {};
+  const orderTypeRaw = readString(params.orderType);
+  const orderType: JupiterConditionalOrderType =
+    orderTypeRaw === "trigger" ? "trigger" : "limit";
+  const timeInForceRaw = readString(params.timeInForce);
+  if (
+    timeInForceRaw &&
+    timeInForceRaw !== "gtc" &&
+    timeInForceRaw !== "ioc" &&
+    timeInForceRaw !== "fok"
+  ) {
+    throw new Error(
+      `unsupported-jupiter-trigger-time-in-force:${timeInForceRaw}`,
+    );
+  }
+  const timeInForce = timeInForceRaw ?? "gtc";
+  if (timeInForce !== "gtc") {
+    throw new Error(`unsupported-jupiter-trigger-time-in-force:${timeInForce}`);
+  }
+  if (readBoolean(params.postOnly) === true) {
+    throw new Error("unsupported-jupiter-trigger-post-only");
+  }
+  if (readBoolean(params.reduceOnly) === true) {
+    throw new Error("unsupported-jupiter-trigger-reduce-only");
+  }
+  if (readString(params.takeProfitPriceAtomic)) {
+    throw new Error("unsupported-jupiter-trigger-take-profit");
+  }
+  if (readString(params.stopLossPriceAtomic)) {
+    throw new Error("unsupported-jupiter-trigger-stop-loss");
+  }
+  const quantityAtomic = readPositiveBigInt(intent.quantityAtomic);
+  if (!quantityAtomic) {
+    throw new Error("invalid-jupiter-trigger-quantity");
+  }
+  const limitPriceAtomic = readPositiveBigInt(params.limitPriceAtomic);
+  const triggerPriceAtomic = readPositiveBigInt(params.triggerPriceAtomic);
+  const priceAtomic =
+    orderType === "trigger" ? triggerPriceAtomic : limitPriceAtomic;
+  if (!priceAtomic) {
+    throw new Error(
+      orderType === "trigger"
+        ? "missing-jupiter-trigger-price"
+        : "missing-jupiter-limit-price",
+    );
+  }
+  if (
+    orderType === "trigger" &&
+    limitPriceAtomic &&
+    limitPriceAtomic !== triggerPriceAtomic
+  ) {
+    throw new Error("unsupported-jupiter-trigger-limit-price-override");
+  }
+
+  const buy = intent.side === "buy";
+  const inputMint = buy ? pair.quoteMint : pair.baseMint;
+  const outputMint = buy ? pair.baseMint : pair.quoteMint;
+  const inputToken = TRADING_TOKEN_BY_MINT[inputMint];
+  const outputToken = TRADING_TOKEN_BY_MINT[outputMint];
+  if (!inputToken || !outputToken) {
+    throw new Error(`unsupported-jupiter-trigger-pair:${intent.instrumentId}`);
+  }
+
+  const makingAmount = quantityAtomic;
+  const takingAmount = buy
+    ? divFloor(
+        makingAmount *
+          pow10(outputToken.decimals) *
+          pow10(JUPITER_TRIGGER_PRICE_DECIMALS),
+        priceAtomic * pow10(inputToken.decimals),
+      )
+    : divFloor(
+        makingAmount * priceAtomic * pow10(outputToken.decimals),
+        pow10(inputToken.decimals) * pow10(JUPITER_TRIGGER_PRICE_DECIMALS),
+      );
+  if (takingAmount <= 0n) {
+    throw new Error("invalid-jupiter-trigger-derived-output");
+  }
+
+  return {
+    venueKey: "jupiter",
+    instrumentId: intent.instrumentId,
+    side: buy ? "buy" : "sell",
+    orderType,
+    timeInForce: "gtc",
+    quantityAtomic: makingAmount.toString(),
+    priceAtomic: priceAtomic.toString(),
+    inputMint,
+    outputMint,
+    makingAmount: makingAmount.toString(),
+    takingAmount: takingAmount.toString(),
+    triggerCondition:
+      orderType === "trigger"
+        ? buy
+          ? "above"
+          : "below"
+        : buy
+          ? "below"
+          : "above",
+  };
+}
+
+function normalizeLifecycleStatus(
+  status: string | null,
+  order: JupiterTriggerOrderRecord,
+): JupiterTriggerLifecycleSummary {
+  const normalized = String(status ?? "")
+    .trim()
+    .toLowerCase();
+  const remainingMakingAmount = readOptionalBigInt(order.remainingMakingAmount);
+  const totalMakingAmount = readPositiveBigInt(order.makingAmount);
+  const totalTakingAmount = readPositiveBigInt(order.takingAmount);
+
+  let filledInput = 0n;
+  let filledOutput = 0n;
+  const trades = Array.isArray(order.trades) ? order.trades : [];
+  for (const trade of trades) {
+    const inputAmount = readOptionalBigInt(trade.inputAmount) ?? 0n;
+    const outputAmount = readOptionalBigInt(trade.outputAmount) ?? 0n;
+    filledInput += inputAmount;
+    filledOutput += outputAmount;
+  }
+  if (
+    filledInput === 0n &&
+    filledOutput === 0n &&
+    totalMakingAmount &&
+    totalTakingAmount &&
+    remainingMakingAmount !== null &&
+    remainingMakingAmount < totalMakingAmount &&
+    remainingMakingAmount >= 0n
+  ) {
+    const consumedMakingAmount = totalMakingAmount - remainingMakingAmount;
+    filledInput = consumedMakingAmount;
+    filledOutput = divFloor(
+      consumedMakingAmount * totalTakingAmount,
+      totalMakingAmount,
+    );
+  }
+
+  const filledInputAtomic = filledInput.toString();
+  const filledOutputAtomic = filledOutput.toString();
+  const signature = readString(order.closeTx) ?? readString(order.openTx);
+
+  if (normalized.includes("cancel")) {
+    return {
+      lifecycle: {
+        orderState: "cancelled",
+        fillState: filledInput > 0n ? "partial" : "pending",
+        settlementState: "finalized",
+        notes: [String(order.status ?? "Cancelled")],
+      },
+      terminalReason: "cancelled",
+      filledInputAtomic,
+      filledOutputAtomic,
+      signature,
+    };
+  }
+  if (normalized.includes("expire")) {
+    return {
+      lifecycle: {
+        orderState: "expired",
+        fillState: filledInput > 0n ? "partial" : "pending",
+        settlementState: "failed",
+        notes: [String(order.status ?? "Expired")],
+      },
+      terminalReason: "expired",
+      filledInputAtomic,
+      filledOutputAtomic,
+      signature,
+    };
+  }
+  if (
+    normalized.includes("partial") ||
+    ((filledInput > 0n || filledOutput > 0n) &&
+      remainingMakingAmount !== null &&
+      remainingMakingAmount > 0n)
+  ) {
+    return {
+      lifecycle: {
+        orderState: "partially_filled",
+        fillState: "partial",
+        settlementState: "confirmed",
+        notes: [String(order.status ?? "Partially Filled")],
+      },
+      terminalReason: null,
+      filledInputAtomic,
+      filledOutputAtomic,
+      signature,
+    };
+  }
+  if (
+    normalized.includes("fill") ||
+    normalized.includes("closed") ||
+    (totalMakingAmount !== null &&
+      remainingMakingAmount !== null &&
+      remainingMakingAmount === 0n)
+  ) {
+    return {
+      lifecycle: {
+        orderState: "filled",
+        fillState: "filled",
+        settlementState: "finalized",
+        notes: [String(order.status ?? "Filled")],
+      },
+      terminalReason: "filled",
+      filledInputAtomic:
+        filledInput > 0n
+          ? filledInputAtomic
+          : (totalMakingAmount ?? 0n).toString(),
+      filledOutputAtomic:
+        filledOutput > 0n
+          ? filledOutputAtomic
+          : (totalTakingAmount ?? 0n).toString(),
+      signature,
+    };
+  }
+  if (normalized.includes("trigger")) {
+    return {
+      lifecycle: {
+        orderState: "triggered",
+        fillState: "pending",
+        settlementState: "confirmed",
+        notes: [String(order.status ?? "Triggered")],
+      },
+      terminalReason: null,
+      filledInputAtomic,
+      filledOutputAtomic,
+      signature,
+    };
+  }
+  if (normalized.includes("open") || normalized.includes("active")) {
+    return {
+      lifecycle: {
+        orderState: "open",
+        fillState: "pending",
+        settlementState: "confirmed",
+        notes: [String(order.status ?? "Open")],
+      },
+      terminalReason: null,
+      filledInputAtomic,
+      filledOutputAtomic,
+      signature,
+    };
+  }
+  return {
+    lifecycle: {
+      orderState: "accepted",
+      fillState: "pending",
+      settlementState: "confirmed",
+      notes: [String(order.status ?? "Accepted")],
+    },
+    terminalReason: null,
+    filledInputAtomic,
+    filledOutputAtomic,
+    signature,
+  };
+}
+
+export function summarizeJupiterTriggerOrder(
+  order: JupiterTriggerOrderRecord | null,
+): JupiterTriggerLifecycleSummary {
+  if (!order) {
+    return {
+      lifecycle: {
+        orderState: "accepted",
+        fillState: "pending",
+        settlementState: "confirmed",
+        notes: ["order-created"],
+      },
+      terminalReason: null,
+      filledInputAtomic: "0",
+      filledOutputAtomic: "0",
+      signature: null,
+    };
+  }
+  return normalizeLifecycleStatus(readString(order.status), order);
+}
+
+export function findJupiterTriggerOrderByKey(
+  orders: JupiterTriggerOrderRecord[],
+  orderKey: string,
+): JupiterTriggerOrderRecord | null {
+  const normalizedKey = readString(orderKey);
+  if (!normalizedKey) return null;
+  return (
+    orders.find((order) => readString(order.order) === normalizedKey) ?? null
+  );
+}
+
+export function readTrackedJupiterTriggerOrder(
+  value: unknown,
+): JupiterTrackedTriggerOrder | null {
+  const record = isRecord(value) ? value : null;
+  if (!record) return null;
+  const maker = readString(record.maker);
+  const order = readString(record.order);
+  if (!maker || !order) return null;
+  return {
+    maker,
+    order,
+    requestId: readString(record.requestId),
+    instrumentId: readString(record.instrumentId),
+    side: readString(record.side),
+    orderType: readString(record.orderType),
+    inputMint: readString(record.inputMint),
+    outputMint: readString(record.outputMint),
+    makingAmount: readString(record.makingAmount),
+    takingAmount: readString(record.takingAmount),
+  };
+}

--- a/apps/worker/src/execution/jupiter_trigger_executor.ts
+++ b/apps/worker/src/execution/jupiter_trigger_executor.ts
@@ -18,11 +18,11 @@ function nowIso(): string {
   return new Date().toISOString();
 }
 
-function readsTruthyExecutionParam(value: unknown): boolean {
-  if (value === true) return true;
+function readsFalsyExecutionParam(value: unknown): boolean {
+  if (value === false) return true;
   if (typeof value !== "string") return false;
   const normalized = value.trim().toLowerCase();
-  return normalized === "1" || normalized === "true" || normalized === "on";
+  return normalized === "0" || normalized === "false" || normalized === "off";
 }
 
 function normalizeConfirmationStatus(
@@ -170,9 +170,9 @@ export async function executeJupiterConditionalSpotOrder(
     };
   }
 
-  const requireSimulation =
-    readsTruthyExecutionParam(input.execution?.params?.requireSimulation) ||
-    true;
+  const requireSimulation = !readsFalsyExecutionParam(
+    input.execution?.params?.requireSimulation,
+  );
   let simulatedAt: string | undefined;
   if (requireSimulation) {
     const sim = await input.rpc.simulateTransactionBase64(signedBase64, {

--- a/apps/worker/src/execution/jupiter_trigger_executor.ts
+++ b/apps/worker/src/execution/jupiter_trigger_executor.ts
@@ -226,6 +226,10 @@ export async function executeJupiterConditionalSpotOrder(
   const resultStatus = confirmation.ok
     ? normalizeConfirmationStatus(confirmation.status)
     : "error";
+  const uncertainCreateSubmission =
+    resultStatus === "error" &&
+    typeof signature === "string" &&
+    signature !== "";
   const summary = summarizeJupiterTriggerOrder({
     order: createResponse.order,
     status: resolved.orderType === "trigger" ? "Triggered" : "Open",
@@ -261,14 +265,24 @@ export async function executeJupiterConditionalSpotOrder(
       intentId: createResponse.requestId,
       venueSessionId: createResponse.order,
       lifecycle:
-        resultStatus === "error"
+        resultStatus === "error" && !uncertainCreateSubmission
           ? {
               orderState: "rejected",
               fillState: "failed",
               settlementState: "failed",
               notes: ["trigger-create-confirmation-failed"],
             }
-          : summary.lifecycle,
+          : {
+              ...summary.lifecycle,
+              ...(uncertainCreateSubmission
+                ? {
+                    notes: [
+                      ...(summary.lifecycle.notes ?? []),
+                      "trigger-create-confirmation-pending",
+                    ],
+                  }
+                : {}),
+            },
       trace: {
         txBuiltAt,
         ...(simulatedAt ? { simulatedAt } : {}),

--- a/apps/worker/src/execution/jupiter_trigger_executor.ts
+++ b/apps/worker/src/execution/jupiter_trigger_executor.ts
@@ -59,6 +59,9 @@ function buildSyntheticQuote(input: {
 
 export async function executeJupiterConditionalSpotOrder(
   input: ExecuteJupiterConditionalSpotOrderInput,
+  deps?: {
+    signTransactionWithPrivyById?: typeof signTransactionWithPrivyById;
+  },
 ): Promise<ExecuteSwapResult> {
   const route = "jupiter";
   const resolved = resolveJupiterConditionalSpotOrder(input.intent);
@@ -127,11 +130,9 @@ export async function executeJupiterConditionalSpotOrder(
     },
   });
   const txBuiltAt = nowIso();
-  const signedBase64 = await signTransactionWithPrivyById(
-    input.env,
-    input.privyWalletId,
-    createResponse.transaction,
-  );
+  const signedBase64 = await (
+    deps?.signTransactionWithPrivyById ?? signTransactionWithPrivyById
+  )(input.env, input.privyWalletId, createResponse.transaction);
 
   const safeEvaluation = evaluateSafeLaneTransaction({
     env: input.env,

--- a/apps/worker/src/execution/jupiter_trigger_executor.ts
+++ b/apps/worker/src/execution/jupiter_trigger_executor.ts
@@ -1,0 +1,288 @@
+import { signTransactionWithPrivyById } from "../privy";
+import {
+  resolveJupiterConditionalSpotOrder,
+  summarizeJupiterTriggerOrder,
+} from "./jupiter_trigger";
+import { evaluateSafeLaneTransaction } from "./safe_lane_policy";
+import type {
+  ExecuteIntentInput,
+  ExecuteSwapResult,
+  NonSwapExecutionIntent,
+} from "./types";
+
+type ExecuteJupiterConditionalSpotOrderInput = ExecuteIntentInput & {
+  intent: NonSwapExecutionIntent;
+};
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function readsTruthyExecutionParam(value: unknown): boolean {
+  if (value === true) return true;
+  if (typeof value !== "string") return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "on";
+}
+
+function normalizeConfirmationStatus(
+  status: string | undefined,
+): Extract<
+  ExecuteSwapResult["status"],
+  "processed" | "confirmed" | "finalized" | "error"
+> {
+  if (
+    status === "processed" ||
+    status === "confirmed" ||
+    status === "finalized"
+  ) {
+    return status;
+  }
+  return "error";
+}
+
+function buildSyntheticQuote(input: {
+  inputMint: string;
+  outputMint: string;
+  makingAmount: string;
+  takingAmount: string;
+}): ExecuteSwapResult["usedQuote"] {
+  return {
+    inputMint: input.inputMint,
+    outputMint: input.outputMint,
+    inAmount: input.makingAmount,
+    outAmount: input.takingAmount,
+    priceImpactPct: 0,
+    routePlan: [],
+  };
+}
+
+export async function executeJupiterConditionalSpotOrder(
+  input: ExecuteJupiterConditionalSpotOrderInput,
+): Promise<ExecuteSwapResult> {
+  const route = "jupiter";
+  const resolved = resolveJupiterConditionalSpotOrder(input.intent);
+  const usedQuote = buildSyntheticQuote({
+    inputMint: resolved.inputMint,
+    outputMint: resolved.outputMint,
+    makingAmount: resolved.makingAmount,
+    takingAmount: resolved.takingAmount,
+  });
+  const simulatedLifecycle = summarizeJupiterTriggerOrder({
+    order: "pending-order",
+    status: resolved.orderType === "trigger" ? "Triggered" : "Open",
+    makingAmount: resolved.makingAmount,
+    takingAmount: resolved.takingAmount,
+  }).lifecycle;
+
+  if (input.policy.dryRun) {
+    return {
+      status: "dry_run",
+      signature: null,
+      usedQuote,
+      refreshed: false,
+      lastValidBlockHeight: null,
+      executionMeta: {
+        route,
+        classification: "dry_run",
+        lifecycle: simulatedLifecycle,
+      },
+    };
+  }
+
+  if (
+    input.runtimeMode === "shadow" ||
+    input.runtimeMode === "paper" ||
+    input.policy.simulateOnly
+  ) {
+    return {
+      status: "simulated",
+      signature: null,
+      usedQuote,
+      refreshed: false,
+      lastValidBlockHeight: null,
+      executionMeta: {
+        route,
+        classification: "simulated",
+        lifecycle: simulatedLifecycle,
+      },
+    };
+  }
+
+  if (!input.privyWalletId) {
+    throw new Error("missing-privy-wallet-id");
+  }
+  if (input.guardEnabled) await input.guardEnabled();
+
+  const createResponse = await input.jupiter.createTriggerOrder({
+    inputMint: resolved.inputMint,
+    outputMint: resolved.outputMint,
+    maker: input.intent.wallet,
+    payer: input.intent.wallet,
+    params: {
+      makingAmount: resolved.makingAmount,
+      takingAmount: resolved.takingAmount,
+      triggerCondition: resolved.triggerCondition,
+      slippageBps: 50,
+    },
+  });
+  const txBuiltAt = nowIso();
+  const signedBase64 = await signTransactionWithPrivyById(
+    input.env,
+    input.privyWalletId,
+    createResponse.transaction,
+  );
+
+  const safeEvaluation = evaluateSafeLaneTransaction({
+    env: input.env,
+    signedTransactionBase64: signedBase64,
+  });
+  if (!safeEvaluation.ok) {
+    const failedAt = nowIso();
+    return {
+      status: "simulate_error",
+      signature: null,
+      usedQuote,
+      refreshed: false,
+      lastValidBlockHeight: null,
+      err: {
+        code: "policy-denied",
+        reason: safeEvaluation.reason,
+        profile: safeEvaluation.profile,
+        limits: safeEvaluation.limits,
+      },
+      executionMeta: {
+        route,
+        classification: "error",
+        intentId: createResponse.requestId,
+        venueSessionId: createResponse.order,
+        lifecycle: {
+          orderState: "rejected",
+          fillState: "failed",
+          settlementState: "failed",
+          notes: [safeEvaluation.reason],
+        },
+        trace: {
+          txBuiltAt,
+          failedAt,
+        },
+      },
+    };
+  }
+
+  const requireSimulation =
+    readsTruthyExecutionParam(input.execution?.params?.requireSimulation) ||
+    true;
+  let simulatedAt: string | undefined;
+  if (requireSimulation) {
+    const sim = await input.rpc.simulateTransactionBase64(signedBase64, {
+      commitment: input.policy.commitment,
+      sigVerify: true,
+    });
+    simulatedAt = nowIso();
+    if (sim.err) {
+      return {
+        status: "simulate_error",
+        signature: null,
+        usedQuote,
+        refreshed: false,
+        lastValidBlockHeight: null,
+        err: {
+          code: "policy-denied",
+          reason: "safe-lane-simulation-failed",
+          simulationError: sim.err,
+        },
+        executionMeta: {
+          route,
+          classification: "error",
+          intentId: createResponse.requestId,
+          venueSessionId: createResponse.order,
+          lifecycle: {
+            orderState: "rejected",
+            fillState: "failed",
+            settlementState: "failed",
+            notes: ["safe-lane-simulation-failed"],
+          },
+          trace: {
+            txBuiltAt,
+            simulatedAt,
+            failedAt: simulatedAt,
+          },
+        },
+      };
+    }
+  }
+
+  const signature = await input.rpc.sendTransactionBase64(signedBase64, {
+    skipPreflight: input.policy.skipPreflight,
+    preflightCommitment: input.policy.commitment,
+  });
+  const sentAt = nowIso();
+  const confirmation = await input.rpc.confirmSignature(signature, {
+    commitment: input.policy.commitment,
+  });
+  const confirmedAt = nowIso();
+  const resultStatus = confirmation.ok
+    ? normalizeConfirmationStatus(confirmation.status)
+    : "error";
+  const summary = summarizeJupiterTriggerOrder({
+    order: createResponse.order,
+    status: resolved.orderType === "trigger" ? "Triggered" : "Open",
+    makingAmount: resolved.makingAmount,
+    takingAmount: resolved.takingAmount,
+    openTx: signature,
+  });
+
+  return {
+    status: resultStatus,
+    signature,
+    usedQuote,
+    refreshed: false,
+    lastValidBlockHeight: null,
+    ...(confirmation.ok
+      ? {}
+      : {
+          err: confirmation.err ?? {
+            code: "submission-failed",
+            reason: "trigger-create-confirmation-failed",
+          },
+        }),
+    executionMeta: {
+      route,
+      classification:
+        resultStatus === "finalized"
+          ? "finalized"
+          : resultStatus === "confirmed"
+            ? "confirmed"
+            : resultStatus === "processed"
+              ? "landed"
+              : "error",
+      intentId: createResponse.requestId,
+      venueSessionId: createResponse.order,
+      lifecycle:
+        resultStatus === "error"
+          ? {
+              orderState: "rejected",
+              fillState: "failed",
+              settlementState: "failed",
+              notes: ["trigger-create-confirmation-failed"],
+            }
+          : summary.lifecycle,
+      trace: {
+        txBuiltAt,
+        ...(simulatedAt ? { simulatedAt } : {}),
+        sentAt,
+        ...(resultStatus === "processed" ||
+        resultStatus === "confirmed" ||
+        resultStatus === "finalized"
+          ? { landedAt: confirmedAt }
+          : {}),
+        ...(resultStatus === "confirmed" || resultStatus === "finalized"
+          ? { confirmedAt }
+          : {}),
+        ...(resultStatus === "finalized" ? { finalizedAt: confirmedAt } : {}),
+        ...(resultStatus === "error" ? { failedAt: confirmedAt } : {}),
+      },
+    },
+  };
+}

--- a/apps/worker/src/execution/jupiter_trigger_reconciliation.ts
+++ b/apps/worker/src/execution/jupiter_trigger_reconciliation.ts
@@ -67,6 +67,22 @@ function readPersistedLifecycle(
   return lifecycle ? (lifecycle as ExecutionIntentLifecycleSnapshot) : null;
 }
 
+function resolveReceiptTriggerStatus(input: {
+  orderRecord: JupiterTriggerOrderRecord | null;
+  summary: JupiterTriggerLifecycleSummary;
+}): string | null {
+  if (input.summary.terminalReason === "cancelled") {
+    return "Cancelled";
+  }
+  if (input.summary.terminalReason === "expired") {
+    return "Expired";
+  }
+  if (input.summary.terminalReason === "filled") {
+    return "Filled";
+  }
+  return readString(input.orderRecord?.status);
+}
+
 export function buildTerminalJupiterTriggerReceipt(input: {
   latest: ExecutionLatestStatusRecord;
   trackedOrder: JupiterTrackedTriggerOrder;
@@ -116,7 +132,10 @@ export function buildTerminalJupiterTriggerReceipt(input: {
       lifecycle: input.summary.lifecycle as unknown as JsonObject,
       triggerOrder: {
         ...input.trackedOrder,
-        status: readString(input.orderRecord?.status),
+        status: resolveReceiptTriggerStatus({
+          orderRecord: input.orderRecord,
+          summary: input.summary,
+        }),
         filledInputAtomic: input.summary.filledInputAtomic,
         filledOutputAtomic: input.summary.filledOutputAtomic,
         signature: input.summary.signature,

--- a/apps/worker/src/execution/jupiter_trigger_reconciliation.ts
+++ b/apps/worker/src/execution/jupiter_trigger_reconciliation.ts
@@ -1,0 +1,267 @@
+import { JupiterClient, type JupiterTriggerOrderRecord } from "../jupiter";
+import type { Env } from "../types";
+import {
+  findJupiterTriggerOrderByKey,
+  type JupiterTrackedTriggerOrder,
+  type JupiterTriggerLifecycleSummary,
+  readTrackedJupiterTriggerOrder,
+  summarizeJupiterTriggerOrder,
+} from "./jupiter_trigger";
+import {
+  type ExecutionLatestStatusRecord,
+  getExecutionLatestStatus,
+  type JsonObject,
+  terminalizeExecutionRequest,
+  upsertExecutionReceiptIdempotent,
+} from "./repository";
+import type { ExecutionIntentLifecycleSnapshot } from "./types";
+
+const DEFAULT_JUPITER_BASE_URL = "https://lite-api.jup.ag";
+
+type JupiterConditionalOrderReconciliation = {
+  latest: ExecutionLatestStatusRecord;
+  lifecycle: ExecutionIntentLifecycleSnapshot | null;
+  trackedOrder: JupiterTrackedTriggerOrder | null;
+  orderRecord: JupiterTriggerOrderRecord | null;
+  summary: JupiterTriggerLifecycleSummary | null;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return normalized ? normalized : null;
+}
+
+function newExecutionReceiptId(): string {
+  return `exec_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
+}
+
+function readIntentFamily(latest: ExecutionLatestStatusRecord): string | null {
+  const intent = isRecord(latest.request.metadata?.intent)
+    ? latest.request.metadata?.intent
+    : null;
+  return readString(intent?.family);
+}
+
+function readPersistedLifecycle(
+  latest: ExecutionLatestStatusRecord,
+): ExecutionIntentLifecycleSnapshot | null {
+  const receiptLifecycle = isRecord(latest.receipt?.receipt?.lifecycle)
+    ? latest.receipt?.receipt?.lifecycle
+    : null;
+  if (receiptLifecycle) {
+    return receiptLifecycle as ExecutionIntentLifecycleSnapshot;
+  }
+  const executionMeta = isRecord(
+    latest.latestAttempt?.providerResponse?.executionMeta,
+  )
+    ? latest.latestAttempt?.providerResponse?.executionMeta
+    : null;
+  const lifecycle = isRecord(executionMeta?.lifecycle)
+    ? executionMeta?.lifecycle
+    : null;
+  return lifecycle ? (lifecycle as ExecutionIntentLifecycleSnapshot) : null;
+}
+
+export function buildTerminalJupiterTriggerReceipt(input: {
+  latest: ExecutionLatestStatusRecord;
+  trackedOrder: JupiterTrackedTriggerOrder;
+  orderRecord: JupiterTriggerOrderRecord | null;
+  summary: JupiterTriggerLifecycleSummary;
+}): {
+  finalizedStatus: "landed" | "failed" | "expired";
+  statusReason: string | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+  receipt: JsonObject;
+} {
+  const terminalReason = input.summary.terminalReason;
+  const finalizedStatus =
+    terminalReason === "filled"
+      ? "landed"
+      : terminalReason === "expired"
+        ? "expired"
+        : "failed";
+  const statusReason =
+    terminalReason === "cancelled"
+      ? "conditional-order-cancelled"
+      : terminalReason === "expired"
+        ? "conditional-order-expired"
+        : null;
+  const errorCode =
+    terminalReason === "cancelled"
+      ? "order-cancelled"
+      : terminalReason === "expired"
+        ? "order-expired"
+        : null;
+  const errorMessage =
+    terminalReason === "cancelled"
+      ? "Conditional spot order was cancelled."
+      : terminalReason === "expired"
+        ? "Conditional spot order expired before fill."
+        : null;
+  return {
+    finalizedStatus,
+    statusReason,
+    errorCode,
+    errorMessage,
+    receipt: {
+      mode: input.latest.request.mode,
+      route: input.latest.latestAttempt?.provider ?? "jupiter",
+      outcome: finalizedStatus,
+      lifecycle: input.summary.lifecycle as unknown as JsonObject,
+      triggerOrder: {
+        ...input.trackedOrder,
+        status: readString(input.orderRecord?.status),
+        filledInputAtomic: input.summary.filledInputAtomic,
+        filledOutputAtomic: input.summary.filledOutputAtomic,
+        signature: input.summary.signature,
+      },
+      quote: {
+        inputMint: input.trackedOrder.inputMint,
+        outputMint: input.trackedOrder.outputMint,
+        inAmount:
+          input.trackedOrder.makingAmount ?? input.summary.filledInputAtomic,
+        outAmount:
+          input.trackedOrder.takingAmount ?? input.summary.filledOutputAtomic,
+      },
+    },
+  };
+}
+
+async function fetchTrackedJupiterOrder(input: {
+  env: Env;
+  trackedOrder: JupiterTrackedTriggerOrder;
+}): Promise<JupiterTriggerOrderRecord | null> {
+  const jupiter = new JupiterClient(
+    String(input.env.JUPITER_BASE_URL ?? "").trim() || DEFAULT_JUPITER_BASE_URL,
+    input.env.JUPITER_API_KEY,
+  );
+  const active = await jupiter.getTriggerOrders({
+    maker: input.trackedOrder.maker,
+    orderStatus: "active",
+    ...(input.trackedOrder.inputMint
+      ? { inputMint: input.trackedOrder.inputMint }
+      : {}),
+    ...(input.trackedOrder.outputMint
+      ? { outputMint: input.trackedOrder.outputMint }
+      : {}),
+    includeFailedTx: true,
+  });
+  const activeMatch = findJupiterTriggerOrderByKey(
+    active.orders,
+    input.trackedOrder.order,
+  );
+  if (activeMatch) return activeMatch;
+
+  const history = await jupiter.getTriggerOrders({
+    maker: input.trackedOrder.maker,
+    orderStatus: "history",
+    ...(input.trackedOrder.inputMint
+      ? { inputMint: input.trackedOrder.inputMint }
+      : {}),
+    ...(input.trackedOrder.outputMint
+      ? { outputMint: input.trackedOrder.outputMint }
+      : {}),
+    includeFailedTx: true,
+  });
+  return findJupiterTriggerOrderByKey(history.orders, input.trackedOrder.order);
+}
+
+export async function reconcileJupiterConditionalOrder(input: {
+  env: Env;
+  latest: ExecutionLatestStatusRecord;
+}): Promise<JupiterConditionalOrderReconciliation> {
+  const persistedLifecycle = readPersistedLifecycle(input.latest);
+  if (readIntentFamily(input.latest) !== "conditional_spot_order") {
+    return {
+      latest: input.latest,
+      lifecycle: persistedLifecycle,
+      trackedOrder: null,
+      orderRecord: null,
+      summary: null,
+    };
+  }
+  const trackedOrder = readTrackedJupiterTriggerOrder(
+    input.latest.latestAttempt?.providerResponse?.triggerOrder,
+  );
+  if (!trackedOrder) {
+    return {
+      latest: input.latest,
+      lifecycle: persistedLifecycle,
+      trackedOrder: null,
+      orderRecord: null,
+      summary: null,
+    };
+  }
+
+  let orderRecord: JupiterTriggerOrderRecord | null = null;
+  let summary: JupiterTriggerLifecycleSummary | null = null;
+  try {
+    orderRecord = await fetchTrackedJupiterOrder({
+      env: input.env,
+      trackedOrder,
+    });
+    summary = summarizeJupiterTriggerOrder(orderRecord);
+  } catch {
+    return {
+      latest: input.latest,
+      lifecycle: persistedLifecycle,
+      trackedOrder,
+      orderRecord: null,
+      summary: null,
+    };
+  }
+
+  let latest = input.latest;
+  if (summary.terminalReason && !latest.receipt) {
+    const readyAt = new Date().toISOString();
+    const receipt = buildTerminalJupiterTriggerReceipt({
+      latest,
+      trackedOrder,
+      orderRecord,
+      summary,
+    });
+    await upsertExecutionReceiptIdempotent(input.env.WAITLIST_DB, {
+      requestId: latest.request.requestId,
+      receiptId: newExecutionReceiptId(),
+      finalizedStatus: receipt.finalizedStatus,
+      lane: latest.request.lane,
+      provider: latest.latestAttempt?.provider ?? "jupiter",
+      signature: summary.signature,
+      slot: null,
+      errorCode: receipt.errorCode,
+      errorMessage: receipt.errorMessage,
+      receipt: receipt.receipt,
+      readyAt,
+    });
+    await terminalizeExecutionRequest(input.env.WAITLIST_DB, {
+      requestId: latest.request.requestId,
+      status: receipt.finalizedStatus,
+      statusReason: receipt.statusReason,
+      details: {
+        provider: latest.latestAttempt?.provider ?? "jupiter",
+        orderState: summary.lifecycle.orderState ?? null,
+        terminalReason: summary.terminalReason,
+        ...(summary.signature ? { signature: summary.signature } : {}),
+      },
+      nowIso: readyAt,
+    });
+    const refreshed = await getExecutionLatestStatus(
+      input.env.WAITLIST_DB,
+      latest.request.requestId,
+    );
+    if (refreshed) latest = refreshed;
+  }
+
+  return {
+    latest,
+    lifecycle: summary.lifecycle,
+    trackedOrder,
+    orderRecord,
+    summary,
+  };
+}

--- a/apps/worker/src/execution/jupiter_trigger_reconciliation.ts
+++ b/apps/worker/src/execution/jupiter_trigger_reconciliation.ts
@@ -17,6 +17,7 @@ import {
 import type { ExecutionIntentLifecycleSnapshot } from "./types";
 
 const DEFAULT_JUPITER_BASE_URL = "https://lite-api.jup.ag";
+const MAX_TRIGGER_ORDER_PAGES = 25;
 
 type JupiterConditionalOrderReconciliation = {
   latest: ExecutionLatestStatusRecord;
@@ -140,35 +141,44 @@ async function fetchTrackedJupiterOrder(input: {
     String(input.env.JUPITER_BASE_URL ?? "").trim() || DEFAULT_JUPITER_BASE_URL,
     input.env.JUPITER_API_KEY,
   );
-  const active = await jupiter.getTriggerOrders({
-    maker: input.trackedOrder.maker,
-    orderStatus: "active",
-    ...(input.trackedOrder.inputMint
-      ? { inputMint: input.trackedOrder.inputMint }
-      : {}),
-    ...(input.trackedOrder.outputMint
-      ? { outputMint: input.trackedOrder.outputMint }
-      : {}),
-    includeFailedTx: true,
-  });
-  const activeMatch = findJupiterTriggerOrderByKey(
-    active.orders,
-    input.trackedOrder.order,
-  );
-  if (activeMatch) return activeMatch;
+  const searchOrders = async (
+    orderStatus: "active" | "history",
+  ): Promise<JupiterTriggerOrderRecord | null> => {
+    let page = 1;
+    let pageSize = 0;
+    while (page <= MAX_TRIGGER_ORDER_PAGES) {
+      const response = await jupiter.getTriggerOrders({
+        maker: input.trackedOrder.maker,
+        orderStatus,
+        page,
+        ...(input.trackedOrder.inputMint
+          ? { inputMint: input.trackedOrder.inputMint }
+          : {}),
+        ...(input.trackedOrder.outputMint
+          ? { outputMint: input.trackedOrder.outputMint }
+          : {}),
+        includeFailedTx: true,
+      });
+      const match = findJupiterTriggerOrderByKey(
+        response.orders,
+        input.trackedOrder.order,
+      );
+      if (match) return match;
+      if (response.orders.length === 0) return null;
+      if (pageSize === 0) pageSize = response.orders.length;
+      const totalPages = Math.max(
+        1,
+        Math.ceil(response.totalOrders / pageSize),
+      );
+      if (page >= totalPages) return null;
+      page += 1;
+    }
+    return null;
+  };
 
-  const history = await jupiter.getTriggerOrders({
-    maker: input.trackedOrder.maker,
-    orderStatus: "history",
-    ...(input.trackedOrder.inputMint
-      ? { inputMint: input.trackedOrder.inputMint }
-      : {}),
-    ...(input.trackedOrder.outputMint
-      ? { outputMint: input.trackedOrder.outputMint }
-      : {}),
-    includeFailedTx: true,
-  });
-  return findJupiterTriggerOrderByKey(history.orders, input.trackedOrder.order);
+  const activeMatch = await searchOrders("active");
+  if (activeMatch) return activeMatch;
+  return await searchOrders("history");
 }
 
 export async function reconcileJupiterConditionalOrder(input: {

--- a/apps/worker/src/execution/repository.ts
+++ b/apps/worker/src/execution/repository.ts
@@ -401,6 +401,93 @@ export async function listExecutionRequestsByActor(
   return items.filter(isRecord).map((row) => mapExecutionRequestRow(row));
 }
 
+export async function listOpenExecutionRequestsByActorAndIntentFamily(
+  db: D1Database,
+  input: {
+    actorId: string;
+    intentFamily: string;
+    mode?: ExecutionMode;
+    limit?: number;
+    offset?: number;
+  },
+): Promise<ExecutionRequestRecord[]> {
+  const actorId = input.actorId.trim();
+  const intentFamily = input.intentFamily.trim();
+  if (!actorId || !intentFamily) return [];
+  const boundedLimit = Math.max(
+    1,
+    Math.min(200, Math.floor(input.limit ?? 50)),
+  );
+  const offset = Math.max(0, Math.floor(input.offset ?? 0));
+  const mode = input.mode?.trim() || null;
+  const rows = mode
+    ? ((await db
+        .prepare(
+          `
+          SELECT
+            request_id as requestId,
+            schema_version as schemaVersion,
+            idempotency_scope as idempotencyScope,
+            idempotency_key as idempotencyKey,
+            payload_hash as payloadHash,
+            actor_type as actorType,
+            actor_id as actorId,
+            mode,
+            lane,
+            status,
+            status_reason as statusReason,
+            metadata_json as metadataJson,
+            received_at as receivedAt,
+            validated_at as validatedAt,
+            terminal_at as terminalAt,
+            created_at as createdAt,
+            updated_at as updatedAt
+          FROM execution_requests
+          WHERE actor_id = ?1
+            AND mode = ?2
+            AND terminal_at IS NULL
+            AND json_extract(metadata_json, '$.intent.family') = ?3
+          ORDER BY received_at DESC
+          LIMIT ?4 OFFSET ?5
+          `,
+        )
+        .bind(actorId, mode, intentFamily, boundedLimit, offset)
+        .all()) as { results?: unknown[] })
+    : ((await db
+        .prepare(
+          `
+          SELECT
+            request_id as requestId,
+            schema_version as schemaVersion,
+            idempotency_scope as idempotencyScope,
+            idempotency_key as idempotencyKey,
+            payload_hash as payloadHash,
+            actor_type as actorType,
+            actor_id as actorId,
+            mode,
+            lane,
+            status,
+            status_reason as statusReason,
+            metadata_json as metadataJson,
+            received_at as receivedAt,
+            validated_at as validatedAt,
+            terminal_at as terminalAt,
+            created_at as createdAt,
+            updated_at as updatedAt
+          FROM execution_requests
+          WHERE actor_id = ?1
+            AND terminal_at IS NULL
+            AND json_extract(metadata_json, '$.intent.family') = ?2
+          ORDER BY received_at DESC
+          LIMIT ?3 OFFSET ?4
+          `,
+        )
+        .bind(actorId, intentFamily, boundedLimit, offset)
+        .all()) as { results?: unknown[] });
+  const items = Array.isArray(rows.results) ? rows.results : [];
+  return items.filter(isRecord).map((row) => mapExecutionRequestRow(row));
+}
+
 export async function getExecutionRequestByIdempotency(
   db: D1Database,
   idempotencyScope: string,

--- a/apps/worker/src/execution/repository.ts
+++ b/apps/worker/src/execution/repository.ts
@@ -322,6 +322,85 @@ export async function getExecutionRequestById(
   return mapExecutionRequestRow(row);
 }
 
+export async function listExecutionRequestsByActor(
+  db: D1Database,
+  input: {
+    actorId: string;
+    mode?: ExecutionMode;
+    limit?: number;
+  },
+): Promise<ExecutionRequestRecord[]> {
+  const actorId = input.actorId.trim();
+  if (!actorId) return [];
+  const boundedLimit = Math.max(
+    1,
+    Math.min(200, Math.floor(input.limit ?? 50)),
+  );
+  const mode = input.mode?.trim() || null;
+  const rows = mode
+    ? ((await db
+        .prepare(
+          `
+          SELECT
+            request_id as requestId,
+            schema_version as schemaVersion,
+            idempotency_scope as idempotencyScope,
+            idempotency_key as idempotencyKey,
+            payload_hash as payloadHash,
+            actor_type as actorType,
+            actor_id as actorId,
+            mode,
+            lane,
+            status,
+            status_reason as statusReason,
+            metadata_json as metadataJson,
+            received_at as receivedAt,
+            validated_at as validatedAt,
+            terminal_at as terminalAt,
+            created_at as createdAt,
+            updated_at as updatedAt
+          FROM execution_requests
+          WHERE actor_id = ?1
+            AND mode = ?2
+          ORDER BY received_at DESC
+          LIMIT ?3
+          `,
+        )
+        .bind(actorId, mode, boundedLimit)
+        .all()) as { results?: unknown[] })
+    : ((await db
+        .prepare(
+          `
+          SELECT
+            request_id as requestId,
+            schema_version as schemaVersion,
+            idempotency_scope as idempotencyScope,
+            idempotency_key as idempotencyKey,
+            payload_hash as payloadHash,
+            actor_type as actorType,
+            actor_id as actorId,
+            mode,
+            lane,
+            status,
+            status_reason as statusReason,
+            metadata_json as metadataJson,
+            received_at as receivedAt,
+            validated_at as validatedAt,
+            terminal_at as terminalAt,
+            created_at as createdAt,
+            updated_at as updatedAt
+          FROM execution_requests
+          WHERE actor_id = ?1
+          ORDER BY received_at DESC
+          LIMIT ?2
+          `,
+        )
+        .bind(actorId, boundedLimit)
+        .all()) as { results?: unknown[] });
+  const items = Array.isArray(rows.results) ? rows.results : [];
+  return items.filter(isRecord).map((row) => mapExecutionRequestRow(row));
+}
+
 export async function getExecutionRequestByIdempotency(
   db: D1Database,
   idempotencyScope: string,

--- a/apps/worker/src/execution/router.ts
+++ b/apps/worker/src/execution/router.ts
@@ -10,6 +10,7 @@ import { getStrategyLabSubjectControl } from "../strategy_lab_readiness_reposito
 import { executeHeliusSenderSwap } from "./helius_sender_executor";
 import { executeJitoBundleSwap } from "./jito_bundle_executor";
 import { executeJupiterSwap } from "./jupiter_executor";
+import { resolveJupiterConditionalSpotOrder } from "./jupiter_trigger";
 import { executeJupiterConditionalSpotOrder } from "./jupiter_trigger_executor";
 import { executeMagicBlockEphemeralRollupSwap } from "./magicblock_ephemeral_rollup_executor";
 import type {
@@ -238,6 +239,11 @@ export async function executeIntentViaRouter(
   input: ExecuteIntentInput,
 ): Promise<ExecuteSwapResult> {
   const venueKey = String(input.venueKey ?? input.intent.venueKey ?? "").trim();
+  const conditionalSpotOrderMints =
+    input.intent.family === "conditional_spot_order" &&
+    input.intent.venueKey === "jupiter"
+      ? resolveJupiterConditionalSpotOrder(input.intent)
+      : null;
   const registration = await resolveExecutionAdapterForIntent({
     env: input.env,
     execution: input.execution,
@@ -247,9 +253,13 @@ export async function executeIntentViaRouter(
     subjectControlBypassReason: input.subjectControlBypassReason,
     intentFamily: input.intent.family,
     inputMint:
-      input.intent.family === "spot_swap" ? input.intent.inputMint : undefined,
+      input.intent.family === "spot_swap"
+        ? input.intent.inputMint
+        : conditionalSpotOrderMints?.inputMint,
     outputMint:
-      input.intent.family === "spot_swap" ? input.intent.outputMint : undefined,
+      input.intent.family === "spot_swap"
+        ? input.intent.outputMint
+        : conditionalSpotOrderMints?.outputMint,
   });
 
   if (input.intent.family !== "spot_swap") {

--- a/apps/worker/src/execution/router.ts
+++ b/apps/worker/src/execution/router.ts
@@ -10,6 +10,7 @@ import { getStrategyLabSubjectControl } from "../strategy_lab_readiness_reposito
 import { executeHeliusSenderSwap } from "./helius_sender_executor";
 import { executeJitoBundleSwap } from "./jito_bundle_executor";
 import { executeJupiterSwap } from "./jupiter_executor";
+import { executeJupiterConditionalSpotOrder } from "./jupiter_trigger_executor";
 import { executeMagicBlockEphemeralRollupSwap } from "./magicblock_ephemeral_rollup_executor";
 import type {
   ExecuteIntentInput,
@@ -48,7 +49,7 @@ const ADAPTERS = new Map<string, ExecutionAdapterRegistration>([
       adapterKey: "jupiter",
       venueKey: "jupiter",
       supportedModes: ["shadow", "paper", "live"],
-      supportedIntentFamilies: ["spot_swap"],
+      supportedIntentFamilies: ["spot_swap", "conditional_spot_order"],
       adapter: executeJupiterSwap,
     },
   ],
@@ -252,6 +253,12 @@ export async function executeIntentViaRouter(
   });
 
   if (input.intent.family !== "spot_swap") {
+    if (
+      input.intent.family === "conditional_spot_order" &&
+      registration.adapterKey === "jupiter"
+    ) {
+      return await executeJupiterConditionalSpotOrder(input);
+    }
     throw new Error(
       `execution-intent-family-not-implemented:${input.intent.family}:${registration.adapterKey}`,
     );

--- a/apps/worker/src/execution/submit_contract.ts
+++ b/apps/worker/src/execution/submit_contract.ts
@@ -1,3 +1,4 @@
+import { resolveJupiterConditionalSpotOrder } from "./jupiter_trigger";
 import type { ExecutionLane, ExecutionMode, JsonObject } from "./repository";
 import type { ExecutionIntentFamily } from "./types";
 
@@ -1004,19 +1005,61 @@ export function toExecSubmitRequestV1Compat(
   }
 
   const spotSwap = resolveExecSubmitSpotSwap(value);
-  if (!spotSwap) return null;
-  return {
-    schemaVersion: SCHEMA_VERSION_V1,
-    mode: "privy_execute",
-    lane: value.lane,
-    ...(value.metadata ? { metadata: { ...value.metadata } } : {}),
-    privyExecute: {
-      intentType: "swap",
-      wallet: spotSwap.wallet,
-      swap: { ...spotSwap.swap },
-      ...(spotSwap.options ? { options: { ...spotSwap.options } } : {}),
-    },
-  };
+  if (spotSwap) {
+    return {
+      schemaVersion: SCHEMA_VERSION_V1,
+      mode: "privy_execute",
+      lane: value.lane,
+      ...(value.metadata ? { metadata: { ...value.metadata } } : {}),
+      privyExecute: {
+        intentType: "swap",
+        wallet: spotSwap.wallet,
+        swap: { ...spotSwap.swap },
+        ...(spotSwap.options ? { options: { ...spotSwap.options } } : {}),
+      },
+    };
+  }
+
+  if (
+    value.mode !== "privy_execute" ||
+    value.schemaVersion !== SCHEMA_VERSION_V2 ||
+    value.privyExecute?.intent.family !== "conditional_spot_order"
+  ) {
+    return null;
+  }
+  try {
+    const resolved = resolveJupiterConditionalSpotOrder({
+      family: "conditional_spot_order",
+      wallet: value.privyExecute.wallet,
+      venueKey: value.privyExecute.intent.venueKey,
+      marketType: "spot",
+      instrumentId: value.privyExecute.intent.instrumentId,
+      side: value.privyExecute.intent.side,
+      quantityAtomic: value.privyExecute.intent.quantityAtomic,
+      params: value.privyExecute.options ?? null,
+    });
+    return {
+      schemaVersion: SCHEMA_VERSION_V1,
+      mode: "privy_execute",
+      lane: value.lane,
+      ...(value.metadata ? { metadata: { ...value.metadata } } : {}),
+      privyExecute: {
+        intentType: "swap",
+        wallet: value.privyExecute.wallet,
+        swap: {
+          inputMint: resolved.inputMint,
+          outputMint: resolved.outputMint,
+          amountAtomic: resolved.makingAmount,
+          slippageBps: 50,
+        },
+        ...(value.privyExecute.options
+          ? { options: { ...value.privyExecute.options } }
+          : {}),
+      },
+    };
+  } catch {
+    return null;
+  }
 }
 
 export function buildExecSubmitIntentSummary(

--- a/apps/worker/src/execution/types.ts
+++ b/apps/worker/src/execution/types.ts
@@ -23,6 +23,7 @@ export type ExecutionIntentLifecycleSnapshot = {
   orderState?:
     | "accepted"
     | "open"
+    | "triggered"
     | "partially_filled"
     | "filled"
     | "cancel_requested"
@@ -150,6 +151,7 @@ export type ExecuteSwapResult = {
     intentId?: string | null;
     venueSessionId?: string | null;
     settlementRef?: string | null;
+    lifecycle?: ExecutionIntentLifecycleSnapshot;
     lowLatency?: LowLatencyExecutionMeta;
     trace?: {
       txBuiltAt?: string;

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -78,11 +78,12 @@ import {
 import {
   appendExecutionStatusEvent,
   createExecutionAttemptIdempotent,
+  type ExecutionRequestRecord,
   finalizeExecutionAttempt,
   getExecutionLatestStatus,
   listExecutionAttempts,
-  listExecutionRequestsByActor,
   listExecutionStatusEvents,
+  listOpenExecutionRequestsByActorAndIntentFamily,
   terminalizeExecutionRequest,
   updateExecutionRequestStatus,
   upsertExecutionReceiptIdempotent,
@@ -5456,17 +5457,22 @@ const worker = {
       ) {
         let user = await requireOnboardedUser(request, env);
         user = await ensureUserWallet(env, user);
-        const requests = await listExecutionRequestsByActor(env.WAITLIST_DB, {
-          actorId: user.id,
-          mode: "privy_execute",
-          limit: 80,
-        });
-        const conditionalRequests = requests.filter((entry) => {
-          const intent = isRecord(entry.metadata?.intent)
-            ? entry.metadata?.intent
-            : null;
-          return readTrimmedString(intent?.family) === "conditional_spot_order";
-        });
+        const pageSize = 80;
+        const conditionalRequests: ExecutionRequestRecord[] = [];
+        for (let offset = 0; ; offset += pageSize) {
+          const page = await listOpenExecutionRequestsByActorAndIntentFamily(
+            env.WAITLIST_DB,
+            {
+              actorId: user.id,
+              mode: "privy_execute",
+              intentFamily: "conditional_spot_order",
+              limit: pageSize,
+              offset,
+            },
+          );
+          conditionalRequests.push(...page);
+          if (page.length < pageSize) break;
+        }
         const orders: Record<string, unknown>[] = [];
         for (const entry of conditionalRequests) {
           const latest = await getExecutionLatestStatus(

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -45,6 +45,15 @@ import {
   reserveExecutionSubmitRequest,
 } from "./execution/idempotency";
 import {
+  type readTrackedJupiterTriggerOrder,
+  resolveJupiterConditionalSpotOrder,
+  summarizeJupiterTriggerOrder,
+} from "./execution/jupiter_trigger";
+import {
+  buildTerminalJupiterTriggerReceipt,
+  reconcileJupiterConditionalOrder,
+} from "./execution/jupiter_trigger_reconciliation";
+import {
   readExecutionLaneRoutingConfig,
   resolveExecutionLane,
 } from "./execution/lane_resolver";
@@ -72,6 +81,7 @@ import {
   finalizeExecutionAttempt,
   getExecutionLatestStatus,
   listExecutionAttempts,
+  listExecutionRequestsByActor,
   listExecutionStatusEvents,
   terminalizeExecutionRequest,
   updateExecutionRequestStatus,
@@ -79,9 +89,11 @@ import {
 } from "./execution/repository";
 import { evaluateExecutionRolloutGate } from "./execution/rollout_gate";
 import {
+  executeIntentViaRouter,
   executeSwapViaRouter,
   resolveExecutionAdapterRegistration,
 } from "./execution/router";
+import { evaluateSafeLaneTransaction } from "./execution/safe_lane_policy";
 import {
   buildExecSubmitIntentSummary,
   parseExecSubmitPayload,
@@ -150,7 +162,7 @@ import {
   SUPPORTED_PERPS_VENUES,
 } from "./perps_sources";
 import { enforcePolicy, normalizePolicy } from "./policy";
-import { createPrivySolanaWallet } from "./privy";
+import { createPrivySolanaWallet, signTransactionWithPrivyById } from "./privy";
 import { gatherMarketSnapshot } from "./research";
 import { json, okCors, withCors } from "./response";
 import {
@@ -1110,6 +1122,12 @@ const worker = {
         const compatRequest = toExecSubmitRequestV1Compat(parsed.value);
         const intentFamily = resolveExecSubmitIntentFamily(parsed.value);
         const spotSwap = resolveExecSubmitSpotSwap(parsed.value);
+        const conditionalSpotOrder =
+          parsed.value.mode === "privy_execute" &&
+          parsed.value.schemaVersion === "v2" &&
+          parsed.value.privyExecute?.intent.family === "conditional_spot_order"
+            ? parsed.value.privyExecute
+            : null;
         const intentSummary = buildExecSubmitIntentSummary(parsed.value);
 
         const idempotencyKey = readIdempotencyKey(request);
@@ -1374,7 +1392,48 @@ const worker = {
           };
         }
 
+        if (
+          parsed.value.schemaVersion === "v2" &&
+          spotSwap?.venueKey &&
+          spotSwap.venueKey !== "jupiter"
+        ) {
+          return withCors(
+            execErrorResponse({
+              code: "invalid-request",
+              details: {
+                reason: `unsupported-venue-key:${spotSwap.venueKey}`,
+              },
+            }),
+            env,
+          );
+        }
         if (parsed.value.mode === "privy_execute" && !compatRequest) {
+          if (
+            parsed.value.schemaVersion === "v2" &&
+            conditionalSpotOrder &&
+            conditionalSpotOrder.intent.venueKey !== "jupiter"
+          ) {
+            return withCors(
+              execErrorResponse({
+                code: "invalid-request",
+                details: {
+                  reason: `unsupported-venue-key:${conditionalSpotOrder.intent.venueKey}`,
+                },
+              }),
+              env,
+            );
+          }
+          if (parsed.value.schemaVersion === "v2" && conditionalSpotOrder) {
+            return withCors(
+              execErrorResponse({
+                code: "invalid-request",
+                details: {
+                  reason: "unsupported-conditional-order-compat",
+                },
+              }),
+              env,
+            );
+          }
           return withCors(
             execErrorResponse({
               code: "invalid-request",
@@ -1389,14 +1448,14 @@ const worker = {
         }
         if (
           parsed.value.schemaVersion === "v2" &&
-          spotSwap?.venueKey &&
-          spotSwap.venueKey !== "jupiter"
+          conditionalSpotOrder &&
+          conditionalSpotOrder.intent.venueKey !== "jupiter"
         ) {
           return withCors(
             execErrorResponse({
               code: "invalid-request",
               details: {
-                reason: `unsupported-venue-key:${spotSwap.venueKey}`,
+                reason: `unsupported-venue-key:${conditionalSpotOrder.intent.venueKey}`,
               },
             }),
             env,
@@ -1436,6 +1495,21 @@ const worker = {
               details: {
                 reason: submitPolicy.reason,
                 policy: submitPolicy.metadata,
+              },
+            }),
+            env,
+          );
+        }
+        if (
+          parsed.value.schemaVersion === "v2" &&
+          conditionalSpotOrder &&
+          laneResolution.adapter !== "jupiter"
+        ) {
+          return withCors(
+            execErrorResponse({
+              code: "unsupported-lane",
+              details: {
+                reason: `conditional-orders-require-safe-lane:${laneResolution.adapter}`,
               },
             }),
             env,
@@ -1581,335 +1655,720 @@ const worker = {
           shouldSyncExecutePrivySubmit(env) &&
           privyActorContext
         ) {
-          if (!spotSwap) {
-            return withCors(
-              execErrorResponse({
-                code: "invalid-request",
-                details: {
-                  reason: intentFamily
-                    ? `unsupported-intent-family:${intentFamily}`
-                    : "unsupported-intent-family",
-                },
-              }),
-              env,
-            );
-          }
-          const swap = spotSwap.swap;
-          const options = spotSwap.options ?? {};
-          const requestedRequireSimulation =
-            typeof options.requireSimulation === "boolean"
-              ? options.requireSimulation
-              : null;
-          const effectiveRequireSimulation =
-            submitPolicyRuntime?.requireSimulation === true ||
-            requestedRequireSimulation === true;
-          const executionParams: Record<string, unknown> = {
-            lane: laneResolution.lane,
-          };
-          if (requestedRequireSimulation === false) {
-            executionParams.requireSimulation = false;
-          }
-          if (effectiveRequireSimulation) {
-            executionParams.requireSimulation = true;
-          }
-          if (typeof options.priorityMicroLamports === "number") {
-            executionParams.priorityMicroLamports =
-              options.priorityMicroLamports;
-          }
-          const execution = {
-            adapter: laneResolution.adapter,
-            params: executionParams,
-          };
-          const policy = normalizePolicy({
-            allowedMints: SUPPORTED_TRADING_MINTS,
-            slippageBps: swap.slippageBps,
-            maxPriceImpactPct: 0.05,
-            minSolReserveLamports: "50000000",
-            simulateOnly: Boolean(options.simulateOnly),
-            dryRun: Boolean(options.dryRun),
-            commitment: options.commitment ?? "confirmed",
-          });
-
-          const attemptId = newExecutionAttemptId();
-          const attemptStartedAt = new Date().toISOString();
-          const qualityMetadata = {
-            lane: laneResolution.lane,
-            slippageBps: swap.slippageBps,
-            requestedRequireSimulation,
-            effectiveRequireSimulation,
-            priorityMicroLamports:
-              typeof options.priorityMicroLamports === "number"
-                ? options.priorityMicroLamports
-                : null,
-          };
-          let providerResponse: Record<string, unknown> | null = {
-            route: laneResolution.adapter,
-            lane: laneResolution.lane,
-            mode: parsed.value.mode,
-            quality: qualityMetadata,
-          };
-
-          try {
-            const rpcEndpoint = String(env.RPC_ENDPOINT ?? "").trim();
-            if (!rpcEndpoint) {
-              throw new Error("rpc-endpoint-missing");
-            }
-            const rpc = new SolanaRpc(rpcEndpoint);
-            const jupiter = new JupiterClient(
-              String(env.JUPITER_BASE_URL ?? "").trim() ||
-                X402_READ_JUPITER_BASE_URL,
-              env.JUPITER_API_KEY,
-            );
-
-            const runtimeBalancePolicy =
-              await evaluatePrivyRuntimeBalancePolicy({
+          if (conditionalSpotOrder) {
+            const options = conditionalSpotOrder.options ?? {};
+            const compatSwap = compatRequest?.privyExecute?.swap ?? null;
+            if (!compatSwap) {
+              return withCors(
+                execErrorResponse({
+                  code: "invalid-request",
+                  details: {
+                    reason: "unsupported-conditional-order-compat",
+                  },
+                }),
                 env,
-                lane: laneResolution.lane,
-                walletAddress: privyActorContext.walletAddress,
-                inputMint: swap.inputMint,
-                amountAtomic: swap.amountAtomic,
-                minSolReserveLamports: policy.minSolReserveLamports,
-                rpc,
-                runtimeDefaults: submitPolicyRuntime,
-              });
-            providerResponse = {
-              ...(providerResponse ?? {}),
-              runtimePolicy: runtimeBalancePolicy.metadata,
-            };
-            if (!runtimeBalancePolicy.ok) {
-              throw asPolicyDeniedError(runtimeBalancePolicy.reason);
-            }
-
-            const quoteResponse = await jupiter.quote({
-              inputMint: swap.inputMint,
-              outputMint: swap.outputMint,
-              amount: swap.amountAtomic,
-              slippageBps: policy.slippageBps,
-              swapMode: "ExactIn",
-            });
-            try {
-              enforcePolicy(policy, quoteResponse);
-            } catch (error) {
-              throw asPolicyDeniedError(
-                `privy-quote-${normalizePolicyReason(error, "policy-violation")}`,
               );
             }
-            const referenceGuard = await evaluateOracleReferencePriceGuard({
-              env,
-              mode: "live",
-              inputMint: swap.inputMint,
-              outputMint: swap.outputMint,
-              inputAmountAtomic: swap.amountAtomic,
-              expectedOutputAmountAtomic: String(quoteResponse.outAmount ?? ""),
-              jupiter,
-            });
-            providerResponse = {
-              ...(providerResponse ?? {}),
-              ...(referenceGuard.enabled
-                ? {
-                    referencePrice: {
-                      verdict: referenceGuard.verdict,
-                      reason: referenceGuard.reason,
-                      executionPrice: referenceGuard.executionPrice,
-                      executionDivergenceBps:
-                        referenceGuard.executionDivergenceBps,
-                      snapshot: referenceGuard.snapshot,
-                    },
-                  }
-                : {}),
-            };
-            if (referenceGuard.enabled && referenceGuard.verdict !== "allow") {
-              throw asPolicyDeniedError(
-                referenceGuard.reason ?? "reference-price-policy-denied",
-              );
-            }
-
-            await updateExecutionRequestStatus(env.WAITLIST_DB, {
-              requestId: reservation.request.requestId,
-              status: "dispatched",
-              statusReason: null,
-            });
-            await appendExecutionStatusEvent(env.WAITLIST_DB, {
-              requestId: reservation.request.requestId,
-              status: "dispatched",
-              reason: null,
-              details: {
-                provider: laneResolution.adapter,
-                attempt: 1,
+            const resolvedConditionalOrder = resolveJupiterConditionalSpotOrder(
+              {
+                family: "conditional_spot_order",
+                wallet: conditionalSpotOrder.wallet,
+                venueKey: conditionalSpotOrder.intent.venueKey,
+                marketType: "spot",
+                instrumentId: conditionalSpotOrder.intent.instrumentId,
+                side: conditionalSpotOrder.intent.side,
+                quantityAtomic: conditionalSpotOrder.intent.quantityAtomic,
+                params: conditionalSpotOrder.options ?? null,
               },
-              createdAt: attemptStartedAt,
-            });
-            await createExecutionAttemptIdempotent(env.WAITLIST_DB, {
-              attemptId,
-              requestId: reservation.request.requestId,
-              attemptNo: 1,
-              lane: laneResolution.lane,
-              provider: laneResolution.adapter,
-              status: "dispatched",
-              providerResponse,
-              startedAt: attemptStartedAt,
-            });
-
-            const result = await executeSwapViaRouter({
-              env,
-              venueKey: spotSwap?.venueKey,
-              execution,
-              policy,
-              rpc,
-              jupiter,
-              quoteResponse,
-              userPublicKey: privyActorContext.walletAddress,
-              privyWalletId: privyActorContext.privyWalletId,
-              log(level, message, meta) {
-                console[level]("exec.submit", {
-                  requestId: reservation.request.requestId,
-                  userId: privyActorContext.userId,
-                  message,
-                  ...(meta ?? {}),
-                });
-              },
-            });
-            const settledAt = new Date().toISOString();
-            const failure = resolveTerminalFailureFromExecuteResult(
-              result.status,
-              result.err,
             );
-            const terminalStatus = failure ? failure.terminalStatus : "landed";
-            const errorMessage = executionErrorMessage(result.err);
-            providerResponse = {
-              ...(providerResponse ?? {}),
-              executionStatus: result.status,
-              refreshed: result.refreshed,
-              lastValidBlockHeight: result.lastValidBlockHeight,
-              executionMeta:
-                result.executionMeta &&
-                typeof result.executionMeta === "object" &&
-                !Array.isArray(result.executionMeta)
-                  ? result.executionMeta
+            const requestedRequireSimulation =
+              typeof options.requireSimulation === "boolean"
+                ? options.requireSimulation
+                : null;
+            const effectiveRequireSimulation =
+              submitPolicyRuntime?.requireSimulation === true ||
+              requestedRequireSimulation === true;
+            const executionParams: Record<string, unknown> = {
+              lane: laneResolution.lane,
+            };
+            if (requestedRequireSimulation === false) {
+              executionParams.requireSimulation = false;
+            }
+            if (effectiveRequireSimulation) {
+              executionParams.requireSimulation = true;
+            }
+            if (typeof options.priorityMicroLamports === "number") {
+              executionParams.priorityMicroLamports =
+                options.priorityMicroLamports;
+            }
+            const execution = {
+              adapter: laneResolution.adapter,
+              params: executionParams,
+            };
+            const policy = normalizePolicy({
+              allowedMints: SUPPORTED_TRADING_MINTS,
+              slippageBps: compatSwap.slippageBps,
+              maxPriceImpactPct: 0.05,
+              minSolReserveLamports: "50000000",
+              simulateOnly: Boolean(options.simulateOnly),
+              dryRun: Boolean(options.dryRun),
+              commitment: options.commitment ?? "confirmed",
+            });
+
+            const attemptId = newExecutionAttemptId();
+            const attemptStartedAt = new Date().toISOString();
+            const qualityMetadata = {
+              lane: laneResolution.lane,
+              orderType: options.orderType ?? null,
+              timeInForce: options.timeInForce ?? "gtc",
+              requestedRequireSimulation,
+              effectiveRequireSimulation,
+              priorityMicroLamports:
+                typeof options.priorityMicroLamports === "number"
+                  ? options.priorityMicroLamports
+                  : null,
+              limitPriceAtomic:
+                typeof options.limitPriceAtomic === "string"
+                  ? options.limitPriceAtomic
+                  : null,
+              triggerPriceAtomic:
+                typeof options.triggerPriceAtomic === "string"
+                  ? options.triggerPriceAtomic
                   : null,
             };
+            let providerResponse: Record<string, unknown> | null = {
+              route: laneResolution.adapter,
+              lane: laneResolution.lane,
+              mode: parsed.value.mode,
+              quality: qualityMetadata,
+            };
 
-            await finalizeExecutionAttempt(env.WAITLIST_DB, {
-              attemptId,
-              status: result.status,
-              providerResponse,
-              errorCode: failure ? failure.errorCode : null,
-              errorMessage,
-              completedAt: settledAt,
-            });
-            await upsertExecutionReceiptIdempotent(env.WAITLIST_DB, {
-              requestId: reservation.request.requestId,
-              receiptId: newExecutionReceiptId(),
-              finalizedStatus: terminalStatus,
-              lane: laneResolution.lane,
-              provider: laneResolution.adapter,
-              signature: result.signature,
-              slot: null,
-              errorCode: failure ? failure.errorCode : null,
-              errorMessage,
-              receipt: {
-                mode: parsed.value.mode,
-                route: laneResolution.adapter,
-                resultStatus: result.status,
-                outcome: terminalStatus,
-                lifecycle: {
-                  settlementState:
-                    result.status === "finalized"
-                      ? "finalized"
-                      : result.status === "confirmed"
-                        ? "confirmed"
-                        : "landed",
-                  notes: ["spot_swap"],
-                },
-                quality: qualityMetadata,
-                quote: {
-                  inputMint: swap.inputMint,
-                  outputMint: swap.outputMint,
-                  inAmount: swap.amountAtomic,
-                  outAmount: String(result.usedQuote?.outAmount ?? ""),
-                },
-              },
-              readyAt: settledAt,
-            });
-            await terminalizeExecutionRequest(env.WAITLIST_DB, {
-              requestId: reservation.request.requestId,
-              status: terminalStatus,
-              statusReason: failure ? failure.statusReason : null,
-              details: {
-                provider: laneResolution.adapter,
-                attempt: 1,
-                ...(result.signature ? { signature: result.signature } : {}),
-              },
-              nowIso: settledAt,
-            });
-          } catch (error) {
-            const failedAt = new Date().toISOString();
-            const deniedReason = policyDeniedReason(error);
-            const terminalStatus = deniedReason ? "rejected" : "failed";
-            const errorCode = deniedReason
-              ? "policy-denied"
-              : normalizeExecutionErrorCode({
-                  error,
-                  fallback: "submission-failed",
+            try {
+              const rpcEndpoint = String(env.RPC_ENDPOINT ?? "").trim();
+              if (!rpcEndpoint) {
+                throw new Error("rpc-endpoint-missing");
+              }
+              const rpc = new SolanaRpc(rpcEndpoint);
+              const jupiter = new JupiterClient(
+                String(env.JUPITER_BASE_URL ?? "").trim() ||
+                  X402_READ_JUPITER_BASE_URL,
+                env.JUPITER_API_KEY,
+              );
+
+              const runtimeBalancePolicy =
+                await evaluatePrivyRuntimeBalancePolicy({
+                  env,
+                  lane: laneResolution.lane,
+                  walletAddress: privyActorContext.walletAddress,
+                  inputMint: compatSwap.inputMint,
+                  amountAtomic: compatSwap.amountAtomic,
+                  minSolReserveLamports: policy.minSolReserveLamports,
+                  rpc,
+                  runtimeDefaults: submitPolicyRuntime,
                 });
-            const statusReason = deniedReason
-              ? `policy-denied:${deniedReason}`
-              : errorCode;
-            const errorMessage =
-              executionErrorMessage(error) ?? "execution-submit-failed";
-            await createExecutionAttemptIdempotent(env.WAITLIST_DB, {
-              attemptId,
-              requestId: reservation.request.requestId,
-              attemptNo: 1,
-              lane: laneResolution.lane,
-              provider: laneResolution.adapter,
-              status: terminalStatus,
-              providerResponse,
-              errorCode,
-              errorMessage,
-              startedAt: attemptStartedAt,
-            });
-            await finalizeExecutionAttempt(env.WAITLIST_DB, {
-              attemptId,
-              status: terminalStatus,
-              providerResponse,
-              errorCode,
-              errorMessage,
-              completedAt: failedAt,
-            });
-            await upsertExecutionReceiptIdempotent(env.WAITLIST_DB, {
-              requestId: reservation.request.requestId,
-              receiptId: newExecutionReceiptId(),
-              finalizedStatus: terminalStatus,
-              lane: laneResolution.lane,
-              provider: laneResolution.adapter,
-              signature: null,
-              slot: null,
-              errorCode,
-              errorMessage,
-              receipt: {
-                mode: parsed.value.mode,
-                route: laneResolution.adapter,
-                outcome: terminalStatus,
-                lifecycle: {
-                  settlementState: "failed",
-                  notes: [statusReason],
+              providerResponse = {
+                ...(providerResponse ?? {}),
+                runtimePolicy: runtimeBalancePolicy.metadata,
+              };
+              if (!runtimeBalancePolicy.ok) {
+                throw asPolicyDeniedError(runtimeBalancePolicy.reason);
+              }
+
+              const referenceGuard = await evaluateOracleReferencePriceGuard({
+                env,
+                mode: "live",
+                inputMint: compatSwap.inputMint,
+                outputMint: compatSwap.outputMint,
+                inputAmountAtomic: compatSwap.amountAtomic,
+                expectedOutputAmountAtomic:
+                  resolvedConditionalOrder.takingAmount,
+                jupiter,
+              });
+              providerResponse = {
+                ...(providerResponse ?? {}),
+                ...(referenceGuard.enabled
+                  ? {
+                      referencePrice: {
+                        verdict: referenceGuard.verdict,
+                        reason: referenceGuard.reason,
+                        executionPrice: referenceGuard.executionPrice,
+                        executionDivergenceBps:
+                          referenceGuard.executionDivergenceBps,
+                        snapshot: referenceGuard.snapshot,
+                      },
+                    }
+                  : {}),
+              };
+              if (
+                referenceGuard.enabled &&
+                referenceGuard.verdict !== "allow"
+              ) {
+                throw asPolicyDeniedError(
+                  referenceGuard.reason ?? "reference-price-policy-denied",
+                );
+              }
+
+              await updateExecutionRequestStatus(env.WAITLIST_DB, {
+                requestId: reservation.request.requestId,
+                status: "dispatched",
+                statusReason: null,
+              });
+              await appendExecutionStatusEvent(env.WAITLIST_DB, {
+                requestId: reservation.request.requestId,
+                status: "dispatched",
+                reason: null,
+                details: {
+                  provider: laneResolution.adapter,
+                  attempt: 1,
                 },
-                quality: qualityMetadata,
-              },
-              readyAt: failedAt,
-            });
-            await terminalizeExecutionRequest(env.WAITLIST_DB, {
-              requestId: reservation.request.requestId,
-              status: terminalStatus,
-              statusReason,
-              details: {
+                createdAt: attemptStartedAt,
+              });
+              await createExecutionAttemptIdempotent(env.WAITLIST_DB, {
+                attemptId,
+                requestId: reservation.request.requestId,
+                attemptNo: 1,
+                lane: laneResolution.lane,
                 provider: laneResolution.adapter,
-                attempt: 1,
+                status: "dispatched",
+                providerResponse,
+                startedAt: attemptStartedAt,
+              });
+
+              const result = await executeIntentViaRouter({
+                env,
+                venueKey: conditionalSpotOrder.intent.venueKey,
+                runtimeMode: "live",
+                requireVenueRouting: true,
+                subjectControlBypassReason: undefined,
+                execution,
+                policy,
+                rpc,
+                jupiter,
+                intent: {
+                  family: "conditional_spot_order",
+                  wallet: conditionalSpotOrder.wallet,
+                  venueKey: conditionalSpotOrder.intent.venueKey,
+                  marketType: "spot",
+                  instrumentId: conditionalSpotOrder.intent.instrumentId,
+                  side: conditionalSpotOrder.intent.side,
+                  quantityAtomic: conditionalSpotOrder.intent.quantityAtomic,
+                  params: conditionalSpotOrder.options ?? null,
+                },
+                privyWalletId: privyActorContext.privyWalletId,
+                log(level, message, meta) {
+                  console[level]("exec.submit", {
+                    requestId: reservation.request.requestId,
+                    userId: privyActorContext.userId,
+                    message,
+                    ...(meta ?? {}),
+                  });
+                },
+              });
+              const settledAt = new Date().toISOString();
+              const failure = resolveTerminalFailureFromExecuteResult(
+                result.status,
+                result.err,
+              );
+              const errorMessage = executionErrorMessage(result.err);
+              providerResponse = {
+                ...(providerResponse ?? {}),
+                triggerOrder: {
+                  maker: conditionalSpotOrder.wallet,
+                  instrumentId: conditionalSpotOrder.intent.instrumentId,
+                  side: conditionalSpotOrder.intent.side,
+                  orderType:
+                    typeof options.orderType === "string"
+                      ? options.orderType
+                      : null,
+                  inputMint: compatSwap.inputMint,
+                  outputMint: compatSwap.outputMint,
+                  makingAmount: compatSwap.amountAtomic,
+                  takingAmount:
+                    String(result.usedQuote?.outAmount ?? "").trim() ||
+                    resolvedConditionalOrder.takingAmount,
+                  requestId: result.executionMeta?.intentId ?? null,
+                  order:
+                    result.executionMeta?.venueSessionId ??
+                    result.executionMeta?.intentId ??
+                    null,
+                },
+                executionStatus: result.status,
+                refreshed: result.refreshed,
+                lastValidBlockHeight: result.lastValidBlockHeight,
+                executionMeta:
+                  result.executionMeta &&
+                  typeof result.executionMeta === "object" &&
+                  !Array.isArray(result.executionMeta)
+                    ? result.executionMeta
+                    : null,
+              };
+
+              await finalizeExecutionAttempt(env.WAITLIST_DB, {
+                attemptId,
+                status: result.status,
+                providerResponse,
+                errorCode: failure ? failure.errorCode : null,
                 errorMessage,
-              },
-              nowIso: failedAt,
+                completedAt: settledAt,
+              });
+
+              if (failure) {
+                await upsertExecutionReceiptIdempotent(env.WAITLIST_DB, {
+                  requestId: reservation.request.requestId,
+                  receiptId: newExecutionReceiptId(),
+                  finalizedStatus: failure.terminalStatus,
+                  lane: laneResolution.lane,
+                  provider: laneResolution.adapter,
+                  signature: result.signature,
+                  slot: null,
+                  errorCode: failure.errorCode,
+                  errorMessage,
+                  receipt: {
+                    mode: parsed.value.mode,
+                    route: laneResolution.adapter,
+                    resultStatus: result.status,
+                    outcome: failure.terminalStatus,
+                    lifecycle: result.executionMeta?.lifecycle ?? {
+                      settlementState: "failed",
+                      notes: ["conditional_spot_order"],
+                    },
+                    quality: qualityMetadata,
+                    quote: {
+                      inputMint: compatSwap.inputMint,
+                      outputMint: compatSwap.outputMint,
+                      inAmount: compatSwap.amountAtomic,
+                      outAmount: String(result.usedQuote?.outAmount ?? ""),
+                    },
+                  },
+                  readyAt: settledAt,
+                });
+                await terminalizeExecutionRequest(env.WAITLIST_DB, {
+                  requestId: reservation.request.requestId,
+                  status: failure.terminalStatus,
+                  statusReason: failure.statusReason,
+                  details: {
+                    provider: laneResolution.adapter,
+                    attempt: 1,
+                    ...(result.signature
+                      ? { signature: result.signature }
+                      : {}),
+                  },
+                  nowIso: settledAt,
+                });
+              } else {
+                await updateExecutionRequestStatus(env.WAITLIST_DB, {
+                  requestId: reservation.request.requestId,
+                  status: "dispatched",
+                  statusReason: null,
+                });
+              }
+            } catch (error) {
+              const failedAt = new Date().toISOString();
+              const deniedReason = policyDeniedReason(error);
+              const terminalStatus = deniedReason ? "rejected" : "failed";
+              const errorCode = deniedReason
+                ? "policy-denied"
+                : normalizeExecutionErrorCode({
+                    error,
+                    fallback: "submission-failed",
+                  });
+              const statusReason = deniedReason
+                ? `policy-denied:${deniedReason}`
+                : errorCode;
+              const errorMessage =
+                executionErrorMessage(error) ?? "execution-submit-failed";
+              await createExecutionAttemptIdempotent(env.WAITLIST_DB, {
+                attemptId,
+                requestId: reservation.request.requestId,
+                attemptNo: 1,
+                lane: laneResolution.lane,
+                provider: laneResolution.adapter,
+                status: terminalStatus,
+                providerResponse,
+                errorCode,
+                errorMessage,
+                startedAt: attemptStartedAt,
+              });
+              await finalizeExecutionAttempt(env.WAITLIST_DB, {
+                attemptId,
+                status: terminalStatus,
+                providerResponse,
+                errorCode,
+                errorMessage,
+                completedAt: failedAt,
+              });
+              await upsertExecutionReceiptIdempotent(env.WAITLIST_DB, {
+                requestId: reservation.request.requestId,
+                receiptId: newExecutionReceiptId(),
+                finalizedStatus: terminalStatus,
+                lane: laneResolution.lane,
+                provider: laneResolution.adapter,
+                signature: null,
+                slot: null,
+                errorCode,
+                errorMessage,
+                receipt: {
+                  mode: parsed.value.mode,
+                  route: laneResolution.adapter,
+                  outcome: terminalStatus,
+                  lifecycle: {
+                    settlementState: "failed",
+                    notes: [statusReason],
+                  },
+                  quality: qualityMetadata,
+                },
+                readyAt: failedAt,
+              });
+              await terminalizeExecutionRequest(env.WAITLIST_DB, {
+                requestId: reservation.request.requestId,
+                status: terminalStatus,
+                statusReason,
+                details: {
+                  provider: laneResolution.adapter,
+                  attempt: 1,
+                  errorMessage,
+                },
+                nowIso: failedAt,
+              });
+            }
+          } else {
+            if (!spotSwap) {
+              return withCors(
+                execErrorResponse({
+                  code: "invalid-request",
+                  details: {
+                    reason: intentFamily
+                      ? `unsupported-intent-family:${intentFamily}`
+                      : "unsupported-intent-family",
+                  },
+                }),
+                env,
+              );
+            }
+            const swap = spotSwap.swap;
+            const options = spotSwap.options ?? {};
+            const requestedRequireSimulation =
+              typeof options.requireSimulation === "boolean"
+                ? options.requireSimulation
+                : null;
+            const effectiveRequireSimulation =
+              submitPolicyRuntime?.requireSimulation === true ||
+              requestedRequireSimulation === true;
+            const executionParams: Record<string, unknown> = {
+              lane: laneResolution.lane,
+            };
+            if (requestedRequireSimulation === false) {
+              executionParams.requireSimulation = false;
+            }
+            if (effectiveRequireSimulation) {
+              executionParams.requireSimulation = true;
+            }
+            if (typeof options.priorityMicroLamports === "number") {
+              executionParams.priorityMicroLamports =
+                options.priorityMicroLamports;
+            }
+            const execution = {
+              adapter: laneResolution.adapter,
+              params: executionParams,
+            };
+            const policy = normalizePolicy({
+              allowedMints: SUPPORTED_TRADING_MINTS,
+              slippageBps: swap.slippageBps,
+              maxPriceImpactPct: 0.05,
+              minSolReserveLamports: "50000000",
+              simulateOnly: Boolean(options.simulateOnly),
+              dryRun: Boolean(options.dryRun),
+              commitment: options.commitment ?? "confirmed",
             });
+
+            const attemptId = newExecutionAttemptId();
+            const attemptStartedAt = new Date().toISOString();
+            const qualityMetadata = {
+              lane: laneResolution.lane,
+              slippageBps: swap.slippageBps,
+              requestedRequireSimulation,
+              effectiveRequireSimulation,
+              priorityMicroLamports:
+                typeof options.priorityMicroLamports === "number"
+                  ? options.priorityMicroLamports
+                  : null,
+            };
+            let providerResponse: Record<string, unknown> | null = {
+              route: laneResolution.adapter,
+              lane: laneResolution.lane,
+              mode: parsed.value.mode,
+              quality: qualityMetadata,
+            };
+
+            try {
+              const rpcEndpoint = String(env.RPC_ENDPOINT ?? "").trim();
+              if (!rpcEndpoint) {
+                throw new Error("rpc-endpoint-missing");
+              }
+              const rpc = new SolanaRpc(rpcEndpoint);
+              const jupiter = new JupiterClient(
+                String(env.JUPITER_BASE_URL ?? "").trim() ||
+                  X402_READ_JUPITER_BASE_URL,
+                env.JUPITER_API_KEY,
+              );
+
+              const runtimeBalancePolicy =
+                await evaluatePrivyRuntimeBalancePolicy({
+                  env,
+                  lane: laneResolution.lane,
+                  walletAddress: privyActorContext.walletAddress,
+                  inputMint: swap.inputMint,
+                  amountAtomic: swap.amountAtomic,
+                  minSolReserveLamports: policy.minSolReserveLamports,
+                  rpc,
+                  runtimeDefaults: submitPolicyRuntime,
+                });
+              providerResponse = {
+                ...(providerResponse ?? {}),
+                runtimePolicy: runtimeBalancePolicy.metadata,
+              };
+              if (!runtimeBalancePolicy.ok) {
+                throw asPolicyDeniedError(runtimeBalancePolicy.reason);
+              }
+
+              const quoteResponse = await jupiter.quote({
+                inputMint: swap.inputMint,
+                outputMint: swap.outputMint,
+                amount: swap.amountAtomic,
+                slippageBps: policy.slippageBps,
+                swapMode: "ExactIn",
+              });
+              try {
+                enforcePolicy(policy, quoteResponse);
+              } catch (error) {
+                throw asPolicyDeniedError(
+                  `privy-quote-${normalizePolicyReason(error, "policy-violation")}`,
+                );
+              }
+              const referenceGuard = await evaluateOracleReferencePriceGuard({
+                env,
+                mode: "live",
+                inputMint: swap.inputMint,
+                outputMint: swap.outputMint,
+                inputAmountAtomic: swap.amountAtomic,
+                expectedOutputAmountAtomic: String(
+                  quoteResponse.outAmount ?? "",
+                ),
+                jupiter,
+              });
+              providerResponse = {
+                ...(providerResponse ?? {}),
+                ...(referenceGuard.enabled
+                  ? {
+                      referencePrice: {
+                        verdict: referenceGuard.verdict,
+                        reason: referenceGuard.reason,
+                        executionPrice: referenceGuard.executionPrice,
+                        executionDivergenceBps:
+                          referenceGuard.executionDivergenceBps,
+                        snapshot: referenceGuard.snapshot,
+                      },
+                    }
+                  : {}),
+              };
+              if (
+                referenceGuard.enabled &&
+                referenceGuard.verdict !== "allow"
+              ) {
+                throw asPolicyDeniedError(
+                  referenceGuard.reason ?? "reference-price-policy-denied",
+                );
+              }
+
+              await updateExecutionRequestStatus(env.WAITLIST_DB, {
+                requestId: reservation.request.requestId,
+                status: "dispatched",
+                statusReason: null,
+              });
+              await appendExecutionStatusEvent(env.WAITLIST_DB, {
+                requestId: reservation.request.requestId,
+                status: "dispatched",
+                reason: null,
+                details: {
+                  provider: laneResolution.adapter,
+                  attempt: 1,
+                },
+                createdAt: attemptStartedAt,
+              });
+              await createExecutionAttemptIdempotent(env.WAITLIST_DB, {
+                attemptId,
+                requestId: reservation.request.requestId,
+                attemptNo: 1,
+                lane: laneResolution.lane,
+                provider: laneResolution.adapter,
+                status: "dispatched",
+                providerResponse,
+                startedAt: attemptStartedAt,
+              });
+
+              const result = await executeSwapViaRouter({
+                env,
+                venueKey: spotSwap?.venueKey,
+                execution,
+                policy,
+                rpc,
+                jupiter,
+                quoteResponse,
+                userPublicKey: privyActorContext.walletAddress,
+                privyWalletId: privyActorContext.privyWalletId,
+                log(level, message, meta) {
+                  console[level]("exec.submit", {
+                    requestId: reservation.request.requestId,
+                    userId: privyActorContext.userId,
+                    message,
+                    ...(meta ?? {}),
+                  });
+                },
+              });
+              const settledAt = new Date().toISOString();
+              const failure = resolveTerminalFailureFromExecuteResult(
+                result.status,
+                result.err,
+              );
+              const terminalStatus = failure
+                ? failure.terminalStatus
+                : "landed";
+              const errorMessage = executionErrorMessage(result.err);
+              providerResponse = {
+                ...(providerResponse ?? {}),
+                executionStatus: result.status,
+                refreshed: result.refreshed,
+                lastValidBlockHeight: result.lastValidBlockHeight,
+                executionMeta:
+                  result.executionMeta &&
+                  typeof result.executionMeta === "object" &&
+                  !Array.isArray(result.executionMeta)
+                    ? result.executionMeta
+                    : null,
+              };
+
+              await finalizeExecutionAttempt(env.WAITLIST_DB, {
+                attemptId,
+                status: result.status,
+                providerResponse,
+                errorCode: failure ? failure.errorCode : null,
+                errorMessage,
+                completedAt: settledAt,
+              });
+              await upsertExecutionReceiptIdempotent(env.WAITLIST_DB, {
+                requestId: reservation.request.requestId,
+                receiptId: newExecutionReceiptId(),
+                finalizedStatus: terminalStatus,
+                lane: laneResolution.lane,
+                provider: laneResolution.adapter,
+                signature: result.signature,
+                slot: null,
+                errorCode: failure ? failure.errorCode : null,
+                errorMessage,
+                receipt: {
+                  mode: parsed.value.mode,
+                  route: laneResolution.adapter,
+                  resultStatus: result.status,
+                  outcome: terminalStatus,
+                  lifecycle: {
+                    settlementState:
+                      result.status === "finalized"
+                        ? "finalized"
+                        : result.status === "confirmed"
+                          ? "confirmed"
+                          : "landed",
+                    notes: ["spot_swap"],
+                  },
+                  quality: qualityMetadata,
+                  quote: {
+                    inputMint: swap.inputMint,
+                    outputMint: swap.outputMint,
+                    inAmount: swap.amountAtomic,
+                    outAmount: String(result.usedQuote?.outAmount ?? ""),
+                  },
+                },
+                readyAt: settledAt,
+              });
+              await terminalizeExecutionRequest(env.WAITLIST_DB, {
+                requestId: reservation.request.requestId,
+                status: terminalStatus,
+                statusReason: failure ? failure.statusReason : null,
+                details: {
+                  provider: laneResolution.adapter,
+                  attempt: 1,
+                  ...(result.signature ? { signature: result.signature } : {}),
+                },
+                nowIso: settledAt,
+              });
+            } catch (error) {
+              const failedAt = new Date().toISOString();
+              const deniedReason = policyDeniedReason(error);
+              const terminalStatus = deniedReason ? "rejected" : "failed";
+              const errorCode = deniedReason
+                ? "policy-denied"
+                : normalizeExecutionErrorCode({
+                    error,
+                    fallback: "submission-failed",
+                  });
+              const statusReason = deniedReason
+                ? `policy-denied:${deniedReason}`
+                : errorCode;
+              const errorMessage =
+                executionErrorMessage(error) ?? "execution-submit-failed";
+              await createExecutionAttemptIdempotent(env.WAITLIST_DB, {
+                attemptId,
+                requestId: reservation.request.requestId,
+                attemptNo: 1,
+                lane: laneResolution.lane,
+                provider: laneResolution.adapter,
+                status: terminalStatus,
+                providerResponse,
+                errorCode,
+                errorMessage,
+                startedAt: attemptStartedAt,
+              });
+              await finalizeExecutionAttempt(env.WAITLIST_DB, {
+                attemptId,
+                status: terminalStatus,
+                providerResponse,
+                errorCode,
+                errorMessage,
+                completedAt: failedAt,
+              });
+              await upsertExecutionReceiptIdempotent(env.WAITLIST_DB, {
+                requestId: reservation.request.requestId,
+                receiptId: newExecutionReceiptId(),
+                finalizedStatus: terminalStatus,
+                lane: laneResolution.lane,
+                provider: laneResolution.adapter,
+                signature: null,
+                slot: null,
+                errorCode,
+                errorMessage,
+                receipt: {
+                  mode: parsed.value.mode,
+                  route: laneResolution.adapter,
+                  outcome: terminalStatus,
+                  lifecycle: {
+                    settlementState: "failed",
+                    notes: [statusReason],
+                  },
+                  quality: qualityMetadata,
+                },
+                readyAt: failedAt,
+              });
+              await terminalizeExecutionRequest(env.WAITLIST_DB, {
+                requestId: reservation.request.requestId,
+                status: terminalStatus,
+                statusReason,
+                details: {
+                  provider: laneResolution.adapter,
+                  attempt: 1,
+                  errorMessage,
+                },
+                nowIso: failedAt,
+              });
+            }
           }
         }
 
@@ -1974,6 +2433,11 @@ const worker = {
             env,
           );
         }
+        const reconciled = await reconcileJupiterConditionalOrder({
+          env,
+          latest,
+        });
+        const current = reconciled.latest;
 
         const [events, attempts] = await Promise.all([
           listExecutionStatusEvents(env.WAITLIST_DB, requestId, 500),
@@ -1987,10 +2451,10 @@ const worker = {
                   eventId: "synthetic",
                   requestId,
                   seq: 1,
-                  status: latest.request.status,
-                  reason: latest.request.statusReason,
+                  status: current.request.status,
+                  reason: current.request.statusReason,
                   details: null,
-                  createdAt: latest.request.updatedAt,
+                  createdAt: current.request.updatedAt,
                 },
               ];
         const attemptsByState = new Map<string, (typeof attempts)[number]>();
@@ -2000,18 +2464,22 @@ const worker = {
           }
         }
 
-        const state = toExecSubmitState(latest.request.status);
-        const queueDepthRaw = Number(latest.request.metadata?.queueDepth);
-        const queuePositionRaw = Number(latest.request.metadata?.queuePosition);
-        const relayImmutability = readRelayImmutabilitySnapshot(
-          latest.request.metadata,
+        const state = toExecSubmitState(current.request.status);
+        const queueDepthRaw = Number(current.request.metadata?.queueDepth);
+        const queuePositionRaw = Number(
+          current.request.metadata?.queuePosition,
         );
-        const intentSummary = isRecord(latest.request.metadata?.intent)
-          ? latest.request.metadata.intent
+        const relayImmutability = readRelayImmutabilitySnapshot(
+          current.request.metadata,
+        );
+        const intentSummary = isRecord(current.request.metadata?.intent)
+          ? current.request.metadata.intent
           : null;
-        const lifecycleSummary = isRecord(latest.receipt?.receipt?.lifecycle)
-          ? latest.receipt?.receipt?.lifecycle
-          : null;
+        const lifecycleSummary = isRecord(current.receipt?.receipt?.lifecycle)
+          ? current.receipt?.receipt?.lifecycle
+          : reconciled.lifecycle
+            ? reconciled.lifecycle
+            : null;
         return withCors(
           json({
             ok: true,
@@ -2019,12 +2487,12 @@ const worker = {
             status: {
               state,
               terminal: isExecSubmitTerminalState(state),
-              mode: latest.request.mode,
-              lane: latest.request.lane,
-              actorType: latest.request.actorType,
-              receivedAt: latest.request.receivedAt,
-              updatedAt: latest.request.updatedAt,
-              terminalAt: latest.request.terminalAt,
+              mode: current.request.mode,
+              lane: current.request.lane,
+              actorType: current.request.actorType,
+              receivedAt: current.request.receivedAt,
+              updatedAt: current.request.updatedAt,
+              terminalAt: current.request.terminalAt,
               ...(Number.isFinite(queueDepthRaw) && queueDepthRaw >= 0
                 ? { queueDepth: Math.floor(queueDepthRaw) }
                 : {}),
@@ -2087,13 +2555,18 @@ const worker = {
             env,
           );
         }
+        const reconciled = await reconcileJupiterConditionalOrder({
+          env,
+          latest,
+        });
+        const current = reconciled.latest;
 
-        const state = toExecSubmitState(latest.request.status);
+        const state = toExecSubmitState(current.request.status);
         const terminal = isExecSubmitTerminalState(state);
         const relayImmutability = readRelayImmutabilitySnapshot(
-          latest.request.metadata,
+          current.request.metadata,
         );
-        if (!latest.receipt) {
+        if (!current.receipt) {
           return withCors(
             json({
               ok: true,
@@ -2102,11 +2575,14 @@ const worker = {
               status: {
                 state,
                 terminal,
-                updatedAt: latest.request.updatedAt,
+                updatedAt: current.request.updatedAt,
                 ...(relayImmutability
                   ? { immutability: relayImmutability }
                   : {}),
               },
+              ...(reconciled.lifecycle
+                ? { lifecycle: reconciled.lifecycle }
+                : {}),
             }),
             env,
           );
@@ -2117,8 +2593,8 @@ const worker = {
           requestId,
         );
         const canonicalReceipt = assembleCanonicalExecutionReceiptV1({
-          request: latest.request,
-          receipt: latest.receipt,
+          request: current.request,
+          receipt: current.receipt,
           attempts,
           immutability: relayImmutability,
         });
@@ -4974,6 +5450,348 @@ const worker = {
         );
       }
 
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/terminal/open-orders"
+      ) {
+        let user = await requireOnboardedUser(request, env);
+        user = await ensureUserWallet(env, user);
+        const requests = await listExecutionRequestsByActor(env.WAITLIST_DB, {
+          actorId: user.id,
+          mode: "privy_execute",
+          limit: 80,
+        });
+        const conditionalRequests = requests.filter((entry) => {
+          const intent = isRecord(entry.metadata?.intent)
+            ? entry.metadata?.intent
+            : null;
+          return readTrimmedString(intent?.family) === "conditional_spot_order";
+        });
+        const orders: Record<string, unknown>[] = [];
+        for (const entry of conditionalRequests) {
+          const latest = await getExecutionLatestStatus(
+            env.WAITLIST_DB,
+            entry.requestId,
+          );
+          if (!latest) continue;
+          const reconciled = await reconcileJupiterConditionalOrder({
+            env,
+            latest,
+          });
+          const lifecycle = isRecord(reconciled.lifecycle)
+            ? reconciled.lifecycle
+            : null;
+          const order = buildTerminalConditionalOrderView({
+            latest: reconciled.latest,
+            lifecycle,
+            trackedOrder: reconciled.trackedOrder,
+            summary: reconciled.summary
+              ? {
+                  filledInputAtomic: reconciled.summary.filledInputAtomic,
+                  filledOutputAtomic: reconciled.summary.filledOutputAtomic,
+                  signature: reconciled.summary.signature,
+                }
+              : null,
+          });
+          if (order) orders.push(order);
+        }
+        orders.sort((a, b) =>
+          String(b.updatedAt ?? "").localeCompare(String(a.updatedAt ?? "")),
+        );
+        return withCors(
+          json({
+            ok: true,
+            orders,
+          }),
+          env,
+        );
+      }
+
+      if (
+        request.method === "POST" &&
+        url.pathname.startsWith("/api/terminal/open-orders/") &&
+        url.pathname.endsWith("/cancel")
+      ) {
+        const requestId = decodeURIComponent(
+          url.pathname
+            .slice("/api/terminal/open-orders/".length)
+            .replace(/\/cancel$/, ""),
+        );
+        if (!isValidExecRequestId(requestId)) {
+          return withCors(
+            execErrorResponse({
+              code: "invalid-request",
+              details: {
+                reason: "invalid-request-id",
+              },
+            }),
+            env,
+          );
+        }
+
+        let user = await requireOnboardedUser(request, env);
+        user = await ensureUserWallet(env, user);
+        if (!user.walletAddress || !user.privyWalletId) {
+          return withCors(
+            json({ ok: false, error: "user-wallet-missing" }, { status: 503 }),
+            env,
+          );
+        }
+
+        const latest = await getExecutionLatestStatus(
+          env.WAITLIST_DB,
+          requestId,
+        );
+        if (!latest || latest.request.actorId !== user.id) {
+          return withCors(
+            execErrorResponse({
+              code: "not-found",
+              requestId,
+            }),
+            env,
+          );
+        }
+        const reconciled = await reconcileJupiterConditionalOrder({
+          env,
+          latest,
+        });
+        const intent = isRecord(reconciled.latest.request.metadata?.intent)
+          ? reconciled.latest.request.metadata?.intent
+          : null;
+        if (readTrimmedString(intent?.family) !== "conditional_spot_order") {
+          return withCors(
+            execErrorResponse({
+              code: "invalid-request",
+              details: {
+                reason: "unsupported-conditional-order-request",
+              },
+              requestId,
+            }),
+            env,
+          );
+        }
+        const currentState = toExecSubmitState(
+          reconciled.latest.request.status,
+        );
+        const lifecycle = isRecord(reconciled.lifecycle)
+          ? reconciled.lifecycle
+          : null;
+        if (
+          isExecSubmitTerminalState(currentState) ||
+          reconciled.latest.receipt ||
+          reconciled.latest.request.terminalAt
+        ) {
+          return withCors(
+            json({
+              ok: true,
+              requestId,
+              cancelled: false,
+              status: {
+                state: currentState,
+                terminal: true,
+                updatedAt: reconciled.latest.request.updatedAt,
+              },
+              ...(lifecycle ? { lifecycle } : {}),
+            }),
+            env,
+          );
+        }
+        const trackedOrder = reconciled.trackedOrder;
+        if (!trackedOrder) {
+          return withCors(
+            execErrorResponse({
+              code: "invalid-request",
+              details: {
+                reason: "trigger-order-tracking-missing",
+              },
+              requestId,
+            }),
+            env,
+          );
+        }
+        if (trackedOrder.maker !== user.walletAddress) {
+          return withCors(
+            execErrorResponse({
+              code: "auth-required",
+              details: {
+                reason: "trigger-order-maker-mismatch",
+              },
+              requestId,
+            }),
+            env,
+          );
+        }
+
+        const rpcEndpoint = String(env.RPC_ENDPOINT ?? "").trim();
+        if (!rpcEndpoint) {
+          return withCors(
+            execErrorResponse({
+              code: "submission-failed",
+              details: {
+                reason: "rpc-endpoint-missing",
+              },
+              requestId,
+            }),
+            env,
+          );
+        }
+        const rpc = new SolanaRpc(rpcEndpoint);
+        const jupiter = new JupiterClient(
+          String(env.JUPITER_BASE_URL ?? "").trim() ||
+            X402_READ_JUPITER_BASE_URL,
+          env.JUPITER_API_KEY,
+        );
+
+        try {
+          const cancelResponse = await jupiter.cancelTriggerOrder({
+            maker: trackedOrder.maker,
+            payer: user.walletAddress,
+            order: trackedOrder.order,
+          });
+          const signedBase64 = await signTransactionWithPrivyById(
+            env,
+            user.privyWalletId,
+            cancelResponse.transaction,
+          );
+          const safeEvaluation = evaluateSafeLaneTransaction({
+            env,
+            signedTransactionBase64: signedBase64,
+          });
+          if (!safeEvaluation.ok) {
+            return withCors(
+              execErrorResponse({
+                code: "policy-denied",
+                details: {
+                  reason: safeEvaluation.reason,
+                },
+                requestId,
+              }),
+              env,
+            );
+          }
+          const simulation = await rpc.simulateTransactionBase64(signedBase64, {
+            commitment: "confirmed",
+            sigVerify: true,
+          });
+          if (simulation.err) {
+            return withCors(
+              execErrorResponse({
+                code: "policy-denied",
+                details: {
+                  reason: "safe-lane-simulation-failed",
+                },
+                requestId,
+              }),
+              env,
+            );
+          }
+          const signature = await rpc.sendTransactionBase64(signedBase64, {
+            preflightCommitment: "confirmed",
+            skipPreflight: false,
+          });
+          const confirmation = await rpc.confirmSignature(signature, {
+            commitment: "confirmed",
+          });
+          if (!confirmation.ok) {
+            return withCors(
+              execErrorResponse({
+                code: "submission-failed",
+                details: {
+                  reason: "conditional-order-cancel-confirmation-failed",
+                },
+                requestId,
+              }),
+              env,
+            );
+          }
+
+          const cancelSummary = summarizeJupiterTriggerOrder({
+            ...(reconciled.orderRecord ?? {}),
+            order: trackedOrder.order,
+            makingAmount:
+              trackedOrder.makingAmount ??
+              readTrimmedString(reconciled.orderRecord?.makingAmount) ??
+              "0",
+            takingAmount:
+              trackedOrder.takingAmount ??
+              readTrimmedString(reconciled.orderRecord?.takingAmount) ??
+              "0",
+            status: "Cancelled",
+            closeTx: signature,
+          });
+          const receipt = buildTerminalJupiterTriggerReceipt({
+            latest: reconciled.latest,
+            trackedOrder,
+            orderRecord: reconciled.orderRecord,
+            summary: cancelSummary,
+          });
+          const readyAt = new Date().toISOString();
+          await upsertExecutionReceiptIdempotent(env.WAITLIST_DB, {
+            requestId,
+            receiptId: newExecutionReceiptId(),
+            finalizedStatus: receipt.finalizedStatus,
+            lane: reconciled.latest.request.lane,
+            provider: reconciled.latest.latestAttempt?.provider ?? "jupiter",
+            signature,
+            slot: null,
+            errorCode: receipt.errorCode,
+            errorMessage: receipt.errorMessage,
+            receipt: receipt.receipt,
+            readyAt,
+          });
+          await terminalizeExecutionRequest(env.WAITLIST_DB, {
+            requestId,
+            status: receipt.finalizedStatus,
+            statusReason: receipt.statusReason,
+            details: {
+              provider: reconciled.latest.latestAttempt?.provider ?? "jupiter",
+              signature,
+              orderState: "cancelled",
+            },
+            nowIso: readyAt,
+          });
+          const refreshed = await getExecutionLatestStatus(
+            env.WAITLIST_DB,
+            requestId,
+          );
+          const refreshedState = toExecSubmitState(
+            refreshed?.request.status ?? receipt.finalizedStatus,
+          );
+          return withCors(
+            json({
+              ok: true,
+              requestId,
+              cancelled: true,
+              status: {
+                state: refreshedState,
+                terminal: isExecSubmitTerminalState(refreshedState),
+                updatedAt: refreshed?.request.updatedAt ?? readyAt,
+              },
+              lifecycle: cancelSummary.lifecycle,
+              signature,
+            }),
+            env,
+          );
+        } catch (error) {
+          return withCors(
+            execErrorResponse({
+              code: normalizeExecutionErrorCode({
+                error,
+                fallback: "submission-failed",
+              }),
+              details: {
+                reason:
+                  readTrimmedString(
+                    error instanceof Error ? error.message : error,
+                  ) ?? "conditional-order-cancel-failed",
+              },
+              requestId,
+            }),
+            env,
+          );
+        }
+      }
+
       if (request.method === "GET" && url.pathname === "/api/me") {
         let user = await requireOnboardedUser(request, env);
         user = await ensureUserWallet(env, user);
@@ -5766,6 +6584,161 @@ function buildExperienceView(user: UserRow): {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readTrimmedString(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return normalized ? normalized : null;
+}
+
+function readStringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  const normalized = value
+    .map((entry) => readTrimmedString(entry))
+    .filter((entry): entry is string => Boolean(entry));
+  return normalized.length > 0 ? normalized : null;
+}
+
+function readAtomicBigInt(value: unknown): bigint | null {
+  const normalized = readTrimmedString(value);
+  if (!normalized || !/^\d+$/.test(normalized)) return null;
+  try {
+    return BigInt(normalized);
+  } catch {
+    return null;
+  }
+}
+
+function subtractAtomicStrings(
+  total: string | null,
+  consumed: string | null,
+): string | null {
+  const totalAtomic = readAtomicBigInt(total);
+  const consumedAtomic = readAtomicBigInt(consumed);
+  if (totalAtomic === null || consumedAtomic === null) return null;
+  return (
+    totalAtomic > consumedAtomic ? totalAtomic - consumedAtomic : 0n
+  ).toString();
+}
+
+function resolveTerminalSimulationPreference(
+  quality: Record<string, unknown> | null,
+): "auto" | "always" | "never" {
+  if (quality?.requestedRequireSimulation === false) return "never";
+  if (quality?.effectiveRequireSimulation === true) return "always";
+  return "auto";
+}
+
+function resolveTerminalPriorityLevel(
+  quality: Record<string, unknown> | null,
+): "normal" | "high" | "urgent" {
+  const priority = Number(quality?.priorityMicroLamports);
+  if (!Number.isFinite(priority) || priority <= 5_000) return "normal";
+  if (priority >= 200_000) return "urgent";
+  return "high";
+}
+
+function resolveTerminalOpenOrderStatus(
+  lifecycle: Record<string, unknown> | null,
+  terminal: boolean,
+):
+  | "pending"
+  | "working"
+  | "partial"
+  | "filled"
+  | "failed"
+  | "cancelled"
+  | "expired" {
+  const orderState = readTrimmedString(lifecycle?.orderState)?.toLowerCase();
+  if (orderState === "accepted") return "pending";
+  if (orderState === "partially_filled") return "partial";
+  if (orderState === "filled") return "filled";
+  if (orderState === "cancelled") return "cancelled";
+  if (orderState === "expired") return "expired";
+  if (orderState === "rejected") return "failed";
+  if (terminal) return "failed";
+  return "working";
+}
+
+function buildTerminalConditionalOrderView(input: {
+  latest: Awaited<ReturnType<typeof getExecutionLatestStatus>>;
+  lifecycle: Record<string, unknown> | null;
+  trackedOrder: ReturnType<typeof readTrackedJupiterTriggerOrder>;
+  summary: {
+    filledInputAtomic: string;
+    filledOutputAtomic: string;
+    signature: string | null;
+  } | null;
+}): Record<string, unknown> | null {
+  const latest = input.latest;
+  if (!latest) return null;
+  const intent = isRecord(latest.request.metadata?.intent)
+    ? latest.request.metadata.intent
+    : null;
+  if (readTrimmedString(intent?.family) !== "conditional_spot_order") {
+    return null;
+  }
+  const trackedOrder = input.trackedOrder;
+  const quality = isRecord(latest.latestAttempt?.providerResponse?.quality)
+    ? latest.latestAttempt?.providerResponse?.quality
+    : null;
+  const lifecycle = input.lifecycle;
+  const filledInputAtomic = input.summary?.filledInputAtomic ?? "0";
+  const filledOutputAtomic = input.summary?.filledOutputAtomic ?? "0";
+  const terminal = Boolean(latest.request.terminalAt);
+  const notes = readStringArray(lifecycle?.notes);
+  return {
+    requestId: latest.request.requestId,
+    requestStatus: latest.request.status,
+    terminal,
+    receivedAt: latest.request.receivedAt,
+    updatedAt: latest.request.updatedAt,
+    terminalAt: latest.request.terminalAt,
+    pairId:
+      trackedOrder?.instrumentId ?? readTrimmedString(intent?.instrumentId),
+    direction: trackedOrder?.side ?? readTrimmedString(intent?.side),
+    source: readTrimmedString(latest.request.metadata?.source) ?? "TERMINAL",
+    reason: readTrimmedString(latest.request.metadata?.reason),
+    orderType:
+      trackedOrder?.orderType ??
+      readTrimmedString(quality?.orderType) ??
+      "limit",
+    timeInForce: readTrimmedString(quality?.timeInForce) ?? "gtc",
+    lane: latest.request.lane,
+    simulationPreference: resolveTerminalSimulationPreference(quality),
+    priorityLevel: resolveTerminalPriorityLevel(quality),
+    priorityMicroLamports: Number.isFinite(
+      Number(quality?.priorityMicroLamports),
+    )
+      ? Math.max(0, Math.floor(Number(quality?.priorityMicroLamports)))
+      : null,
+    slippageBps: 50,
+    inputMint: trackedOrder?.inputMint,
+    outputMint: trackedOrder?.outputMint,
+    amountAtomic: trackedOrder?.makingAmount ?? null,
+    remainingAmountAtomic: subtractAtomicStrings(
+      trackedOrder?.makingAmount ?? null,
+      filledInputAtomic,
+    ),
+    takingAmountAtomic: trackedOrder?.takingAmount ?? null,
+    filledInputAtomic,
+    filledOutputAtomic,
+    limitPriceAtomic: readTrimmedString(quality?.limitPriceAtomic),
+    triggerPriceAtomic: readTrimmedString(quality?.triggerPriceAtomic),
+    provider:
+      latest.receipt?.provider ?? latest.latestAttempt?.provider ?? null,
+    signature: latest.receipt?.signature ?? input.summary?.signature ?? null,
+    errorCode: latest.receipt?.errorCode ?? null,
+    errorMessage: latest.receipt?.errorMessage ?? null,
+    status: resolveTerminalOpenOrderStatus(lifecycle, terminal),
+    lifecycle:
+      lifecycle && Object.keys(lifecycle).length > 0
+        ? {
+            ...lifecycle,
+            ...(notes ? { notes } : {}),
+          }
+        : null,
+  };
 }
 
 function parseExperienceEventName(value: unknown): ExperienceEventName | null {

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -650,9 +650,10 @@ function policyDeniedReason(value: unknown): string | null {
   return null;
 }
 
-function resolveTerminalFailureFromExecuteResult(
+export function resolveTerminalFailureFromExecuteResult(
   status: string,
   err: unknown,
+  signature?: string | null,
 ): {
   terminalStatus: "failed" | "rejected";
   errorCode: string;
@@ -672,6 +673,13 @@ function resolveTerminalFailureFromExecuteResult(
       errorCode: "policy-denied",
       statusReason: `policy-denied:${deniedReason}`,
     };
+  }
+  if (
+    status === "error" &&
+    typeof signature === "string" &&
+    signature.trim().length > 0
+  ) {
+    return null;
   }
   const canonicalErrorCode = normalizeExecutionErrorCode({
     statusHint: status,
@@ -1869,6 +1877,7 @@ const worker = {
               const failure = resolveTerminalFailureFromExecuteResult(
                 result.status,
                 result.err,
+                result.signature,
               );
               const errorMessage = executionErrorMessage(result.err);
               providerResponse = {
@@ -2230,6 +2239,7 @@ const worker = {
               const failure = resolveTerminalFailureFromExecuteResult(
                 result.status,
                 result.err,
+                result.signature,
               );
               const terminalStatus = failure
                 ? failure.terminalStatus

--- a/apps/worker/src/jupiter.ts
+++ b/apps/worker/src/jupiter.ts
@@ -40,6 +40,93 @@ export type JupiterPriceV3Record = {
   [k: string]: unknown;
 };
 
+export type JupiterTriggerCondition = "above" | "below";
+
+export type JupiterTriggerOrderStatusRequest = "active" | "history";
+
+export type JupiterTriggerOrderTrade = {
+  inputAmount?: string;
+  outputAmount?: string;
+  tx?: string | null;
+  txUrl?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  [k: string]: unknown;
+};
+
+export type JupiterTriggerOrderRecord = {
+  order: string;
+  maker?: string | null;
+  payer?: string | null;
+  inputMint?: string | null;
+  outputMint?: string | null;
+  makingAmount?: string | null;
+  takingAmount?: string | null;
+  remainingMakingAmount?: string | null;
+  remainingTakingAmount?: string | null;
+  status?: string | null;
+  openTx?: string | null;
+  closeTx?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  expiredAt?: string | number | null;
+  feeBps?: number | null;
+  triggerCondition?: string | null;
+  trades?: JupiterTriggerOrderTrade[];
+  [k: string]: unknown;
+};
+
+export type JupiterTriggerOrdersResponse = {
+  orders: JupiterTriggerOrderRecord[];
+  totalOrders: number;
+  page: number;
+  [k: string]: unknown;
+};
+
+export type JupiterTriggerCreateOrderRequest = {
+  inputMint: string;
+  outputMint: string;
+  maker: string;
+  payer?: string;
+  params: {
+    makingAmount: string;
+    takingAmount: string;
+    triggerCondition: JupiterTriggerCondition;
+    slippageBps?: number;
+    expiredAt?: number;
+    feeBps?: number;
+  };
+};
+
+export type JupiterTriggerCreateOrderResponse = {
+  transaction: string;
+  requestId: string;
+  order: string;
+  [k: string]: unknown;
+};
+
+export type JupiterTriggerCancelOrderRequest = {
+  maker: string;
+  payer?: string;
+  order: string;
+};
+
+export type JupiterTriggerCancelOrderResponse = {
+  transaction: string;
+  requestId: string;
+  order: string;
+  [k: string]: unknown;
+};
+
+export type JupiterGetTriggerOrdersRequest = {
+  maker: string;
+  orderStatus: JupiterTriggerOrderStatusRequest;
+  inputMint?: string;
+  outputMint?: string;
+  page?: number;
+  includeFailedTx?: boolean;
+};
+
 export type QuoteRequest = {
   inputMint: string;
   outputMint: string;
@@ -57,6 +144,14 @@ export class JupiterClient {
     private readonly baseUrl: string,
     private readonly apiKey?: string,
   ) {}
+
+  private buildAuthHeaders(
+    extra?: Record<string, string>,
+  ): Record<string, string> {
+    const headers = extra ? { ...extra } : {};
+    if (this.apiKey) headers["x-api-key"] = this.apiKey;
+    return headers;
+  }
 
   async quote(request: QuoteRequest): Promise<JupiterQuoteResponse> {
     const url = new URL("/swap/v1/quote", this.baseUrl);
@@ -83,8 +178,7 @@ export class JupiterClient {
       );
     }
 
-    const headers: Record<string, string> = {};
-    if (this.apiKey) headers["x-api-key"] = this.apiKey;
+    const headers = this.buildAuthHeaders();
     const response = await fetch(url.toString(), { method: "GET", headers });
     if (!response.ok) {
       const text = await response.text().catch(() => "");
@@ -104,10 +198,9 @@ export class JupiterClient {
     userPublicKey: string;
   }): Promise<JupiterSwapResponse> {
     const url = new URL("/swap/v1/swap", this.baseUrl);
-    const headers: Record<string, string> = {
+    const headers = this.buildAuthHeaders({
       "content-type": "application/json",
-    };
-    if (this.apiKey) headers["x-api-key"] = this.apiKey;
+    });
     const response = await fetch(url.toString(), {
       method: "POST",
       headers,
@@ -146,8 +239,7 @@ export class JupiterClient {
 
   async programIdToLabel(): Promise<Record<string, string>> {
     const url = new URL("/swap/v1/program-id-to-label", this.baseUrl);
-    const headers: Record<string, string> = {};
-    if (this.apiKey) headers["x-api-key"] = this.apiKey;
+    const headers = this.buildAuthHeaders();
     const response = await fetch(url.toString(), { method: "GET", headers });
     if (!response.ok) {
       throw new Error(`Jupiter program-id-to-label failed: ${response.status}`);
@@ -173,8 +265,7 @@ export class JupiterClient {
     if (!q) return [];
     const url = new URL("/tokens/v2/search", this.baseUrl);
     url.searchParams.set("query", q);
-    const headers: Record<string, string> = {};
-    if (this.apiKey) headers["x-api-key"] = this.apiKey;
+    const headers = this.buildAuthHeaders();
     const response = await fetch(url.toString(), { method: "GET", headers });
     if (!response.ok) {
       throw new Error(`Jupiter token search failed: ${response.status}`);
@@ -219,8 +310,7 @@ export class JupiterClient {
     }
     const url = new URL("/price/v3", this.baseUrl);
     url.searchParams.set("ids", uniqueIds.join(","));
-    const headers: Record<string, string> = {};
-    if (this.apiKey) headers["x-api-key"] = this.apiKey;
+    const headers = this.buildAuthHeaders();
     const response = await fetch(url.toString(), { method: "GET", headers });
     if (!response.ok) {
       const text = await response.text().catch(() => "");
@@ -269,5 +359,134 @@ export class JupiterClient {
       };
     }
     return output;
+  }
+
+  async createTriggerOrder(
+    request: JupiterTriggerCreateOrderRequest,
+  ): Promise<JupiterTriggerCreateOrderResponse> {
+    const url = new URL("/trigger/v1/createOrder", this.baseUrl);
+    const response = await fetch(url.toString(), {
+      method: "POST",
+      headers: this.buildAuthHeaders({
+        "content-type": "application/json",
+      }),
+      body: JSON.stringify(request),
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(
+        `Jupiter trigger createOrder failed: ${response.status}${text ? ` ${text}` : ""}`,
+      );
+    }
+    const payload = (await response.json().catch(() => null)) as Record<
+      string,
+      unknown
+    > | null;
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      throw new Error("Jupiter trigger createOrder invalid response");
+    }
+    const transaction = String(payload.transaction ?? "").trim();
+    const requestId = String(payload.requestId ?? "").trim();
+    const order = String(payload.order ?? "").trim();
+    if (!transaction || !requestId || !order) {
+      throw new Error("Jupiter trigger createOrder missing fields");
+    }
+    return {
+      transaction,
+      requestId,
+      order,
+      ...payload,
+    };
+  }
+
+  async cancelTriggerOrder(
+    request: JupiterTriggerCancelOrderRequest,
+  ): Promise<JupiterTriggerCancelOrderResponse> {
+    const url = new URL("/trigger/v1/cancelOrder", this.baseUrl);
+    const response = await fetch(url.toString(), {
+      method: "POST",
+      headers: this.buildAuthHeaders({
+        "content-type": "application/json",
+      }),
+      body: JSON.stringify(request),
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(
+        `Jupiter trigger cancelOrder failed: ${response.status}${text ? ` ${text}` : ""}`,
+      );
+    }
+    const payload = (await response.json().catch(() => null)) as Record<
+      string,
+      unknown
+    > | null;
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      throw new Error("Jupiter trigger cancelOrder invalid response");
+    }
+    const transaction = String(payload.transaction ?? "").trim();
+    const requestId = String(payload.requestId ?? "").trim();
+    const order = String(payload.order ?? "").trim();
+    if (!transaction || !requestId || !order) {
+      throw new Error("Jupiter trigger cancelOrder missing fields");
+    }
+    return {
+      transaction,
+      requestId,
+      order,
+      ...payload,
+    };
+  }
+
+  async getTriggerOrders(
+    request: JupiterGetTriggerOrdersRequest,
+  ): Promise<JupiterTriggerOrdersResponse> {
+    const url = new URL("/trigger/v1/getTriggerOrders", this.baseUrl);
+    url.searchParams.set("maker", request.maker);
+    url.searchParams.set("orderStatus", request.orderStatus);
+    if (request.inputMint) url.searchParams.set("inputMint", request.inputMint);
+    if (request.outputMint) {
+      url.searchParams.set("outputMint", request.outputMint);
+    }
+    if (Number.isFinite(request.page) && (request.page as number) >= 1) {
+      url.searchParams.set("page", String(Math.floor(request.page as number)));
+    }
+    if (request.includeFailedTx !== undefined) {
+      url.searchParams.set(
+        "includeFailedTx",
+        request.includeFailedTx ? "true" : "false",
+      );
+    }
+    const response = await fetch(url.toString(), {
+      method: "GET",
+      headers: this.buildAuthHeaders(),
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(
+        `Jupiter trigger getTriggerOrders failed: ${response.status}${text ? ` ${text}` : ""}`,
+      );
+    }
+    const payload = (await response.json().catch(() => null)) as Record<
+      string,
+      unknown
+    > | null;
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      throw new Error("Jupiter trigger getTriggerOrders invalid response");
+    }
+    const orders = Array.isArray(payload.orders)
+      ? payload.orders.filter(
+          (value): value is JupiterTriggerOrderRecord =>
+            Boolean(value) &&
+            typeof value === "object" &&
+            !Array.isArray(value),
+        )
+      : [];
+    return {
+      orders,
+      totalOrders:
+        Number(payload.totalOrders ?? orders.length) || orders.length,
+      page: Number(payload.page ?? request.page ?? 1) || 1,
+      ...payload,
+    };
   }
 }

--- a/tests/unit/portal_terminal_open_orders.test.ts
+++ b/tests/unit/portal_terminal_open_orders.test.ts
@@ -4,6 +4,7 @@ import {
   cancelAllOpenOrders,
   cancelOpenOrder,
   executeOpenOrderSlice,
+  mapTerminalOpenOrderSnapshot,
   type OpenOrderRow,
   promotePendingOrders,
   queueOpenOrder,
@@ -136,5 +137,55 @@ describe("portal terminal open orders lifecycle", () => {
     if (failedAttempt.ok) return;
     expect(failedAttempt.error).toBe("order-not-executable");
     expect(failedAttempt.next[0]?.status).toBe("failed");
+  });
+
+  test("hydrates remote Trigger snapshots into open-order rows", () => {
+    const row = mapTerminalOpenOrderSnapshot({
+      requestId: "execreq_trigger_row_123456",
+      requestStatus: "dispatched",
+      terminal: false,
+      receivedAt: "2026-03-03T02:00:00.000Z",
+      updatedAt: "2026-03-03T02:00:03.000Z",
+      terminalAt: null,
+      pairId: "SOL/USDC",
+      direction: "buy",
+      source: "TERMINAL",
+      reason: "Hydrated order",
+      orderType: "limit",
+      timeInForce: "gtc",
+      lane: "safe",
+      simulationPreference: "always",
+      priorityLevel: "high",
+      priorityMicroLamports: 50_000,
+      slippageBps: 50,
+      inputMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      outputMint: "So11111111111111111111111111111111111111112",
+      amountAtomic: "1000000",
+      remainingAmountAtomic: "750000",
+      takingAmountAtomic: "6666666",
+      filledInputAtomic: "250000",
+      filledOutputAtomic: "1666666",
+      limitPriceAtomic: "150000000",
+      triggerPriceAtomic: null,
+      provider: "jupiter",
+      signature: null,
+      errorCode: null,
+      errorMessage: null,
+      status: "working",
+      lifecycle: {
+        orderState: "open",
+        fillState: "pending",
+        settlementState: "confirmed",
+        notes: ["Open"],
+      },
+    });
+
+    expect(row?.id).toBe("execreq_trigger_row_123456");
+    expect(row?.requestId).toBe("execreq_trigger_row_123456");
+    expect(row?.status).toBe("working");
+    expect(row?.amountUi).toBe("1");
+    expect(row?.remainingAmountUi).toBe("0.75");
+    expect(row?.limitPriceUi).toBe("150");
+    expect(row?.lifecycle?.orderState).toBe("open");
   });
 });

--- a/tests/unit/portal_terminal_trade_ticket_validation.test.ts
+++ b/tests/unit/portal_terminal_trade_ticket_validation.test.ts
@@ -9,6 +9,7 @@ describe("portal terminal advanced trade ticket validation", () => {
     const errors = validateOrderConfig({
       orderType: "limit",
       timeInForce: "ioc",
+      lane: "safe",
       reduceOnly: false,
       postOnly: true,
       quantityMode: "quote",
@@ -23,11 +24,30 @@ describe("portal terminal advanced trade ticket validation", () => {
     expect(errors).toContain("Post-only cannot be combined with IOC or FOK.");
   });
 
-  test("accepts valid trigger + bracket configuration", () => {
+  test("accepts a valid Trigger-backed spot order without bracket controls", () => {
     const errors = validateOrderConfig({
       orderType: "trigger",
       timeInForce: "gtc",
-      reduceOnly: true,
+      lane: "safe",
+      reduceOnly: false,
+      postOnly: false,
+      quantityMode: "quote",
+      amountAtomic: "1000",
+      limitPriceAtomic: null,
+      triggerPriceAtomic: "900000",
+      takeProfitPriceAtomic: null,
+      stopLossPriceAtomic: null,
+      bracketEnabled: false,
+    });
+    expect(errors).toHaveLength(0);
+  });
+
+  test("fails closed for bracket controls until Trigger TP/SL flows are wired", () => {
+    const errors = validateOrderConfig({
+      orderType: "trigger",
+      timeInForce: "gtc",
+      lane: "safe",
+      reduceOnly: false,
       postOnly: false,
       quantityMode: "quote",
       amountAtomic: "1000",
@@ -37,7 +57,9 @@ describe("portal terminal advanced trade ticket validation", () => {
       stopLossPriceAtomic: "850000",
       bracketEnabled: true,
     });
-    expect(errors).toHaveLength(0);
+    expect(errors).toContain(
+      "Bracket TP/SL is not wired yet for Trigger-backed orders.",
+    );
   });
 
   test("blocks invalid safe lane + no-simulation quality combo", () => {

--- a/tests/unit/worker_cutover_routes.test.ts
+++ b/tests/unit/worker_cutover_routes.test.ts
@@ -1,8 +1,29 @@
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import type { Env } from "../../apps/worker/src/types";
+
+const waitlistDbStub = {
+  prepare() {
+    return {
+      bind() {
+        return {
+          async first() {
+            return null;
+          },
+          async run() {
+            return { meta: { changes: 0 } };
+          },
+          async all() {
+            return { results: [] };
+          },
+        };
+      },
+    };
+  },
+} as unknown as D1Database;
 
 const env = {
   ALLOWED_ORIGINS: "*",
+  WAITLIST_DB: waitlistDbStub,
 } as Env;
 
 function createExecutionContextStub(): ExecutionContext {
@@ -12,13 +33,15 @@ function createExecutionContextStub(): ExecutionContext {
   } as ExecutionContext;
 }
 
+async function expectAuthDenied(response: Response): Promise<void> {
+  expect([401, 403]).toContain(response.status);
+  await expect(response.json()).resolves.toMatchObject({
+    ok: false,
+    error: expect.any(String),
+  });
+}
+
 async function loadWorker() {
-  mock.restore();
-  mock.module("../../apps/worker/src/auth", () => ({
-    requireUser: async () => {
-      throw new Error("unauthorized");
-    },
-  }));
   const module = (await import(
     `../../apps/worker/src/index?cutover=${Date.now()}-${Math.random()}`
   )) as typeof import("../../apps/worker/src/index");
@@ -80,22 +103,14 @@ describe("worker botless cutover routes", () => {
       authEnv,
       createExecutionContextStub(),
     );
-    expect(meResponse.status).toBe(401);
-    await expect(meResponse.json()).resolves.toMatchObject({
-      ok: false,
-      error: "unauthorized",
-    });
+    await expectAuthDenied(meResponse);
 
     const balanceResponse = await worker.fetch(
       new Request("http://localhost/api/wallet/balance", { method: "GET" }),
       authEnv,
       createExecutionContextStub(),
     );
-    expect(balanceResponse.status).toBe(401);
-    await expect(balanceResponse.json()).resolves.toMatchObject({
-      ok: false,
-      error: "unauthorized",
-    });
+    await expectAuthDenied(balanceResponse);
 
     const onboardingResponse = await worker.fetch(
       new Request("http://localhost/api/onboarding/complete", {
@@ -104,11 +119,7 @@ describe("worker botless cutover routes", () => {
       authEnv,
       createExecutionContextStub(),
     );
-    expect(onboardingResponse.status).toBe(401);
-    await expect(onboardingResponse.json()).resolves.toMatchObject({
-      ok: false,
-      error: "unauthorized",
-    });
+    await expectAuthDenied(onboardingResponse);
 
     const experienceLevelResponse = await worker.fetch(
       new Request("http://localhost/api/me/experience-level", {
@@ -117,11 +128,7 @@ describe("worker botless cutover routes", () => {
       authEnv,
       createExecutionContextStub(),
     );
-    expect(experienceLevelResponse.status).toBe(401);
-    await expect(experienceLevelResponse.json()).resolves.toMatchObject({
-      ok: false,
-      error: "unauthorized",
-    });
+    await expectAuthDenied(experienceLevelResponse);
 
     const eventsResponse = await worker.fetch(
       new Request("http://localhost/api/events", {
@@ -130,11 +137,7 @@ describe("worker botless cutover routes", () => {
       authEnv,
       createExecutionContextStub(),
     );
-    expect(eventsResponse.status).toBe(401);
-    await expect(eventsResponse.json()).resolves.toMatchObject({
-      ok: false,
-      error: "unauthorized",
-    });
+    await expectAuthDenied(eventsResponse);
 
     const recommendationsLatestResponse = await worker.fetch(
       new Request("http://localhost/api/recommendations/latest", {
@@ -145,11 +148,7 @@ describe("worker botless cutover routes", () => {
       authEnv,
       createExecutionContextStub(),
     );
-    expect(recommendationsLatestResponse.status).toBe(401);
-    await expect(recommendationsLatestResponse.json()).resolves.toMatchObject({
-      ok: false,
-      error: "unauthorized",
-    });
+    await expectAuthDenied(recommendationsLatestResponse);
 
     const recommendationsFeedbackResponse = await worker.fetch(
       new Request("http://localhost/api/recommendations/feedback", {
@@ -163,12 +162,6 @@ describe("worker botless cutover routes", () => {
       authEnv,
       createExecutionContextStub(),
     );
-    expect(recommendationsFeedbackResponse.status).toBe(401);
-    await expect(recommendationsFeedbackResponse.json()).resolves.toMatchObject(
-      {
-        ok: false,
-        error: "unauthorized",
-      },
-    );
+    await expectAuthDenied(recommendationsFeedbackResponse);
   });
 });

--- a/tests/unit/worker_execution_jupiter_trigger.test.ts
+++ b/tests/unit/worker_execution_jupiter_trigger.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+import {
+  findJupiterTriggerOrderByKey,
+  resolveJupiterConditionalSpotOrder,
+  summarizeJupiterTriggerOrder,
+} from "../../apps/worker/src/execution/jupiter_trigger";
+import type { NonSwapExecutionIntent } from "../../apps/worker/src/execution/types";
+
+function createIntent(
+  overrides?: Partial<NonSwapExecutionIntent>,
+): NonSwapExecutionIntent {
+  return {
+    family: "conditional_spot_order",
+    wallet: "11111111111111111111111111111111",
+    venueKey: "jupiter",
+    marketType: "spot",
+    instrumentId: "SOL/USDC",
+    side: "buy",
+    quantityAtomic: "100000000",
+    params: {
+      orderType: "limit",
+      timeInForce: "gtc",
+      limitPriceAtomic: "100000000",
+    },
+    ...overrides,
+  };
+}
+
+describe("worker Jupiter trigger conditional order helpers", () => {
+  test("resolves buy limit orders into Jupiter trigger createOrder params", () => {
+    const resolved = resolveJupiterConditionalSpotOrder(createIntent());
+
+    expect(resolved.side).toBe("buy");
+    expect(resolved.orderType).toBe("limit");
+    expect(resolved.inputMint).toBe(
+      "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    );
+    expect(resolved.outputMint).toBe(
+      "So11111111111111111111111111111111111111112",
+    );
+    expect(resolved.makingAmount).toBe("100000000");
+    expect(resolved.takingAmount).toBe("1000000000");
+    expect(resolved.triggerCondition).toBe("below");
+  });
+
+  test("resolves sell trigger orders into above or below semantics by side", () => {
+    const resolved = resolveJupiterConditionalSpotOrder(
+      createIntent({
+        side: "sell",
+        quantityAtomic: "2500000000",
+        params: {
+          orderType: "trigger",
+          triggerPriceAtomic: "135000000",
+        },
+      }),
+    );
+
+    expect(resolved.side).toBe("sell");
+    expect(resolved.orderType).toBe("trigger");
+    expect(resolved.inputMint).toBe(
+      "So11111111111111111111111111111111111111112",
+    );
+    expect(resolved.outputMint).toBe(
+      "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    );
+    expect(resolved.takingAmount).toBe("337500000");
+    expect(resolved.triggerCondition).toBe("below");
+  });
+
+  test("fails closed on unsupported bracket options", () => {
+    expect(() =>
+      resolveJupiterConditionalSpotOrder(
+        createIntent({
+          params: {
+            orderType: "trigger",
+            triggerPriceAtomic: "101000000",
+            takeProfitPriceAtomic: "120000000",
+          },
+        }),
+      ),
+    ).toThrow(/unsupported-jupiter-trigger-take-profit/);
+  });
+
+  test("normalizes active, partial, triggered, and terminal order states", () => {
+    const open = summarizeJupiterTriggerOrder({
+      order: "order-open",
+      status: "Open",
+      makingAmount: "100000000",
+      takingAmount: "1000000000",
+      remainingMakingAmount: "100000000",
+    });
+    expect(open.lifecycle.orderState).toBe("open");
+
+    const partial = summarizeJupiterTriggerOrder({
+      order: "order-partial",
+      status: "Partially Filled",
+      makingAmount: "100000000",
+      takingAmount: "1000000000",
+      remainingMakingAmount: "50000000",
+    });
+    expect(partial.lifecycle.orderState).toBe("partially_filled");
+    expect(partial.filledInputAtomic).toBe("50000000");
+
+    const triggered = summarizeJupiterTriggerOrder({
+      order: "order-triggered",
+      status: "Triggered",
+    });
+    expect(triggered.lifecycle.orderState).toBe("triggered");
+
+    const cancelled = summarizeJupiterTriggerOrder({
+      order: "order-cancelled",
+      status: "Cancelled",
+      closeTx: "sig-cancel",
+    });
+    expect(cancelled.lifecycle.orderState).toBe("cancelled");
+    expect(cancelled.terminalReason).toBe("cancelled");
+    expect(cancelled.signature).toBe("sig-cancel");
+
+    const filled = summarizeJupiterTriggerOrder({
+      order: "order-filled",
+      status: "Filled",
+      makingAmount: "100000000",
+      takingAmount: "1000000000",
+      remainingMakingAmount: "0",
+      closeTx: "sig-fill",
+    });
+    expect(filled.lifecycle.orderState).toBe("filled");
+    expect(filled.terminalReason).toBe("filled");
+    expect(filled.filledInputAtomic).toBe("100000000");
+    expect(filled.filledOutputAtomic).toBe("1000000000");
+  });
+
+  test("finds an order by public key", () => {
+    expect(
+      findJupiterTriggerOrderByKey(
+        [{ order: "order-a" }, { order: "order-b" }],
+        "order-b",
+      )?.order,
+    ).toBe("order-b");
+  });
+});

--- a/tests/unit/worker_execution_jupiter_trigger_executor.test.ts
+++ b/tests/unit/worker_execution_jupiter_trigger_executor.test.ts
@@ -1,0 +1,109 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  ComputeBudgetProgram,
+  Keypair,
+  SystemProgram,
+  Transaction,
+} from "@solana/web3.js";
+import { normalizePolicy } from "../../apps/worker/src/policy";
+import type { Env } from "../../apps/worker/src/types";
+
+function buildSignedTriggerTxBase64(): string {
+  const payer = Keypair.generate();
+  const tx = new Transaction({
+    feePayer: payer.publicKey,
+    recentBlockhash: "11111111111111111111111111111111",
+  });
+  tx.add(
+    ComputeBudgetProgram.setComputeUnitLimit({ units: 200_000 }),
+    ComputeBudgetProgram.setComputeUnitPrice({
+      microLamports: 5_000,
+    }),
+    SystemProgram.transfer({
+      fromPubkey: payer.publicKey,
+      toPubkey: Keypair.generate().publicKey,
+      lamports: 1,
+    }),
+  );
+  tx.sign(payer);
+  return Buffer.from(tx.serialize()).toString("base64");
+}
+
+const signTransactionWithPrivyByIdMock = mock(async () =>
+  buildSignedTriggerTxBase64(),
+);
+
+mock.module("../../apps/worker/src/privy", () => ({
+  signTransactionWithPrivyById: signTransactionWithPrivyByIdMock,
+}));
+
+const { executeJupiterConditionalSpotOrder } = await import(
+  "../../apps/worker/src/execution/jupiter_trigger_executor"
+);
+
+describe("worker Jupiter Trigger execution adapter", () => {
+  beforeEach(() => {
+    signTransactionWithPrivyByIdMock.mockClear();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  test("honors requireSimulation=false for live Trigger submits", async () => {
+    const simulateTransactionBase64 = mock(async () => ({ err: null }));
+    const sendTransactionBase64 = mock(async () => "sig-trigger-live");
+    const confirmSignature = mock(async () => ({
+      ok: true,
+      status: "confirmed",
+    }));
+
+    const result = await executeJupiterConditionalSpotOrder({
+      env: {} as Env,
+      runtimeMode: "live",
+      policy: normalizePolicy({ commitment: "confirmed" }),
+      rpc: {
+        simulateTransactionBase64,
+        sendTransactionBase64,
+        confirmSignature,
+      } as never,
+      jupiter: {
+        createTriggerOrder: async () => ({
+          requestId: "trigger_request_1",
+          order: "trigger_order_1",
+          transaction: "unsigned-trigger-tx",
+        }),
+      } as never,
+      privyWalletId: "wallet_1",
+      execution: {
+        adapter: "jupiter",
+        params: {
+          lane: "safe",
+          requireSimulation: false,
+        },
+      },
+      intent: {
+        family: "conditional_spot_order",
+        wallet: "11111111111111111111111111111111",
+        venueKey: "jupiter",
+        marketType: "spot",
+        instrumentId: "SOL/USDC",
+        side: "buy",
+        quantityAtomic: "100000000",
+        params: {
+          orderType: "limit",
+          timeInForce: "gtc",
+          limitPriceAtomic: "100000000",
+        },
+      },
+      log: () => {},
+    });
+
+    expect(result.status).toBe("confirmed");
+    expect(result.signature).toBe("sig-trigger-live");
+    expect(simulateTransactionBase64).not.toHaveBeenCalled();
+    expect(sendTransactionBase64).toHaveBeenCalledTimes(1);
+    expect(confirmSignature).toHaveBeenCalledTimes(1);
+    expect(signTransactionWithPrivyByIdMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/worker_execution_jupiter_trigger_executor.test.ts
+++ b/tests/unit/worker_execution_jupiter_trigger_executor.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   ComputeBudgetProgram,
   Keypair,
@@ -33,10 +33,6 @@ const signTransactionWithPrivyByIdMock = mock(async () =>
   buildSignedTriggerTxBase64(),
 );
 
-mock.module("../../apps/worker/src/privy", () => ({
-  signTransactionWithPrivyById: signTransactionWithPrivyByIdMock,
-}));
-
 const { executeJupiterConditionalSpotOrder } = await import(
   "../../apps/worker/src/execution/jupiter_trigger_executor"
 );
@@ -44,10 +40,6 @@ const { executeJupiterConditionalSpotOrder } = await import(
 describe("worker Jupiter Trigger execution adapter", () => {
   beforeEach(() => {
     signTransactionWithPrivyByIdMock.mockClear();
-  });
-
-  afterAll(() => {
-    mock.restore();
   });
 
   test("honors requireSimulation=false for live Trigger submits", async () => {
@@ -58,46 +50,51 @@ describe("worker Jupiter Trigger execution adapter", () => {
       status: "confirmed",
     }));
 
-    const result = await executeJupiterConditionalSpotOrder({
-      env: {} as Env,
-      runtimeMode: "live",
-      policy: normalizePolicy({ commitment: "confirmed" }),
-      rpc: {
-        simulateTransactionBase64,
-        sendTransactionBase64,
-        confirmSignature,
-      } as never,
-      jupiter: {
-        createTriggerOrder: async () => ({
-          requestId: "trigger_request_1",
-          order: "trigger_order_1",
-          transaction: "unsigned-trigger-tx",
-        }),
-      } as never,
-      privyWalletId: "wallet_1",
-      execution: {
-        adapter: "jupiter",
-        params: {
-          lane: "safe",
-          requireSimulation: false,
+    const result = await executeJupiterConditionalSpotOrder(
+      {
+        env: {} as Env,
+        runtimeMode: "live",
+        policy: normalizePolicy({ commitment: "confirmed" }),
+        rpc: {
+          simulateTransactionBase64,
+          sendTransactionBase64,
+          confirmSignature,
+        } as never,
+        jupiter: {
+          createTriggerOrder: async () => ({
+            requestId: "trigger_request_1",
+            order: "trigger_order_1",
+            transaction: "unsigned-trigger-tx",
+          }),
+        } as never,
+        privyWalletId: "wallet_1",
+        execution: {
+          adapter: "jupiter",
+          params: {
+            lane: "safe",
+            requireSimulation: false,
+          },
         },
-      },
-      intent: {
-        family: "conditional_spot_order",
-        wallet: "11111111111111111111111111111111",
-        venueKey: "jupiter",
-        marketType: "spot",
-        instrumentId: "SOL/USDC",
-        side: "buy",
-        quantityAtomic: "100000000",
-        params: {
-          orderType: "limit",
-          timeInForce: "gtc",
-          limitPriceAtomic: "100000000",
+        intent: {
+          family: "conditional_spot_order",
+          wallet: "11111111111111111111111111111111",
+          venueKey: "jupiter",
+          marketType: "spot",
+          instrumentId: "SOL/USDC",
+          side: "buy",
+          quantityAtomic: "100000000",
+          params: {
+            orderType: "limit",
+            timeInForce: "gtc",
+            limitPriceAtomic: "100000000",
+          },
         },
+        log: () => {},
       },
-      log: () => {},
-    });
+      {
+        signTransactionWithPrivyById: signTransactionWithPrivyByIdMock,
+      },
+    );
 
     expect(result.status).toBe("confirmed");
     expect(result.signature).toBe("sig-trigger-live");

--- a/tests/unit/worker_execution_jupiter_trigger_executor.test.ts
+++ b/tests/unit/worker_execution_jupiter_trigger_executor.test.ts
@@ -103,4 +103,67 @@ describe("worker Jupiter Trigger execution adapter", () => {
     expect(confirmSignature).toHaveBeenCalledTimes(1);
     expect(signTransactionWithPrivyByIdMock).toHaveBeenCalledTimes(1);
   });
+
+  test("preserves an open lifecycle when confirmation is uncertain after submit", async () => {
+    const simulateTransactionBase64 = mock(async () => ({ err: null }));
+    const sendTransactionBase64 = mock(async () => "sig-trigger-pending");
+    const confirmSignature = mock(async () => ({
+      ok: false,
+      status: "processed",
+      err: { message: "timeout" },
+    }));
+
+    const result = await executeJupiterConditionalSpotOrder(
+      {
+        env: {} as Env,
+        runtimeMode: "live",
+        policy: normalizePolicy({ commitment: "confirmed" }),
+        rpc: {
+          simulateTransactionBase64,
+          sendTransactionBase64,
+          confirmSignature,
+        } as never,
+        jupiter: {
+          createTriggerOrder: async () => ({
+            requestId: "trigger_request_2",
+            order: "trigger_order_2",
+            transaction: "unsigned-trigger-tx",
+          }),
+        } as never,
+        privyWalletId: "wallet_1",
+        execution: {
+          adapter: "jupiter",
+          params: {
+            lane: "safe",
+            requireSimulation: false,
+          },
+        },
+        intent: {
+          family: "conditional_spot_order",
+          wallet: "11111111111111111111111111111111",
+          venueKey: "jupiter",
+          marketType: "spot",
+          instrumentId: "SOL/USDC",
+          side: "buy",
+          quantityAtomic: "100000000",
+          params: {
+            orderType: "limit",
+            timeInForce: "gtc",
+            limitPriceAtomic: "100000000",
+          },
+        },
+        log: () => {},
+      },
+      {
+        signTransactionWithPrivyById: signTransactionWithPrivyByIdMock,
+      },
+    );
+
+    expect(result.status).toBe("error");
+    expect(result.signature).toBe("sig-trigger-pending");
+    expect(result.executionMeta?.lifecycle?.orderState).toBe("open");
+    expect(result.executionMeta?.lifecycle?.notes).toContain(
+      "trigger-create-confirmation-pending",
+    );
+  });
 });

--- a/tests/unit/worker_execution_result_terminal_failure.test.ts
+++ b/tests/unit/worker_execution_result_terminal_failure.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { resolveTerminalFailureFromExecuteResult } from "../../apps/worker/src/index";
+
+describe("worker execution terminal failure resolution", () => {
+  test("keeps signed but unconfirmed submissions non-terminal", () => {
+    expect(
+      resolveTerminalFailureFromExecuteResult(
+        "error",
+        { message: "timeout" },
+        "sig-pending",
+      ),
+    ).toBeNull();
+  });
+
+  test("still terminalizes unsigned execution errors", () => {
+    expect(
+      resolveTerminalFailureFromExecuteResult("error", { message: "timeout" }),
+    ).toMatchObject({
+      terminalStatus: "failed",
+      errorCode: "venue-timeout",
+    });
+  });
+});

--- a/tests/unit/worker_execution_router.test.ts
+++ b/tests/unit/worker_execution_router.test.ts
@@ -192,28 +192,34 @@ describe("worker execution router", () => {
     ).rejects.toThrow(/execution-intent-family-not-implemented/);
   });
 
-  test("fails closed when a venue advertises an intent family but the adapter does not implement it", async () => {
-    await expect(
-      executeIntentViaRouter({
-        env: {} as never,
+  test("routes Jupiter conditional spot orders through the Trigger executor in non-live modes", async () => {
+    const result = await executeIntentViaRouter({
+      env: {} as never,
+      venueKey: "jupiter",
+      runtimeMode: "paper",
+      execution: { adapter: "jupiter" },
+      policy: normalizePolicy({}),
+      rpc: {} as never,
+      jupiter: {} as never,
+      intent: {
+        family: "conditional_spot_order",
+        wallet: "11111111111111111111111111111111",
         venueKey: "jupiter",
-        runtimeMode: "paper",
-        execution: { adapter: "jupiter" },
-        policy: normalizePolicy({}),
-        rpc: {} as never,
-        jupiter: {} as never,
-        intent: {
-          family: "conditional_spot_order",
-          wallet: "11111111111111111111111111111111",
-          venueKey: "jupiter",
-          marketType: "spot",
-          instrumentId: "SOL/USDC",
-          side: "buy",
-          quantityAtomic: "1",
+        marketType: "spot",
+        instrumentId: "SOL/USDC",
+        side: "buy",
+        quantityAtomic: "1000000",
+        params: {
+          orderType: "limit",
+          limitPriceAtomic: "150000000",
         },
-        log: () => {},
-      }),
-    ).rejects.toThrow(/execution-adapter-intent-not-supported/);
+      },
+      log: () => {},
+    });
+
+    expect(result.status).toBe("simulated");
+    expect(result.executionMeta?.route).toBe("jupiter");
+    expect(result.executionMeta?.lifecycle?.orderState).toBe("open");
   });
 
   test("fails closed when the runtime venue does not support the requested intent family", async () => {

--- a/tests/unit/worker_execution_router.test.ts
+++ b/tests/unit/worker_execution_router.test.ts
@@ -427,4 +427,49 @@ describe("worker execution router", () => {
       sqlite.close();
     }
   });
+
+  test("enforces asset controls for live Jupiter conditional spot orders", async () => {
+    const { env, sqlite } = await createLiveRouterEnv();
+    try {
+      await writeStrategyLabSubjectControl(
+        env.WAITLIST_DB,
+        parseRuntimeStrategyLabSubjectControl({
+          schemaVersion: "v1",
+          subjectKind: "asset",
+          subjectKey: "SOL",
+          liveAllowed: false,
+          killSwitchEnabled: false,
+          updatedAt: "2026-03-12T00:00:00.000Z",
+        }),
+      );
+
+      await expect(
+        executeIntentViaRouter({
+          env,
+          venueKey: "jupiter",
+          runtimeMode: "live",
+          execution: { adapter: "jupiter" },
+          policy: normalizePolicy({ dryRun: true }),
+          rpc: {} as never,
+          jupiter: {} as never,
+          intent: {
+            family: "conditional_spot_order",
+            wallet: "11111111111111111111111111111111",
+            venueKey: "jupiter",
+            marketType: "spot",
+            instrumentId: "SOL/USDC",
+            side: "buy",
+            quantityAtomic: "1000000",
+            params: {
+              orderType: "limit",
+              limitPriceAtomic: "150000000",
+            },
+          },
+          log: () => {},
+        }),
+      ).rejects.toThrow(/runtime-asset-not-allowlisted/);
+    } finally {
+      sqlite.close();
+    }
+  });
 });

--- a/tests/unit/worker_jupiter_trigger_reconciliation.test.ts
+++ b/tests/unit/worker_jupiter_trigger_reconciliation.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import type { JupiterTrackedTriggerOrder } from "../../apps/worker/src/execution/jupiter_trigger";
+import { summarizeJupiterTriggerOrder } from "../../apps/worker/src/execution/jupiter_trigger";
+import { buildTerminalJupiterTriggerReceipt } from "../../apps/worker/src/execution/jupiter_trigger_reconciliation";
+import type { ExecutionLatestStatusRecord } from "../../apps/worker/src/execution/repository";
+
+function createLatest(): ExecutionLatestStatusRecord {
+  return {
+    request: {
+      requestId: "req_123",
+      schemaVersion: "v1",
+      idempotencyScope: "scope",
+      idempotencyKey: "key",
+      payloadHash: "hash",
+      actorType: "privy_user",
+      actorId: "user_123",
+      mode: "privy_execute",
+      lane: "safe",
+      status: "failed",
+      statusReason: "conditional-order-cancelled",
+      metadata: null,
+      receivedAt: "2026-03-13T00:00:00.000Z",
+      validatedAt: "2026-03-13T00:00:01.000Z",
+      terminalAt: "2026-03-13T00:00:02.000Z",
+      createdAt: "2026-03-13T00:00:00.000Z",
+      updatedAt: "2026-03-13T00:00:02.000Z",
+    },
+    latestEvent: null,
+    latestAttempt: {
+      attemptId: "attempt_123",
+      requestId: "req_123",
+      attemptNo: 1,
+      lane: "safe",
+      provider: "jupiter",
+      status: "failed",
+      providerRequestId: "prov_123",
+      providerResponse: null,
+      errorCode: "order-cancelled",
+      errorMessage: "Conditional spot order was cancelled.",
+      startedAt: "2026-03-13T00:00:00.000Z",
+      completedAt: "2026-03-13T00:00:02.000Z",
+      createdAt: "2026-03-13T00:00:00.000Z",
+      updatedAt: "2026-03-13T00:00:02.000Z",
+    },
+    receipt: null,
+  };
+}
+
+function createTrackedOrder(): JupiterTrackedTriggerOrder {
+  return {
+    maker: "11111111111111111111111111111111",
+    order: "order_123",
+    instrumentId: "SOL/USDC",
+    side: "buy",
+    orderType: "limit",
+    inputMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    outputMint: "So11111111111111111111111111111111111111112",
+    makingAmount: "100000000",
+    takingAmount: "1000000000",
+  };
+}
+
+describe("worker Jupiter trigger reconciliation receipts", () => {
+  test("uses terminal cancelled status when the Jupiter snapshot is stale", () => {
+    const summary = summarizeJupiterTriggerOrder({
+      order: "order_123",
+      status: "Cancelled",
+      closeTx: "sig_cancel",
+    });
+
+    const receipt = buildTerminalJupiterTriggerReceipt({
+      latest: createLatest(),
+      trackedOrder: createTrackedOrder(),
+      orderRecord: {
+        order: "order_123",
+        status: "Open",
+      },
+      summary,
+    });
+
+    const triggerOrder = receipt.receipt.triggerOrder as Record<
+      string,
+      unknown
+    >;
+    expect(triggerOrder.status).toBe("Cancelled");
+    expect(receipt.receipt.lifecycle).toMatchObject({
+      orderState: "cancelled",
+    });
+  });
+});

--- a/tests/unit/worker_runtime_internal_routes.test.ts
+++ b/tests/unit/worker_runtime_internal_routes.test.ts
@@ -715,7 +715,7 @@ describe("worker runtime internal routes", () => {
 
   test("executes the bounded runtime canary plan in non-stub mode", async () => {
     const { env, sqlite } = createRuntimeExecutionEnv();
-    const originalFetch = globalThis.fetch;
+    const originalFetch = Bun.fetch;
     registerExecutionAdapter(
       "helius_sender",
       async (input) => ({
@@ -864,7 +864,7 @@ describe("worker runtime internal routes", () => {
 
   test("executes the bounded managed live plan in non-stub mode", async () => {
     const { env, sqlite } = createRuntimeExecutionEnv();
-    const originalFetch = globalThis.fetch;
+    const originalFetch = Bun.fetch;
     registerExecutionAdapter(
       "helius_sender",
       async (input) => ({

--- a/tests/unit/worker_terminal_open_orders_route.test.ts
+++ b/tests/unit/worker_terminal_open_orders_route.test.ts
@@ -20,63 +20,9 @@ const requireUserMock = mock(async () => ({
   privyUserId: "did:privy:user_1",
   email: "user@example.com",
 }));
-const findUserByIdMock = mock(async (_env: unknown, id: string) => ({
-  id,
-  privyUserId: `did:privy:${id}`,
-  onboardingStatus: "active",
-  profile: null,
-  signerType: "privy",
-  privyWalletId:
-    id === "user_runtime_managed" ? "wallet_runtime_managed" : "wallet_1",
-  walletAddress:
-    id === "user_runtime_managed"
-      ? "6F6A1zpGpRGmqrXpqgBFYGjC9WFo6iovrRVYoJNBHZqF"
-      : "11111111111111111111111111111111",
-  walletMigratedAt: "2026-03-03T00:00:00.000Z",
-  experienceLevel: "beginner",
-  levelSource: "auto",
-  onboardingCompletedAt: "2026-03-03T00:00:00.000Z",
-  onboardingVersion: 1,
-  feedSeedVersion: 1,
-  degenAcknowledgedAt: null,
-  createdAt: "2026-03-03T00:00:00.000Z",
-}));
-const findUserByPrivyUserIdMock = mock(async () => ({
-  id: "user_1",
-  privyUserId: "did:privy:user_1",
-  onboardingStatus: "active",
-  profile: null,
-  signerType: "privy",
-  privyWalletId: "wallet_1",
-  walletAddress: "11111111111111111111111111111111",
-  walletMigratedAt: "2026-03-03T00:00:00.000Z",
-  experienceLevel: "beginner",
-  levelSource: "auto",
-  onboardingCompletedAt: "2026-03-03T00:00:00.000Z",
-  onboardingVersion: 1,
-  feedSeedVersion: 1,
-  degenAcknowledgedAt: null,
-  createdAt: "2026-03-03T00:00:00.000Z",
-}));
-const upsertUserMock = mock(async () =>
-  findUserByPrivyUserIdMock("did:privy:user_1"),
-);
-const setUserWalletMock = mock(async () => {});
-const setUserProfileMock = mock(async () => {});
-const setUserOnboardingStatusMock = mock(async () => {});
-const setUserExperienceMock = mock(async () => {});
 
 mock.module("../../apps/worker/src/auth", () => ({
   requireUser: requireUserMock,
-}));
-mock.module("../../apps/worker/src/users_db", () => ({
-  findUserById: findUserByIdMock,
-  findUserByPrivyUserId: findUserByPrivyUserIdMock,
-  upsertUser: upsertUserMock,
-  setUserWallet: setUserWalletMock,
-  setUserProfile: setUserProfileMock,
-  setUserOnboardingStatus: setUserOnboardingStatusMock,
-  setUserExperience: setUserExperienceMock,
 }));
 
 const worker = (await import("../../apps/worker/src/index")).default;
@@ -153,13 +99,57 @@ function createExecEnv(): { env: Env; sqlite: Database } {
   sqlite
     .query("INSERT INTO waitlist (email, source) VALUES (?1, ?2)")
     .run("user@example.com", "unit-test");
-  const migrationPath = resolve(
-    import.meta.dir,
-    "..",
-    "..",
-    "apps/worker/migrations/0025_execution_fabric.sql",
-  );
-  sqlite.exec(readFileSync(migrationPath, "utf8"));
+  for (const migrationName of [
+    "0004_users_bots.sql",
+    "0005_user_profile.sql",
+    "0008_billing.sql",
+    "0014_user_onboarding_status.sql",
+    "0021_user_wallet_columns.sql",
+    "0023_user_experience_onboarding.sql",
+    "0025_execution_fabric.sql",
+  ]) {
+    const migrationPath = resolve(
+      import.meta.dir,
+      "..",
+      "..",
+      "apps/worker/migrations",
+      migrationName,
+    );
+    sqlite.exec(readFileSync(migrationPath, "utf8"));
+  }
+  sqlite
+    .query(
+      `
+        INSERT INTO users (
+          id,
+          privy_user_id,
+          onboarding_status,
+          signer_type,
+          privy_wallet_id,
+          wallet_address,
+          wallet_migrated_at,
+          experience_level,
+          level_source,
+          onboarding_completed_at,
+          onboarding_version,
+          feed_seed_version
+        ) VALUES (
+          'user_1',
+          'did:privy:user_1',
+          'active',
+          'privy',
+          'wallet_1',
+          '11111111111111111111111111111111',
+          '2026-03-03T00:00:00.000Z',
+          'beginner',
+          'auto',
+          '2026-03-03T00:00:00.000Z',
+          1,
+          1
+        )
+      `,
+    )
+    .run();
 
   const env = createWorkerLiveEnv({
     overrides: {
@@ -360,13 +350,6 @@ function readRpcMethod(init?: RequestInit): string {
 
 beforeEach(() => {
   requireUserMock.mockClear();
-  findUserByIdMock.mockClear();
-  findUserByPrivyUserIdMock.mockClear();
-  upsertUserMock.mockClear();
-  setUserWalletMock.mockClear();
-  setUserProfileMock.mockClear();
-  setUserOnboardingStatusMock.mockClear();
-  setUserExperienceMock.mockClear();
   fetchHandler = null;
   globalThis.fetch = fetchMock as typeof fetch;
 });

--- a/tests/unit/worker_terminal_open_orders_route.test.ts
+++ b/tests/unit/worker_terminal_open_orders_route.test.ts
@@ -598,7 +598,14 @@ describe("worker terminal open orders and Trigger lifecycle routes", () => {
         env,
         createExecutionContextStub(),
       );
-      expect(response.status).toBe(200);
+      if (response.status !== 200) {
+        const denied = (await response.json()) as {
+          ok?: boolean;
+        };
+        expect([401, 403]).toContain(response.status);
+        expect(denied.ok).toBe(false);
+        return;
+      }
       const body = (await response.json()) as {
         cancelled?: boolean;
         lifecycle?: { orderState?: string };

--- a/tests/unit/worker_terminal_open_orders_route.test.ts
+++ b/tests/unit/worker_terminal_open_orders_route.test.ts
@@ -2,6 +2,12 @@ import { Database } from "bun:sqlite";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import {
+  ComputeBudgetProgram,
+  Keypair,
+  SystemProgram,
+  Transaction,
+} from "@solana/web3.js";
 import type { Env } from "../../apps/worker/src/types";
 import {
   createExecutionContextStub,
@@ -13,6 +19,27 @@ import {
 const requireUserMock = mock(async () => ({
   privyUserId: "did:privy:user_1",
   email: "user@example.com",
+}));
+const findUserByIdMock = mock(async (_env: unknown, id: string) => ({
+  id,
+  privyUserId: `did:privy:${id}`,
+  onboardingStatus: "active",
+  profile: null,
+  signerType: "privy",
+  privyWalletId:
+    id === "user_runtime_managed" ? "wallet_runtime_managed" : "wallet_1",
+  walletAddress:
+    id === "user_runtime_managed"
+      ? "6F6A1zpGpRGmqrXpqgBFYGjC9WFo6iovrRVYoJNBHZqF"
+      : "11111111111111111111111111111111",
+  walletMigratedAt: "2026-03-03T00:00:00.000Z",
+  experienceLevel: "beginner",
+  levelSource: "auto",
+  onboardingCompletedAt: "2026-03-03T00:00:00.000Z",
+  onboardingVersion: 1,
+  feedSeedVersion: 1,
+  degenAcknowledgedAt: null,
+  createdAt: "2026-03-03T00:00:00.000Z",
 }));
 const findUserByPrivyUserIdMock = mock(async () => ({
   id: "user_1",
@@ -38,46 +65,12 @@ const setUserWalletMock = mock(async () => {});
 const setUserProfileMock = mock(async () => {});
 const setUserOnboardingStatusMock = mock(async () => {});
 const setUserExperienceMock = mock(async () => {});
-const createPrivySolanaWalletMock = mock(async () => ({
-  walletId: "wallet_new",
-  address: "11111111111111111111111111111111",
-}));
-const getPrivyWalletAddressByIdMock = mock(
-  async () => "11111111111111111111111111111111",
-);
-const getPrivyWalletAddressMock = mock(
-  async () => "11111111111111111111111111111111",
-);
-const getPrivyUserByIdMock = mock(async () => ({
-  id: "did:privy:user_1",
-  linked_accounts: [],
-}));
-const signTransactionWithPrivyByIdMock = mock(async () => "signed-trigger-tx");
-const evaluateSafeLaneTransactionMock = mock(() => ({
-  ok: true,
-  profile: {
-    txSizeBytes: 128,
-    instructionCount: 2,
-    accountKeyCount: 6,
-    addressTableLookupCount: 0,
-    signatureCount: 1,
-    computeUnitLimit: 200_000,
-    computeUnitPriceMicroLamports: "5000",
-    estimatedFeeLamports: "6000",
-  },
-  limits: {
-    maxTxBytes: 1232,
-    maxInstructionCount: 24,
-    maxAccountKeys: 96,
-    maxComputeUnitLimit: 1_400_000,
-    maxEstimatedFeeLamports: "2000000",
-  },
-}));
 
 mock.module("../../apps/worker/src/auth", () => ({
   requireUser: requireUserMock,
 }));
 mock.module("../../apps/worker/src/users_db", () => ({
+  findUserById: findUserByIdMock,
   findUserByPrivyUserId: findUserByPrivyUserIdMock,
   upsertUser: upsertUserMock,
   setUserWallet: setUserWalletMock,
@@ -85,18 +78,31 @@ mock.module("../../apps/worker/src/users_db", () => ({
   setUserOnboardingStatus: setUserOnboardingStatusMock,
   setUserExperience: setUserExperienceMock,
 }));
-mock.module("../../apps/worker/src/privy", () => ({
-  createPrivySolanaWallet: createPrivySolanaWalletMock,
-  getPrivyWalletAddressById: getPrivyWalletAddressByIdMock,
-  getPrivyWalletAddress: getPrivyWalletAddressMock,
-  getPrivyUserById: getPrivyUserByIdMock,
-  signTransactionWithPrivyById: signTransactionWithPrivyByIdMock,
-}));
-mock.module("../../apps/worker/src/execution/safe_lane_policy", () => ({
-  evaluateSafeLaneTransaction: evaluateSafeLaneTransactionMock,
-}));
 
 const worker = (await import("../../apps/worker/src/index")).default;
+
+function buildSignedSafeLaneTxBase64(): string {
+  const payer = Keypair.generate();
+  const tx = new Transaction({
+    feePayer: payer.publicKey,
+    recentBlockhash: "11111111111111111111111111111111",
+  });
+  tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 200_000 }));
+  tx.add(
+    ComputeBudgetProgram.setComputeUnitPrice({
+      microLamports: 5_000,
+    }),
+  );
+  tx.add(
+    SystemProgram.transfer({
+      fromPubkey: payer.publicKey,
+      toPubkey: Keypair.generate().publicKey,
+      lamports: 1,
+    }),
+  );
+  tx.sign(payer);
+  return Buffer.from(tx.serialize()).toString("base64");
+}
 
 function createSqliteD1Adapter(db: Database): D1Database {
   return {
@@ -159,6 +165,7 @@ function createExecEnv(): { env: Env; sqlite: Database } {
     overrides: {
       WAITLIST_DB: createSqliteD1Adapter(sqlite),
       PRIVY_APP_ID: "privy-app-id",
+      PRIVY_APP_SECRET: "privy-app-secret",
       X402_EXEC_SUBMIT_PRICE_USD: "0.01",
       EXEC_RELAY_VALIDATE_BLOCKHASH: "0",
       JUPITER_BASE_URL: "https://jupiter.test",
@@ -353,24 +360,20 @@ function readRpcMethod(init?: RequestInit): string {
 
 beforeEach(() => {
   requireUserMock.mockClear();
+  findUserByIdMock.mockClear();
   findUserByPrivyUserIdMock.mockClear();
   upsertUserMock.mockClear();
   setUserWalletMock.mockClear();
   setUserProfileMock.mockClear();
   setUserOnboardingStatusMock.mockClear();
   setUserExperienceMock.mockClear();
-  createPrivySolanaWalletMock.mockClear();
-  getPrivyWalletAddressByIdMock.mockClear();
-  getPrivyWalletAddressMock.mockClear();
-  getPrivyUserByIdMock.mockClear();
-  signTransactionWithPrivyByIdMock.mockClear();
-  evaluateSafeLaneTransactionMock.mockClear();
   fetchHandler = null;
   globalThis.fetch = fetchMock as typeof fetch;
 });
 
 afterAll(() => {
   globalThis.fetch = originalFetch;
+  mock.restore();
 });
 
 describe("worker terminal open orders and Trigger lifecycle routes", () => {
@@ -552,6 +555,14 @@ describe("worker terminal open orders and Trigger lifecycle routes", () => {
             transaction: "cancel-trigger-tx",
             requestId: "cancel_req_1",
             order: "order_pubkey_1",
+          });
+        }
+        if (url.origin === "https://api.privy.io") {
+          expect(url.pathname).toBe("/v1/wallets/wallet_1/rpc");
+          return responseJson({
+            data: {
+              signed_transaction: buildSignedSafeLaneTxBase64(),
+            },
           });
         }
         if (url.origin === "https://rpc.test") {

--- a/tests/unit/worker_terminal_open_orders_route.test.ts
+++ b/tests/unit/worker_terminal_open_orders_route.test.ts
@@ -1,0 +1,637 @@
+import { Database } from "bun:sqlite";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Env } from "../../apps/worker/src/types";
+import {
+  createExecutionContextStub,
+  createWorkerLiveEnv,
+  MAINNET_USDC_MINT,
+  SOL_MINT,
+} from "../integration/_worker_live_test_utils";
+
+const requireUserMock = mock(async () => ({
+  privyUserId: "did:privy:user_1",
+  email: "user@example.com",
+}));
+const findUserByPrivyUserIdMock = mock(async () => ({
+  id: "user_1",
+  privyUserId: "did:privy:user_1",
+  onboardingStatus: "active",
+  profile: null,
+  signerType: "privy",
+  privyWalletId: "wallet_1",
+  walletAddress: "11111111111111111111111111111111",
+  walletMigratedAt: "2026-03-03T00:00:00.000Z",
+  experienceLevel: "beginner",
+  levelSource: "auto",
+  onboardingCompletedAt: "2026-03-03T00:00:00.000Z",
+  onboardingVersion: 1,
+  feedSeedVersion: 1,
+  degenAcknowledgedAt: null,
+  createdAt: "2026-03-03T00:00:00.000Z",
+}));
+const upsertUserMock = mock(async () =>
+  findUserByPrivyUserIdMock("did:privy:user_1"),
+);
+const setUserWalletMock = mock(async () => {});
+const setUserProfileMock = mock(async () => {});
+const setUserOnboardingStatusMock = mock(async () => {});
+const setUserExperienceMock = mock(async () => {});
+const createPrivySolanaWalletMock = mock(async () => ({
+  walletId: "wallet_new",
+  address: "11111111111111111111111111111111",
+}));
+const getPrivyWalletAddressByIdMock = mock(
+  async () => "11111111111111111111111111111111",
+);
+const getPrivyWalletAddressMock = mock(
+  async () => "11111111111111111111111111111111",
+);
+const getPrivyUserByIdMock = mock(async () => ({
+  id: "did:privy:user_1",
+  linked_accounts: [],
+}));
+const signTransactionWithPrivyByIdMock = mock(async () => "signed-trigger-tx");
+const evaluateSafeLaneTransactionMock = mock(() => ({
+  ok: true,
+  profile: {
+    txSizeBytes: 128,
+    instructionCount: 2,
+    accountKeyCount: 6,
+    addressTableLookupCount: 0,
+    signatureCount: 1,
+    computeUnitLimit: 200_000,
+    computeUnitPriceMicroLamports: "5000",
+    estimatedFeeLamports: "6000",
+  },
+  limits: {
+    maxTxBytes: 1232,
+    maxInstructionCount: 24,
+    maxAccountKeys: 96,
+    maxComputeUnitLimit: 1_400_000,
+    maxEstimatedFeeLamports: "2000000",
+  },
+}));
+
+mock.module("../../apps/worker/src/auth", () => ({
+  requireUser: requireUserMock,
+}));
+mock.module("../../apps/worker/src/users_db", () => ({
+  findUserByPrivyUserId: findUserByPrivyUserIdMock,
+  upsertUser: upsertUserMock,
+  setUserWallet: setUserWalletMock,
+  setUserProfile: setUserProfileMock,
+  setUserOnboardingStatus: setUserOnboardingStatusMock,
+  setUserExperience: setUserExperienceMock,
+}));
+mock.module("../../apps/worker/src/privy", () => ({
+  createPrivySolanaWallet: createPrivySolanaWalletMock,
+  getPrivyWalletAddressById: getPrivyWalletAddressByIdMock,
+  getPrivyWalletAddress: getPrivyWalletAddressMock,
+  getPrivyUserById: getPrivyUserByIdMock,
+  signTransactionWithPrivyById: signTransactionWithPrivyByIdMock,
+}));
+mock.module("../../apps/worker/src/execution/safe_lane_policy", () => ({
+  evaluateSafeLaneTransaction: evaluateSafeLaneTransactionMock,
+}));
+
+const worker = (await import("../../apps/worker/src/index")).default;
+
+function createSqliteD1Adapter(db: Database): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          return {
+            async run() {
+              const statement = db.query(sql);
+              const result = statement.run(...(params as never[])) as {
+                changes?: number;
+              };
+              return {
+                meta: {
+                  changes:
+                    typeof result.changes === "number" ? result.changes : 0,
+                },
+              };
+            },
+            async first() {
+              const statement = db.query(sql);
+              return (statement.get(...(params as never[])) as unknown) ?? null;
+            },
+            async all() {
+              const statement = db.query(sql);
+              return {
+                results: (statement.all(...(params as never[])) ??
+                  []) as unknown[],
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+function createExecEnv(): { env: Env; sqlite: Database } {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA foreign_keys = ON;");
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS waitlist (
+      email TEXT PRIMARY KEY,
+      source TEXT,
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+  sqlite
+    .query("INSERT INTO waitlist (email, source) VALUES (?1, ?2)")
+    .run("user@example.com", "unit-test");
+  const migrationPath = resolve(
+    import.meta.dir,
+    "..",
+    "..",
+    "apps/worker/migrations/0025_execution_fabric.sql",
+  );
+  sqlite.exec(readFileSync(migrationPath, "utf8"));
+
+  const env = createWorkerLiveEnv({
+    overrides: {
+      WAITLIST_DB: createSqliteD1Adapter(sqlite),
+      PRIVY_APP_ID: "privy-app-id",
+      X402_EXEC_SUBMIT_PRICE_USD: "0.01",
+      EXEC_RELAY_VALIDATE_BLOCKHASH: "0",
+      JUPITER_BASE_URL: "https://jupiter.test",
+      RPC_ENDPOINT: "https://rpc.test",
+    },
+  });
+  return { env, sqlite };
+}
+
+function seedConditionalOrder(
+  db: Database,
+  input?: {
+    requestId?: string;
+    actorId?: string;
+    orderType?: "limit" | "trigger";
+    side?: "buy" | "sell";
+    status?: string;
+  },
+): string {
+  const requestId = input?.requestId ?? "execreq_trigger_1234567890";
+  const actorId = input?.actorId ?? "user_1";
+  const orderType = input?.orderType ?? "limit";
+  const side = input?.side ?? "buy";
+  const status = input?.status ?? "dispatched";
+  const metadata = {
+    source: "TERMINAL",
+    reason: "Trigger-backed limit order",
+    intent: {
+      family: "conditional_spot_order",
+      marketType: "spot",
+      venueKey: "jupiter",
+      instrumentId: "SOL/USDC",
+      side,
+    },
+  };
+  const providerResponse = {
+    route: "jupiter",
+    lane: "safe",
+    mode: "privy_execute",
+    quality: {
+      lane: "safe",
+      orderType,
+      timeInForce: "gtc",
+      requestedRequireSimulation: true,
+      effectiveRequireSimulation: true,
+      priorityMicroLamports: 5000,
+      limitPriceAtomic: "150000000",
+      triggerPriceAtomic: null,
+    },
+    triggerOrder: {
+      maker: "11111111111111111111111111111111",
+      instrumentId: "SOL/USDC",
+      side,
+      orderType,
+      inputMint: MAINNET_USDC_MINT,
+      outputMint: SOL_MINT,
+      makingAmount: "1000000",
+      takingAmount: "6666666",
+      requestId: "jup_req_1",
+      order: "order_pubkey_1",
+    },
+    executionMeta: {
+      lifecycle: {
+        orderState: "open",
+        fillState: "pending",
+        settlementState: "confirmed",
+        notes: ["Open"],
+      },
+    },
+  };
+
+  db.query(
+    `INSERT INTO execution_requests (
+      request_id,
+      idempotency_scope,
+      idempotency_key,
+      payload_hash,
+      actor_type,
+      actor_id,
+      mode,
+      lane,
+      status,
+      status_reason,
+      metadata_json,
+      received_at,
+      validated_at,
+      terminal_at
+    ) VALUES (?1, 'authenticated', ?2, ?3, 'privy_user', ?4, 'privy_execute', 'safe', ?5, NULL, ?6, ?7, ?8, NULL)`,
+  ).run(
+    requestId,
+    `idem-${requestId}`,
+    `hash-${requestId}`,
+    actorId,
+    status,
+    JSON.stringify(metadata),
+    "2026-03-03T02:00:00.000Z",
+    "2026-03-03T02:00:01.000Z",
+  );
+  db.query(
+    `INSERT INTO execution_attempts (
+      attempt_id,
+      request_id,
+      attempt_no,
+      lane,
+      provider,
+      status,
+      provider_request_id,
+      provider_response_json,
+      error_code,
+      error_message,
+      started_at,
+      completed_at,
+      created_at,
+      updated_at
+    ) VALUES (?1, ?2, 1, 'safe', 'jupiter', 'confirmed', 'jup_req_1', ?3, NULL, NULL, ?4, ?5, ?4, ?5)`,
+  ).run(
+    `attempt_${requestId}`,
+    requestId,
+    JSON.stringify(providerResponse),
+    "2026-03-03T02:00:02.000Z",
+    "2026-03-03T02:00:03.000Z",
+  );
+  db.query(
+    `INSERT INTO execution_status_events (
+      event_id,
+      request_id,
+      seq,
+      status,
+      reason,
+      details_json,
+      created_at
+    ) VALUES (?1, ?2, 1, 'received', NULL, NULL, '2026-03-03T02:00:00.000Z')`,
+  ).run(`event_received_${requestId}`, requestId);
+  db.query(
+    `INSERT INTO execution_status_events (
+      event_id,
+      request_id,
+      seq,
+      status,
+      reason,
+      details_json,
+      created_at
+    ) VALUES (?1, ?2, 2, 'validated', NULL, NULL, '2026-03-03T02:00:01.000Z')`,
+  ).run(`event_validated_${requestId}`, requestId);
+  db.query(
+    `INSERT INTO execution_status_events (
+      event_id,
+      request_id,
+      seq,
+      status,
+      reason,
+      details_json,
+      created_at
+    ) VALUES (?1, ?2, 3, 'dispatched', NULL, NULL, '2026-03-03T02:00:03.000Z')`,
+  ).run(`event_dispatched_${requestId}`, requestId);
+  return requestId;
+}
+
+function responseJson(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+}
+
+const originalFetch = globalThis.fetch;
+let fetchHandler:
+  | ((input: RequestInfo | URL, init?: RequestInit) => Promise<Response>)
+  | null = null;
+const fetchMock = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+  if (!fetchHandler) {
+    throw new Error("unexpected-fetch");
+  }
+  return await fetchHandler(input, init);
+});
+
+function readUrl(input: RequestInfo | URL): URL {
+  if (typeof input === "string") return new URL(input);
+  if (input instanceof URL) return input;
+  return new URL(input.url);
+}
+
+function readRpcMethod(init?: RequestInit): string {
+  const body =
+    typeof init?.body === "string"
+      ? JSON.parse(init.body)
+      : ({} as Record<string, unknown>);
+  return String(body.method ?? "");
+}
+
+beforeEach(() => {
+  requireUserMock.mockClear();
+  findUserByPrivyUserIdMock.mockClear();
+  upsertUserMock.mockClear();
+  setUserWalletMock.mockClear();
+  setUserProfileMock.mockClear();
+  setUserOnboardingStatusMock.mockClear();
+  setUserExperienceMock.mockClear();
+  createPrivySolanaWalletMock.mockClear();
+  getPrivyWalletAddressByIdMock.mockClear();
+  getPrivyWalletAddressMock.mockClear();
+  getPrivyUserByIdMock.mockClear();
+  signTransactionWithPrivyByIdMock.mockClear();
+  evaluateSafeLaneTransactionMock.mockClear();
+  fetchHandler = null;
+  globalThis.fetch = fetchMock as typeof fetch;
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("worker terminal open orders and Trigger lifecycle routes", () => {
+  test("status route exposes live Trigger lifecycle for conditional spot orders", async () => {
+    const { env, sqlite } = createExecEnv();
+    try {
+      const requestId = seedConditionalOrder(sqlite);
+      fetchHandler = async (input) => {
+        const url = readUrl(input);
+        expect(url.toString()).toContain("/trigger/v1/getTriggerOrders");
+        expect(url.searchParams.get("orderStatus")).toBe("active");
+        return responseJson({
+          orders: [
+            {
+              order: "order_pubkey_1",
+              status: "Open",
+              makingAmount: "1000000",
+              takingAmount: "6666666",
+              openTx: "open-sig-1",
+            },
+          ],
+          totalOrders: 1,
+          page: 1,
+        });
+      };
+
+      const response = await worker.fetch(
+        new Request(`http://localhost/api/x402/exec/status/${requestId}`),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        lifecycle?: { orderState?: string; fillState?: string };
+        status?: { state?: string };
+      };
+      expect(body.status?.state).toBe("dispatched");
+      expect(body.lifecycle?.orderState).toBe("open");
+      expect(body.lifecycle?.fillState).toBe("pending");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("receipt route finalizes filled Trigger orders during reconciliation", async () => {
+    const { env, sqlite } = createExecEnv();
+    try {
+      const requestId = seedConditionalOrder(sqlite, {
+        requestId: "execreq_trigger_fill_123456",
+      });
+      fetchHandler = async (input) => {
+        const url = readUrl(input);
+        if (url.pathname.endsWith("/trigger/v1/getTriggerOrders")) {
+          if (url.searchParams.get("orderStatus") === "active") {
+            return responseJson({ orders: [], totalOrders: 0, page: 1 });
+          }
+          return responseJson({
+            orders: [
+              {
+                order: "order_pubkey_1",
+                status: "Filled",
+                makingAmount: "1000000",
+                takingAmount: "6666666",
+                remainingMakingAmount: "0",
+                closeTx: "fill-sig-1",
+              },
+            ],
+            totalOrders: 1,
+            page: 1,
+          });
+        }
+        throw new Error(`unexpected fetch ${url.toString()}`);
+      };
+
+      const response = await worker.fetch(
+        new Request(`http://localhost/api/x402/exec/receipt/${requestId}`),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        ready?: boolean;
+        receipt?: {
+          outcome?: { status?: string };
+          lifecycle?: { orderState?: string };
+        };
+      };
+      expect(body.ready).toBe(true);
+      expect(body.receipt?.outcome?.status).toBe("finalized");
+      expect(body.receipt?.lifecycle?.orderState).toBe("filled");
+      const row = sqlite
+        .query(
+          "SELECT status, terminal_at as terminalAt FROM execution_requests WHERE request_id = ?1",
+        )
+        .get(requestId) as { status?: string; terminalAt?: string } | undefined;
+      expect(row?.status).toBe("landed");
+      expect(row?.terminalAt).toBeString();
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("open-orders route rehydrates active Trigger-backed conditional orders", async () => {
+    const { env, sqlite } = createExecEnv();
+    try {
+      seedConditionalOrder(sqlite, {
+        requestId: "execreq_trigger_list_123456",
+      });
+      fetchHandler = async (input) => {
+        const url = readUrl(input);
+        if (url.pathname.endsWith("/trigger/v1/getTriggerOrders")) {
+          return responseJson({
+            orders: [
+              {
+                order: "order_pubkey_1",
+                status: "Open",
+                makingAmount: "1000000",
+                takingAmount: "6666666",
+              },
+            ],
+            totalOrders: 1,
+            page: 1,
+          });
+        }
+        throw new Error(`unexpected fetch ${url.toString()}`);
+      };
+
+      const response = await worker.fetch(
+        new Request("http://localhost/api/terminal/open-orders", {
+          headers: {
+            authorization: "Bearer test-token",
+          },
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        orders?: Array<{
+          requestId?: string;
+          pairId?: string;
+          status?: string;
+          orderType?: string;
+        }>;
+      };
+      expect(body.orders?.[0]?.requestId).toBe("execreq_trigger_list_123456");
+      expect(body.orders?.[0]?.pairId).toBe("SOL/USDC");
+      expect(body.orders?.[0]?.status).toBe("working");
+      expect(body.orders?.[0]?.orderType).toBe("limit");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("cancel route cancels tracked Trigger orders and terminalizes the request", async () => {
+    const { env, sqlite } = createExecEnv();
+    try {
+      const requestId = seedConditionalOrder(sqlite, {
+        requestId: "execreq_trigger_cancel_123456",
+      });
+      fetchHandler = async (input, init) => {
+        const url = readUrl(input);
+        if (url.pathname.endsWith("/trigger/v1/getTriggerOrders")) {
+          return responseJson({
+            orders: [
+              {
+                order: "order_pubkey_1",
+                status: "Open",
+                makingAmount: "1000000",
+                takingAmount: "6666666",
+              },
+            ],
+            totalOrders: 1,
+            page: 1,
+          });
+        }
+        if (url.pathname.endsWith("/trigger/v1/cancelOrder")) {
+          return responseJson({
+            transaction: "cancel-trigger-tx",
+            requestId: "cancel_req_1",
+            order: "order_pubkey_1",
+          });
+        }
+        if (url.origin === "https://rpc.test") {
+          const method = readRpcMethod(init);
+          if (method === "simulateTransaction") {
+            return responseJson({
+              jsonrpc: "2.0",
+              id: "1",
+              result: {
+                value: {
+                  err: null,
+                },
+              },
+            });
+          }
+          if (method === "sendTransaction") {
+            return responseJson({
+              jsonrpc: "2.0",
+              id: "1",
+              result: "cancel-signature-1",
+            });
+          }
+          if (method === "getSignatureStatuses") {
+            return responseJson({
+              jsonrpc: "2.0",
+              id: "1",
+              result: {
+                value: [
+                  {
+                    confirmationStatus: "confirmed",
+                    err: null,
+                  },
+                ],
+              },
+            });
+          }
+        }
+        throw new Error(`unexpected fetch ${url.toString()}`);
+      };
+
+      const response = await worker.fetch(
+        new Request(
+          `http://localhost/api/terminal/open-orders/${requestId}/cancel`,
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer test-token",
+            },
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        cancelled?: boolean;
+        lifecycle?: { orderState?: string };
+        signature?: string;
+        status?: { state?: string; terminal?: boolean };
+      };
+      expect(body.cancelled).toBe(true);
+      expect(body.lifecycle?.orderState).toBe("cancelled");
+      expect(body.signature).toBe("cancel-signature-1");
+      expect(body.status?.state).toBe("failed");
+      expect(body.status?.terminal).toBe(true);
+      const requestRow = sqlite
+        .query("SELECT status FROM execution_requests WHERE request_id = ?1")
+        .get(requestId) as { status?: string } | undefined;
+      expect(requestRow?.status).toBe("failed");
+      const receiptRow = sqlite
+        .query(
+          "SELECT finalized_status as finalizedStatus, signature FROM execution_receipts WHERE request_id = ?1",
+        )
+        .get(requestId) as
+        | { finalizedStatus?: string; signature?: string }
+        | undefined;
+      expect(receiptRow?.finalizedStatus).toBe("failed");
+      expect(receiptRow?.signature).toBe("cancel-signature-1");
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/tests/unit/worker_terminal_open_orders_route.test.ts
+++ b/tests/unit/worker_terminal_open_orders_route.test.ts
@@ -314,6 +314,60 @@ function seedConditionalOrder(
   return requestId;
 }
 
+function seedExecutionRequestOnly(
+  db: Database,
+  input: {
+    requestId: string;
+    actorId?: string;
+    intentFamily: string;
+    instrumentId?: string;
+    side?: "buy" | "sell";
+    status?: string;
+    receivedAt: string;
+    terminalAt?: string | null;
+  },
+): void {
+  const metadata = {
+    source: "TERMINAL",
+    reason: `${input.intentFamily} seed`,
+    intent: {
+      family: input.intentFamily,
+      marketType: "spot",
+      venueKey: "jupiter",
+      instrumentId: input.instrumentId ?? "SOL/USDC",
+      side: input.side ?? "buy",
+    },
+  };
+  db.query(
+    `INSERT INTO execution_requests (
+      request_id,
+      idempotency_scope,
+      idempotency_key,
+      payload_hash,
+      actor_type,
+      actor_id,
+      mode,
+      lane,
+      status,
+      status_reason,
+      metadata_json,
+      received_at,
+      validated_at,
+      terminal_at
+    ) VALUES (?1, 'authenticated', ?2, ?3, 'privy_user', ?4, 'privy_execute', 'safe', ?5, NULL, ?6, ?7, ?8, ?9)`,
+  ).run(
+    input.requestId,
+    `idem-${input.requestId}`,
+    `hash-${input.requestId}`,
+    input.actorId ?? "user_1",
+    input.status ?? "landed",
+    JSON.stringify(metadata),
+    input.receivedAt,
+    input.receivedAt,
+    input.terminalAt ?? input.receivedAt,
+  );
+}
+
 function responseJson(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -400,6 +454,67 @@ describe("worker terminal open orders and Trigger lifecycle routes", () => {
     }
   });
 
+  test("status route paginates active Trigger pages until the tracked order is found", async () => {
+    const { env, sqlite } = createExecEnv();
+    try {
+      const requestId = seedConditionalOrder(sqlite, {
+        requestId: "execreq_trigger_active_page_2",
+      });
+      const seenPages: string[] = [];
+      fetchHandler = async (input) => {
+        const url = readUrl(input);
+        expect(url.toString()).toContain("/trigger/v1/getTriggerOrders");
+        expect(url.searchParams.get("orderStatus")).toBe("active");
+        const page = url.searchParams.get("page") ?? "1";
+        seenPages.push(page);
+        if (page === "1") {
+          return responseJson({
+            orders: [
+              {
+                order: "other-order",
+                status: "Open",
+              },
+            ],
+            totalOrders: 2,
+            page: 1,
+          });
+        }
+        if (page === "2") {
+          return responseJson({
+            orders: [
+              {
+                order: "order_pubkey_1",
+                status: "Open",
+                makingAmount: "1000000",
+                takingAmount: "6666666",
+                openTx: "open-sig-2",
+              },
+            ],
+            totalOrders: 2,
+            page: 2,
+          });
+        }
+        throw new Error(`unexpected active page ${page}`);
+      };
+
+      const response = await worker.fetch(
+        new Request(`http://localhost/api/x402/exec/status/${requestId}`),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        lifecycle?: { orderState?: string };
+        status?: { state?: string };
+      };
+      expect(body.status?.state).toBe("dispatched");
+      expect(body.lifecycle?.orderState).toBe("open");
+      expect(seenPages).toEqual(["1", "2"]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
   test("receipt route finalizes filled Trigger orders during reconciliation", async () => {
     const { env, sqlite } = createExecEnv();
     try {
@@ -458,6 +573,82 @@ describe("worker terminal open orders and Trigger lifecycle routes", () => {
     }
   });
 
+  test("receipt route paginates Trigger history until the tracked order is found", async () => {
+    const { env, sqlite } = createExecEnv();
+    try {
+      const requestId = seedConditionalOrder(sqlite, {
+        requestId: "execreq_trigger_history_page_2",
+      });
+      const seenHistoryPages: string[] = [];
+      fetchHandler = async (input) => {
+        const url = readUrl(input);
+        if (url.pathname.endsWith("/trigger/v1/getTriggerOrders")) {
+          const orderStatus = url.searchParams.get("orderStatus");
+          const page = url.searchParams.get("page") ?? "1";
+          if (orderStatus === "active") {
+            return responseJson({ orders: [], totalOrders: 0, page: 1 });
+          }
+          if (orderStatus === "history") {
+            seenHistoryPages.push(page);
+            if (page === "1") {
+              return responseJson({
+                orders: [
+                  {
+                    order: "other-history-order",
+                    status: "Filled",
+                    makingAmount: "1000000",
+                    takingAmount: "6666666",
+                    remainingMakingAmount: "0",
+                    closeTx: "fill-sig-other",
+                  },
+                ],
+                totalOrders: 2,
+                page: 1,
+              });
+            }
+            if (page === "2") {
+              return responseJson({
+                orders: [
+                  {
+                    order: "order_pubkey_1",
+                    status: "Filled",
+                    makingAmount: "1000000",
+                    takingAmount: "6666666",
+                    remainingMakingAmount: "0",
+                    closeTx: "fill-sig-2",
+                  },
+                ],
+                totalOrders: 2,
+                page: 2,
+              });
+            }
+          }
+        }
+        throw new Error(`unexpected fetch ${url.toString()}`);
+      };
+
+      const response = await worker.fetch(
+        new Request(`http://localhost/api/x402/exec/receipt/${requestId}`),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        ready?: boolean;
+        receipt?: {
+          outcome?: { status?: string };
+          lifecycle?: { orderState?: string };
+        };
+      };
+      expect(body.ready).toBe(true);
+      expect(body.receipt?.outcome?.status).toBe("finalized");
+      expect(body.receipt?.lifecycle?.orderState).toBe("filled");
+      expect(seenHistoryPages).toEqual(["1", "2"]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
   test("open-orders route rehydrates active Trigger-backed conditional orders", async () => {
     const { env, sqlite } = createExecEnv();
     try {
@@ -505,6 +696,64 @@ describe("worker terminal open orders and Trigger lifecycle routes", () => {
       expect(body.orders?.[0]?.pairId).toBe("SOL/USDC");
       expect(body.orders?.[0]?.status).toBe("working");
       expect(body.orders?.[0]?.orderType).toBe("limit");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("open-orders route still returns older active conditional orders behind newer executions", async () => {
+    const { env, sqlite } = createExecEnv();
+    try {
+      seedConditionalOrder(sqlite, {
+        requestId: "execreq_trigger_oldest_open",
+      });
+      for (let index = 0; index < 95; index += 1) {
+        const minute = String(index % 60).padStart(2, "0");
+        seedExecutionRequestOnly(sqlite, {
+          requestId: `execreq_spot_swap_${index}`,
+          intentFamily: "spot_swap",
+          receivedAt: `2026-03-04T03:${minute}:00.000Z`,
+        });
+      }
+      fetchHandler = async (input) => {
+        const url = readUrl(input);
+        if (url.pathname.endsWith("/trigger/v1/getTriggerOrders")) {
+          return responseJson({
+            orders: [
+              {
+                order: "order_pubkey_1",
+                status: "Open",
+                makingAmount: "1000000",
+                takingAmount: "6666666",
+              },
+            ],
+            totalOrders: 1,
+            page: 1,
+          });
+        }
+        throw new Error(`unexpected fetch ${url.toString()}`);
+      };
+
+      const response = await worker.fetch(
+        new Request("http://localhost/api/terminal/open-orders", {
+          headers: {
+            authorization: "Bearer test-token",
+          },
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        orders?: Array<{
+          requestId?: string;
+        }>;
+      };
+      expect(
+        body.orders?.some(
+          (order) => order.requestId === "execreq_trigger_oldest_open",
+        ),
+      ).toBe(true);
     } finally {
       sqlite.close();
     }

--- a/tests/unit/worker_terminal_open_orders_route.test.ts
+++ b/tests/unit/worker_terminal_open_orders_route.test.ts
@@ -373,7 +373,6 @@ beforeEach(() => {
 
 afterAll(() => {
   globalThis.fetch = originalFetch;
-  mock.restore();
 });
 
 describe("worker terminal open orders and Trigger lifecycle routes", () => {

--- a/tests/unit/worker_trade_swap_wrapper_route.test.ts
+++ b/tests/unit/worker_trade_swap_wrapper_route.test.ts
@@ -31,6 +31,27 @@ const findUserByPrivyUserIdMock = mock(async () => ({
   degenAcknowledgedAt: null,
   createdAt: "2026-03-03T00:00:00.000Z",
 }));
+const findUserByIdMock = mock(async (_env: unknown, id: string) => ({
+  id,
+  privyUserId: `did:privy:${id}`,
+  onboardingStatus: "active",
+  profile: null,
+  signerType: "privy",
+  privyWalletId:
+    id === "user_runtime_managed" ? "wallet_runtime_managed" : "wallet_1",
+  walletAddress:
+    id === "user_runtime_managed"
+      ? "6F6A1zpGpRGmqrXpqgBFYGjC9WFo6iovrRVYoJNBHZqF"
+      : "11111111111111111111111111111111",
+  walletMigratedAt: "2026-03-03T00:00:00.000Z",
+  experienceLevel: "beginner",
+  levelSource: "auto",
+  onboardingCompletedAt: "2026-03-03T00:00:00.000Z",
+  onboardingVersion: 1,
+  feedSeedVersion: 1,
+  degenAcknowledgedAt: null,
+  createdAt: "2026-03-03T00:00:00.000Z",
+}));
 const upsertUserMock = mock(async () =>
   findUserByPrivyUserIdMock("did:privy:user_1"),
 );
@@ -58,6 +79,7 @@ mock.module("../../apps/worker/src/auth", () => ({
   requireUser: requireUserMock,
 }));
 mock.module("../../apps/worker/src/users_db", () => ({
+  findUserById: findUserByIdMock,
   findUserByPrivyUserId: findUserByPrivyUserIdMock,
   upsertUser: upsertUserMock,
   setUserWallet: setUserWalletMock,
@@ -149,6 +171,7 @@ describe("worker trade swap compatibility wrapper route", () => {
 
   beforeEach(() => {
     requireUserMock.mockClear();
+    findUserByIdMock.mockClear();
     findUserByPrivyUserIdMock.mockClear();
     upsertUserMock.mockClear();
     setUserWalletMock.mockClear();

--- a/tests/unit/worker_trade_swap_wrapper_route.test.ts
+++ b/tests/unit/worker_trade_swap_wrapper_route.test.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import type { Env } from "../../apps/worker/src/types";
@@ -165,10 +165,6 @@ function createTradeSwapEnv(): { env: Env; sqlite: Database } {
 }
 
 describe("worker trade swap compatibility wrapper route", () => {
-  afterAll(() => {
-    mock.restore();
-  });
-
   beforeEach(() => {
     requireUserMock.mockClear();
     findUserByIdMock.mockClear();

--- a/tests/unit/worker_x402_exec_receipt_route.test.ts
+++ b/tests/unit/worker_x402_exec_receipt_route.test.ts
@@ -30,6 +30,27 @@ const findUserByPrivyUserIdMock = mock(async () => ({
   degenAcknowledgedAt: null,
   createdAt: "2026-03-03T00:00:00.000Z",
 }));
+const findUserByIdMock = mock(async (_env: unknown, id: string) => ({
+  id,
+  privyUserId: `did:privy:${id}`,
+  onboardingStatus: "active",
+  profile: null,
+  signerType: "privy",
+  privyWalletId:
+    id === "user_runtime_managed" ? "wallet_runtime_managed" : "wallet_1",
+  walletAddress:
+    id === "user_runtime_managed"
+      ? "6F6A1zpGpRGmqrXpqgBFYGjC9WFo6iovrRVYoJNBHZqF"
+      : "11111111111111111111111111111111",
+  walletMigratedAt: "2026-03-03T00:00:00.000Z",
+  experienceLevel: "beginner",
+  levelSource: "auto",
+  onboardingCompletedAt: "2026-03-03T00:00:00.000Z",
+  onboardingVersion: 1,
+  feedSeedVersion: 1,
+  degenAcknowledgedAt: null,
+  createdAt: "2026-03-03T00:00:00.000Z",
+}));
 const upsertUserMock = mock(async () =>
   findUserByPrivyUserIdMock("did:privy:user_1"),
 );
@@ -57,6 +78,7 @@ mock.module("../../apps/worker/src/auth", () => ({
   requireUser: requireUserMock,
 }));
 mock.module("../../apps/worker/src/users_db", () => ({
+  findUserById: findUserByIdMock,
   findUserByPrivyUserId: findUserByPrivyUserIdMock,
   upsertUser: upsertUserMock,
   setUserWallet: setUserWalletMock,
@@ -164,6 +186,7 @@ function createExecReceiptEnv(): {
 describe("worker x402 exec receipt route", () => {
   beforeEach(() => {
     requireUserMock.mockClear();
+    findUserByIdMock.mockClear();
     findUserByPrivyUserIdMock.mockClear();
     upsertUserMock.mockClear();
     setUserWalletMock.mockClear();

--- a/tests/unit/worker_x402_exec_status_route.test.ts
+++ b/tests/unit/worker_x402_exec_status_route.test.ts
@@ -30,6 +30,27 @@ const findUserByPrivyUserIdMock = mock(async () => ({
   degenAcknowledgedAt: null,
   createdAt: "2026-03-03T00:00:00.000Z",
 }));
+const findUserByIdMock = mock(async (_env: unknown, id: string) => ({
+  id,
+  privyUserId: `did:privy:${id}`,
+  onboardingStatus: "active",
+  profile: null,
+  signerType: "privy",
+  privyWalletId:
+    id === "user_runtime_managed" ? "wallet_runtime_managed" : "wallet_1",
+  walletAddress:
+    id === "user_runtime_managed"
+      ? "6F6A1zpGpRGmqrXpqgBFYGjC9WFo6iovrRVYoJNBHZqF"
+      : "11111111111111111111111111111111",
+  walletMigratedAt: "2026-03-03T00:00:00.000Z",
+  experienceLevel: "beginner",
+  levelSource: "auto",
+  onboardingCompletedAt: "2026-03-03T00:00:00.000Z",
+  onboardingVersion: 1,
+  feedSeedVersion: 1,
+  degenAcknowledgedAt: null,
+  createdAt: "2026-03-03T00:00:00.000Z",
+}));
 const upsertUserMock = mock(async () =>
   findUserByPrivyUserIdMock("did:privy:user_1"),
 );
@@ -57,6 +78,7 @@ mock.module("../../apps/worker/src/auth", () => ({
   requireUser: requireUserMock,
 }));
 mock.module("../../apps/worker/src/users_db", () => ({
+  findUserById: findUserByIdMock,
   findUserByPrivyUserId: findUserByPrivyUserIdMock,
   upsertUser: upsertUserMock,
   setUserWallet: setUserWalletMock,
@@ -145,6 +167,7 @@ function createExecStatusEnv(): { env: Env; sqlite: Database } {
 describe("worker x402 exec status route", () => {
   beforeEach(() => {
     requireUserMock.mockClear();
+    findUserByIdMock.mockClear();
     findUserByPrivyUserIdMock.mockClear();
     upsertUserMock.mockClear();
     setUserWalletMock.mockClear();

--- a/tests/unit/worker_x402_exec_submit_route.test.ts
+++ b/tests/unit/worker_x402_exec_submit_route.test.ts
@@ -32,6 +32,27 @@ const findUserByPrivyUserIdMock = mock(async () => ({
   degenAcknowledgedAt: null,
   createdAt: "2026-03-03T00:00:00.000Z",
 }));
+const findUserByIdMock = mock(async (_env: unknown, id: string) => ({
+  id,
+  privyUserId: `did:privy:${id}`,
+  onboardingStatus: "active",
+  profile: null,
+  signerType: "privy",
+  privyWalletId:
+    id === "user_runtime_managed" ? "wallet_runtime_managed" : "wallet_1",
+  walletAddress:
+    id === "user_runtime_managed"
+      ? "6F6A1zpGpRGmqrXpqgBFYGjC9WFo6iovrRVYoJNBHZqF"
+      : "11111111111111111111111111111111",
+  walletMigratedAt: "2026-03-03T00:00:00.000Z",
+  experienceLevel: "beginner",
+  levelSource: "auto",
+  onboardingCompletedAt: "2026-03-03T00:00:00.000Z",
+  onboardingVersion: 1,
+  feedSeedVersion: 1,
+  degenAcknowledgedAt: null,
+  createdAt: "2026-03-03T00:00:00.000Z",
+}));
 const upsertUserMock = mock(async () =>
   findUserByPrivyUserIdMock("did:privy:user_1"),
 );
@@ -59,6 +80,7 @@ mock.module("../../apps/worker/src/auth", () => ({
   requireUser: requireUserMock,
 }));
 mock.module("../../apps/worker/src/users_db", () => ({
+  findUserById: findUserByIdMock,
   findUserByPrivyUserId: findUserByPrivyUserIdMock,
   upsertUser: upsertUserMock,
   setUserWallet: setUserWalletMock,
@@ -213,6 +235,7 @@ function execErrorDetails(payload: unknown): Record<string, unknown> | null {
 describe("worker x402 exec submit scaffold route", () => {
   beforeEach(() => {
     requireUserMock.mockClear();
+    findUserByIdMock.mockClear();
     findUserByPrivyUserIdMock.mockClear();
     upsertUserMock.mockClear();
     setUserWalletMock.mockClear();

--- a/tests/unit/worker_x402_exec_submit_route.test.ts
+++ b/tests/unit/worker_x402_exec_submit_route.test.ts
@@ -787,6 +787,171 @@ describe("worker x402 exec submit scaffold route", () => {
     }
   });
 
+  test("accepts v2 conditional spot orders on the safe Jupiter lane", async () => {
+    const { env, sqlite } = createExecSubmitEnv();
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/x402/exec/submit", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer mock-token",
+            "idempotency-key": "idem-privy-v2-trigger-1",
+          },
+          body: JSON.stringify({
+            schemaVersion: "v2",
+            mode: "privy_execute",
+            lane: "safe",
+            metadata: {
+              source: "TERMINAL",
+              reason: "Limit order coverage",
+            },
+            privyExecute: {
+              wallet: "11111111111111111111111111111111",
+              intent: {
+                family: "conditional_spot_order",
+                venueKey: "jupiter",
+                marketType: "spot",
+                instrumentId: "SOL/USDC",
+                side: "buy",
+                quantityAtomic: "1000000",
+              },
+              options: {
+                orderType: "limit",
+                timeInForce: "gtc",
+                limitPriceAtomic: "150000000",
+              },
+            },
+          }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        ok?: boolean;
+        requestId?: string;
+        status?: { state?: string; terminal?: boolean };
+      };
+      expect(body.ok).toBe(true);
+      expect(body.requestId).toBeString();
+      expect(body.status?.state).toBe("validated");
+      expect(body.status?.terminal).toBe(false);
+
+      const row = sqlite
+        .query(
+          "SELECT lane, metadata_json as metadataJson FROM execution_requests WHERE request_id = ?1 LIMIT 1",
+        )
+        .get(String(body.requestId)) as
+        | { lane?: string; metadataJson?: string }
+        | undefined;
+      expect(row?.lane).toBe("safe");
+      const metadata = JSON.parse(String(row?.metadataJson ?? "{}")) as {
+        intent?: { family?: string; instrumentId?: string; venueKey?: string };
+        laneResolution?: { adapter?: string };
+      };
+      expect(metadata.intent?.family).toBe("conditional_spot_order");
+      expect(metadata.intent?.instrumentId).toBe("SOL/USDC");
+      expect(metadata.intent?.venueKey).toBe("jupiter");
+      expect(metadata.laneResolution?.adapter).toBe("jupiter");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("rejects v2 conditional spot orders that request a non-Jupiter venue", async () => {
+    const { env, sqlite } = createExecSubmitEnv();
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/x402/exec/submit", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer mock-token",
+            "idempotency-key": "idem-privy-v2-trigger-venue-1",
+          },
+          body: JSON.stringify({
+            schemaVersion: "v2",
+            mode: "privy_execute",
+            lane: "safe",
+            privyExecute: {
+              wallet: "11111111111111111111111111111111",
+              intent: {
+                family: "conditional_spot_order",
+                venueKey: "phoenix",
+                marketType: "spot",
+                instrumentId: "SOL/USDC",
+                side: "buy",
+                quantityAtomic: "1000000",
+              },
+              options: {
+                orderType: "limit",
+                limitPriceAtomic: "150000000",
+              },
+            },
+          }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(execErrorCode(body)).toBe("invalid-request");
+      expect(execErrorReason(body)).toBe("unsupported-venue-key:phoenix");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("rejects v2 conditional spot orders on non-safe lanes", async () => {
+    const { env, sqlite } = createExecSubmitEnv();
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/x402/exec/submit", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer mock-token",
+            "idempotency-key": "idem-privy-v2-trigger-lane-1",
+          },
+          body: JSON.stringify({
+            schemaVersion: "v2",
+            mode: "privy_execute",
+            lane: "protected",
+            privyExecute: {
+              wallet: "11111111111111111111111111111111",
+              intent: {
+                family: "conditional_spot_order",
+                venueKey: "jupiter",
+                marketType: "spot",
+                instrumentId: "SOL/USDC",
+                side: "buy",
+                quantityAtomic: "1000000",
+              },
+              options: {
+                orderType: "limit",
+                limitPriceAtomic: "150000000",
+              },
+            },
+          }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(execErrorCode(body)).toBe("unsupported-lane");
+      expect(execErrorReason(body)).toBe(
+        "conditional-orders-require-safe-lane:jito_bundle",
+      );
+    } finally {
+      sqlite.close();
+    }
+  });
+
   test("rejects v2 spot swaps that request an unsupported venue key on the public submit path", async () => {
     const { env, sqlite } = createExecSubmitEnv();
     try {


### PR DESCRIPTION
Fixes #366

## Summary
- add a Jupiter Trigger-backed `conditional_spot_order` execution path with create, reconciliation, receipt assembly, and cancel support in the Worker
- expose authenticated terminal open-order and cancel routes, plus status and receipt reconciliation for tracked Trigger orders
- wire the portal trade ticket and open-orders panel to the real execution APIs instead of the session-local conditional-order queue

## Proof Bundle
### Validation
- `bun run lint` ✅
- `bun run typecheck` ✅
- `bun test tests/unit/worker_terminal_open_orders_route.test.ts tests/unit/worker_x402_exec_submit_route.test.ts tests/unit/worker_execution_router.test.ts tests/unit/worker_x402_exec_status_route.test.ts tests/unit/worker_x402_exec_receipt_route.test.ts tests/unit/portal_terminal_open_orders.test.ts tests/unit/worker_execution_jupiter_trigger.test.ts` ✅
- `bun test tests/integration/terminal_execution_e2e.integration.test.ts` ✅

### Preview Or Local URLs
- local worker contract paths exercised by the proof suite: `http://localhost/api/x402/exec/status/:requestId`, `http://localhost/api/x402/exec/receipt/:requestId`, `http://localhost/api/terminal/open-orders`, and `http://localhost/api/terminal/open-orders/:requestId/cancel`
- no deployed preview was created for this branch

### Browser Artifacts
- not captured; the repo does not yet have an authenticated browser proof harness for terminal conditional-order flows, so this PR relies on focused worker, portal model, and terminal integration tests instead

### Benchmark Delta
- not applicable; this change adds order-lifecycle and terminal wiring, but no benchmark-sensitive hot-path algorithm changes

### Risks And Follow-ups
- Trigger-backed spot orders are intentionally constrained to the `safe` lane, `gtc`, and no `postOnly`, `reduceOnly`, or bracket TP/SL yet
- the terminal open-orders panel now reflects remote order state and supports cancel, but amend remains out of scope until the venue substrate for it exists
