### PR TITLE
[Phase 1] Integrate Orca Whirlpools concentrated-liquidity adapter

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -14,6 +14,10 @@
     "deploy": "wrangler deploy"
   },
   "dependencies": {
+    "@coral-xyz/anchor": "^0.32.1",
+    "@noble/hashes": "^1.8.0",
+    "@orca-so/common-sdk": "^0.7.0",
+    "@orca-so/whirlpools-sdk": "^0.20.0",
     "@solana/web3.js": "^1.98.4",
     "bs58": "^6.0.0",
     "jose": "^6.1.3",

--- a/apps/worker/src/execution/orca_executor.ts
+++ b/apps/worker/src/execution/orca_executor.ts
@@ -1,0 +1,306 @@
+import { signTransactionWithPrivyById } from "../privy";
+import { evaluateSafeLaneTransaction } from "./safe_lane_policy";
+import type { ExecuteSwapInput, ExecuteSwapResult } from "./types";
+
+type OrcaExecutorDeps = {
+  signTransactionWithPrivyById?: typeof signTransactionWithPrivyById;
+  evaluateSafeLaneTransaction?: typeof evaluateSafeLaneTransaction;
+};
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function isSafeLaneExecution(input: ExecuteSwapInput): boolean {
+  const lane = String(input.execution?.params?.lane ?? "")
+    .trim()
+    .toLowerCase();
+  return lane === "safe";
+}
+
+function readsTruthyExecutionParam(value: unknown): boolean {
+  if (value === true) return true;
+  if (typeof value !== "string") return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "on";
+}
+
+function normalizeConfirmationStatus(
+  status: string | undefined,
+): Extract<
+  ExecuteSwapResult["status"],
+  "processed" | "confirmed" | "finalized" | "error"
+> {
+  if (
+    status === "processed" ||
+    status === "confirmed" ||
+    status === "finalized"
+  ) {
+    return status;
+  }
+  return "error";
+}
+
+function readOrcaPoolAddress(input: ExecuteSwapInput): string | null {
+  const pool = (input.quoteResponse as Record<string, unknown>)
+    ?.orcaPoolSnapshot as Record<string, unknown> | null;
+  const address = String(pool?.address ?? "").trim();
+  return address || null;
+}
+
+export async function executeOrcaSwap(
+  input: ExecuteSwapInput,
+  deps: OrcaExecutorDeps = {},
+): Promise<ExecuteSwapResult> {
+  const route = "orca";
+  const { policy, rpc, quoteResponse, log, guardEnabled } = input;
+  const safeLane = isSafeLaneExecution(input);
+
+  if (policy.dryRun) {
+    return {
+      status: "dry_run",
+      signature: null,
+      usedQuote: quoteResponse,
+      refreshed: false,
+      lastValidBlockHeight: null,
+      executionMeta: {
+        route,
+        classification: "dry_run",
+      },
+    };
+  }
+
+  if (!input.orca) {
+    throw new Error("orca-client-missing");
+  }
+  if (!input.privyWalletId) {
+    throw new Error("missing-privy-wallet-id");
+  }
+
+  if (guardEnabled) await guardEnabled();
+
+  const txBuiltAt = nowIso();
+  const built = await input.orca.buildSwapTransaction({
+    quoteResponse: input.quoteResponse,
+    walletPublicKey: input.userPublicKey,
+  });
+  const poolAddress = readOrcaPoolAddress(input);
+
+  const signWithPrivy =
+    deps.signTransactionWithPrivyById ?? signTransactionWithPrivyById;
+  const signedBase64 = await signWithPrivy(
+    input.env,
+    input.privyWalletId,
+    built.unsignedTransactionBase64,
+  );
+
+  const evaluateSafeLane =
+    deps.evaluateSafeLaneTransaction ?? evaluateSafeLaneTransaction;
+  if (safeLane) {
+    const evaluation = evaluateSafeLane({
+      env: input.env,
+      signedTransactionBase64: signedBase64,
+    });
+    log(evaluation.ok ? "info" : "warn", "safe lane tx guardrails", {
+      ok: evaluation.ok,
+      reason: evaluation.ok ? null : evaluation.reason,
+      profile: evaluation.profile,
+      limits: evaluation.limits,
+      route,
+    });
+    if (!evaluation.ok) {
+      const failedAt = nowIso();
+      return {
+        status: "simulate_error",
+        signature: null,
+        usedQuote: quoteResponse,
+        refreshed: false,
+        lastValidBlockHeight: built.lastValidBlockHeight,
+        err: {
+          code: "policy-denied",
+          reason: evaluation.reason,
+          profile: evaluation.profile,
+          limits: evaluation.limits,
+        },
+        executionMeta: {
+          route,
+          classification: "error",
+          lifecycle: {
+            fillState: "failed",
+            settlementState: "failed",
+            notes: [
+              "orca-whirlpool",
+              ...(poolAddress ? [`pool:${poolAddress}`] : []),
+            ],
+          },
+          trace: {
+            txBuiltAt,
+            failedAt,
+          },
+        },
+      };
+    }
+  }
+
+  const requiresSimulation =
+    safeLane ||
+    policy.simulateOnly ||
+    input.runtimeMode === "shadow" ||
+    input.runtimeMode === "paper" ||
+    readsTruthyExecutionParam(input.execution?.params?.requireSimulation);
+  let simulatedAt: string | undefined;
+  if (requiresSimulation) {
+    const simulation = await rpc.simulateTransactionBase64(signedBase64, {
+      commitment: policy.commitment,
+      sigVerify: true,
+    });
+    simulatedAt = nowIso();
+    const ok = !simulation.err;
+    log(ok ? "info" : "warn", "orca tx simulated", {
+      ok,
+      err: simulation.err ?? null,
+      unitsConsumed: simulation.unitsConsumed ?? null,
+      route,
+      poolAddress,
+    });
+    if (!ok) {
+      return {
+        status: "simulate_error",
+        signature: null,
+        usedQuote: quoteResponse,
+        refreshed: false,
+        lastValidBlockHeight: built.lastValidBlockHeight,
+        err: safeLane
+          ? {
+              code: "policy-denied",
+              reason: "safe-lane-simulation-failed",
+              simulationError: simulation.err ?? null,
+            }
+          : (simulation.err ?? null),
+        executionMeta: {
+          route,
+          classification: "error",
+          lifecycle: {
+            fillState: "failed",
+            settlementState: "failed",
+            notes: [
+              "orca-whirlpool",
+              `orca-additional-signers:${built.additionalSignerCount}`,
+              ...(poolAddress ? [`pool:${poolAddress}`] : []),
+            ],
+          },
+          trace: {
+            txBuiltAt,
+            simulatedAt,
+            failedAt: simulatedAt,
+          },
+        },
+      };
+    }
+  }
+
+  if (
+    policy.simulateOnly ||
+    input.runtimeMode === "shadow" ||
+    input.runtimeMode === "paper"
+  ) {
+    return {
+      status: "simulated",
+      signature: null,
+      usedQuote: quoteResponse,
+      refreshed: false,
+      lastValidBlockHeight: built.lastValidBlockHeight,
+      executionMeta: {
+        route,
+        classification: "simulated",
+        lifecycle: {
+          fillState: "pending",
+          settlementState: "pending",
+          notes: [
+            "orca-whirlpool",
+            `orca-additional-signers:${built.additionalSignerCount}`,
+            ...(poolAddress ? [`pool:${poolAddress}`] : []),
+          ],
+        },
+        trace: {
+          txBuiltAt,
+          ...(simulatedAt ? { simulatedAt } : {}),
+        },
+      },
+    };
+  }
+
+  if (guardEnabled) await guardEnabled();
+
+  const signature = await rpc.sendTransactionBase64(signedBase64, {
+    skipPreflight: policy.skipPreflight,
+    preflightCommitment: policy.commitment,
+  });
+  const sentAt = nowIso();
+  log("info", "orca tx submitted", {
+    route,
+    signature,
+    poolAddress,
+  });
+
+  const confirmation = await rpc.confirmSignature(signature, {
+    commitment: policy.commitment,
+  });
+  const confirmedAt = nowIso();
+  log(confirmation.ok ? "info" : "warn", "orca tx confirmation", {
+    route,
+    signature,
+    confirmationStatus: confirmation.status ?? null,
+    err: confirmation.ok ? null : (confirmation.err ?? null),
+    poolAddress,
+  });
+
+  const resultStatus = confirmation.ok
+    ? normalizeConfirmationStatus(confirmation.status)
+    : "error";
+
+  return {
+    status: resultStatus,
+    signature,
+    usedQuote: quoteResponse,
+    refreshed: false,
+    lastValidBlockHeight: built.lastValidBlockHeight,
+    ...(confirmation.ok ? {} : { err: confirmation.err ?? null }),
+    executionMeta: {
+      route,
+      classification:
+        resultStatus === "finalized"
+          ? "finalized"
+          : resultStatus === "confirmed"
+            ? "confirmed"
+            : resultStatus === "processed"
+              ? "submitted"
+              : "error",
+      lifecycle: {
+        fillState: resultStatus === "error" ? "failed" : "filled",
+        settlementState:
+          resultStatus === "finalized"
+            ? "finalized"
+            : resultStatus === "error"
+              ? "failed"
+              : "confirmed",
+        notes: [
+          "orca-whirlpool",
+          `orca-additional-signers:${built.additionalSignerCount}`,
+          ...(poolAddress ? [`pool:${poolAddress}`] : []),
+        ],
+      },
+      trace: {
+        txBuiltAt,
+        ...(simulatedAt ? { simulatedAt } : {}),
+        sentAt,
+        confirmedAt,
+        ...(resultStatus === "finalized"
+          ? { finalizedAt: confirmedAt }
+          : resultStatus === "error"
+            ? { failedAt: confirmedAt }
+            : {}),
+      },
+    },
+  };
+}

--- a/apps/worker/src/execution/router.ts
+++ b/apps/worker/src/execution/router.ts
@@ -13,6 +13,7 @@ import { executeJupiterSwap } from "./jupiter_executor";
 import { resolveJupiterConditionalSpotOrder } from "./jupiter_trigger";
 import { executeJupiterConditionalSpotOrder } from "./jupiter_trigger_executor";
 import { executeMagicBlockEphemeralRollupSwap } from "./magicblock_ephemeral_rollup_executor";
+import { executeOrcaSwap } from "./orca_executor";
 import { executeRaydiumSwap } from "./raydium_executor";
 import type {
   ExecuteIntentInput,
@@ -83,6 +84,16 @@ const ADAPTERS = new Map<string, ExecutionAdapterRegistration>([
       supportedModes: ["shadow", "paper"],
       supportedIntentFamilies: ["spot_swap"],
       adapter: executeMagicBlockEphemeralRollupSwap,
+    },
+  ],
+  [
+    "orca",
+    {
+      adapterKey: "orca",
+      venueKey: "orca",
+      supportedModes: ["shadow", "paper"],
+      supportedIntentFamilies: ["spot_swap"],
+      adapter: executeOrcaSwap,
     },
   ],
   [
@@ -295,6 +306,7 @@ export async function executeIntentViaRouter(
     policy: input.policy,
     rpc: input.rpc,
     jupiter: input.jupiter,
+    orca: input.orca,
     raydium: input.raydium,
     quoteResponse: input.quoteResponse,
     userPublicKey: input.userPublicKey,

--- a/apps/worker/src/execution/spot_venues.ts
+++ b/apps/worker/src/execution/spot_venues.ts
@@ -1,4 +1,5 @@
 import type { JupiterClient, JupiterQuoteResponse } from "../jupiter";
+import type { OrcaClient, OrcaPoolSnapshot } from "../orca";
 import type { RaydiumClient } from "../raydium";
 import type { RuntimeMode } from "../runtime_contracts";
 
@@ -11,6 +12,16 @@ export type SpotVenueQuoteTelemetry = {
   quotedOutAmountAtomic: string;
   minExpectedOutAmountAtomic: string | null;
   priceImpactPct: number | null;
+  poolAddress?: string | null;
+  poolFeeRateBps?: number | null;
+  poolTickSpacing?: number | null;
+  poolCurrentTickIndex?: number | null;
+  poolTvlUsd?: string | null;
+  poolLiquidityAtomic?: string | null;
+  adaptiveFeeEnabled?: boolean | null;
+  warningActive?: boolean | null;
+  addressLookupTable?: string | null;
+  dailyVolumeUsd?: string | null;
 };
 
 function readQuotePriceImpactPct(quoteResponse: JupiterQuoteResponse): number {
@@ -20,6 +31,29 @@ function readQuotePriceImpactPct(quoteResponse: JupiterQuoteResponse): number {
   }
   const parsed = Number(raw ?? 0);
   return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function readFiniteNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function readTrimmedString(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return normalized || null;
+}
+
+function readOrcaPoolSnapshot(
+  quoteResponse: JupiterQuoteResponse,
+): OrcaPoolSnapshot | null {
+  const record = (quoteResponse as Record<string, unknown>)?.orcaPoolSnapshot;
+  if (!record || typeof record !== "object" || Array.isArray(record)) {
+    return null;
+  }
+  return record as OrcaPoolSnapshot;
 }
 
 export function buildSpotVenueQuoteTelemetry(input: {
@@ -55,7 +89,7 @@ export function buildSpotVenueQuoteTelemetry(input: {
       "",
   ).trim();
 
-  return {
+  const base = {
     venueKey: input.venueKey,
     quoteProvider: input.quoteProvider,
     routeHopCount: routePlan.length,
@@ -64,6 +98,27 @@ export function buildSpotVenueQuoteTelemetry(input: {
     quotedOutAmountAtomic: String(input.quoteResponse.outAmount ?? ""),
     minExpectedOutAmountAtomic: minExpectedOutAmountAtomic || null,
     priceImpactPct: readQuotePriceImpactPct(input.quoteResponse),
+  };
+  const orcaPool = readOrcaPoolSnapshot(input.quoteResponse);
+  if (!orcaPool) {
+    return base;
+  }
+  return {
+    ...base,
+    poolAddress: readTrimmedString(orcaPool.address),
+    poolFeeRateBps: readFiniteNumber(orcaPool.feeRate),
+    poolTickSpacing: readFiniteNumber(orcaPool.tickSpacing),
+    poolCurrentTickIndex: readFiniteNumber(orcaPool.tickCurrentIndex),
+    poolTvlUsd: readTrimmedString(orcaPool.tvlUsdc),
+    poolLiquidityAtomic: readTrimmedString(orcaPool.liquidity),
+    adaptiveFeeEnabled:
+      typeof orcaPool.adaptiveFeeEnabled === "boolean"
+        ? orcaPool.adaptiveFeeEnabled
+        : null,
+    warningActive:
+      typeof orcaPool.hasWarning === "boolean" ? orcaPool.hasWarning : null,
+    addressLookupTable: readTrimmedString(orcaPool.addressLookupTable),
+    dailyVolumeUsd: readTrimmedString(orcaPool.stats?.["24h"]?.volume),
   };
 }
 
@@ -74,6 +129,7 @@ export async function quoteSpotSwap(input: {
   amountAtomic: string;
   slippageBps: number;
   jupiter: JupiterClient;
+  orca?: OrcaClient;
   raydium?: RaydiumClient;
 }): Promise<{
   venueKey: string;
@@ -82,6 +138,27 @@ export async function quoteSpotSwap(input: {
   routeQuality: SpotVenueQuoteTelemetry;
 }> {
   const venueKey = String(input.venueKey ?? "jupiter").trim() || "jupiter";
+  if (venueKey === "orca") {
+    if (!input.orca) {
+      throw new Error("orca-client-missing");
+    }
+    const { normalizedQuote } = await input.orca.quoteBaseIn({
+      inputMint: input.inputMint,
+      outputMint: input.outputMint,
+      amount: input.amountAtomic,
+      slippageBps: input.slippageBps,
+    });
+    return {
+      venueKey,
+      quoteProvider: "orca",
+      quoteResponse: normalizedQuote,
+      routeQuality: buildSpotVenueQuoteTelemetry({
+        venueKey,
+        quoteProvider: "orca",
+        quoteResponse: normalizedQuote,
+      }),
+    };
+  }
   if (venueKey === "raydium") {
     if (!input.raydium) {
       throw new Error("raydium-client-missing");
@@ -130,6 +207,9 @@ export function resolveSpotVenueExecutionAdapter(input: {
   defaultAdapter: string;
 }): string {
   const venueKey = String(input.venueKey ?? "").trim();
+  if (venueKey === "orca") {
+    return "orca";
+  }
   if (venueKey === "raydium") {
     return "raydium";
   }

--- a/apps/worker/src/execution/types.ts
+++ b/apps/worker/src/execution/types.ts
@@ -1,4 +1,5 @@
 import type { JupiterClient, JupiterQuoteResponse } from "../jupiter";
+import type { OrcaClient } from "../orca";
 import type { NormalizedPolicy } from "../policy";
 import type { RaydiumClient } from "../raydium";
 import type { RuntimeMode } from "../runtime_contracts";
@@ -89,6 +90,7 @@ type ExecuteIntentInputBase = {
   policy: NormalizedPolicy;
   rpc: SolanaRpc;
   jupiter: JupiterClient;
+  orca?: OrcaClient;
   raydium?: RaydiumClient;
   log: ExecutionLogFn;
   guardEnabled?: () => Promise<void>;
@@ -117,6 +119,7 @@ export type ExecuteSwapInput = {
   policy: NormalizedPolicy;
   rpc: SolanaRpc;
   jupiter: JupiterClient;
+  orca?: OrcaClient;
   raydium?: RaydiumClient;
   quoteResponse: JupiterQuoteResponse;
   userPublicKey: string;

--- a/apps/worker/src/orca.ts
+++ b/apps/worker/src/orca.ts
@@ -250,6 +250,7 @@ export function normalizeOrcaQuoteResponse(input: {
   pool: OrcaPoolSnapshot;
   inputMint: string;
   outputMint: string;
+  slippageBps: number;
   sdkQuote: OrcaSdkQuoteResponse;
 }): JupiterQuoteResponse {
   return {
@@ -278,6 +279,7 @@ export function normalizeOrcaQuoteResponse(input: {
         },
       },
     ],
+    slippageBps: input.slippageBps,
     quoteProvider: "orca",
     orcaPoolSnapshot: input.pool,
     orcaQuote: input.sdkQuote,
@@ -437,6 +439,7 @@ export class OrcaClient {
         pool,
         inputMint: request.inputMint,
         outputMint: request.outputMint,
+        slippageBps: request.slippageBps,
         sdkQuote,
       }),
     };

--- a/apps/worker/src/orca.ts
+++ b/apps/worker/src/orca.ts
@@ -1,0 +1,467 @@
+import { BN } from "@coral-xyz/anchor";
+import { Percentage, ReadOnlyWallet } from "@orca-so/common-sdk";
+import {
+  buildWhirlpoolClient,
+  swapQuoteByInputToken,
+  WhirlpoolContext,
+} from "@orca-so/whirlpools-sdk";
+import {
+  Connection,
+  PublicKey,
+  type Transaction,
+  type VersionedTransaction,
+} from "@solana/web3.js";
+import type { JupiterQuoteResponse } from "./jupiter";
+
+export type OrcaTokenSnapshot = {
+  address?: string;
+  programId?: string;
+  name?: string;
+  symbol?: string;
+  decimals?: number;
+  tags?: string[];
+  [k: string]: unknown;
+};
+
+export type OrcaPoolStatsSnapshot = {
+  volume?: string;
+  fees?: string;
+  rewards?: string;
+  yieldOverTvl?: string;
+  [k: string]: unknown;
+};
+
+export type OrcaLockedLiquiditySnapshot = {
+  name?: string;
+  lockedPercentage?: string;
+  locked_percentage?: string;
+  [k: string]: unknown;
+};
+
+export type OrcaPoolSnapshot = {
+  address?: string;
+  whirlpoolsConfig?: string;
+  tickSpacing?: number;
+  feeRate?: number;
+  feeTierIndex?: number;
+  liquidity?: string;
+  sqrtPrice?: string;
+  tickCurrentIndex?: number;
+  tokenMintA?: string;
+  tokenVaultA?: string;
+  tokenMintB?: string;
+  tokenVaultB?: string;
+  tokenA?: OrcaTokenSnapshot;
+  tokenB?: OrcaTokenSnapshot;
+  price?: string;
+  tvlUsdc?: string;
+  yieldOverTvl?: string;
+  hasWarning?: boolean;
+  poolType?: string;
+  adaptiveFeeEnabled?: boolean;
+  addressLookupTable?: string;
+  lockedLiquidityPercent?: OrcaLockedLiquiditySnapshot[];
+  stats?: Record<string, OrcaPoolStatsSnapshot>;
+  [k: string]: unknown;
+};
+
+export type OrcaPoolsResponse = {
+  data?: OrcaPoolSnapshot[];
+  [k: string]: unknown;
+};
+
+export type OrcaSdkQuoteResponse = {
+  estimatedAmountInAtomic: string;
+  estimatedAmountOutAtomic: string;
+  otherAmountThresholdAtomic: string;
+  estimatedFeeAmountAtomic: string;
+  sqrtPriceLimit: string;
+  tickArrayAddresses: string[];
+  aToB: boolean;
+  amountSpecifiedIsInput: boolean;
+};
+
+export type OrcaBuiltSwapTransaction = {
+  unsignedTransactionBase64: string;
+  additionalSignerCount: number;
+  lastValidBlockHeight: number | null;
+};
+
+export type OrcaSdkFacade = {
+  quoteByInputPool(request: {
+    rpcEndpoint: string;
+    poolAddress: string;
+    inputMint: string;
+    amountAtomic: string;
+    slippageBps: number;
+  }): Promise<OrcaSdkQuoteResponse>;
+  buildSwapTransaction(request: {
+    rpcEndpoint: string;
+    poolAddress: string;
+    inputMint: string;
+    amountAtomic: string;
+    slippageBps: number;
+    walletPublicKey: string;
+  }): Promise<OrcaBuiltSwapTransaction>;
+};
+
+function normalizeOrcaPath(pathname: string): string {
+  return pathname.startsWith("/") ? pathname : `/${pathname}`;
+}
+
+function isVersionedTransaction(
+  tx: Transaction | VersionedTransaction,
+): tx is VersionedTransaction {
+  return "version" in tx;
+}
+
+function serializeUnsignedTransactionBase64(input: {
+  transaction: Transaction | VersionedTransaction;
+  signers: Array<{
+    publicKey: PublicKey;
+    secretKey: Uint8Array;
+  }>;
+}): string {
+  if (isVersionedTransaction(input.transaction)) {
+    input.transaction.sign(input.signers);
+    return Buffer.from(input.transaction.serialize()).toString("base64");
+  }
+  for (const signer of input.signers) {
+    input.transaction.partialSign(signer);
+  }
+  return Buffer.from(
+    input.transaction.serialize({
+      requireAllSignatures: false,
+      verifySignatures: false,
+    }),
+  ).toString("base64");
+}
+
+function readFiniteNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function readTrimmedString(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return normalized || null;
+}
+
+function parseAtomicToUi(
+  amountAtomic: string,
+  decimals: number | null,
+): number | null {
+  const amount = readFiniteNumber(amountAtomic);
+  if (amount === null || decimals === null) return null;
+  return amount / 10 ** decimals;
+}
+
+function poolContainsMintPair(input: {
+  pool: OrcaPoolSnapshot;
+  inputMint: string;
+  outputMint: string;
+}): boolean {
+  const mintA = readTrimmedString(input.pool.tokenMintA);
+  const mintB = readTrimmedString(input.pool.tokenMintB);
+  if (!mintA || !mintB) return false;
+  return (
+    (mintA === input.inputMint && mintB === input.outputMint) ||
+    (mintA === input.outputMint && mintB === input.inputMint)
+  );
+}
+
+function compareOrcaPoolPriority(
+  a: OrcaPoolSnapshot,
+  b: OrcaPoolSnapshot,
+): number {
+  const warningA = a.hasWarning === true ? 1 : 0;
+  const warningB = b.hasWarning === true ? 1 : 0;
+  if (warningA !== warningB) return warningA - warningB;
+  const tvlA = readFiniteNumber(a.tvlUsdc) ?? 0;
+  const tvlB = readFiniteNumber(b.tvlUsdc) ?? 0;
+  if (tvlA !== tvlB) return tvlB - tvlA;
+  const feeRateA = readFiniteNumber(a.feeRate) ?? 0;
+  const feeRateB = readFiniteNumber(b.feeRate) ?? 0;
+  if (feeRateA !== feeRateB) return feeRateA - feeRateB;
+  return String(a.address ?? "").localeCompare(String(b.address ?? ""));
+}
+
+function computeOrcaPriceImpactPct(input: {
+  pool: OrcaPoolSnapshot;
+  inputMint: string;
+  outputMint: string;
+  estimatedAmountInAtomic: string;
+  estimatedAmountOutAtomic: string;
+}): number {
+  const poolPrice = readFiniteNumber(input.pool.price);
+  if (poolPrice === null || poolPrice <= 0) {
+    return 0;
+  }
+  const decimalsA = readFiniteNumber(input.pool.tokenA?.decimals);
+  const decimalsB = readFiniteNumber(input.pool.tokenB?.decimals);
+  const inUi =
+    input.inputMint === input.pool.tokenMintA
+      ? parseAtomicToUi(input.estimatedAmountInAtomic, decimalsA)
+      : parseAtomicToUi(input.estimatedAmountInAtomic, decimalsB);
+  const outUi =
+    input.outputMint === input.pool.tokenMintB
+      ? parseAtomicToUi(input.estimatedAmountOutAtomic, decimalsB)
+      : parseAtomicToUi(input.estimatedAmountOutAtomic, decimalsA);
+  if (!inUi || !outUi) return 0;
+
+  const executionPrice =
+    input.inputMint === input.pool.tokenMintA &&
+    input.outputMint === input.pool.tokenMintB
+      ? outUi / inUi
+      : inUi / outUi;
+  if (!Number.isFinite(executionPrice) || executionPrice <= 0) {
+    return 0;
+  }
+  return Math.max(0, Math.abs((executionPrice - poolPrice) / poolPrice) * 100);
+}
+
+export function selectBestOrcaPoolSnapshot(input: {
+  pools: OrcaPoolSnapshot[];
+  inputMint: string;
+  outputMint: string;
+}): OrcaPoolSnapshot {
+  const candidates = input.pools
+    .filter(
+      (pool) => pool.poolType === undefined || pool.poolType === "whirlpool",
+    )
+    .filter((pool) =>
+      poolContainsMintPair({
+        pool,
+        inputMint: input.inputMint,
+        outputMint: input.outputMint,
+      }),
+    )
+    .sort(compareOrcaPoolPriority);
+  if (candidates.length < 1) {
+    throw new Error("orca-whirlpool-pool-not-found");
+  }
+  return candidates[0] as OrcaPoolSnapshot;
+}
+
+export function normalizeOrcaQuoteResponse(input: {
+  pool: OrcaPoolSnapshot;
+  inputMint: string;
+  outputMint: string;
+  sdkQuote: OrcaSdkQuoteResponse;
+}): JupiterQuoteResponse {
+  return {
+    inputMint: input.inputMint,
+    outputMint: input.outputMint,
+    inAmount: input.sdkQuote.estimatedAmountInAtomic,
+    outAmount: input.sdkQuote.estimatedAmountOutAtomic,
+    otherAmountThreshold: input.sdkQuote.otherAmountThresholdAtomic,
+    priceImpactPct: computeOrcaPriceImpactPct({
+      pool: input.pool,
+      inputMint: input.inputMint,
+      outputMint: input.outputMint,
+      estimatedAmountInAtomic: input.sdkQuote.estimatedAmountInAtomic,
+      estimatedAmountOutAtomic: input.sdkQuote.estimatedAmountOutAtomic,
+    }),
+    routePlan: [
+      {
+        poolId: input.pool.address,
+        swapInfo: {
+          label: "Orca Whirlpool",
+          poolId: input.pool.address,
+          inputMint: input.inputMint,
+          outputMint: input.outputMint,
+          feeRate: input.pool.feeRate,
+          feeAmount: input.sdkQuote.estimatedFeeAmountAtomic,
+        },
+      },
+    ],
+    quoteProvider: "orca",
+    orcaPoolSnapshot: input.pool,
+    orcaQuote: input.sdkQuote,
+  };
+}
+
+export function createOrcaSdkFacade(): OrcaSdkFacade {
+  async function buildQuote(input: {
+    rpcEndpoint: string;
+    poolAddress: string;
+    inputMint: string;
+    amountAtomic: string;
+    slippageBps: number;
+    walletPublicKey: string;
+  }) {
+    const connection = new Connection(input.rpcEndpoint, "confirmed");
+    const wallet = new ReadOnlyWallet(new PublicKey(input.walletPublicKey));
+    const ctx = WhirlpoolContext.from(connection, wallet);
+    const client = buildWhirlpoolClient(ctx);
+    const pool = await client.getPool(new PublicKey(input.poolAddress));
+    const quote = await swapQuoteByInputToken(
+      pool,
+      new PublicKey(input.inputMint),
+      new BN(input.amountAtomic),
+      Percentage.fromFraction(input.slippageBps, 10_000),
+      ctx.program.programId,
+      ctx.fetcher,
+    );
+    return { ctx, pool, quote };
+  }
+
+  return {
+    async quoteByInputPool(request) {
+      const { quote } = await buildQuote({
+        ...request,
+        walletPublicKey: PublicKey.default.toBase58(),
+      });
+      return {
+        estimatedAmountInAtomic: quote.estimatedAmountIn.toString(),
+        estimatedAmountOutAtomic: quote.estimatedAmountOut.toString(),
+        otherAmountThresholdAtomic: quote.otherAmountThreshold.toString(),
+        estimatedFeeAmountAtomic: quote.estimatedFeeAmount.toString(),
+        sqrtPriceLimit: quote.sqrtPriceLimit.toString(),
+        tickArrayAddresses: [
+          quote.tickArray0.toBase58(),
+          quote.tickArray1.toBase58(),
+          quote.tickArray2.toBase58(),
+        ],
+        aToB: quote.aToB,
+        amountSpecifiedIsInput: quote.amountSpecifiedIsInput,
+      };
+    },
+    async buildSwapTransaction(request) {
+      const { pool, quote } = await buildQuote(request);
+      const txBuilder = await pool.swap(
+        quote,
+        new PublicKey(request.walletPublicKey),
+      );
+      const built = await txBuilder.build({
+        maxSupportedTransactionVersion: 0,
+        blockhashCommitment: "confirmed",
+      });
+      return {
+        unsignedTransactionBase64: serializeUnsignedTransactionBase64({
+          transaction: built.transaction,
+          signers: built.signers,
+        }),
+        additionalSignerCount: built.signers.length,
+        lastValidBlockHeight: built.recentBlockhash.lastValidBlockHeight,
+      };
+    },
+  };
+}
+
+export class OrcaClient {
+  private readonly fetchImpl: typeof fetch;
+  private readonly sdk: OrcaSdkFacade;
+
+  constructor(
+    private readonly rpcEndpoint: string,
+    private readonly apiBaseUrl = "https://api.orca.so",
+    deps?: {
+      fetch?: typeof fetch;
+      sdk?: OrcaSdkFacade;
+    },
+  ) {
+    this.fetchImpl = deps?.fetch ?? fetch;
+    this.sdk = deps?.sdk ?? createOrcaSdkFacade();
+  }
+
+  async listPoolsByPair(request: {
+    inputMint: string;
+    outputMint: string;
+    size?: number;
+    statsWindow?: string;
+  }): Promise<OrcaPoolSnapshot[]> {
+    const url = new URL(normalizeOrcaPath("/v2/solana/pools"), this.apiBaseUrl);
+    url.searchParams.set(
+      "tokensBothOf",
+      [request.inputMint, request.outputMint].join(","),
+    );
+    url.searchParams.set("size", String(request.size ?? 10));
+    url.searchParams.set("sortBy", "tvl");
+    url.searchParams.set("sortDirection", "desc");
+    url.searchParams.set("stats", request.statsWindow ?? "24h");
+    const response = await this.fetchImpl(url.toString(), { method: "GET" });
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(
+        `orca-pools-fetch-failed: ${response.status}${body ? ` ${body}` : ""}`,
+      );
+    }
+    const payload = (await response.json()) as OrcaPoolsResponse;
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      throw new Error("orca-pools-invalid-response");
+    }
+    if (!Array.isArray(payload.data)) {
+      throw new Error("orca-pools-missing-data");
+    }
+    return payload.data;
+  }
+
+  async quoteBaseIn(request: {
+    inputMint: string;
+    outputMint: string;
+    amount: string;
+    slippageBps: number;
+  }): Promise<{
+    pool: OrcaPoolSnapshot;
+    sdkQuote: OrcaSdkQuoteResponse;
+    normalizedQuote: JupiterQuoteResponse;
+  }> {
+    const pools = await this.listPoolsByPair({
+      inputMint: request.inputMint,
+      outputMint: request.outputMint,
+    });
+    const pool = selectBestOrcaPoolSnapshot({
+      pools,
+      inputMint: request.inputMint,
+      outputMint: request.outputMint,
+    });
+    const poolAddress = readTrimmedString(pool.address);
+    if (!poolAddress) {
+      throw new Error("orca-whirlpool-pool-address-missing");
+    }
+    const sdkQuote = await this.sdk.quoteByInputPool({
+      rpcEndpoint: this.rpcEndpoint,
+      poolAddress,
+      inputMint: request.inputMint,
+      amountAtomic: request.amount,
+      slippageBps: request.slippageBps,
+    });
+    return {
+      pool,
+      sdkQuote,
+      normalizedQuote: normalizeOrcaQuoteResponse({
+        pool,
+        inputMint: request.inputMint,
+        outputMint: request.outputMint,
+        sdkQuote,
+      }),
+    };
+  }
+
+  async buildSwapTransaction(request: {
+    quoteResponse: JupiterQuoteResponse;
+    walletPublicKey: string;
+  }): Promise<OrcaBuiltSwapTransaction> {
+    const pool = (request.quoteResponse as Record<string, unknown>)
+      ?.orcaPoolSnapshot as OrcaPoolSnapshot | null;
+    if (!pool || typeof pool !== "object" || Array.isArray(pool)) {
+      throw new Error("orca-pool-snapshot-missing");
+    }
+    const poolAddress = readTrimmedString(pool.address);
+    if (!poolAddress) {
+      throw new Error("orca-whirlpool-pool-address-missing");
+    }
+    return await this.sdk.buildSwapTransaction({
+      rpcEndpoint: this.rpcEndpoint,
+      poolAddress,
+      inputMint: request.quoteResponse.inputMint,
+      amountAtomic: String(request.quoteResponse.inAmount ?? ""),
+      slippageBps: readFiniteNumber(request.quoteResponse.slippageBps) ?? 50,
+      walletPublicKey: request.walletPublicKey,
+    });
+  }
+}

--- a/apps/worker/src/orca.ts
+++ b/apps/worker/src/orca.ts
@@ -1,10 +1,3 @@
-import { BN } from "@coral-xyz/anchor";
-import { Percentage, ReadOnlyWallet } from "@orca-so/common-sdk";
-import {
-  buildWhirlpoolClient,
-  swapQuoteByInputToken,
-  WhirlpoolContext,
-} from "@orca-so/whirlpools-sdk";
 import {
   Connection,
   PublicKey,
@@ -295,6 +288,14 @@ export function createOrcaSdkFacade(): OrcaSdkFacade {
     slippageBps: number;
     walletPublicKey: string;
   }) {
+    const [{ BN }, { Percentage, ReadOnlyWallet }, whirlpoolSdk] =
+      await Promise.all([
+        import("@coral-xyz/anchor"),
+        import("@orca-so/common-sdk"),
+        import("@orca-so/whirlpools-sdk"),
+      ]);
+    const { buildWhirlpoolClient, swapQuoteByInputToken, WhirlpoolContext } =
+      whirlpoolSdk;
     const connection = new Connection(input.rpcEndpoint, "confirmed");
     const wallet = new ReadOnlyWallet(new PublicKey(input.walletPublicKey));
     const ctx = WhirlpoolContext.from(connection, wallet);

--- a/apps/worker/src/runtime_canary.ts
+++ b/apps/worker/src/runtime_canary.ts
@@ -25,6 +25,7 @@ import {
   executionLaneRuntimeControlsFromSnapshot,
   readOpsControlSnapshot,
 } from "./ops_controls";
+import { OrcaClient } from "./orca";
 import { enforcePolicy, normalizePolicy } from "./policy";
 import { createPrivySolanaWallet, getPrivyWalletAddressById } from "./privy";
 import { RaydiumClient } from "./raydium";
@@ -824,6 +825,11 @@ export async function submitRuntimeCanaryExecutionPlan(input: {
     String(env.JUPITER_BASE_URL ?? "").trim() || "https://lite-api.jup.ag",
     env.JUPITER_API_KEY,
   );
+  const orca = new OrcaClient(
+    String(env.RPC_ENDPOINT ?? "").trim() ||
+      "https://api.mainnet-beta.solana.com",
+    String(env.ORCA_API_BASE_URL ?? "").trim() || "https://api.orca.so",
+  );
   const raydium = new RaydiumClient(
     String(env.RAYDIUM_API_BASE_URL ?? "").trim() ||
       "https://api-v3.raydium.io",
@@ -837,6 +843,7 @@ export async function submitRuntimeCanaryExecutionPlan(input: {
     amountAtomic: slice.inputAmountAtomic,
     slippageBps: slice.slippageBps,
     jupiter,
+    orca,
     raydium,
   });
   const quoteResponse = quotedSwap.quoteResponse;
@@ -961,6 +968,7 @@ export async function submitRuntimeCanaryExecutionPlan(input: {
       policy,
       rpc,
       jupiter,
+      orca,
       raydium,
       quoteResponse,
       userPublicKey: wallet.walletAddress,

--- a/apps/worker/src/runtime_internal.ts
+++ b/apps/worker/src/runtime_internal.ts
@@ -1235,6 +1235,18 @@ function createRuntimeAssetFixture(
         notes: "Paper-only mapping.",
       },
       {
+        venueKey: "orca",
+        nativeId,
+        venueSymbol: assetKey,
+        decimals: isSol ? 9 : 6,
+        listingState: "paper",
+        quoteAssetKeys: ["USDC"],
+        priceDecimals: 6,
+        sizeDecimals: isSol ? 9 : 6,
+        minNotionalUsd: "0.01",
+        notes: "Concentrated-liquidity paper routing mapping.",
+      },
+      {
         venueKey: "raydium",
         nativeId,
         venueSymbol: assetKey,

--- a/apps/worker/src/types.ts
+++ b/apps/worker/src/types.ts
@@ -70,6 +70,7 @@ export type Env = {
   JUPITER_BASE_URL?: string;
   JUPITER_PRICE_BASE_URL?: string;
   JUPITER_API_KEY?: string;
+  ORCA_API_BASE_URL?: string;
   RAYDIUM_API_BASE_URL?: string;
   RAYDIUM_TRANSACTION_BASE_URL?: string;
   PYTH_HERMES_BASE_URL?: string;

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,8 @@
         "@coral-xyz/anchor": "^0.32.1",
         "@ellipsis-labs/phoenix-sdk": "^2.0.3",
         "@openbook-dex/openbook-v2": "^0.2.10",
+        "@orca-so/common-sdk": "^0.7.0",
+        "@orca-so/whirlpools-sdk": "^0.20.0",
         "@solana/web3.js": "^1.98.4",
         "bs58": "^6.0.0",
         "commander": "^14.0.3",
@@ -353,6 +355,10 @@
     "@openbook-dex/openbook-v2": ["@openbook-dex/openbook-v2@0.2.10", "", { "dependencies": { "@coral-xyz/anchor": "^0.29.0", "@solana/spl-token": "^0.4.0", "@solana/web3.js": "^1.77.3", "big.js": "^6.2.1" } }, "sha512-JOroVQHeia+RbghpluDJB5psUIhdhYRPLu0zWoG0h5vgDU4SjXwlcC+LJiIa2HVPasvZjWuCtlKWFyrOS75lOA=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@orca-so/common-sdk": ["@orca-so/common-sdk@0.7.0", "", { "dependencies": { "decimal.js": "^10.5.0", "tiny-invariant": "^1.3.1" }, "peerDependencies": { "@solana/spl-token": "^0.4.14", "@solana/web3.js": "^1.98.4" } }, "sha512-YJHmVvj+1EYbHnnGAyMoRKij6qkVFeecp0mIPt4xLKO7ZaAylqLCi6j4jxFY1fZCgHVhlgLNukFxXEln4skxbA=="],
+
+    "@orca-so/whirlpools-sdk": ["@orca-so/whirlpools-sdk@0.20.0", "", { "dependencies": { "@orca-so/common-sdk": "0.7.0", "decimal.js": "^10.5.0", "tiny-invariant": "^1.3.1" }, "peerDependencies": { "@coral-xyz/anchor": "~0.32.1", "@solana/spl-token": "^0.4.14", "@solana/web3.js": "^1.98.4" } }, "sha512-7i8VG7KKIC3/opB+qeLHuHIbJVsJyN3d47ENHcD45tXy0m+7dTx2opQVEXMQFmCX7VNCg+T7G/18MI1T8ABc+Q=="],
 
     "@paulmillr/qr": ["@paulmillr/qr@0.2.1", "", {}, "sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ=="],
 
@@ -809,6 +815,8 @@
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "decode-uri-component": ["decode-uri-component@0.2.2", "", {}, "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="],
 
@@ -1336,6 +1344,8 @@
 
     "thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
 
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
+
     "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
 
     "to-buffer": ["to-buffer@1.2.2", "", { "dependencies": { "isarray": "^2.0.5", "safe-buffer": "^5.2.1", "typed-array-buffer": "^1.0.3" } }, "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw=="],
@@ -1523,6 +1533,10 @@
     "@openbook-dex/openbook-v2/@coral-xyz/anchor": ["@coral-xyz/anchor@0.29.0", "", { "dependencies": { "@coral-xyz/borsh": "^0.29.0", "@noble/hashes": "^1.3.1", "@solana/web3.js": "^1.68.0", "bn.js": "^5.1.2", "bs58": "^4.0.1", "buffer-layout": "^1.2.2", "camelcase": "^6.3.0", "cross-fetch": "^3.1.5", "crypto-hash": "^1.3.0", "eventemitter3": "^4.0.7", "pako": "^2.0.3", "snake-case": "^3.0.4", "superstruct": "^0.15.4", "toml": "^3.0.0" } }, "sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA=="],
 
     "@openbook-dex/openbook-v2/@solana/spl-token": ["@solana/spl-token@0.4.14", "", { "dependencies": { "@solana/buffer-layout": "^4.0.0", "@solana/buffer-layout-utils": "^0.2.0", "@solana/spl-token-group": "^0.0.7", "@solana/spl-token-metadata": "^0.1.6", "buffer": "^6.0.3" }, "peerDependencies": { "@solana/web3.js": "^1.95.5" } }, "sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA=="],
+
+    "@orca-so/common-sdk/@solana/spl-token": ["@solana/spl-token@0.4.14", "", { "dependencies": { "@solana/buffer-layout": "^4.0.0", "@solana/buffer-layout-utils": "^0.2.0", "@solana/spl-token-group": "^0.0.7", "@solana/spl-token-metadata": "^0.1.6", "buffer": "^6.0.3" }, "peerDependencies": { "@solana/web3.js": "^1.95.5" } }, "sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA=="],
+
+    "@orca-so/whirlpools-sdk/@solana/spl-token": ["@solana/spl-token@0.4.14", "", { "dependencies": { "@solana/buffer-layout": "^4.0.0", "@solana/buffer-layout-utils": "^0.2.0", "@solana/spl-token-group": "^0.0.7", "@solana/spl-token-metadata": "^0.1.6", "buffer": "^6.0.3" }, "peerDependencies": { "@solana/web3.js": "^1.95.5" } }, "sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA=="],
 
     "@privy-io/api-base/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
         "8004-solana": "^0.7.8",
         "@coral-xyz/anchor": "^0.32.1",
         "@ellipsis-labs/phoenix-sdk": "^2.0.3",
+        "@noble/hashes": "^1.8.0",
         "@openbook-dex/openbook-v2": "^0.2.10",
         "@orca-so/common-sdk": "^0.7.0",
         "@orca-so/whirlpools-sdk": "^0.20.0",
@@ -350,7 +351,7 @@
 
     "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
-    "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
+    "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@openbook-dex/openbook-v2": ["@openbook-dex/openbook-v2@0.2.10", "", { "dependencies": { "@coral-xyz/anchor": "^0.29.0", "@solana/spl-token": "^0.4.0", "@solana/web3.js": "^1.77.3", "big.js": "^6.2.1" } }, "sha512-JOroVQHeia+RbghpluDJB5psUIhdhYRPLu0zWoG0h5vgDU4SjXwlcC+LJiIa2HVPasvZjWuCtlKWFyrOS75lOA=="],
 
@@ -1452,6 +1453,8 @@
 
     "zustand": ["zustand@5.0.11", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg=="],
 
+    "8004-solana/@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
+
     "@base-org/account/@noble/hashes": ["@noble/hashes@1.4.0", "", {}, "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="],
 
     "@base-org/account/clsx": ["clsx@1.2.1", "", {}, "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="],
@@ -1464,8 +1467,6 @@
 
     "@coinbase/cdp-sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "@coinbase/wallet-sdk/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
     "@coinbase/wallet-sdk/clsx": ["clsx@1.2.1", "", {}, "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="],
 
     "@coinbase/wallet-sdk/eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
@@ -1473,8 +1474,6 @@
     "@coinbase/wallet-sdk/preact": ["preact@10.28.3", "", {}, "sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA=="],
 
     "@coral-xyz/anchor/@coral-xyz/borsh": ["@coral-xyz/borsh@0.31.1", "", { "dependencies": { "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" }, "peerDependencies": { "@solana/web3.js": "^1.69.0" } }, "sha512-9N8AU9F0ubriKfNE3g1WF0/4dtlGXoBN/hd1PvbNBamBNwRgHxH4P+o3Zt7rSEloW1HUs6LfZEchlx9fW7POYw=="],
-
-    "@coral-xyz/anchor/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@coral-xyz/anchor/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
@@ -1520,15 +1519,11 @@
 
     "@metamask/sdk-communication-layer/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
-    "@metamask/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
     "@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "@metaplex-foundation/beet-solana/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
 
     "@metaplex-foundation/solita/@metaplex-foundation/beet": ["@metaplex-foundation/beet@0.4.0", "", { "dependencies": { "ansicolors": "^0.3.2", "bn.js": "^5.2.0", "debug": "^4.3.3" } }, "sha512-2OAKJnLatCc3mBXNL0QmWVQKAWK2C7XDfepgL0p/9+8oSx4bmRAFHFqptl1A/C0U5O3dxGwKfmKluW161OVGcA=="],
-
-    "@noble/curves/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@openbook-dex/openbook-v2/@coral-xyz/anchor": ["@coral-xyz/anchor@0.29.0", "", { "dependencies": { "@coral-xyz/borsh": "^0.29.0", "@noble/hashes": "^1.3.1", "@solana/web3.js": "^1.68.0", "bn.js": "^5.1.2", "bs58": "^4.0.1", "buffer-layout": "^1.2.2", "camelcase": "^6.3.0", "cross-fetch": "^3.1.5", "crypto-hash": "^1.3.0", "eventemitter3": "^4.0.7", "pako": "^2.0.3", "snake-case": "^3.0.4", "superstruct": "^0.15.4", "toml": "^3.0.0" } }, "sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA=="],
 
@@ -1577,10 +1572,6 @@
     "@reown/appkit-wallet/@walletconnect/logger": ["@walletconnect/logger@2.1.2", "", { "dependencies": { "@walletconnect/safe-json": "^1.0.2", "pino": "7.11.0" } }, "sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw=="],
 
     "@reown/appkit-wallet/zod": ["zod@3.22.4", "", {}, "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="],
-
-    "@scure/bip32/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
-    "@scure/bip39/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@solana-commerce/sdk/@solana-program/compute-budget": ["@solana-program/compute-budget@0.8.0", "", { "peerDependencies": { "@solana/kit": "^2.1.0" } }, "sha512-qPKxdxaEsFxebZ4K5RPuy7VQIm/tfJLa1+Nlt3KNA8EYQkz9Xm8htdoEaXVrer9kpgzzp9R3I3Bh6omwCM06tQ=="],
 
@@ -1702,8 +1693,6 @@
 
     "@solana/transactions/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
-    "@solana/web3.js/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
     "@solana/web3.js/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "@solana/web3.js/superstruct": ["superstruct@2.0.2", "", {}, "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A=="],
@@ -1754,8 +1743,6 @@
 
     "@walletconnect/time/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
-    "@walletconnect/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
     "@walletconnect/utils/ox": ["ox@0.9.3", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg=="],
 
     "@walletconnect/window-getters/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
@@ -1771,8 +1758,6 @@
     "cbw-sdk/preact": ["preact@10.28.3", "", {}, "sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA=="],
 
     "duplexify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
-
-    "eciesjs/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "engine.io-client/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
@@ -1826,8 +1811,6 @@
 
     "obj-multiplex/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
-    "ox/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
     "ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
     "pino/pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
@@ -1847,8 +1830,6 @@
     "to-buffer/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
     "viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
-
-    "viem/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "viem/ox": ["ox@0.11.3", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw=="],
 
@@ -1874,17 +1855,11 @@
 
     "@metamask/json-rpc-engine/@metamask/rpc-errors/@metamask/utils": ["@metamask/utils@9.3.0", "", { "dependencies": { "@ethereumjs/tx": "^4.2.0", "@metamask/superstruct": "^3.1.0", "@noble/hashes": "^1.3.1", "@scure/base": "^1.1.3", "@types/debug": "^4.1.7", "debug": "^4.3.4", "pony-cause": "^2.1.10", "semver": "^7.5.4", "uuid": "^9.0.1" } }, "sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g=="],
 
-    "@metamask/json-rpc-engine/@metamask/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
     "@metamask/json-rpc-engine/@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
-
-    "@metamask/json-rpc-middleware-stream/@metamask/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@metamask/json-rpc-middleware-stream/@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "@metamask/providers/@metamask/rpc-errors/@metamask/utils": ["@metamask/utils@9.3.0", "", { "dependencies": { "@ethereumjs/tx": "^4.2.0", "@metamask/superstruct": "^3.1.0", "@noble/hashes": "^1.3.1", "@scure/base": "^1.1.3", "@types/debug": "^4.1.7", "debug": "^4.3.4", "pony-cause": "^2.1.10", "semver": "^7.5.4", "uuid": "^9.0.1" } }, "sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g=="],
-
-    "@metamask/providers/@metamask/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@metamask/providers/@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
@@ -1895,8 +1870,6 @@
     "@metaplex-foundation/beet-solana/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
 
     "@openbook-dex/openbook-v2/@coral-xyz/anchor/@coral-xyz/borsh": ["@coral-xyz/borsh@0.29.0", "", { "dependencies": { "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" }, "peerDependencies": { "@solana/web3.js": "^1.68.0" } }, "sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ=="],
-
-    "@openbook-dex/openbook-v2/@coral-xyz/anchor/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@openbook-dex/openbook-v2/@coral-xyz/anchor/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
@@ -2168,23 +2141,15 @@
 
     "porto/ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
-    "porto/ox/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
     "porto/ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
     "viem/ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/rpc-errors/@metamask/utils": ["@metamask/utils@9.3.0", "", { "dependencies": { "@ethereumjs/tx": "^4.2.0", "@metamask/superstruct": "^3.1.0", "@noble/hashes": "^1.3.1", "@scure/base": "^1.1.3", "@types/debug": "^4.1.7", "debug": "^4.3.4", "pony-cause": "^2.1.10", "semver": "^7.5.4", "uuid": "^9.0.1" } }, "sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g=="],
 
-    "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
-    "@metamask/json-rpc-engine/@metamask/rpc-errors/@metamask/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
     "@metamask/json-rpc-engine/@metamask/rpc-errors/@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
-
-    "@metamask/providers/@metamask/rpc-errors/@metamask/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@metamask/providers/@metamask/rpc-errors/@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
@@ -2193,8 +2158,6 @@
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/logger/pino": ["pino@7.11.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "fast-redact": "^3.0.0", "on-exit-leak-free": "^0.2.0", "pino-abstract-transport": "v0.5.0", "pino-std-serializers": "^4.0.0", "process-warning": "^1.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.1.0", "safe-stable-stringify": "^2.1.0", "sonic-boom": "^2.2.1", "thread-stream": "^0.15.1" }, "bin": { "pino": "bin.js" } }, "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/sign-client/@walletconnect/core": ["@walletconnect/core@2.21.9", "", { "dependencies": { "@walletconnect/heartbeat": "1.2.2", "@walletconnect/jsonrpc-provider": "1.0.14", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/jsonrpc-ws-connection": "1.0.16", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "2.1.2", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.21.9", "@walletconnect/utils": "2.21.9", "@walletconnect/window-getters": "1.0.1", "es-toolkit": "1.39.3", "events": "3.3.0", "uint8arrays": "3.1.1" } }, "sha512-SlSknLvbO4i9Y4y8zU0zeCuJv1klQIUX3HRSBs1BaYvQKVVkrdiWPgRj4jcrL2wEOINa9NXw6HXp6x5XCXOolA=="],
-
-    "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/viem": ["viem@2.36.0", "", { "dependencies": { "@noble/curves": "1.9.6", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.0.8", "isows": "1.0.7", "ox": "0.9.1", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-Xz7AkGtR43K+NY74X2lBevwfRrsXuifGUzt8QiULO47NXIcT7g3jcA4nIvl5m2OTE5v8SlzishwXmg64xOIVmQ=="],
 
@@ -2213,8 +2176,6 @@
     "@reown/appkit-utils/@walletconnect/logger/pino/thread-stream": ["thread-stream@0.15.2", "", { "dependencies": { "real-require": "^0.1.0" } }, "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA=="],
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/sign-client/@walletconnect/core": ["@walletconnect/core@2.21.9", "", { "dependencies": { "@walletconnect/heartbeat": "1.2.2", "@walletconnect/jsonrpc-provider": "1.0.14", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/jsonrpc-ws-connection": "1.0.16", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "2.1.2", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.21.9", "@walletconnect/utils": "2.21.9", "@walletconnect/window-getters": "1.0.1", "es-toolkit": "1.39.3", "events": "3.3.0", "uint8arrays": "3.1.1" } }, "sha512-SlSknLvbO4i9Y4y8zU0zeCuJv1klQIUX3HRSBs1BaYvQKVVkrdiWPgRj4jcrL2wEOINa9NXw6HXp6x5XCXOolA=="],
-
-    "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem": ["viem@2.36.0", "", { "dependencies": { "@noble/curves": "1.9.6", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.0.8", "isows": "1.0.7", "ox": "0.9.1", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-Xz7AkGtR43K+NY74X2lBevwfRrsXuifGUzt8QiULO47NXIcT7g3jcA4nIvl5m2OTE5v8SlzishwXmg64xOIVmQ=="],
 
@@ -2235,8 +2196,6 @@
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/logger/pino": ["pino@7.11.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "fast-redact": "^3.0.0", "on-exit-leak-free": "^0.2.0", "pino-abstract-transport": "v0.5.0", "pino-std-serializers": "^4.0.0", "process-warning": "^1.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.1.0", "safe-stable-stringify": "^2.1.0", "sonic-boom": "^2.2.1", "thread-stream": "^0.15.1" }, "bin": { "pino": "bin.js" } }, "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg=="],
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/sign-client/@walletconnect/core": ["@walletconnect/core@2.21.9", "", { "dependencies": { "@walletconnect/heartbeat": "1.2.2", "@walletconnect/jsonrpc-provider": "1.0.14", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/jsonrpc-ws-connection": "1.0.16", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "2.1.2", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.21.9", "@walletconnect/utils": "2.21.9", "@walletconnect/window-getters": "1.0.1", "es-toolkit": "1.39.3", "events": "3.3.0", "uint8arrays": "3.1.1" } }, "sha512-SlSknLvbO4i9Y4y8zU0zeCuJv1klQIUX3HRSBs1BaYvQKVVkrdiWPgRj4jcrL2wEOINa9NXw6HXp6x5XCXOolA=="],
-
-    "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem": ["viem@2.36.0", "", { "dependencies": { "@noble/curves": "1.9.6", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.0.8", "isows": "1.0.7", "ox": "0.9.1", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-Xz7AkGtR43K+NY74X2lBevwfRrsXuifGUzt8QiULO47NXIcT7g3jcA4nIvl5m2OTE5v8SlzishwXmg64xOIVmQ=="],
 
@@ -2469,8 +2428,6 @@
     "gill/@solana/transaction-confirmation/@solana/transactions/@solana/nominal-types": ["@solana/nominal-types@2.3.0", "", { "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA=="],
 
     "jayson/@types/ws/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
-
-    "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/rpc-errors/@metamask/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/rpc-errors/@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -64,6 +64,10 @@
       "name": "ralph-edge-worker",
       "version": "0.1.0",
       "dependencies": {
+        "@coral-xyz/anchor": "^0.32.1",
+        "@noble/hashes": "^1.8.0",
+        "@orca-so/common-sdk": "^0.7.0",
+        "@orca-so/whirlpools-sdk": "^0.20.0",
         "@solana/web3.js": "^1.98.4",
         "bs58": "^6.0.0",
         "jose": "^6.1.3",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
     "@coral-xyz/anchor": "^0.32.1",
     "@ellipsis-labs/phoenix-sdk": "^2.0.3",
     "@openbook-dex/openbook-v2": "^0.2.10",
+    "@orca-so/common-sdk": "^0.7.0",
+    "@orca-so/whirlpools-sdk": "^0.20.0",
     "@solana/web3.js": "^1.98.4",
     "bs58": "^6.0.0",
     "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "8004-solana": "^0.7.8",
     "@coral-xyz/anchor": "^0.32.1",
     "@ellipsis-labs/phoenix-sdk": "^2.0.3",
+    "@noble/hashes": "^1.8.0",
     "@openbook-dex/openbook-v2": "^0.2.10",
     "@orca-so/common-sdk": "^0.7.0",
     "@orca-so/whirlpools-sdk": "^0.20.0",

--- a/src/runtime/venues/catalog.ts
+++ b/src/runtime/venues/catalog.ts
@@ -118,6 +118,43 @@ const BUILTIN_RUNTIME_VENUE_CAPABILITIES = [
   },
   {
     schemaVersion: "v1",
+    venueKey: "orca",
+    displayName: "Orca Whirlpools",
+    adapterKeys: ["orca"],
+    marketTypes: ["spot"],
+    orderTypes: ["market"],
+    intentFamilies: ["spot_swap"],
+    authModel: "privy_solana_wallet",
+    feeModel: "venue_quote_inclusive",
+    precision: {
+      priceDecimals: 6,
+      sizeDecimals: 9,
+      minOrderIncrement: "0.000001",
+      minQuoteNotionalUsd: "0.01",
+    },
+    sizeLimits: {
+      minNotionalUsd: "0.01",
+    },
+    latencyProfile: {
+      expectedQuoteMs: 350,
+      expectedSubmitMs: 950,
+      expectedSettlementMs: 5000,
+    },
+    settlementBehavior: "swap_atomic",
+    lifecycle: {
+      supportsOrderLifecycle: false,
+      supportsPositionLifecycle: false,
+      requiresExternalOracle: false,
+      settlementModel: "atomic_swap",
+    },
+    oracleRequirements: ["venue_reference"],
+    supportedModes: ["shadow", "paper"],
+    onboardingState: "paper_ready",
+    notes:
+      "Direct Orca Whirlpools concentrated-liquidity routing kept bounded to shadow and paper while pool-level route quality evidence accumulates.",
+  },
+  {
+    schemaVersion: "v1",
     venueKey: "phoenix",
     displayName: "Phoenix",
     adapterKeys: ["phoenix_orderbook"],

--- a/tests/unit/worker_execution_orca.test.ts
+++ b/tests/unit/worker_execution_orca.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, mock, test } from "bun:test";
+import { normalizePolicy } from "../../apps/worker/src/policy";
+import type { Env } from "../../apps/worker/src/types";
+
+const { executeOrcaSwap } = await import(
+  "../../apps/worker/src/execution/orca_executor"
+);
+
+function buildQuoteResponse() {
+  return {
+    inputMint: "mint-in",
+    outputMint: "mint-out",
+    inAmount: "1000",
+    outAmount: "2200",
+    slippageBps: 50,
+    priceImpactPct: 0,
+    routePlan: [{ swapInfo: { label: "Orca Whirlpool" }, poolId: "pool-1" }],
+    orcaPoolSnapshot: {
+      address: "pool-1",
+      feeRate: 400,
+      tickSpacing: 4,
+    },
+  };
+}
+
+describe("worker orca execution adapter", () => {
+  test("returns dry_run without building transactions", async () => {
+    const buildSwapTransaction = mock(async () => ({
+      unsignedTransactionBase64: "unsigned",
+      additionalSignerCount: 1,
+      lastValidBlockHeight: 42,
+    }));
+
+    const result = await executeOrcaSwap({
+      env: {} as Env,
+      policy: normalizePolicy({ dryRun: true }),
+      rpc: {} as never,
+      jupiter: {} as never,
+      orca: { buildSwapTransaction } as never,
+      quoteResponse: buildQuoteResponse(),
+      userPublicKey: "11111111111111111111111111111111",
+      privyWalletId: "wallet-id",
+      log: () => {},
+    });
+
+    expect(result.status).toBe("dry_run");
+    expect(result.executionMeta?.route).toBe("orca");
+    expect(buildSwapTransaction).not.toHaveBeenCalled();
+  });
+
+  test("simulates Orca whirlpool swaps in bounded paper mode", async () => {
+    const buildSwapTransaction = mock(async () => ({
+      unsignedTransactionBase64: "unsigned",
+      additionalSignerCount: 1,
+      lastValidBlockHeight: 42,
+    }));
+    const simulateTransactionBase64 = mock(async () => ({ err: null }));
+
+    const result = await executeOrcaSwap(
+      {
+        env: {} as Env,
+        runtimeMode: "paper",
+        policy: normalizePolicy({}),
+        rpc: {
+          simulateTransactionBase64,
+        } as never,
+        jupiter: {} as never,
+        orca: { buildSwapTransaction } as never,
+        quoteResponse: buildQuoteResponse(),
+        userPublicKey: "11111111111111111111111111111111",
+        privyWalletId: "wallet-id",
+        log: () => {},
+      },
+      {
+        signTransactionWithPrivyById: mock(async () => "signed"),
+      },
+    );
+
+    expect(result.status).toBe("simulated");
+    expect(result.executionMeta?.classification).toBe("simulated");
+    expect(result.executionMeta?.lifecycle?.notes).toContain("orca-whirlpool");
+    expect(simulateTransactionBase64).toHaveBeenCalledTimes(1);
+  });
+
+  test("submits and confirms Orca swaps when called in executable mode", async () => {
+    const buildSwapTransaction = mock(async () => ({
+      unsignedTransactionBase64: "unsigned",
+      additionalSignerCount: 1,
+      lastValidBlockHeight: 42,
+    }));
+    const sendTransactionBase64 = mock(async () => "sig-1");
+    const confirmSignature = mock(async () => ({
+      ok: true,
+      status: "confirmed",
+    }));
+
+    const result = await executeOrcaSwap(
+      {
+        env: {} as Env,
+        policy: normalizePolicy({ commitment: "confirmed" }),
+        rpc: {
+          sendTransactionBase64,
+          confirmSignature,
+        } as never,
+        jupiter: {} as never,
+        orca: { buildSwapTransaction } as never,
+        quoteResponse: buildQuoteResponse(),
+        userPublicKey: "11111111111111111111111111111111",
+        privyWalletId: "wallet-id",
+        log: () => {},
+      },
+      {
+        signTransactionWithPrivyById: mock(async () => "signed"),
+      },
+    );
+
+    expect(result.status).toBe("confirmed");
+    expect(result.signature).toBe("sig-1");
+    expect(confirmSignature).toHaveBeenCalledTimes(1);
+  });
+
+  test("fails closed when Orca simulation fails", async () => {
+    const buildSwapTransaction = mock(async () => ({
+      unsignedTransactionBase64: "unsigned",
+      additionalSignerCount: 1,
+      lastValidBlockHeight: 42,
+    }));
+    const simulateTransactionBase64 = mock(async () => ({
+      err: { message: "simulation-failed" },
+    }));
+
+    const result = await executeOrcaSwap(
+      {
+        env: {} as Env,
+        runtimeMode: "paper",
+        policy: normalizePolicy({}),
+        rpc: {
+          simulateTransactionBase64,
+        } as never,
+        jupiter: {} as never,
+        orca: { buildSwapTransaction } as never,
+        quoteResponse: buildQuoteResponse(),
+        userPublicKey: "11111111111111111111111111111111",
+        privyWalletId: "wallet-id",
+        log: () => {},
+      },
+      {
+        signTransactionWithPrivyById: mock(async () => "signed"),
+      },
+    );
+
+    expect(result.status).toBe("simulate_error");
+    expect(result.signature).toBeNull();
+    expect(result.executionMeta?.classification).toBe("error");
+  });
+});

--- a/tests/unit/worker_execution_router.test.ts
+++ b/tests/unit/worker_execution_router.test.ts
@@ -186,6 +186,33 @@ describe("worker execution router", () => {
     expect(result.executionMeta?.route).toBe("raydium");
   });
 
+  test("routes bounded Orca spot swaps in paper mode", async () => {
+    const result = await executeSwapViaRouter({
+      env: {} as never,
+      venueKey: "orca",
+      runtimeMode: "paper",
+      requireVenueRouting: true,
+      execution: { adapter: "orca" },
+      policy: normalizePolicy({ dryRun: true }),
+      rpc: {} as never,
+      jupiter: {} as never,
+      quoteResponse: {
+        inputMint: "A",
+        outputMint: "B",
+        inAmount: "1",
+        outAmount: "2",
+        orcaPoolSnapshot: {
+          address: "orca-pool-1",
+        },
+      },
+      userPublicKey: "11111111111111111111111111111111",
+      log: () => {},
+    });
+
+    expect(result.status).toBe("dry_run");
+    expect(result.executionMeta?.route).toBe("orca");
+  });
+
   test("custom execution adapters can be registered for new intent families", async () => {
     registerExecutionAdapter(
       "phoenix_orderbook",
@@ -357,6 +384,32 @@ describe("worker execution router", () => {
         log: () => {},
       }),
     ).rejects.toThrow(/runtime-venue-mode-not-supported:raydium:live/);
+  });
+
+  test("fails closed when Orca spot swaps are requested in live mode", async () => {
+    await expect(
+      executeSwapViaRouter({
+        env: {} as never,
+        venueKey: "orca",
+        runtimeMode: "live",
+        requireVenueRouting: true,
+        execution: { adapter: "orca" },
+        policy: normalizePolicy({ dryRun: true }),
+        rpc: {} as never,
+        jupiter: {} as never,
+        quoteResponse: {
+          inputMint: "A",
+          outputMint: "B",
+          inAmount: "1",
+          outAmount: "2",
+          orcaPoolSnapshot: {
+            address: "orca-pool-1",
+          },
+        },
+        userPublicKey: "11111111111111111111111111111111",
+        log: () => {},
+      }),
+    ).rejects.toThrow(/runtime-venue-mode-not-supported:orca:live/);
   });
 
   test("fails closed when adapter is not allowlisted for the runtime venue", async () => {

--- a/tests/unit/worker_orca.test.ts
+++ b/tests/unit/worker_orca.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  normalizeOrcaQuoteResponse,
+  OrcaClient,
+  selectBestOrcaPoolSnapshot,
+} from "../../apps/worker/src/orca";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+describe("worker orca client", () => {
+  test("selects the healthiest high-TVL whirlpool for a mint pair", () => {
+    const pool = selectBestOrcaPoolSnapshot({
+      pools: [
+        {
+          address: "warning-pool",
+          poolType: "whirlpool",
+          tokenMintA: "mint-a",
+          tokenMintB: "mint-b",
+          tvlUsdc: "999999",
+          hasWarning: true,
+        },
+        {
+          address: "best-pool",
+          poolType: "whirlpool",
+          tokenMintA: "mint-a",
+          tokenMintB: "mint-b",
+          tvlUsdc: "500000",
+          hasWarning: false,
+        },
+      ],
+      inputMint: "mint-a",
+      outputMint: "mint-b",
+    });
+
+    expect(pool.address).toBe("best-pool");
+  });
+
+  test("normalizes Orca whirlpool quotes into the shared spot quote shape", () => {
+    const normalized = normalizeOrcaQuoteResponse({
+      pool: {
+        address: "pool-1",
+        tokenMintA: "mint-a",
+        tokenMintB: "mint-b",
+        feeRate: 400,
+        tickSpacing: 4,
+        tickCurrentIndex: -12,
+        liquidity: "999",
+        price: "2.2",
+        tvlUsdc: "10000",
+        tokenA: { decimals: 6 },
+        tokenB: { decimals: 6 },
+        stats: { "24h": { volume: "1200" } },
+      },
+      inputMint: "mint-a",
+      outputMint: "mint-b",
+      sdkQuote: {
+        estimatedAmountInAtomic: "1000",
+        estimatedAmountOutAtomic: "2200",
+        otherAmountThresholdAtomic: "2100",
+        estimatedFeeAmountAtomic: "3",
+        sqrtPriceLimit: "123",
+        tickArrayAddresses: ["tick-0", "tick-1", "tick-2"],
+        aToB: true,
+        amountSpecifiedIsInput: true,
+      },
+    });
+
+    expect(normalized).toMatchObject({
+      inputMint: "mint-a",
+      outputMint: "mint-b",
+      inAmount: "1000",
+      outAmount: "2200",
+      otherAmountThreshold: "2100",
+      quoteProvider: "orca",
+    });
+    expect(normalized.routePlan?.[0]?.swapInfo?.label).toBe("Orca Whirlpool");
+    expect(
+      (normalized as Record<string, unknown>).orcaPoolSnapshot,
+    ).toBeTruthy();
+  });
+
+  test("quotes through the Orca pools API and injected SDK facade", async () => {
+    const requests: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      requests.push(String(input));
+      return new Response(
+        JSON.stringify({
+          data: [
+            {
+              address: "pool-1",
+              poolType: "whirlpool",
+              tokenMintA: "mint-a",
+              tokenMintB: "mint-b",
+              feeRate: 400,
+              tickSpacing: 4,
+              liquidity: "999",
+              tickCurrentIndex: -12,
+              tvlUsdc: "10000",
+              hasWarning: false,
+              tokenA: { decimals: 6 },
+              tokenB: { decimals: 6 },
+              price: "2.2",
+              stats: { "24h": { volume: "1200" } },
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const quoteByInputPool = mock(async () => ({
+      estimatedAmountInAtomic: "1000",
+      estimatedAmountOutAtomic: "2200",
+      otherAmountThresholdAtomic: "2100",
+      estimatedFeeAmountAtomic: "3",
+      sqrtPriceLimit: "123",
+      tickArrayAddresses: ["tick-0", "tick-1", "tick-2"],
+      aToB: true,
+      amountSpecifiedIsInput: true,
+    }));
+
+    const client = new OrcaClient(
+      "https://rpc.orca.test",
+      "https://api.orca.test",
+      {
+        sdk: {
+          quoteByInputPool,
+          buildSwapTransaction: mock(async () => ({
+            unsignedTransactionBase64: "unsigned",
+            additionalSignerCount: 1,
+            lastValidBlockHeight: 42,
+          })),
+        },
+      },
+    );
+    const quote = await client.quoteBaseIn({
+      inputMint: "mint-a",
+      outputMint: "mint-b",
+      amount: "1000",
+      slippageBps: 50,
+    });
+
+    expect(requests).toEqual([
+      "https://api.orca.test/v2/solana/pools?tokensBothOf=mint-a%2Cmint-b&size=10&sortBy=tvl&sortDirection=desc&stats=24h",
+    ]);
+    expect(quote.pool.address).toBe("pool-1");
+    expect(quote.normalizedQuote.outAmount).toBe("2200");
+    expect(quoteByInputPool).toHaveBeenCalledTimes(1);
+  });
+
+  test("rebuilds swap transactions from the normalized quote metadata", async () => {
+    const buildSwapTransaction = mock(async () => ({
+      unsignedTransactionBase64: "unsigned-base64",
+      additionalSignerCount: 1,
+      lastValidBlockHeight: 55,
+    }));
+
+    const client = new OrcaClient(
+      "https://rpc.orca.test",
+      "https://api.orca.test",
+      {
+        sdk: {
+          quoteByInputPool: mock(async () => ({
+            estimatedAmountInAtomic: "1000",
+            estimatedAmountOutAtomic: "2200",
+            otherAmountThresholdAtomic: "2100",
+            estimatedFeeAmountAtomic: "3",
+            sqrtPriceLimit: "123",
+            tickArrayAddresses: ["tick-0", "tick-1", "tick-2"],
+            aToB: true,
+            amountSpecifiedIsInput: true,
+          })),
+          buildSwapTransaction,
+        },
+      },
+    );
+
+    const built = await client.buildSwapTransaction({
+      walletPublicKey: "wallet-1",
+      quoteResponse: {
+        inputMint: "mint-a",
+        outputMint: "mint-b",
+        inAmount: "1000",
+        outAmount: "2200",
+        slippageBps: 50,
+        orcaPoolSnapshot: {
+          address: "pool-1",
+        },
+      },
+    });
+
+    expect(built.unsignedTransactionBase64).toBe("unsigned-base64");
+    expect(buildSwapTransaction).toHaveBeenCalledWith({
+      rpcEndpoint: "https://rpc.orca.test",
+      poolAddress: "pool-1",
+      inputMint: "mint-a",
+      amountAtomic: "1000",
+      slippageBps: 50,
+      walletPublicKey: "wallet-1",
+    });
+  });
+});

--- a/tests/unit/worker_orca.test.ts
+++ b/tests/unit/worker_orca.test.ts
@@ -57,6 +57,7 @@ describe("worker orca client", () => {
       },
       inputMint: "mint-a",
       outputMint: "mint-b",
+      slippageBps: 25,
       sdkQuote: {
         estimatedAmountInAtomic: "1000",
         estimatedAmountOutAtomic: "2200",
@@ -75,6 +76,7 @@ describe("worker orca client", () => {
       inAmount: "1000",
       outAmount: "2200",
       otherAmountThreshold: "2100",
+      slippageBps: 25,
       quoteProvider: "orca",
     });
     expect(normalized.routePlan?.[0]?.swapInfo?.label).toBe("Orca Whirlpool");
@@ -149,6 +151,7 @@ describe("worker orca client", () => {
     ]);
     expect(quote.pool.address).toBe("pool-1");
     expect(quote.normalizedQuote.outAmount).toBe("2200");
+    expect(quote.normalizedQuote.slippageBps).toBe(50);
     expect(quoteByInputPool).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/unit/worker_spot_venues.test.ts
+++ b/tests/unit/worker_spot_venues.test.ts
@@ -82,4 +82,86 @@ describe("worker spot venue helpers", () => {
     ).toBe("raydium");
     expect(quoteBaseIn).toHaveBeenCalledTimes(1);
   });
+
+  test("quotes Orca via the dedicated client and captures pool-level telemetry", async () => {
+    const quoteBaseIn = mock(async () => ({
+      pool: {
+        address: "orca-pool-1",
+        feeRate: 400,
+        tickSpacing: 4,
+        tickCurrentIndex: -12,
+        liquidity: "999",
+        tvlUsdc: "10000",
+        adaptiveFeeEnabled: false,
+        hasWarning: false,
+        addressLookupTable: "alt-1",
+        stats: {
+          "24h": {
+            volume: "1200",
+          },
+        },
+      },
+      sdkQuote: {
+        estimatedAmountInAtomic: "1000",
+        estimatedAmountOutAtomic: "2200",
+        otherAmountThresholdAtomic: "2100",
+        estimatedFeeAmountAtomic: "3",
+        sqrtPriceLimit: "123",
+        tickArrayAddresses: ["tick-0", "tick-1", "tick-2"],
+        aToB: true,
+        amountSpecifiedIsInput: true,
+      },
+      normalizedQuote: {
+        inputMint: "mint-in",
+        outputMint: "mint-out",
+        inAmount: "1000",
+        outAmount: "2200",
+        priceImpactPct: 0.001,
+        routePlan: [
+          { swapInfo: { label: "Orca Whirlpool" }, poolId: "orca-pool-1" },
+        ],
+        otherAmountThreshold: "2100",
+        orcaPoolSnapshot: {
+          address: "orca-pool-1",
+          feeRate: 400,
+          tickSpacing: 4,
+          tickCurrentIndex: -12,
+          liquidity: "999",
+          tvlUsdc: "10000",
+          adaptiveFeeEnabled: false,
+          hasWarning: false,
+          addressLookupTable: "alt-1",
+          stats: {
+            "24h": {
+              volume: "1200",
+            },
+          },
+        },
+      },
+    }));
+
+    const quoted = await quoteSpotSwap({
+      venueKey: "orca",
+      inputMint: "mint-in",
+      outputMint: "mint-out",
+      amountAtomic: "1000",
+      slippageBps: 50,
+      jupiter: {} as never,
+      orca: { quoteBaseIn } as never,
+    });
+
+    expect(quoted.quoteProvider).toBe("orca");
+    expect(quoted.routeQuality.routeLabels).toEqual(["Orca Whirlpool"]);
+    expect(quoted.routeQuality.poolAddress).toBe("orca-pool-1");
+    expect(quoted.routeQuality.poolTickSpacing).toBe(4);
+    expect(quoted.routeQuality.dailyVolumeUsd).toBe("1200");
+    expect(
+      resolveSpotVenueExecutionAdapter({
+        venueKey: "orca",
+        runtimeMode: "paper",
+        defaultAdapter: "jupiter",
+      }),
+    ).toBe("orca");
+    expect(quoteBaseIn).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Fixes #371

## Summary
- add a bounded Orca Whirlpools spot adapter with REST pool discovery, SDK-backed quoting, and unsigned transaction construction for Privy signing
- route Orca through the shared spot venue helpers, runtime venue catalog, and runtime canary quality metadata with pool-level CLMM fields
- add focused unit coverage for Orca normalization, routing, execution, and runtime harness touchpoints

## Validation Commands And Results
- `bun test tests/unit/worker_orca.test.ts tests/unit/worker_execution_orca.test.ts tests/unit/worker_spot_venues.test.ts tests/unit/worker_execution_router.test.ts` ✅
- `bun test tests/unit/runtime_protocol_contracts.test.ts tests/unit/worker_runtime_internal_routes.test.ts tests/unit/worker_execution_canary.test.ts` ✅
- `bun test tests/unit/worker_runtime_canary_route.test.ts` ✅
- `bun run lint` ✅
- `bun run typecheck` ✅

## Preview Or Local URLs
- N/A, worker-only harness changes

## Browser Artifacts For UI Changes
- N/A

## Benchmark Delta For Performance-Sensitive Changes
- N/A

## Risk Notes And Follow-ups
- Orca pool discovery is REST-backed and quote or tx construction is legacy SDK-backed; that split is intentional for this repo's current web3.js and Privy custody model
- live Orca execution remains fail-closed; the venue is registered for `shadow` and `paper` only
- LP position management stays out of scope for this issue
