### PR TITLE
Add Jupiter composed instruction plans (#367)

### DIFF
--- a/apps/worker/src/execution/jupiter_composed_plan.ts
+++ b/apps/worker/src/execution/jupiter_composed_plan.ts
@@ -1,0 +1,321 @@
+import {
+  ComputeBudgetProgram,
+  PublicKey,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import type {
+  JupiterQuoteResponse,
+  JupiterSerializedInstruction,
+} from "../jupiter";
+import { evaluateOracleReferencePriceGuard } from "../oracle_reference";
+import type { ExecutionConfig } from "../types";
+import type { ExecuteSwapInput } from "./types";
+
+const COMPUTE_BUDGET_PROGRAM_ID = "ComputeBudget111111111111111111111111111111";
+
+export type JupiterComposedPlanSummary = {
+  mode: "instructions";
+  routeHopCount: number;
+  routeLabels: string[];
+  instructionCount: number;
+  computeBudgetInstructionCount: number;
+  setupInstructionCount: number;
+  cleanupInstructionCount: number;
+  otherInstructionCount: number;
+  addressLookupTableCount: number;
+  addressLookupTableAddresses: string[];
+  computeUnitLimit: number | null;
+  computeUnitPriceMicroLamports: string | null;
+};
+
+export type BuiltJupiterComposedPlan = {
+  serializedBase64: string;
+  usedQuote: JupiterQuoteResponse;
+  txBuiltAt: string;
+  lastValidBlockHeight: number;
+  summary: JupiterComposedPlanSummary;
+  referenceGuard: Awaited<ReturnType<typeof evaluateOracleReferencePriceGuard>>;
+};
+
+function readsTruthyExecutionParam(value: unknown): boolean {
+  if (value === true) return true;
+  if (typeof value !== "string") return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "on";
+}
+
+export function shouldUseJupiterComposedPlan(input: ExecuteSwapInput): boolean {
+  return (
+    readsTruthyExecutionParam(input.execution?.params?.composePlan) ||
+    readsTruthyExecutionParam(input.execution?.params?.useSwapInstructions) ||
+    String(input.execution?.params?.transactionShape ?? "")
+      .trim()
+      .toLowerCase() === "instructions"
+  );
+}
+
+function encodeBase64Bytes(value: Uint8Array): string {
+  let binary = "";
+  for (const item of value) {
+    binary += String.fromCharCode(item);
+  }
+  return btoa(binary);
+}
+
+function decodeBase64Bytes(value: string): Uint8Array {
+  const binary = atob(value);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    out[i] = binary.charCodeAt(i);
+  }
+  return out;
+}
+
+function toTransactionInstruction(
+  input: JupiterSerializedInstruction,
+): TransactionInstruction {
+  return new TransactionInstruction({
+    programId: new PublicKey(input.programId),
+    keys: (Array.isArray(input.accounts) ? input.accounts : []).map(
+      (account) => ({
+        pubkey: new PublicKey(account.pubkey),
+        isSigner: Boolean(account.isSigner),
+        isWritable: Boolean(account.isWritable),
+      }),
+    ),
+    data: decodeBase64Bytes(String(input.data ?? "")),
+  });
+}
+
+function readInstructionDiscriminator(
+  input: JupiterSerializedInstruction,
+): number | null {
+  if (input.programId !== COMPUTE_BUDGET_PROGRAM_ID) return null;
+  const data = decodeBase64Bytes(String(input.data ?? ""));
+  return data.length > 0 ? (data[0] ?? null) : null;
+}
+
+function parseOverrideInt(value: unknown): number | null {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+function appendComputeBudgetOverrides(input: {
+  instructions: JupiterSerializedInstruction[];
+  execution?: ExecutionConfig;
+}): TransactionInstruction[] {
+  const computeUnitLimit = parseOverrideInt(
+    input.execution?.params?.computeUnitLimit,
+  );
+  const priorityMicroLamports = parseOverrideInt(
+    input.execution?.params?.priorityMicroLamports,
+  );
+  const filtered = input.instructions.filter((instruction) => {
+    const discriminator = readInstructionDiscriminator(instruction);
+    if (computeUnitLimit !== null && discriminator === 2) {
+      return false;
+    }
+    if (priorityMicroLamports !== null && discriminator === 3) {
+      return false;
+    }
+    return true;
+  });
+  const output = filtered.map((instruction) =>
+    toTransactionInstruction(instruction),
+  );
+  if (computeUnitLimit !== null) {
+    output.push(
+      ComputeBudgetProgram.setComputeUnitLimit({
+        units: computeUnitLimit,
+      }),
+    );
+  }
+  if (priorityMicroLamports !== null) {
+    output.push(
+      ComputeBudgetProgram.setComputeUnitPrice({
+        microLamports: priorityMicroLamports,
+      }),
+    );
+  }
+  return output;
+}
+
+function readU32Le(data: Uint8Array, offset: number): number | null {
+  if (offset < 0 || offset + 4 > data.length) return null;
+  const view = new DataView(
+    data.buffer,
+    data.byteOffset + offset,
+    data.byteLength - offset,
+  );
+  return view.getUint32(0, true);
+}
+
+function readU64LeBigInt(data: Uint8Array, offset: number): bigint | null {
+  if (offset < 0 || offset + 8 > data.length) return null;
+  let value = 0n;
+  for (let index = 0; index < 8; index += 1) {
+    value += BigInt(data[offset + index] ?? 0) << (8n * BigInt(index));
+  }
+  return value;
+}
+
+function summarizeComputeBudget(
+  instructions: TransactionInstruction[],
+): Pick<
+  JupiterComposedPlanSummary,
+  "computeUnitLimit" | "computeUnitPriceMicroLamports"
+> {
+  let computeUnitLimit: number | null = null;
+  let computeUnitPriceMicroLamports: string | null = null;
+  for (const instruction of instructions) {
+    if (instruction.programId.toBase58() !== COMPUTE_BUDGET_PROGRAM_ID) {
+      continue;
+    }
+    const discriminator = instruction.data[0];
+    if (discriminator === 2) {
+      computeUnitLimit = readU32Le(instruction.data, 1);
+    } else if (discriminator === 3) {
+      const price = readU64LeBigInt(instruction.data, 1);
+      computeUnitPriceMicroLamports = price === null ? null : price.toString();
+    }
+  }
+  return {
+    computeUnitLimit,
+    computeUnitPriceMicroLamports,
+  };
+}
+
+function routeLabelsFromQuote(quote: JupiterQuoteResponse): string[] {
+  const labels = new Set<string>();
+  for (const hop of Array.isArray(quote.routePlan) ? quote.routePlan : []) {
+    const label = String(hop?.swapInfo?.label ?? "").trim();
+    if (label) labels.add(label);
+  }
+  return Array.from(labels);
+}
+
+function shouldAssembleComposedPlan(input: ExecuteSwapInput): boolean {
+  if (input.policy.simulateOnly) return true;
+  return input.runtimeMode === "shadow" || input.runtimeMode === "paper";
+}
+
+export function shouldFallbackToPrebuiltJupiterSwap(
+  input: ExecuteSwapInput,
+): boolean {
+  return (
+    shouldUseJupiterComposedPlan(input) && !shouldAssembleComposedPlan(input)
+  );
+}
+
+export async function buildJupiterComposedPlan(
+  input: ExecuteSwapInput,
+): Promise<BuiltJupiterComposedPlan> {
+  const priorityMicroLamports = parseOverrideInt(
+    input.execution?.params?.priorityMicroLamports,
+  );
+  const instructionsResponse = await input.jupiter.swapInstructions({
+    quoteResponse: input.quoteResponse,
+    userPublicKey: input.userPublicKey,
+    dynamicComputeUnitLimit: true,
+  });
+  const addressLookupTableAddresses = Array.from(
+    new Set(
+      (Array.isArray(instructionsResponse.addressLookupTableAddresses)
+        ? instructionsResponse.addressLookupTableAddresses
+        : []
+      )
+        .map((value) => String(value ?? "").trim())
+        .filter((value) => Boolean(value)),
+    ),
+  );
+  const lookupTableAccounts = await input.rpc.getAddressLookupTableAccounts(
+    addressLookupTableAddresses,
+  );
+  const latestBlockhash = await input.rpc.getLatestBlockhash(
+    input.policy.commitment,
+  );
+  const computeBudgetInstructions = appendComputeBudgetOverrides({
+    instructions: Array.isArray(instructionsResponse.computeBudgetInstructions)
+      ? instructionsResponse.computeBudgetInstructions
+      : [],
+    execution: input.execution,
+  });
+  const otherInstructions = (
+    Array.isArray(instructionsResponse.otherInstructions)
+      ? instructionsResponse.otherInstructions
+      : []
+  ).map((instruction) => toTransactionInstruction(instruction));
+  const setupInstructions = (
+    Array.isArray(instructionsResponse.setupInstructions)
+      ? instructionsResponse.setupInstructions
+      : []
+  ).map((instruction) => toTransactionInstruction(instruction));
+  const tokenLedgerInstruction = instructionsResponse.tokenLedgerInstruction
+    ? [toTransactionInstruction(instructionsResponse.tokenLedgerInstruction)]
+    : [];
+  const swapInstruction = toTransactionInstruction(
+    instructionsResponse.swapInstruction,
+  );
+  const cleanupInstructions = instructionsResponse.cleanupInstruction
+    ? [toTransactionInstruction(instructionsResponse.cleanupInstruction)]
+    : [];
+  const instructions = [
+    ...computeBudgetInstructions,
+    ...otherInstructions,
+    ...setupInstructions,
+    ...tokenLedgerInstruction,
+    swapInstruction,
+    ...cleanupInstructions,
+  ];
+  const compiledMessage = new TransactionMessage({
+    payerKey: new PublicKey(input.userPublicKey),
+    recentBlockhash: latestBlockhash.blockhash,
+    instructions,
+  }).compileToV0Message(lookupTableAccounts);
+  const transaction = new VersionedTransaction(compiledMessage);
+  transaction.signatures = Array.from(
+    { length: compiledMessage.header.numRequiredSignatures },
+    () => new Uint8Array(64),
+  );
+  const serializedBase64 = encodeBase64Bytes(transaction.serialize());
+  const computeBudget = summarizeComputeBudget(instructions);
+  const referenceGuard = await evaluateOracleReferencePriceGuard({
+    env: input.env,
+    mode: input.runtimeMode ?? "paper",
+    inputMint: input.quoteResponse.inputMint,
+    outputMint: input.quoteResponse.outputMint,
+    inputAmountAtomic: String(input.quoteResponse.inAmount ?? ""),
+    expectedOutputAmountAtomic: String(input.quoteResponse.outAmount ?? ""),
+    jupiter: input.jupiter,
+  });
+  return {
+    serializedBase64,
+    usedQuote: input.quoteResponse,
+    txBuiltAt: new Date().toISOString(),
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+    summary: {
+      mode: "instructions",
+      routeHopCount: Array.isArray(input.quoteResponse.routePlan)
+        ? input.quoteResponse.routePlan.length
+        : 0,
+      routeLabels: routeLabelsFromQuote(input.quoteResponse),
+      instructionCount: instructions.length,
+      computeBudgetInstructionCount: computeBudgetInstructions.length,
+      setupInstructionCount:
+        setupInstructions.length + tokenLedgerInstruction.length,
+      cleanupInstructionCount: cleanupInstructions.length,
+      otherInstructionCount: otherInstructions.length,
+      addressLookupTableCount: lookupTableAccounts.length,
+      addressLookupTableAddresses,
+      computeUnitLimit: computeBudget.computeUnitLimit,
+      computeUnitPriceMicroLamports:
+        priorityMicroLamports !== null
+          ? String(priorityMicroLamports)
+          : computeBudget.computeUnitPriceMicroLamports,
+    },
+    referenceGuard,
+  };
+}

--- a/apps/worker/src/execution/jupiter_executor.ts
+++ b/apps/worker/src/execution/jupiter_executor.ts
@@ -1,3 +1,8 @@
+import {
+  buildJupiterComposedPlan,
+  shouldFallbackToPrebuiltJupiterSwap,
+  shouldUseJupiterComposedPlan,
+} from "./jupiter_composed_plan";
 import { buildAndSignPrivySwapTransaction } from "./privy_swap_builder";
 import { evaluateSafeLaneTransaction } from "./safe_lane_policy";
 import type { ExecuteSwapInput, ExecuteSwapResult } from "./types";
@@ -5,6 +10,7 @@ import type { ExecuteSwapInput, ExecuteSwapResult } from "./types";
 type JupiterExecutorDeps = {
   buildAndSignPrivySwapTransaction?: typeof buildAndSignPrivySwapTransaction;
   evaluateSafeLaneTransaction?: typeof evaluateSafeLaneTransaction;
+  buildJupiterComposedPlan?: typeof buildJupiterComposedPlan;
 };
 
 function nowIso(): string {
@@ -41,22 +47,51 @@ function normalizeConfirmationStatus(
   return "error";
 }
 
+function routeLabelsFromQuote(input: ExecuteSwapInput): string[] {
+  const labels = new Set<string>();
+  for (const hop of Array.isArray(input.quoteResponse.routePlan)
+    ? input.quoteResponse.routePlan
+    : []) {
+    const label = String(hop?.swapInfo?.label ?? "").trim();
+    if (label) labels.add(label);
+  }
+  return Array.from(labels);
+}
+
+function buildPrebuiltFallbackMeta(
+  input: ExecuteSwapInput,
+): NonNullable<ExecuteSwapResult["executionMeta"]>["composedPlan"] | undefined {
+  if (!shouldFallbackToPrebuiltJupiterSwap(input)) {
+    return undefined;
+  }
+  return {
+    mode: "prebuilt_fallback",
+    fallbackReason: "live-composed-plan-disabled",
+    routeHopCount: Array.isArray(input.quoteResponse.routePlan)
+      ? input.quoteResponse.routePlan.length
+      : 0,
+    routeLabels: routeLabelsFromQuote(input),
+    instructionCount: 0,
+    computeBudgetInstructionCount: 0,
+    setupInstructionCount: 0,
+    cleanupInstructionCount: 0,
+    otherInstructionCount: 0,
+    addressLookupTableCount: 0,
+    computeUnitLimit: null,
+    computeUnitPriceMicroLamports: null,
+  };
+}
+
 export async function executeJupiterSwap(
   input: ExecuteSwapInput,
   deps: JupiterExecutorDeps = {},
 ): Promise<ExecuteSwapResult> {
   const route = "jupiter";
-  const {
-    env,
-    policy,
-    rpc,
-    jupiter,
-    quoteResponse,
-    userPublicKey,
-    privyWalletId,
-    log,
-    guardEnabled,
-  } = input;
+  const { env, policy, rpc, quoteResponse, log, guardEnabled } = input;
+  const safeLane = isSafeLaneExecution(input);
+  const evaluateSafeLane =
+    deps.evaluateSafeLaneTransaction ?? evaluateSafeLaneTransaction;
+  const fallbackComposedPlan = buildPrebuiltFallbackMeta(input);
 
   if (policy.dryRun) {
     return {
@@ -68,16 +103,221 @@ export async function executeJupiterSwap(
       executionMeta: {
         route,
         classification: "dry_run",
+        ...(fallbackComposedPlan
+          ? {
+              composedPlan: fallbackComposedPlan,
+            }
+          : {}),
       },
     };
   }
 
   if (guardEnabled) await guardEnabled();
+
+  if (
+    shouldUseJupiterComposedPlan(input) &&
+    !shouldFallbackToPrebuiltJupiterSwap(input)
+  ) {
+    const buildComposedPlan =
+      deps.buildJupiterComposedPlan ?? buildJupiterComposedPlan;
+    const composedPlan = await buildComposedPlan(input);
+    if (
+      composedPlan.referenceGuard.enabled &&
+      composedPlan.referenceGuard.verdict !== "allow"
+    ) {
+      const failedAt = nowIso();
+      return {
+        status: "simulate_error",
+        signature: null,
+        usedQuote: composedPlan.usedQuote,
+        refreshed: false,
+        lastValidBlockHeight: composedPlan.lastValidBlockHeight,
+        err: {
+          code: "policy-denied",
+          reason:
+            composedPlan.referenceGuard.reason ??
+            "reference-price-policy-denied",
+        },
+        executionMeta: {
+          route,
+          classification: "error",
+          referencePrice: {
+            verdict: composedPlan.referenceGuard.verdict,
+            reason: composedPlan.referenceGuard.reason,
+            executionPrice: composedPlan.referenceGuard.executionPrice,
+            executionDivergenceBps:
+              composedPlan.referenceGuard.executionDivergenceBps,
+            snapshot: composedPlan.referenceGuard.snapshot
+              ? (composedPlan.referenceGuard.snapshot as Record<
+                  string,
+                  unknown
+                >)
+              : null,
+          },
+          composedPlan: {
+            ...composedPlan.summary,
+          },
+          trace: {
+            txBuiltAt: composedPlan.txBuiltAt,
+            failedAt,
+          },
+        },
+      };
+    }
+
+    if (safeLane) {
+      const safeEvaluation = evaluateSafeLane({
+        env,
+        signedTransactionBase64: composedPlan.serializedBase64,
+      });
+      log(safeEvaluation.ok ? "info" : "warn", "safe lane tx guardrails", {
+        ok: safeEvaluation.ok,
+        reason: safeEvaluation.ok ? null : safeEvaluation.reason,
+        profile: safeEvaluation.profile,
+        limits: safeEvaluation.limits,
+      });
+      if (!safeEvaluation.ok) {
+        const failedAt = nowIso();
+        return {
+          status: "simulate_error",
+          signature: null,
+          usedQuote: composedPlan.usedQuote,
+          refreshed: false,
+          lastValidBlockHeight: composedPlan.lastValidBlockHeight,
+          err: {
+            code: "policy-denied",
+            reason: safeEvaluation.reason,
+            profile: safeEvaluation.profile,
+            limits: safeEvaluation.limits,
+          },
+          executionMeta: {
+            route,
+            classification: "error",
+            referencePrice: composedPlan.referenceGuard.enabled
+              ? {
+                  verdict: composedPlan.referenceGuard.verdict,
+                  reason: composedPlan.referenceGuard.reason,
+                  executionPrice: composedPlan.referenceGuard.executionPrice,
+                  executionDivergenceBps:
+                    composedPlan.referenceGuard.executionDivergenceBps,
+                  snapshot: composedPlan.referenceGuard.snapshot
+                    ? (composedPlan.referenceGuard.snapshot as Record<
+                        string,
+                        unknown
+                      >)
+                    : null,
+                }
+              : undefined,
+            composedPlan: {
+              ...composedPlan.summary,
+            },
+            trace: {
+              txBuiltAt: composedPlan.txBuiltAt,
+              failedAt,
+            },
+          },
+        };
+      }
+    }
+
+    const sim = await rpc.simulateTransactionBase64(
+      composedPlan.serializedBase64,
+      {
+        commitment: policy.commitment,
+        sigVerify: false,
+      },
+    );
+    const simulatedAt = nowIso();
+    const ok = !sim.err;
+    log(ok ? "info" : "warn", "composed plan simulated", {
+      ok,
+      err: sim.err ?? null,
+      unitsConsumed: sim.unitsConsumed ?? null,
+      lane: safeLane ? "safe" : "default",
+    });
+    if (!ok) {
+      return {
+        status: "simulate_error",
+        signature: null,
+        usedQuote: composedPlan.usedQuote,
+        refreshed: false,
+        lastValidBlockHeight: composedPlan.lastValidBlockHeight,
+        err: safeLane
+          ? {
+              code: "policy-denied",
+              reason: "safe-lane-simulation-failed",
+              simulationError: sim.err ?? null,
+            }
+          : (sim.err ?? null),
+        executionMeta: {
+          route,
+          classification: "error",
+          referencePrice: composedPlan.referenceGuard.enabled
+            ? {
+                verdict: composedPlan.referenceGuard.verdict,
+                reason: composedPlan.referenceGuard.reason,
+                executionPrice: composedPlan.referenceGuard.executionPrice,
+                executionDivergenceBps:
+                  composedPlan.referenceGuard.executionDivergenceBps,
+                snapshot: composedPlan.referenceGuard.snapshot
+                  ? (composedPlan.referenceGuard.snapshot as Record<
+                      string,
+                      unknown
+                    >)
+                  : null,
+              }
+            : undefined,
+          composedPlan: {
+            ...composedPlan.summary,
+            simulationUnitsConsumed: sim.unitsConsumed ?? null,
+          },
+          trace: {
+            txBuiltAt: composedPlan.txBuiltAt,
+            simulatedAt,
+            failedAt: simulatedAt,
+          },
+        },
+      };
+    }
+
+    return {
+      status: "simulated",
+      signature: null,
+      usedQuote: composedPlan.usedQuote,
+      refreshed: false,
+      lastValidBlockHeight: composedPlan.lastValidBlockHeight,
+      executionMeta: {
+        route,
+        classification: "simulated",
+        referencePrice: composedPlan.referenceGuard.enabled
+          ? {
+              verdict: composedPlan.referenceGuard.verdict,
+              reason: composedPlan.referenceGuard.reason,
+              executionPrice: composedPlan.referenceGuard.executionPrice,
+              executionDivergenceBps:
+                composedPlan.referenceGuard.executionDivergenceBps,
+              snapshot: composedPlan.referenceGuard.snapshot
+                ? (composedPlan.referenceGuard.snapshot as Record<
+                    string,
+                    unknown
+                  >)
+                : null,
+            }
+          : undefined,
+        composedPlan: {
+          ...composedPlan.summary,
+          simulationUnitsConsumed: sim.unitsConsumed ?? null,
+        },
+        trace: {
+          txBuiltAt: composedPlan.txBuiltAt,
+          simulatedAt,
+        },
+      },
+    };
+  }
+
   const buildAndSign =
     deps.buildAndSignPrivySwapTransaction ?? buildAndSignPrivySwapTransaction;
-  const evaluateSafeLane =
-    deps.evaluateSafeLaneTransaction ?? evaluateSafeLaneTransaction;
-
   const {
     signedBase64,
     usedQuote,
@@ -88,16 +328,15 @@ export async function executeJupiterSwap(
     env,
     policy,
     rpc,
-    jupiter,
+    jupiter: input.jupiter,
     quoteResponse,
-    userPublicKey,
-    privyWalletId,
+    userPublicKey: input.userPublicKey,
+    privyWalletId: input.privyWalletId,
     log,
     execution: input.execution,
     guardEnabled,
   });
 
-  const safeLane = isSafeLaneExecution(input);
   if (safeLane) {
     const safeEvaluation = evaluateSafeLane({
       env,
@@ -126,6 +365,11 @@ export async function executeJupiterSwap(
         executionMeta: {
           route,
           classification: "error",
+          ...(fallbackComposedPlan
+            ? {
+                composedPlan: fallbackComposedPlan,
+              }
+            : {}),
           trace: {
             txBuiltAt,
             failedAt: deniedAt,
@@ -170,6 +414,11 @@ export async function executeJupiterSwap(
         executionMeta: {
           route,
           classification: "error",
+          ...(fallbackComposedPlan
+            ? {
+                composedPlan: fallbackComposedPlan,
+              }
+            : {}),
           trace: {
             txBuiltAt,
             simulatedAt,
@@ -190,6 +439,11 @@ export async function executeJupiterSwap(
       executionMeta: {
         route,
         classification: "simulated",
+        ...(fallbackComposedPlan
+          ? {
+              composedPlan: fallbackComposedPlan,
+            }
+          : {}),
         trace: {
           txBuiltAt,
           ...(simulatedAt ? { simulatedAt } : {}),
@@ -241,6 +495,11 @@ export async function executeJupiterSwap(
             : status === "finalized"
               ? "finalized"
               : "error",
+      ...(fallbackComposedPlan
+        ? {
+            composedPlan: fallbackComposedPlan,
+          }
+        : {}),
       trace: {
         txBuiltAt,
         ...(simulatedAt ? { simulatedAt } : {}),

--- a/apps/worker/src/execution/types.ts
+++ b/apps/worker/src/execution/types.ts
@@ -153,6 +153,29 @@ export type ExecuteSwapResult = {
     settlementRef?: string | null;
     lifecycle?: ExecutionIntentLifecycleSnapshot;
     lowLatency?: LowLatencyExecutionMeta;
+    referencePrice?: {
+      verdict: "allow" | "pause" | "reject";
+      reason: string | null;
+      executionPrice: string | null;
+      executionDivergenceBps: number | null;
+      snapshot?: Record<string, unknown> | null;
+    };
+    composedPlan?: {
+      mode: "instructions" | "prebuilt_fallback";
+      fallbackReason?: string | null;
+      routeHopCount: number;
+      routeLabels: string[];
+      instructionCount: number;
+      computeBudgetInstructionCount: number;
+      setupInstructionCount: number;
+      cleanupInstructionCount: number;
+      otherInstructionCount: number;
+      addressLookupTableCount: number;
+      addressLookupTableAddresses?: string[];
+      computeUnitLimit: number | null;
+      computeUnitPriceMicroLamports: string | null;
+      simulationUnitsConsumed?: number | null;
+    };
     trace?: {
       txBuiltAt?: string;
       simulatedAt?: string;

--- a/apps/worker/src/jupiter.ts
+++ b/apps/worker/src/jupiter.ts
@@ -22,6 +22,29 @@ export type JupiterSwapResponse = {
   [k: string]: unknown;
 };
 
+export type JupiterInstructionAccount = {
+  pubkey: string;
+  isSigner: boolean;
+  isWritable: boolean;
+};
+
+export type JupiterSerializedInstruction = {
+  programId: string;
+  accounts: JupiterInstructionAccount[];
+  data: string;
+};
+
+export type JupiterSwapInstructionsResponse = {
+  tokenLedgerInstruction?: JupiterSerializedInstruction | null;
+  computeBudgetInstructions?: JupiterSerializedInstruction[];
+  setupInstructions?: JupiterSerializedInstruction[];
+  swapInstruction: JupiterSerializedInstruction;
+  cleanupInstruction?: JupiterSerializedInstruction | null;
+  otherInstructions?: JupiterSerializedInstruction[];
+  addressLookupTableAddresses?: string[];
+  [k: string]: unknown;
+};
+
 export type TokenInfo = {
   id: string;
   name?: string;
@@ -235,6 +258,57 @@ export class JupiterClient {
       throw new Error("Jupiter swap missing lastValidBlockHeight");
     }
     return parsed as JupiterSwapResponse;
+  }
+
+  async swapInstructions(request: {
+    quoteResponse: JupiterQuoteResponse;
+    userPublicKey: string;
+    dynamicComputeUnitLimit?: boolean;
+  }): Promise<JupiterSwapInstructionsResponse> {
+    const url = new URL("/swap/v1/swap-instructions", this.baseUrl);
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+    };
+    if (this.apiKey) headers["x-api-key"] = this.apiKey;
+    const response = await fetch(url.toString(), {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        quoteResponse: request.quoteResponse,
+        userPublicKey: request.userPublicKey,
+        wrapAndUnwrapSol: true,
+        dynamicComputeUnitLimit:
+          request.dynamicComputeUnitLimit !== undefined
+            ? request.dynamicComputeUnitLimit
+            : true,
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      const requestId =
+        response.headers.get("x-request-id") ??
+        response.headers.get("x-request-id".toLowerCase()) ??
+        "";
+      const idSuffix = requestId ? ` requestId=${requestId}` : "";
+      throw new Error(
+        `Jupiter swap-instructions failed: ${response.status}${idSuffix} ${body}`,
+      );
+    }
+
+    const data = (await response.json()) as unknown;
+    if (!data || typeof data !== "object" || Array.isArray(data)) {
+      throw new Error("Jupiter swap-instructions invalid response");
+    }
+    const parsed = data as Partial<JupiterSwapInstructionsResponse>;
+    if (
+      !parsed.swapInstruction ||
+      typeof parsed.swapInstruction !== "object" ||
+      Array.isArray(parsed.swapInstruction)
+    ) {
+      throw new Error("Jupiter swap-instructions missing swapInstruction");
+    }
+    return parsed as JupiterSwapInstructionsResponse;
   }
 
   async programIdToLabel(): Promise<Record<string, string>> {

--- a/apps/worker/src/solana_rpc.ts
+++ b/apps/worker/src/solana_rpc.ts
@@ -1,3 +1,4 @@
+import { AddressLookupTableAccount, PublicKey } from "@solana/web3.js";
 import type { Env } from "./types";
 
 type RpcError = {
@@ -66,6 +67,33 @@ export class SolanaRpc {
     return BigInt(result.value ?? 0);
   }
 
+  async getLatestBlockhash(
+    commitment?: "processed" | "confirmed" | "finalized",
+  ): Promise<{
+    blockhash: string;
+    lastValidBlockHeight: number;
+  }> {
+    const result = await this.request<{
+      value?: {
+        blockhash?: string;
+        lastValidBlockHeight?: number;
+      };
+    }>("getLatestBlockhash", commitment ? [{ commitment }] : []);
+    const blockhash = result.value?.blockhash;
+    const lastValidBlockHeight = result.value?.lastValidBlockHeight;
+    if (
+      typeof blockhash !== "string" ||
+      !blockhash.trim() ||
+      typeof lastValidBlockHeight !== "number"
+    ) {
+      throw new Error("rpc-invalid-latest-blockhash");
+    }
+    return {
+      blockhash: blockhash.trim(),
+      lastValidBlockHeight,
+    };
+  }
+
   async getSlot(
     commitment?: "processed" | "confirmed" | "finalized",
   ): Promise<number> {
@@ -128,6 +156,49 @@ export class SolanaRpc {
       }
     }
     return total;
+  }
+
+  async getAddressLookupTableAccounts(
+    addresses: string[],
+  ): Promise<AddressLookupTableAccount[]> {
+    const uniqueAddresses = Array.from(
+      new Set(
+        addresses
+          .map((value) => String(value ?? "").trim())
+          .filter((value) => Boolean(value)),
+      ),
+    );
+    if (uniqueAddresses.length < 1) {
+      return [];
+    }
+    const result = await this.request<{
+      value?: Array<{
+        data?: [string, string] | string;
+      } | null>;
+    }>("getMultipleAccounts", [uniqueAddresses, { encoding: "base64" }]);
+    const rows = Array.isArray(result.value) ? result.value : [];
+    const accounts: AddressLookupTableAccount[] = [];
+    for (let index = 0; index < uniqueAddresses.length; index += 1) {
+      const row = rows[index];
+      const encoded =
+        Array.isArray(row?.data) && typeof row.data[0] === "string"
+          ? row.data[0]
+          : typeof row?.data === "string"
+            ? row.data
+            : null;
+      if (!encoded) continue;
+      const raw = Uint8Array.from(atob(encoded), (value) =>
+        value.charCodeAt(0),
+      );
+      const state = AddressLookupTableAccount.deserialize(raw);
+      accounts.push(
+        new AddressLookupTableAccount({
+          key: new PublicKey(uniqueAddresses[index] as string),
+          state,
+        }),
+      );
+    }
+    return accounts;
   }
 
   async sendTransactionBase64(

--- a/tests/unit/worker_execution_jupiter.test.ts
+++ b/tests/unit/worker_execution_jupiter.test.ts
@@ -44,6 +44,43 @@ const buildAndSignPrivySwapTransactionMock = mock(async () => ({
   txBuiltAt: "2026-03-03T00:00:00.000Z",
 }));
 
+const buildJupiterComposedPlanMock = mock(async () => ({
+  serializedBase64: buildSignedSwapTxBase64(),
+  usedQuote: {
+    inputMint: "A",
+    outputMint: "B",
+    inAmount: "10",
+    outAmount: "11",
+    routePlan: [{ swapInfo: { label: "Jupiter" } }],
+  },
+  txBuiltAt: "2026-03-03T00:00:00.000Z",
+  lastValidBlockHeight: 54321,
+  summary: {
+    mode: "instructions" as const,
+    routeHopCount: 1,
+    routeLabels: ["Jupiter"],
+    instructionCount: 4,
+    computeBudgetInstructionCount: 1,
+    setupInstructionCount: 1,
+    cleanupInstructionCount: 1,
+    otherInstructionCount: 0,
+    addressLookupTableCount: 0,
+    addressLookupTableAddresses: [],
+    computeUnitLimit: 300000,
+    computeUnitPriceMicroLamports: "25000",
+  },
+  referenceGuard: {
+    enabled: true,
+    verdict: "allow" as const,
+    reason: null,
+    executionPrice: "1.1",
+    executionDivergenceBps: 12,
+    snapshot: {
+      instrumentKey: "A/B",
+    },
+  },
+}));
+
 const { executeJupiterSwap } = await import(
   "../../apps/worker/src/execution/jupiter_executor"
 );
@@ -51,6 +88,7 @@ const { executeJupiterSwap } = await import(
 describe("worker jupiter execution adapter", () => {
   beforeEach(() => {
     buildAndSignPrivySwapTransactionMock.mockClear();
+    buildJupiterComposedPlanMock.mockClear();
   });
 
   test("safe lane forces pre-dispatch simulation before submission", async () => {
@@ -283,5 +321,173 @@ describe("worker jupiter execution adapter", () => {
     expect(callOrder).toEqual(["simulate", "send", "confirm"]);
     expect(sendTransactionBase64).toHaveBeenCalledTimes(1);
     expect(simulateTransactionBase64).toHaveBeenCalledTimes(1);
+  });
+
+  test("paper mode can simulate a composed Jupiter instruction plan", async () => {
+    const simulateTransactionBase64 = mock(async () => ({
+      err: null,
+      unitsConsumed: 456789,
+    }));
+    const sendTransactionBase64 = mock(async () => "sig-paper");
+
+    const result = await executeJupiterSwap(
+      {
+        env: {} as Env,
+        runtimeMode: "paper",
+        policy: normalizePolicy({ commitment: "confirmed" }),
+        rpc: {
+          simulateTransactionBase64,
+          sendTransactionBase64,
+          confirmSignature: async () => ({ ok: true, status: "confirmed" }),
+        } as never,
+        jupiter: {} as never,
+        quoteResponse: {
+          inputMint: "A",
+          outputMint: "B",
+          inAmount: "1",
+          outAmount: "2",
+          routePlan: [{ swapInfo: { label: "Jupiter" } }],
+        },
+        userPublicKey: "11111111111111111111111111111111",
+        execution: {
+          adapter: "jupiter",
+          params: {
+            composePlan: true,
+          },
+        },
+        log: () => {},
+      },
+      {
+        buildJupiterComposedPlan: buildJupiterComposedPlanMock,
+      },
+    );
+
+    expect(result.status).toBe("simulated");
+    expect(sendTransactionBase64).not.toHaveBeenCalled();
+    expect(simulateTransactionBase64).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        sigVerify: false,
+      }),
+    );
+    expect(result.executionMeta?.referencePrice?.verdict).toBe("allow");
+    expect(result.executionMeta?.composedPlan).toMatchObject({
+      mode: "instructions",
+      routeHopCount: 1,
+      simulationUnitsConsumed: 456789,
+    });
+  });
+
+  test("composed plans fail closed when the reference guard rejects execution", async () => {
+    const simulateTransactionBase64 = mock(async () => ({
+      err: null,
+      unitsConsumed: 1234,
+    }));
+
+    buildJupiterComposedPlanMock.mockImplementationOnce(async () => ({
+      ...(await buildJupiterComposedPlanMock()),
+      referenceGuard: {
+        enabled: true,
+        verdict: "reject" as const,
+        reason: "reference-price-execution-divergence",
+        executionPrice: "1.4",
+        executionDivergenceBps: 600,
+        snapshot: {
+          instrumentKey: "A/B",
+        },
+      },
+    }));
+
+    const result = await executeJupiterSwap(
+      {
+        env: {} as Env,
+        runtimeMode: "paper",
+        policy: normalizePolicy({ commitment: "confirmed" }),
+        rpc: {
+          simulateTransactionBase64,
+          sendTransactionBase64: async () => "sig-paper",
+          confirmSignature: async () => ({ ok: true, status: "confirmed" }),
+        } as never,
+        jupiter: {} as never,
+        quoteResponse: {
+          inputMint: "A",
+          outputMint: "B",
+          inAmount: "1",
+          outAmount: "2",
+          routePlan: [{ swapInfo: { label: "Jupiter" } }],
+        },
+        userPublicKey: "11111111111111111111111111111111",
+        execution: {
+          adapter: "jupiter",
+          params: {
+            composePlan: true,
+          },
+        },
+        log: () => {},
+      },
+      {
+        buildJupiterComposedPlan: buildJupiterComposedPlanMock,
+      },
+    );
+
+    expect(result.status).toBe("simulate_error");
+    expect(simulateTransactionBase64).not.toHaveBeenCalled();
+    expect((result.err as { code?: string; reason?: string }).code).toBe(
+      "policy-denied",
+    );
+    expect(result.executionMeta?.referencePrice?.reason).toBe(
+      "reference-price-execution-divergence",
+    );
+  });
+
+  test("live composed-plan requests fall back to the prebuilt swap path", async () => {
+    const simulateTransactionBase64 = mock(async () => ({ err: null }));
+    const sendTransactionBase64 = mock(async () => "sig-live");
+    const confirmSignature = mock(async () => ({
+      ok: true,
+      status: "confirmed",
+    }));
+
+    const result = await executeJupiterSwap(
+      {
+        env: {} as Env,
+        runtimeMode: "live",
+        policy: normalizePolicy({ commitment: "confirmed" }),
+        rpc: {
+          simulateTransactionBase64,
+          sendTransactionBase64,
+          confirmSignature,
+        } as never,
+        jupiter: {} as never,
+        quoteResponse: {
+          inputMint: "A",
+          outputMint: "B",
+          inAmount: "1",
+          outAmount: "2",
+          routePlan: [{ swapInfo: { label: "Jupiter" } }],
+        },
+        userPublicKey: "11111111111111111111111111111111",
+        privyWalletId: "wallet-id",
+        execution: {
+          adapter: "jupiter",
+          params: {
+            composePlan: true,
+            requireSimulation: true,
+          },
+        },
+        log: () => {},
+      },
+      {
+        buildAndSignPrivySwapTransaction: buildAndSignPrivySwapTransactionMock,
+        buildJupiterComposedPlan: buildJupiterComposedPlanMock,
+      },
+    );
+
+    expect(result.status).toBe("confirmed");
+    expect(buildJupiterComposedPlanMock).not.toHaveBeenCalled();
+    expect(result.executionMeta?.composedPlan).toMatchObject({
+      mode: "prebuilt_fallback",
+      fallbackReason: "live-composed-plan-disabled",
+    });
   });
 });

--- a/tests/unit/worker_jupiter_composed_plan.test.ts
+++ b/tests/unit/worker_jupiter_composed_plan.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test";
+import { ComputeBudgetProgram, Keypair, SystemProgram } from "@solana/web3.js";
+import {
+  buildJupiterComposedPlan,
+  shouldFallbackToPrebuiltJupiterSwap,
+  shouldUseJupiterComposedPlan,
+} from "../../apps/worker/src/execution/jupiter_composed_plan";
+import type { JupiterSerializedInstruction } from "../../apps/worker/src/jupiter";
+import { normalizePolicy } from "../../apps/worker/src/policy";
+import type { Env } from "../../apps/worker/src/types";
+
+function toSerializedInstruction(
+  instruction: ReturnType<typeof ComputeBudgetProgram.setComputeUnitLimit>,
+): JupiterSerializedInstruction;
+function toSerializedInstruction(
+  instruction: ReturnType<typeof ComputeBudgetProgram.setComputeUnitPrice>,
+): JupiterSerializedInstruction;
+function toSerializedInstruction(
+  instruction: ReturnType<typeof SystemProgram.transfer>,
+): JupiterSerializedInstruction;
+function toSerializedInstruction(instruction: {
+  programId: { toBase58(): string };
+  keys: Array<{
+    pubkey: { toBase58(): string };
+    isSigner: boolean;
+    isWritable: boolean;
+  }>;
+  data: Uint8Array;
+}): JupiterSerializedInstruction {
+  return {
+    programId: instruction.programId.toBase58(),
+    accounts: instruction.keys.map((account) => ({
+      pubkey: account.pubkey.toBase58(),
+      isSigner: account.isSigner,
+      isWritable: account.isWritable,
+    })),
+    data: Buffer.from(instruction.data).toString("base64"),
+  };
+}
+
+describe("worker Jupiter composed plan builder", () => {
+  test("assembles instruction plans with compute overrides and route telemetry", async () => {
+    const payer = Keypair.generate();
+    const destination = Keypair.generate();
+    const result = await buildJupiterComposedPlan({
+      env: {} as Env,
+      runtimeMode: "paper",
+      policy: normalizePolicy({ commitment: "confirmed" }),
+      rpc: {
+        getAddressLookupTableAccounts: async () => [],
+        getLatestBlockhash: async () => ({
+          blockhash: "11111111111111111111111111111111",
+          lastValidBlockHeight: 9999,
+        }),
+      } as never,
+      jupiter: {
+        swapInstructions: async () => ({
+          computeBudgetInstructions: [
+            toSerializedInstruction(
+              ComputeBudgetProgram.setComputeUnitLimit({
+                units: 250_000,
+              }),
+            ),
+            toSerializedInstruction(
+              ComputeBudgetProgram.setComputeUnitPrice({
+                microLamports: 5_000,
+              }),
+            ),
+          ],
+          setupInstructions: [
+            toSerializedInstruction(
+              SystemProgram.transfer({
+                fromPubkey: payer.publicKey,
+                toPubkey: destination.publicKey,
+                lamports: 1,
+              }),
+            ),
+          ],
+          swapInstruction: toSerializedInstruction(
+            SystemProgram.transfer({
+              fromPubkey: payer.publicKey,
+              toPubkey: destination.publicKey,
+              lamports: 2,
+            }),
+          ),
+          cleanupInstruction: toSerializedInstruction(
+            SystemProgram.transfer({
+              fromPubkey: payer.publicKey,
+              toPubkey: destination.publicKey,
+              lamports: 3,
+            }),
+          ),
+          addressLookupTableAddresses: [],
+        }),
+      } as never,
+      quoteResponse: {
+        inputMint: "A",
+        outputMint: "B",
+        inAmount: "100",
+        outAmount: "110",
+        routePlan: [
+          { swapInfo: { label: "Meteora" } },
+          { swapInfo: { label: "Raydium" } },
+        ],
+      },
+      userPublicKey: payer.publicKey.toBase58(),
+      execution: {
+        adapter: "jupiter",
+        params: {
+          composePlan: true,
+          computeUnitLimit: 400_000,
+          priorityMicroLamports: 25_000,
+        },
+      },
+      log: () => {},
+    });
+
+    expect(result.serializedBase64.length).toBeGreaterThan(0);
+    expect(result.lastValidBlockHeight).toBe(9999);
+    expect(result.referenceGuard.enabled).toBe(false);
+    expect(result.summary).toMatchObject({
+      mode: "instructions",
+      routeHopCount: 2,
+      routeLabels: ["Meteora", "Raydium"],
+      instructionCount: 5,
+      computeBudgetInstructionCount: 2,
+      setupInstructionCount: 1,
+      cleanupInstructionCount: 1,
+      computeUnitLimit: 400_000,
+      computeUnitPriceMicroLamports: "25000",
+    });
+  });
+
+  test("only enables composed plans in simulate or paper-shadow contexts", () => {
+    expect(
+      shouldUseJupiterComposedPlan({
+        execution: {
+          adapter: "jupiter",
+          params: {
+            composePlan: true,
+          },
+        },
+      } as never),
+    ).toBe(true);
+    expect(
+      shouldFallbackToPrebuiltJupiterSwap({
+        runtimeMode: "live",
+        policy: normalizePolicy({ commitment: "confirmed" }),
+        execution: {
+          adapter: "jupiter",
+          params: {
+            composePlan: true,
+          },
+        },
+      } as never),
+    ).toBe(true);
+    expect(
+      shouldFallbackToPrebuiltJupiterSwap({
+        runtimeMode: "paper",
+        policy: normalizePolicy({ commitment: "confirmed" }),
+        execution: {
+          adapter: "jupiter",
+          params: {
+            composePlan: true,
+          },
+        },
+      } as never),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #367\n\n## Summary\n- add Jupiter swap-instructions client support and composed-plan builder\n- simulate instruction plans in paper/shadow with reference-price telemetry\n- keep live on the bounded prebuilt swap path with explicit fallback metadata\n\n## Validation\n- bun test tests/unit/worker_execution_jupiter.test.ts tests/unit/worker_jupiter_composed_plan.test.ts\n- bun run lint -- apps/worker/src/jupiter.ts apps/worker/src/solana_rpc.ts apps/worker/src/execution/jupiter_composed_plan.ts apps/worker/src/execution/jupiter_executor.ts apps/worker/src/execution/types.ts tests/unit/worker_execution_jupiter.test.ts tests/unit/worker_jupiter_composed_plan.test.ts\n- bun run typecheck