### PR TITLE
[Phase 1] Integrate OpenBook v2 spot CLOB adapter

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@coral-xyz/anchor": "^0.32.1",
     "@noble/hashes": "^1.8.0",
+    "@openbook-dex/openbook-v2": "^0.2.10",
     "@orca-so/common-sdk": "^0.7.0",
     "@orca-so/whirlpools-sdk": "^0.20.0",
     "@solana/web3.js": "^1.98.4",

--- a/apps/worker/src/execution/openbook_executor.ts
+++ b/apps/worker/src/execution/openbook_executor.ts
@@ -1,0 +1,280 @@
+import { OpenBookClient, type OpenBookOrderOptions } from "../openbook";
+import { signTransactionWithPrivyById } from "../privy";
+import { evaluateSafeLaneTransaction } from "./safe_lane_policy";
+import type {
+  ExecuteIntentInput,
+  ExecuteSwapResult,
+  NonSwapExecutionIntent,
+} from "./types";
+
+type ExecuteOpenBookClobOrderInput = ExecuteIntentInput & {
+  intent: NonSwapExecutionIntent;
+};
+
+type OpenBookExecutorDeps = {
+  signTransactionWithPrivyById?: typeof signTransactionWithPrivyById;
+  evaluateSafeLaneTransaction?: typeof evaluateSafeLaneTransaction;
+};
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function readsTruthyExecutionParam(value: unknown): boolean {
+  if (value === true) return true;
+  if (typeof value !== "string") return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "on";
+}
+
+function isSafeLaneExecution(input: ExecuteOpenBookClobOrderInput): boolean {
+  const lane = String(input.execution?.params?.lane ?? "")
+    .trim()
+    .toLowerCase();
+  return lane === "safe";
+}
+
+function buildLifecycle(input: {
+  note: string;
+  requestId: string;
+  marketAddress: string;
+  openOrdersAccount: string;
+}): NonNullable<ExecuteSwapResult["executionMeta"]>["lifecycle"] {
+  return {
+    orderState: "open",
+    fillState: "pending",
+    settlementState: "confirmed",
+    notes: [
+      input.note,
+      `client-order-id:${input.requestId}`,
+      `market:${input.marketAddress}`,
+      `open-orders:${input.openOrdersAccount}`,
+    ],
+  };
+}
+
+function readOpenBookOptions(
+  intent: NonSwapExecutionIntent,
+): OpenBookOrderOptions | null {
+  const params = intent.params;
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    return null;
+  }
+  return params as OpenBookOrderOptions;
+}
+
+export async function executeOpenBookClobOrder(
+  input: ExecuteOpenBookClobOrderInput,
+  deps: OpenBookExecutorDeps = {},
+): Promise<ExecuteSwapResult> {
+  if (input.intent.family !== "clob_order") {
+    throw new Error("invalid-openbook-intent-family");
+  }
+  if (input.intent.venueKey !== "openbook") {
+    throw new Error("invalid-openbook-venue");
+  }
+  if (input.intent.marketType !== "spot") {
+    throw new Error("invalid-openbook-market-type");
+  }
+  if (input.intent.side !== "buy" && input.intent.side !== "sell") {
+    throw new Error("invalid-openbook-side");
+  }
+  if (input.runtimeMode === "live") {
+    throw new Error("openbook-live-mode-not-supported");
+  }
+
+  const route = "openbook_v2";
+  const rpcEndpoint = String(input.env.RPC_ENDPOINT ?? "").trim();
+  if (!rpcEndpoint) {
+    throw new Error("rpc-endpoint-missing");
+  }
+  const openbook =
+    input.openbook ?? new OpenBookClient(rpcEndpoint, undefined, undefined);
+
+  const plan = await openbook.buildPlaceOrderPlan({
+    walletPublicKey: input.intent.wallet,
+    instrumentId: input.intent.instrumentId,
+    side: input.intent.side,
+    quantityAtomic: String(input.intent.quantityAtomic ?? ""),
+    options: readOpenBookOptions(input.intent),
+  });
+  const lifecycle = buildLifecycle({
+    note: `openbook-${plan.request.orderType}`,
+    requestId: plan.request.clientOrderId,
+    marketAddress: plan.market.marketAddress,
+    openOrdersAccount: plan.prerequisites.openOrdersAccount,
+  });
+
+  if (input.policy.dryRun) {
+    return {
+      status: "dry_run",
+      signature: null,
+      usedQuote: plan.quotePreview,
+      refreshed: false,
+      lastValidBlockHeight: plan.lastValidBlockHeight,
+      executionMeta: {
+        route,
+        classification: "dry_run",
+        venueSessionId: plan.prerequisites.openOrdersAccount,
+        intentId: plan.request.clientOrderId,
+        lifecycle,
+        trace: {
+          txBuiltAt: nowIso(),
+        },
+      },
+    };
+  }
+
+  if (!input.privyWalletId) {
+    return {
+      status: "simulated",
+      signature: null,
+      usedQuote: plan.quotePreview,
+      refreshed: false,
+      lastValidBlockHeight: plan.lastValidBlockHeight,
+      executionMeta: {
+        route,
+        classification: "simulated",
+        venueSessionId: plan.prerequisites.openOrdersAccount,
+        intentId: plan.request.clientOrderId,
+        lifecycle: {
+          ...lifecycle,
+          notes: [...(lifecycle.notes ?? []), "unsigned-plan-only"],
+        },
+        trace: {
+          txBuiltAt: nowIso(),
+        },
+      },
+    };
+  }
+
+  if (input.guardEnabled) await input.guardEnabled();
+
+  const txBuiltAt = nowIso();
+  const signWithPrivy =
+    deps.signTransactionWithPrivyById ?? signTransactionWithPrivyById;
+  const signedBase64 = await signWithPrivy(
+    input.env,
+    input.privyWalletId,
+    plan.unsignedTransactionBase64,
+  );
+
+  if (isSafeLaneExecution(input)) {
+    const evaluateSafeLane =
+      deps.evaluateSafeLaneTransaction ?? evaluateSafeLaneTransaction;
+    const safeEvaluation = evaluateSafeLane({
+      env: input.env,
+      signedTransactionBase64: signedBase64,
+    });
+    if (!safeEvaluation.ok) {
+      const failedAt = nowIso();
+      return {
+        status: "simulate_error",
+        signature: null,
+        usedQuote: plan.quotePreview,
+        refreshed: false,
+        lastValidBlockHeight: plan.lastValidBlockHeight,
+        err: {
+          code: "policy-denied",
+          reason: safeEvaluation.reason,
+          profile: safeEvaluation.profile,
+          limits: safeEvaluation.limits,
+        },
+        executionMeta: {
+          route,
+          classification: "error",
+          venueSessionId: plan.prerequisites.openOrdersAccount,
+          intentId: plan.request.clientOrderId,
+          lifecycle: {
+            orderState: "rejected",
+            fillState: "failed",
+            settlementState: "failed",
+            notes: [safeEvaluation.reason],
+          },
+          trace: {
+            txBuiltAt,
+            failedAt,
+          },
+        },
+      };
+    }
+  }
+
+  const requiresSimulation =
+    input.runtimeMode === "shadow" ||
+    input.runtimeMode === "paper" ||
+    input.policy.simulateOnly ||
+    readsTruthyExecutionParam(input.execution?.params?.requireSimulation);
+
+  if (!requiresSimulation) {
+    return {
+      status: "simulated",
+      signature: null,
+      usedQuote: plan.quotePreview,
+      refreshed: false,
+      lastValidBlockHeight: plan.lastValidBlockHeight,
+      executionMeta: {
+        route,
+        classification: "simulated",
+        venueSessionId: plan.prerequisites.openOrdersAccount,
+        intentId: plan.request.clientOrderId,
+        lifecycle,
+        trace: {
+          txBuiltAt,
+        },
+      },
+    };
+  }
+
+  const simulation = await input.rpc.simulateTransactionBase64(signedBase64, {
+    commitment: input.policy.commitment,
+    sigVerify: true,
+  });
+  const simulatedAt = nowIso();
+  if (simulation.err) {
+    return {
+      status: "simulate_error",
+      signature: null,
+      usedQuote: plan.quotePreview,
+      refreshed: false,
+      lastValidBlockHeight: plan.lastValidBlockHeight,
+      err: simulation.err,
+      executionMeta: {
+        route,
+        classification: "error",
+        venueSessionId: plan.prerequisites.openOrdersAccount,
+        intentId: plan.request.clientOrderId,
+        lifecycle: {
+          orderState: "rejected",
+          fillState: "failed",
+          settlementState: "failed",
+          notes: ["openbook-simulation-failed"],
+        },
+        trace: {
+          txBuiltAt,
+          simulatedAt,
+          failedAt: simulatedAt,
+        },
+      },
+    };
+  }
+
+  return {
+    status: "simulated",
+    signature: null,
+    usedQuote: plan.quotePreview,
+    refreshed: false,
+    lastValidBlockHeight: plan.lastValidBlockHeight,
+    executionMeta: {
+      route,
+      classification: "simulated",
+      venueSessionId: plan.prerequisites.openOrdersAccount,
+      intentId: plan.request.clientOrderId,
+      lifecycle,
+      trace: {
+        txBuiltAt,
+        simulatedAt,
+      },
+    },
+  };
+}

--- a/apps/worker/src/execution/router.ts
+++ b/apps/worker/src/execution/router.ts
@@ -14,7 +14,6 @@ import { executeJupiterSwap } from "./jupiter_executor";
 import { resolveJupiterConditionalSpotOrder } from "./jupiter_trigger";
 import { executeJupiterConditionalSpotOrder } from "./jupiter_trigger_executor";
 import { executeMagicBlockEphemeralRollupSwap } from "./magicblock_ephemeral_rollup_executor";
-import { executeOpenBookClobOrder } from "./openbook_executor";
 import { executeOrcaSwap } from "./orca_executor";
 import { executeRaydiumSwap } from "./raydium_executor";
 import type {
@@ -334,6 +333,7 @@ export async function executeIntentViaRouter(
       input.intent.family === "clob_order" &&
       registration.adapterKey === "openbook_v2"
     ) {
+      const { executeOpenBookClobOrder } = await import("./openbook_executor");
       return await executeOpenBookClobOrder(input);
     }
     if (

--- a/apps/worker/src/execution/router.ts
+++ b/apps/worker/src/execution/router.ts
@@ -14,6 +14,7 @@ import { executeJupiterSwap } from "./jupiter_executor";
 import { resolveJupiterConditionalSpotOrder } from "./jupiter_trigger";
 import { executeJupiterConditionalSpotOrder } from "./jupiter_trigger_executor";
 import { executeMagicBlockEphemeralRollupSwap } from "./magicblock_ephemeral_rollup_executor";
+import { executeOpenBookClobOrder } from "./openbook_executor";
 import { executeOrcaSwap } from "./orca_executor";
 import { executeRaydiumSwap } from "./raydium_executor";
 import type {
@@ -129,6 +130,18 @@ const ADAPTERS = new Map<string, ExecutionAdapterRegistration>([
       supportedModes: ["shadow", "paper"],
       supportedIntentFamilies: ["spot_swap"],
       adapter: executeRaydiumSwap,
+    },
+  ],
+  [
+    "openbook_v2",
+    {
+      adapterKey: "openbook_v2",
+      venueKey: "openbook",
+      supportedModes: ["shadow", "paper"],
+      supportedIntentFamilies: ["clob_order"],
+      adapter: async () => {
+        throw new Error("openbook-v2-requires-intent-routing");
+      },
     },
   ],
 ]);
@@ -316,6 +329,12 @@ export async function executeIntentViaRouter(
         registration.adapterKey === "drift_swift")
     ) {
       return await executeDriftPerpOrder(input);
+    }
+    if (
+      input.intent.family === "clob_order" &&
+      registration.adapterKey === "openbook_v2"
+    ) {
+      return await executeOpenBookClobOrder(input);
     }
     if (
       input.intent.family === "conditional_spot_order" &&

--- a/apps/worker/src/execution/types.ts
+++ b/apps/worker/src/execution/types.ts
@@ -1,5 +1,6 @@
 import type { DriftClient } from "../drift";
 import type { JupiterClient, JupiterQuoteResponse } from "../jupiter";
+import type { OpenBookClient } from "../openbook";
 import type { OrcaClient } from "../orca";
 import type { NormalizedPolicy } from "../policy";
 import type { RaydiumClient } from "../raydium";
@@ -94,6 +95,7 @@ type ExecuteIntentInputBase = {
   jupiter: JupiterClient;
   drift?: DriftClient;
   orca?: OrcaClient;
+  openbook?: OpenBookClient;
   raydium?: RaydiumClient;
   log: ExecutionLogFn;
   guardEnabled?: () => Promise<void>;

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -5469,6 +5469,7 @@ const worker = {
         user = await ensureUserWallet(env, user);
         const pageSize = 80;
         const conditionalRequests: ExecutionRequestRecord[] = [];
+        const clobRequests: ExecutionRequestRecord[] = [];
         for (let offset = 0; ; offset += pageSize) {
           const page = await listOpenExecutionRequestsByActorAndIntentFamily(
             env.WAITLIST_DB,
@@ -5481,6 +5482,20 @@ const worker = {
             },
           );
           conditionalRequests.push(...page);
+          if (page.length < pageSize) break;
+        }
+        for (let offset = 0; ; offset += pageSize) {
+          const page = await listOpenExecutionRequestsByActorAndIntentFamily(
+            env.WAITLIST_DB,
+            {
+              actorId: user.id,
+              mode: "privy_execute",
+              intentFamily: "clob_order",
+              limit: pageSize,
+              offset,
+            },
+          );
+          clobRequests.push(...page);
           if (page.length < pageSize) break;
         }
         const orders: Record<string, unknown>[] = [];
@@ -5508,6 +5523,17 @@ const worker = {
                   signature: reconciled.summary.signature,
                 }
               : null,
+          });
+          if (order) orders.push(order);
+        }
+        for (const entry of clobRequests) {
+          const latest = await getExecutionLatestStatus(
+            env.WAITLIST_DB,
+            entry.requestId,
+          );
+          const order = buildTerminalOpenBookOrderView({
+            latest,
+            lifecycle: readPersistedExecutionLifecycle({ latest }),
           });
           if (order) orders.push(order);
         }
@@ -5574,14 +5600,148 @@ const worker = {
         const intent = isRecord(reconciled.latest.request.metadata?.intent)
           ? reconciled.latest.request.metadata?.intent
           : null;
-        if (readTrimmedString(intent?.family) !== "conditional_spot_order") {
+        const intentFamily = readTrimmedString(intent?.family);
+        if (
+          intentFamily !== "conditional_spot_order" &&
+          !(
+            intentFamily === "clob_order" &&
+            readTrimmedString(intent?.venueKey) === "openbook"
+          )
+        ) {
           return withCors(
             execErrorResponse({
               code: "invalid-request",
               details: {
-                reason: "unsupported-conditional-order-request",
+                reason: "unsupported-open-order-request",
               },
               requestId,
+            }),
+            env,
+          );
+        }
+        if (
+          intentFamily === "clob_order" &&
+          readTrimmedString(intent?.venueKey) === "openbook"
+        ) {
+          const lifecycle = readPersistedExecutionLifecycle({
+            latest: reconciled.latest,
+          });
+          const currentState = toExecSubmitState(
+            reconciled.latest.request.status,
+          );
+          if (
+            isExecSubmitTerminalState(currentState) ||
+            reconciled.latest.receipt ||
+            reconciled.latest.request.terminalAt
+          ) {
+            return withCors(
+              json({
+                ok: true,
+                requestId,
+                cancelled: false,
+                status: {
+                  state: currentState,
+                  terminal: true,
+                  updatedAt: reconciled.latest.request.updatedAt,
+                },
+                ...(lifecycle ? { lifecycle } : {}),
+              }),
+              env,
+            );
+          }
+          const trackedOrder = readTrackedOpenBookOrder({
+            latest: reconciled.latest,
+          });
+          const clientOrderId = readTrimmedString(trackedOrder?.clientOrderId);
+          if (!clientOrderId) {
+            return withCors(
+              execErrorResponse({
+                code: "invalid-request",
+                details: {
+                  reason: "openbook-order-tracking-missing",
+                },
+                requestId,
+              }),
+              env,
+            );
+          }
+          const provider =
+            reconciled.latest.latestAttempt?.provider ?? "openbook_v2";
+          const cancelledAt = new Date().toISOString();
+          const cancelLifecycle = {
+            orderState: "cancelled",
+            fillState: "failed",
+            settlementState: "failed",
+            notes: ["openbook-order-cancelled"],
+          };
+          await upsertExecutionReceiptIdempotent(env.WAITLIST_DB, {
+            requestId,
+            receiptId: newExecutionReceiptId(),
+            finalizedStatus: "failed",
+            lane: reconciled.latest.request.lane,
+            provider,
+            signature: null,
+            slot: null,
+            errorCode: "order-cancelled",
+            errorMessage: "OpenBook order was cancelled before settlement.",
+            receipt: {
+              mode: reconciled.latest.request.mode,
+              route: provider,
+              outcome: "failed",
+              lifecycle: cancelLifecycle,
+              openbookOrder: {
+                clientOrderId,
+                openOrdersAccount:
+                  readTrimmedString(trackedOrder?.openOrdersAccount) ?? null,
+                instrumentId:
+                  readTrimmedString(trackedOrder?.instrumentId) ??
+                  readTrimmedString(intent?.instrumentId),
+                side:
+                  readTrimmedString(trackedOrder?.side) ??
+                  readTrimmedString(intent?.side),
+                orderType:
+                  readTrimmedString(trackedOrder?.orderType) ?? "limit",
+                timeInForce:
+                  readTrimmedString(trackedOrder?.timeInForce) ?? "gtc",
+                quantityAtomic:
+                  readTrimmedString(trackedOrder?.quantityAtomic) ??
+                  readTrimmedString(intent?.quantityAtomic),
+                limitPriceAtomic:
+                  readTrimmedString(trackedOrder?.limitPriceAtomic) ?? null,
+              },
+            },
+            readyAt: cancelledAt,
+          });
+          await terminalizeExecutionRequest(env.WAITLIST_DB, {
+            requestId,
+            status: "failed",
+            statusReason: "openbook-order-cancelled",
+            details: {
+              provider,
+              orderState: "cancelled",
+              clientOrderId,
+            },
+            nowIso: cancelledAt,
+          });
+          const refreshed = await getExecutionLatestStatus(
+            env.WAITLIST_DB,
+            requestId,
+          );
+          const refreshedState = toExecSubmitState(
+            refreshed?.request.status ?? "failed",
+          );
+          return withCors(
+            json({
+              ok: true,
+              requestId,
+              cancelled: true,
+              status: {
+                state: refreshedState,
+                terminal: isExecSubmitTerminalState(refreshedState),
+                updatedAt: refreshed?.request.updatedAt ?? cancelledAt,
+              },
+              lifecycle: cancelLifecycle,
+              signature: null,
             }),
             env,
           );
@@ -6672,6 +6832,26 @@ function resolveTerminalProviderStatus(input: {
   return input.latest?.receipt?.errorCode ? "degraded" : "healthy";
 }
 
+function readPersistedExecutionLifecycle(input: {
+  latest: Awaited<ReturnType<typeof getExecutionLatestStatus>>;
+}): Record<string, unknown> | null {
+  const latest = input.latest;
+  if (!latest) return null;
+  const receiptLifecycle = isRecord(latest.receipt?.receipt?.lifecycle)
+    ? latest.receipt?.receipt?.lifecycle
+    : null;
+  if (receiptLifecycle) return receiptLifecycle;
+  const executionMeta = isRecord(
+    latest.latestAttempt?.providerResponse?.executionMeta,
+  )
+    ? latest.latestAttempt?.providerResponse?.executionMeta
+    : null;
+  const executionLifecycle = isRecord(executionMeta?.lifecycle)
+    ? executionMeta?.lifecycle
+    : null;
+  return executionLifecycle ?? null;
+}
+
 function resolveTerminalOpenOrderStatus(
   lifecycle: Record<string, unknown> | null,
   terminal: boolean,
@@ -6692,6 +6872,61 @@ function resolveTerminalOpenOrderStatus(
   if (orderState === "rejected") return "failed";
   if (terminal) return "failed";
   return "working";
+}
+
+function readTrackedOpenBookOrder(input: {
+  latest: Awaited<ReturnType<typeof getExecutionLatestStatus>>;
+}): Record<string, unknown> | null {
+  const latest = input.latest;
+  if (!latest) return null;
+  const intent = isRecord(latest.request.metadata?.intent)
+    ? latest.request.metadata.intent
+    : null;
+  if (
+    readTrimmedString(intent?.family) !== "clob_order" ||
+    readTrimmedString(intent?.venueKey) !== "openbook"
+  ) {
+    return null;
+  }
+  const attemptResponse = isRecord(latest.latestAttempt?.providerResponse)
+    ? latest.latestAttempt?.providerResponse
+    : null;
+  const executionMeta = isRecord(attemptResponse?.executionMeta)
+    ? attemptResponse?.executionMeta
+    : null;
+  const quality = isRecord(attemptResponse?.quality)
+    ? attemptResponse?.quality
+    : null;
+  const receiptOrder = isRecord(latest.receipt?.receipt?.openbookOrder)
+    ? latest.receipt?.receipt?.openbookOrder
+    : null;
+  return {
+    clientOrderId:
+      readTrimmedString(receiptOrder?.clientOrderId) ??
+      readTrimmedString(executionMeta?.intentId),
+    openOrdersAccount:
+      readTrimmedString(receiptOrder?.openOrdersAccount) ??
+      readTrimmedString(executionMeta?.venueSessionId),
+    instrumentId:
+      readTrimmedString(receiptOrder?.instrumentId) ??
+      readTrimmedString(intent?.instrumentId),
+    side:
+      readTrimmedString(receiptOrder?.side) ?? readTrimmedString(intent?.side),
+    orderType:
+      readTrimmedString(receiptOrder?.orderType) ??
+      readTrimmedString(quality?.orderType) ??
+      "limit",
+    timeInForce:
+      readTrimmedString(receiptOrder?.timeInForce) ??
+      readTrimmedString(quality?.timeInForce) ??
+      "gtc",
+    quantityAtomic:
+      readTrimmedString(receiptOrder?.quantityAtomic) ??
+      readTrimmedString(intent?.quantityAtomic),
+    limitPriceAtomic:
+      readTrimmedString(receiptOrder?.limitPriceAtomic) ??
+      readTrimmedString(quality?.limitPriceAtomic),
+  };
 }
 
 function buildTerminalConditionalOrderView(input: {
@@ -6780,6 +7015,57 @@ function buildTerminalConditionalOrderView(input: {
     oracleFreshnessMs: null,
     oracleSource: null,
     oracleStale: false,
+    lifecycle:
+      lifecycle && Object.keys(lifecycle).length > 0
+        ? {
+            ...lifecycle,
+            ...(notes ? { notes } : {}),
+          }
+        : null,
+  };
+}
+
+function buildTerminalOpenBookOrderView(input: {
+  latest: Awaited<ReturnType<typeof getExecutionLatestStatus>>;
+  lifecycle: Record<string, unknown> | null;
+}): Record<string, unknown> | null {
+  const latest = input.latest;
+  if (!latest) return null;
+  const trackedOrder = readTrackedOpenBookOrder({ latest });
+  if (!trackedOrder) return null;
+  const terminal = Boolean(latest.request.terminalAt);
+  const lifecycle = input.lifecycle;
+  const notes = readStringArray(lifecycle?.notes);
+  return {
+    requestId: latest.request.requestId,
+    requestStatus: latest.request.status,
+    terminal,
+    receivedAt: latest.request.receivedAt,
+    updatedAt: latest.request.updatedAt,
+    terminalAt: latest.request.terminalAt,
+    pairId: readTrimmedString(trackedOrder.instrumentId),
+    direction: readTrimmedString(trackedOrder.side),
+    source: readTrimmedString(latest.request.metadata?.source) ?? "TERMINAL",
+    reason: readTrimmedString(latest.request.metadata?.reason),
+    orderType: readTrimmedString(trackedOrder.orderType) ?? "limit",
+    timeInForce: readTrimmedString(trackedOrder.timeInForce) ?? "gtc",
+    lane: latest.request.lane,
+    simulationPreference: "always",
+    priorityLevel: "normal",
+    priorityMicroLamports: null,
+    amountAtomic: readTrimmedString(trackedOrder.quantityAtomic),
+    remainingAmountAtomic: readTrimmedString(trackedOrder.quantityAtomic),
+    limitPriceAtomic: readTrimmedString(trackedOrder.limitPriceAtomic),
+    provider:
+      latest.receipt?.provider ??
+      latest.latestAttempt?.provider ??
+      "openbook_v2",
+    signature: latest.receipt?.signature ?? null,
+    errorCode: latest.receipt?.errorCode ?? null,
+    errorMessage: latest.receipt?.errorMessage ?? null,
+    clientOrderId: readTrimmedString(trackedOrder.clientOrderId),
+    openOrdersAccount: readTrimmedString(trackedOrder.openOrdersAccount),
+    status: resolveTerminalOpenOrderStatus(lifecycle, terminal),
     lifecycle:
       lifecycle && Object.keys(lifecycle).length > 0
         ? {

--- a/apps/worker/src/openbook.ts
+++ b/apps/worker/src/openbook.ts
@@ -1,0 +1,1042 @@
+import { AnchorProvider, BN } from "@coral-xyz/anchor";
+import {
+  createAssociatedTokenAccountIdempotentInstruction,
+  findAccountsByMints,
+  getAssociatedTokenAddress,
+  I64_MAX_BN,
+  OPENBOOK_PROGRAM_ID,
+  Market as OpenBookMarket,
+  OpenBookV2Client,
+  OpenOrders,
+  PlaceOrderTypeUtils,
+  SelfTradeBehaviorUtils,
+  SideUtils,
+} from "@openbook-dex/openbook-v2";
+import {
+  Connection,
+  PublicKey,
+  Transaction,
+  type TransactionInstruction,
+  type VersionedTransaction,
+} from "@solana/web3.js";
+import { SUPPORTED_TRADING_PAIRS, type SupportedTradingPair } from "./defaults";
+import type { JupiterQuoteResponse } from "./jupiter";
+
+export type OpenBookOrderOptions = {
+  orderType?: "market" | "limit" | "trigger" | null;
+  timeInForce?: "gtc" | "ioc" | "fok" | null;
+  postOnly?: boolean | null;
+  reduceOnly?: boolean | null;
+  quantityMode?: "base" | "quote" | "notional" | null;
+  limitPriceAtomic?: string | null;
+  clientOrderId?: string | null;
+};
+
+export type OpenBookMarketSnapshot = {
+  instrumentId: string;
+  marketAddress: string;
+  baseMint: string;
+  quoteMint: string;
+  baseDecimals: number;
+  quoteDecimals: number;
+  bestBidPriceUi: number | null;
+  bestAskPriceUi: number | null;
+  bestBidSizeUi: number | null;
+  bestAskSizeUi: number | null;
+  spreadBps: number | null;
+  tickSizeUi: string;
+  minOrderSizeUi: string;
+  openOrdersAdminRequired: boolean;
+  consumeEventsAdminRequired: boolean;
+  closeMarketAdminRequired: boolean;
+};
+
+export type OpenBookOrderSnapshot = {
+  orderId: string;
+  clientOrderId: string;
+  side: "buy" | "sell";
+  priceUi: string;
+  sizeUi: string;
+  expired: boolean;
+};
+
+export type OpenBookOpenOrdersSummary = {
+  market: OpenBookMarketSnapshot;
+  openOrdersIndexer: string;
+  openOrdersAccount: string | null;
+  userBaseAccount: string;
+  userQuoteAccount: string;
+  makerVolumeNative: string;
+  takerVolumeNative: string;
+  baseBalanceUi: string;
+  quoteBalanceUi: string;
+  orderCount: number;
+  orders: OpenBookOrderSnapshot[];
+};
+
+export type OpenBookAccountPlan = {
+  openOrdersIndexer: string;
+  openOrdersAccount: string;
+  userBaseAccount: string;
+  userQuoteAccount: string;
+  userFundingAccount: string;
+  createdOpenOrdersIndexer: boolean;
+  createdOpenOrdersAccount: boolean;
+};
+
+export type OpenBookResolvedOrderRequest = {
+  side: "buy" | "sell";
+  quantityAtomic: string;
+  quantityBaseUi: number;
+  orderType: "market" | "limit";
+  timeInForce: "gtc" | "ioc" | "fok";
+  postOnly: boolean;
+  limitPriceAtomic: string;
+  limitPriceUi: number;
+  clientOrderId: string;
+  estimatedQuoteUi: number;
+  estimatedQuoteAtomic: string;
+};
+
+export type OpenBookPlaceOrderPlan = {
+  unsignedTransactionBase64: string;
+  lastValidBlockHeight: number | null;
+  market: OpenBookMarketSnapshot;
+  prerequisites: OpenBookAccountPlan;
+  request: OpenBookResolvedOrderRequest;
+  quotePreview: JupiterQuoteResponse;
+};
+
+export type OpenBookCancelOrderPlan = {
+  unsignedTransactionBase64: string;
+  lastValidBlockHeight: number | null;
+  market: OpenBookMarketSnapshot;
+  openOrdersAccount: string;
+  clientOrderId: string;
+};
+
+export type OpenBookReplaceOrderPlan = {
+  unsignedTransactionBase64: string;
+  lastValidBlockHeight: number | null;
+  market: OpenBookMarketSnapshot;
+  openOrdersAccount: string;
+  cancelledClientOrderId: string;
+  replacement: OpenBookResolvedOrderRequest;
+  quotePreview: JupiterQuoteResponse;
+};
+
+export type OpenBookSdkFacade = {
+  buildPlaceOrderPlan(request: {
+    rpcEndpoint: string;
+    programId: string;
+    walletPublicKey: string;
+    instrumentId: string;
+    side: "buy" | "sell";
+    quantityAtomic: string;
+    options?: OpenBookOrderOptions | null;
+  }): Promise<OpenBookPlaceOrderPlan>;
+  buildCancelOrderPlan(request: {
+    rpcEndpoint: string;
+    programId: string;
+    walletPublicKey: string;
+    instrumentId: string;
+    clientOrderId: string;
+  }): Promise<OpenBookCancelOrderPlan>;
+  buildReplaceOrderPlan(request: {
+    rpcEndpoint: string;
+    programId: string;
+    walletPublicKey: string;
+    instrumentId: string;
+    clientOrderId: string;
+    side: "buy" | "sell";
+    quantityAtomic: string;
+    options?: OpenBookOrderOptions | null;
+  }): Promise<OpenBookReplaceOrderPlan>;
+  listOpenOrders(request: {
+    rpcEndpoint: string;
+    programId: string;
+    walletPublicKey: string;
+    instrumentId: string;
+  }): Promise<OpenBookOpenOrdersSummary>;
+};
+
+function readTrimmedString(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return normalized || null;
+}
+
+function readTruthyBoolean(value: unknown): boolean {
+  return (
+    value === true ||
+    String(value ?? "")
+      .trim()
+      .toLowerCase() === "true"
+  );
+}
+
+function parsePositiveAtomicString(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return /^[1-9][0-9]*$/.test(normalized) ? normalized : null;
+}
+
+function parseOptionalClientOrderId(value: unknown): string | null {
+  if (value === undefined || value === null || value === "") return null;
+  return parsePositiveAtomicString(value);
+}
+
+function tryParsePublicKey(value: string): PublicKey | null {
+  try {
+    return new PublicKey(value);
+  } catch {
+    return null;
+  }
+}
+
+function resolveSupportedPair(
+  instrumentId: string,
+): SupportedTradingPair | null {
+  return (
+    SUPPORTED_TRADING_PAIRS.find((pair) => pair.id === instrumentId.trim()) ??
+    null
+  );
+}
+
+function isVersionedTransaction(
+  tx: Transaction | VersionedTransaction,
+): tx is VersionedTransaction {
+  return "version" in tx;
+}
+
+function serializeUnsignedTransactionBase64(
+  tx: Transaction | VersionedTransaction,
+): string {
+  if (isVersionedTransaction(tx)) {
+    return Buffer.from(tx.serialize()).toString("base64");
+  }
+  return Buffer.from(
+    tx.serialize({
+      requireAllSignatures: false,
+      verifySignatures: false,
+    }),
+  ).toString("base64");
+}
+
+function buildReadOnlyWallet(publicKey: PublicKey): {
+  publicKey: PublicKey;
+  signTransaction<T extends Transaction | VersionedTransaction>(
+    tx: T,
+  ): Promise<T>;
+  signAllTransactions<T extends Transaction | VersionedTransaction>(
+    txs: T[],
+  ): Promise<T[]>;
+} {
+  return {
+    publicKey,
+    async signTransaction<T extends Transaction | VersionedTransaction>(
+      _tx: T,
+    ): Promise<T> {
+      throw new Error("openbook-read-only-wallet-cannot-sign");
+    },
+    async signAllTransactions<T extends Transaction | VersionedTransaction>(
+      _txs: T[],
+    ): Promise<T[]> {
+      throw new Error("openbook-read-only-wallet-cannot-sign");
+    },
+  };
+}
+
+function buildConnection(rpcEndpoint: string): Connection {
+  return new Connection(rpcEndpoint, "confirmed");
+}
+
+function buildProvider(
+  rpcEndpoint: string,
+  walletPublicKey: string,
+): AnchorProvider {
+  return new AnchorProvider(
+    buildConnection(rpcEndpoint),
+    buildReadOnlyWallet(new PublicKey(walletPublicKey)) as never,
+    {
+      commitment: "confirmed",
+      preflightCommitment: "confirmed",
+    },
+  );
+}
+
+function buildClient(input: {
+  rpcEndpoint: string;
+  programId: string;
+  walletPublicKey: string;
+}): OpenBookV2Client {
+  return new OpenBookV2Client(
+    buildProvider(input.rpcEndpoint, input.walletPublicKey),
+    new PublicKey(input.programId),
+  );
+}
+
+function buildMarketSnapshot(input: {
+  instrumentId: string;
+  market: OpenBookMarket;
+}): OpenBookMarketSnapshot {
+  const bestBid = input.market.bids?.best();
+  const bestAsk = input.market.asks?.best();
+  const spreadBps =
+    bestBid && bestAsk && bestBid.price > 0
+      ? ((bestAsk.price - bestBid.price) / bestBid.price) * 10_000
+      : null;
+  return {
+    instrumentId: input.instrumentId,
+    marketAddress: input.market.pubkey.toBase58(),
+    baseMint: input.market.account.baseMint.toBase58(),
+    quoteMint: input.market.account.quoteMint.toBase58(),
+    baseDecimals: input.market.account.baseDecimals,
+    quoteDecimals: input.market.account.quoteDecimals,
+    bestBidPriceUi: bestBid?.price ?? null,
+    bestAskPriceUi: bestAsk?.price ?? null,
+    bestBidSizeUi: bestBid?.size ?? null,
+    bestAskSizeUi: bestAsk?.size ?? null,
+    spreadBps:
+      spreadBps !== null && Number.isFinite(spreadBps) ? spreadBps : null,
+    tickSizeUi: input.market.tickSize.toString(),
+    minOrderSizeUi: input.market.minOrderSize.toString(),
+    openOrdersAdminRequired: !input.market.account.openOrdersAdmin.key.equals(
+      PublicKey.default,
+    ),
+    consumeEventsAdminRequired:
+      !input.market.account.consumeEventsAdmin.key.equals(PublicKey.default),
+    closeMarketAdminRequired: !input.market.account.closeMarketAdmin.key.equals(
+      PublicKey.default,
+    ),
+  };
+}
+
+function topOfBookLiquidityScore(snapshot: OpenBookMarketSnapshot): number {
+  return (
+    (snapshot.bestBidPriceUi ?? 0) * (snapshot.bestBidSizeUi ?? 0) +
+    (snapshot.bestAskPriceUi ?? 0) * (snapshot.bestAskSizeUi ?? 0)
+  );
+}
+
+function compareMarketCandidates(
+  a: OpenBookMarketSnapshot,
+  b: OpenBookMarketSnapshot,
+): number {
+  const aHasBoth =
+    a.bestBidPriceUi !== null && a.bestAskPriceUi !== null ? 1 : 0;
+  const bHasBoth =
+    b.bestBidPriceUi !== null && b.bestAskPriceUi !== null ? 1 : 0;
+  if (aHasBoth !== bHasBoth) return bHasBoth - aHasBoth;
+  const spreadA = a.spreadBps ?? Number.POSITIVE_INFINITY;
+  const spreadB = b.spreadBps ?? Number.POSITIVE_INFINITY;
+  if (spreadA !== spreadB) return spreadA - spreadB;
+  const liquidityA = topOfBookLiquidityScore(a);
+  const liquidityB = topOfBookLiquidityScore(b);
+  if (liquidityA !== liquidityB) return liquidityB - liquidityA;
+  return a.marketAddress.localeCompare(b.marketAddress);
+}
+
+async function resolveMarket(input: {
+  client: OpenBookV2Client;
+  instrumentId: string;
+}): Promise<{
+  market: OpenBookMarket;
+  snapshot: OpenBookMarketSnapshot;
+}> {
+  const pair = resolveSupportedPair(input.instrumentId);
+  if (pair) {
+    const accounts = await findAccountsByMints(
+      input.client.connection,
+      new PublicKey(pair.baseMint),
+      new PublicKey(pair.quoteMint),
+      input.client.programId,
+    );
+    if (accounts.length < 1) {
+      throw new Error(`openbook-market-not-found:${input.instrumentId}`);
+    }
+    const loaded = await Promise.all(
+      accounts.map(async ({ publicKey }) => {
+        const market = await OpenBookMarket.load(input.client, publicKey);
+        await market.loadOrderBook();
+        return {
+          market,
+          snapshot: buildMarketSnapshot({
+            instrumentId: input.instrumentId,
+            market,
+          }),
+        };
+      }),
+    );
+    loaded.sort((left, right) =>
+      compareMarketCandidates(left.snapshot, right.snapshot),
+    );
+    return loaded[0] as {
+      market: OpenBookMarket;
+      snapshot: OpenBookMarketSnapshot;
+    };
+  }
+
+  const marketKey = tryParsePublicKey(input.instrumentId);
+  if (!marketKey) {
+    throw new Error(`unsupported-openbook-instrument:${input.instrumentId}`);
+  }
+  const market = await OpenBookMarket.load(input.client, marketKey);
+  await market.loadOrderBook();
+  return {
+    market,
+    snapshot: buildMarketSnapshot({
+      instrumentId: input.instrumentId,
+      market,
+    }),
+  };
+}
+
+function deriveAggressivePriceUi(input: {
+  market: OpenBookMarketSnapshot;
+  side: "buy" | "sell";
+}): number {
+  const anchorPrice =
+    input.side === "buy"
+      ? (input.market.bestAskPriceUi ?? input.market.bestBidPriceUi)
+      : (input.market.bestBidPriceUi ?? input.market.bestAskPriceUi);
+  if (anchorPrice === null || anchorPrice <= 0) {
+    throw new Error("openbook-orderbook-liquidity-missing");
+  }
+  return input.side === "buy" ? anchorPrice * 1.05 : anchorPrice * 0.95;
+}
+
+function priceUiToAtomicString(priceUi: number, quoteDecimals: number): string {
+  return Math.max(1, Math.round(priceUi * 10 ** quoteDecimals)).toString();
+}
+
+function quantityAtomicToBaseUi(
+  quantityAtomic: string,
+  baseDecimals: number,
+): number {
+  const quantity = Number(quantityAtomic);
+  return quantity / 10 ** baseDecimals;
+}
+
+function computeQuoteNotionalAtomic(input: {
+  priceAtomic: string;
+  quantityAtomic: string;
+  baseDecimals: number;
+}): string {
+  const priceAtomic = BigInt(input.priceAtomic);
+  const quantityAtomic = BigInt(input.quantityAtomic);
+  const baseScale = 10n ** BigInt(input.baseDecimals);
+  return ((priceAtomic * quantityAtomic) / baseScale).toString();
+}
+
+function computeEstimatedQuoteUi(input: {
+  limitPriceUi: number;
+  quantityBaseUi: number;
+}): number {
+  return input.limitPriceUi * input.quantityBaseUi;
+}
+
+function computeMaxQuoteLotsIncludingFees(input: {
+  market: OpenBookMarket;
+  request: OpenBookResolvedOrderRequest;
+}): BN {
+  if (input.request.orderType === "market") {
+    return I64_MAX_BN;
+  }
+  const quoteLimitUi = Math.max(
+    input.request.estimatedQuoteUi * 1.02,
+    input.market.quoteLotsToUi(new BN(1)),
+  );
+  return input.market.quoteUiToLots(quoteLimitUi);
+}
+
+export function resolveOpenBookOrderRequest(input: {
+  market: OpenBookMarketSnapshot;
+  side: "buy" | "sell";
+  quantityAtomic: string;
+  options?: OpenBookOrderOptions | null;
+}): OpenBookResolvedOrderRequest {
+  if (readTruthyBoolean(input.options?.reduceOnly)) {
+    throw new Error("openbook-reduce-only-unsupported");
+  }
+  const quantityAtomic = parsePositiveAtomicString(input.quantityAtomic);
+  if (!quantityAtomic) {
+    throw new Error("openbook-quantity-atomic-invalid");
+  }
+  const quantityMode = readTrimmedString(input.options?.quantityMode) ?? "base";
+  if (quantityMode !== "base") {
+    throw new Error(`openbook-quantity-mode-unsupported:${quantityMode}`);
+  }
+  const orderTypeRaw = readTrimmedString(input.options?.orderType) ?? "limit";
+  if (orderTypeRaw === "trigger") {
+    throw new Error("openbook-trigger-orders-unsupported");
+  }
+  const orderType = orderTypeRaw === "market" ? "market" : "limit";
+  const timeInForceRaw = readTrimmedString(input.options?.timeInForce) ?? "gtc";
+  const timeInForce =
+    timeInForceRaw === "ioc" || timeInForceRaw === "fok"
+      ? timeInForceRaw
+      : "gtc";
+  const postOnly = readTruthyBoolean(input.options?.postOnly);
+  if (postOnly && (orderType === "market" || timeInForce !== "gtc")) {
+    throw new Error("openbook-post-only-incompatible");
+  }
+  const explicitLimitPriceAtomic = parsePositiveAtomicString(
+    input.options?.limitPriceAtomic,
+  );
+  const limitPriceUi = explicitLimitPriceAtomic
+    ? Number(explicitLimitPriceAtomic) / 10 ** input.market.quoteDecimals
+    : deriveAggressivePriceUi({
+        market: input.market,
+        side: input.side,
+      });
+  if (!Number.isFinite(limitPriceUi) || limitPriceUi <= 0) {
+    throw new Error("openbook-limit-price-invalid");
+  }
+  const limitPriceAtomic =
+    explicitLimitPriceAtomic ??
+    priceUiToAtomicString(limitPriceUi, input.market.quoteDecimals);
+  const quantityBaseUi = quantityAtomicToBaseUi(
+    quantityAtomic,
+    input.market.baseDecimals,
+  );
+  if (!Number.isFinite(quantityBaseUi) || quantityBaseUi <= 0) {
+    throw new Error("openbook-quantity-base-invalid");
+  }
+  const clientOrderId =
+    parseOptionalClientOrderId(input.options?.clientOrderId) ??
+    String(Date.now());
+  const estimatedQuoteUi = computeEstimatedQuoteUi({
+    limitPriceUi,
+    quantityBaseUi,
+  });
+  return {
+    side: input.side,
+    quantityAtomic,
+    quantityBaseUi,
+    orderType,
+    timeInForce,
+    postOnly,
+    limitPriceAtomic,
+    limitPriceUi,
+    clientOrderId,
+    estimatedQuoteUi,
+    estimatedQuoteAtomic: computeQuoteNotionalAtomic({
+      priceAtomic: limitPriceAtomic,
+      quantityAtomic,
+      baseDecimals: input.market.baseDecimals,
+    }),
+  };
+}
+
+export function buildOpenBookSyntheticQuote(input: {
+  market: OpenBookMarketSnapshot;
+  request: OpenBookResolvedOrderRequest;
+}): JupiterQuoteResponse {
+  return input.request.side === "buy"
+    ? {
+        inputMint: input.market.quoteMint,
+        outputMint: input.market.baseMint,
+        inAmount: input.request.estimatedQuoteAtomic,
+        outAmount: input.request.quantityAtomic,
+        otherAmountThreshold: input.request.quantityAtomic,
+        priceImpactPct:
+          input.market.spreadBps !== null ? input.market.spreadBps / 100 : 0,
+        routePlan: [
+          {
+            poolId: input.market.marketAddress,
+            swapInfo: {
+              label: "OpenBook v2",
+              poolId: input.market.marketAddress,
+            },
+          },
+        ],
+      }
+    : {
+        inputMint: input.market.baseMint,
+        outputMint: input.market.quoteMint,
+        inAmount: input.request.quantityAtomic,
+        outAmount: input.request.estimatedQuoteAtomic,
+        otherAmountThreshold: input.request.estimatedQuoteAtomic,
+        priceImpactPct:
+          input.market.spreadBps !== null ? input.market.spreadBps / 100 : 0,
+        routePlan: [
+          {
+            poolId: input.market.marketAddress,
+            swapInfo: {
+              label: "OpenBook v2",
+              poolId: input.market.marketAddress,
+            },
+          },
+        ],
+      };
+}
+
+function mapSide(side: "buy" | "sell") {
+  return side === "buy" ? SideUtils.Bid : SideUtils.Ask;
+}
+
+function mapPlaceOrderType(input: OpenBookResolvedOrderRequest) {
+  if (input.postOnly) {
+    return PlaceOrderTypeUtils.PostOnly;
+  }
+  if (input.orderType === "market") {
+    return PlaceOrderTypeUtils.Market;
+  }
+  if (input.timeInForce === "ioc") {
+    return PlaceOrderTypeUtils.ImmediateOrCancel;
+  }
+  if (input.timeInForce === "fok") {
+    return PlaceOrderTypeUtils.FillOrKill;
+  }
+  return PlaceOrderTypeUtils.Limit;
+}
+
+function buildOpenOrdersAccountName(instrumentId: string): string {
+  const pair = resolveSupportedPair(instrumentId);
+  if (pair) {
+    return `tr-${pair.baseSymbol.toLowerCase()}-${pair.quoteSymbol.toLowerCase()}`;
+  }
+  return `tr-ob-${instrumentId.slice(-8).toLowerCase()}`;
+}
+
+function collectRemainingAccounts(input: {
+  market: OpenBookMarket;
+  side: "buy" | "sell";
+  postOnly: boolean;
+}): PublicKey[] {
+  if (input.postOnly) return [];
+  const oppositeBook =
+    input.side === "buy" ? input.market.asks : input.market.bids;
+  if (!oppositeBook) return [];
+  const accounts = new Set<string>();
+  for (const order of oppositeBook.items()) {
+    accounts.add(order.leafNode.owner.toBase58());
+    if (accounts.size >= 3) break;
+  }
+  return Array.from(accounts).map((value) => new PublicKey(value));
+}
+
+function orderIdToString(value: unknown): string {
+  if (value instanceof BN) return value.toString();
+  return String(value ?? "");
+}
+
+async function buildUnsignedTransactionBase64(input: {
+  client: OpenBookV2Client;
+  walletPublicKey: PublicKey;
+  instructions: TransactionInstruction[];
+}): Promise<{
+  unsignedTransactionBase64: string;
+  lastValidBlockHeight: number;
+}> {
+  const blockhash =
+    await input.client.connection.getLatestBlockhash("confirmed");
+  const tx = new Transaction({
+    feePayer: input.walletPublicKey,
+    blockhash: blockhash.blockhash,
+    lastValidBlockHeight: blockhash.lastValidBlockHeight,
+  });
+  for (const instruction of input.instructions) {
+    tx.add(instruction);
+  }
+  return {
+    unsignedTransactionBase64: serializeUnsignedTransactionBase64(tx),
+    lastValidBlockHeight: blockhash.lastValidBlockHeight,
+  };
+}
+
+export function createOpenBookSdkFacade(): OpenBookSdkFacade {
+  async function loadSummary(input: {
+    client: OpenBookV2Client;
+    market: OpenBookMarket;
+    snapshot: OpenBookMarketSnapshot;
+    walletPublicKey: PublicKey;
+  }): Promise<OpenBookOpenOrdersSummary> {
+    await input.market.loadEventHeap();
+    const openOrders = await OpenOrders.loadNullableForMarketAndOwner(
+      input.market,
+      input.walletPublicKey,
+    );
+    const userBaseAccount = await getAssociatedTokenAddress(
+      input.market.account.baseMint,
+      input.walletPublicKey,
+    );
+    const userQuoteAccount = await getAssociatedTokenAddress(
+      input.market.account.quoteMint,
+      input.walletPublicKey,
+    );
+    if (!openOrders) {
+      return {
+        market: input.snapshot,
+        openOrdersIndexer: input.client
+          .findOpenOrdersIndexer(input.walletPublicKey)
+          .toBase58(),
+        openOrdersAccount: null,
+        userBaseAccount: userBaseAccount.toBase58(),
+        userQuoteAccount: userQuoteAccount.toBase58(),
+        makerVolumeNative: "0",
+        takerVolumeNative: "0",
+        baseBalanceUi: "0",
+        quoteBalanceUi: "0",
+        orderCount: 0,
+        orders: [],
+      };
+    }
+    await openOrders.reload();
+    const orders = Array.from(openOrders.items()).map((order) => ({
+      orderId: orderIdToString(order.leafNode.key),
+      clientOrderId: orderIdToString(order.leafNode.clientOrderId),
+      side: order.side.bid ? ("buy" as const) : ("sell" as const),
+      priceUi: String(order.price),
+      sizeUi: String(order.size),
+      expired: order.isExpired,
+    }));
+    return {
+      market: input.snapshot,
+      openOrdersIndexer: input.client
+        .findOpenOrdersIndexer(input.walletPublicKey)
+        .toBase58(),
+      openOrdersAccount: openOrders.pubkey.toBase58(),
+      userBaseAccount: userBaseAccount.toBase58(),
+      userQuoteAccount: userQuoteAccount.toBase58(),
+      makerVolumeNative: openOrders.account.position.makerVolume.toString(),
+      takerVolumeNative: openOrders.account.position.takerVolume.toString(),
+      baseBalanceUi: String(openOrders.getBaseBalanceUi()),
+      quoteBalanceUi: String(openOrders.getQuoteBalanceUi()),
+      orderCount: orders.length,
+      orders,
+    };
+  }
+
+  return {
+    async buildPlaceOrderPlan(request) {
+      const client = buildClient(request);
+      const walletPublicKey = new PublicKey(request.walletPublicKey);
+      const { market, snapshot } = await resolveMarket({
+        client,
+        instrumentId: request.instrumentId,
+      });
+      const resolved = resolveOpenBookOrderRequest({
+        market: snapshot,
+        side: request.side,
+        quantityAtomic: request.quantityAtomic,
+        options: request.options,
+      });
+      const openOrdersIndexer = client.findOpenOrdersIndexer(walletPublicKey);
+      const openOrdersIndexerAccount =
+        await client.deserializeOpenOrdersIndexerAccount(openOrdersIndexer);
+      const existingOpenOrders = await client.findOpenOrdersForMarket(
+        walletPublicKey,
+        market.pubkey,
+      );
+      const instructions: import("@solana/web3.js").TransactionInstruction[] =
+        [];
+      let createdOpenOrdersIndexer = false;
+      let createdOpenOrdersAccount = false;
+      if (!openOrdersIndexerAccount) {
+        instructions.push(
+          await client.createOpenOrdersIndexerIx(
+            openOrdersIndexer,
+            walletPublicKey,
+          ),
+        );
+        createdOpenOrdersIndexer = true;
+      }
+      let openOrdersAccount = existingOpenOrders[0] ?? null;
+      if (!openOrdersAccount) {
+        const [createOpenOrdersIxs, createdOpenOrders] =
+          await client.createOpenOrdersIx(
+            market.pubkey,
+            buildOpenOrdersAccountName(request.instrumentId),
+            walletPublicKey,
+            null,
+            openOrdersIndexer,
+          );
+        instructions.push(...createOpenOrdersIxs);
+        openOrdersAccount = createdOpenOrders;
+        createdOpenOrdersAccount = true;
+      }
+      if (!openOrdersAccount) {
+        throw new Error("openbook-open-orders-account-missing");
+      }
+      const userBaseAccount = await getAssociatedTokenAddress(
+        market.account.baseMint,
+        walletPublicKey,
+      );
+      const userQuoteAccount = await getAssociatedTokenAddress(
+        market.account.quoteMint,
+        walletPublicKey,
+      );
+      const userFundingAccount =
+        resolved.side === "buy" ? userQuoteAccount : userBaseAccount;
+      instructions.push(
+        await createAssociatedTokenAccountIdempotentInstruction(
+          walletPublicKey,
+          walletPublicKey,
+          resolved.side === "buy"
+            ? market.account.quoteMint
+            : market.account.baseMint,
+        ),
+      );
+      const priceLots = market.priceUiToLots(resolved.limitPriceUi);
+      const maxBaseLots = market.baseUiToLots(resolved.quantityBaseUi);
+      const remainingAccounts = collectRemainingAccounts({
+        market,
+        side: resolved.side,
+        postOnly: resolved.postOnly,
+      });
+      const [placeOrderIx] = await client.placeOrderIx(
+        openOrdersAccount,
+        market.pubkey,
+        market.account,
+        userFundingAccount,
+        {
+          side: mapSide(resolved.side),
+          priceLots,
+          maxBaseLots,
+          maxQuoteLotsIncludingFees: computeMaxQuoteLotsIncludingFees({
+            market,
+            request: resolved,
+          }),
+          clientOrderId: new BN(resolved.clientOrderId),
+          orderType: mapPlaceOrderType(resolved),
+          expiryTimestamp: new BN(0),
+          selfTradeBehavior: SelfTradeBehaviorUtils.DecrementTake,
+          limit: 16,
+        },
+        remainingAccounts,
+      );
+      instructions.push(placeOrderIx);
+      const built = await buildUnsignedTransactionBase64({
+        client,
+        walletPublicKey,
+        instructions,
+      });
+      return {
+        unsignedTransactionBase64: built.unsignedTransactionBase64,
+        lastValidBlockHeight: built.lastValidBlockHeight,
+        market: snapshot,
+        prerequisites: {
+          openOrdersIndexer: openOrdersIndexer.toBase58(),
+          openOrdersAccount: openOrdersAccount.toBase58(),
+          userBaseAccount: userBaseAccount.toBase58(),
+          userQuoteAccount: userQuoteAccount.toBase58(),
+          userFundingAccount: userFundingAccount.toBase58(),
+          createdOpenOrdersIndexer,
+          createdOpenOrdersAccount,
+        },
+        request: resolved,
+        quotePreview: buildOpenBookSyntheticQuote({
+          market: snapshot,
+          request: resolved,
+        }),
+      };
+    },
+    async buildCancelOrderPlan(request) {
+      const client = buildClient(request);
+      const walletPublicKey = new PublicKey(request.walletPublicKey);
+      const { market, snapshot } = await resolveMarket({
+        client,
+        instrumentId: request.instrumentId,
+      });
+      const openOrdersAccounts = await client.findOpenOrdersForMarket(
+        walletPublicKey,
+        market.pubkey,
+      );
+      const openOrdersAccount = openOrdersAccounts[0];
+      if (!openOrdersAccount) {
+        throw new Error("openbook-open-orders-account-missing");
+      }
+      const openOrdersRecord =
+        await client.deserializeOpenOrderAccount(openOrdersAccount);
+      if (!openOrdersRecord) {
+        throw new Error("openbook-open-orders-account-invalid");
+      }
+      const [cancelIx] = await client.cancelOrderByClientIdIx(
+        openOrdersAccount,
+        openOrdersRecord,
+        market.account,
+        new BN(request.clientOrderId),
+      );
+      const built = await buildUnsignedTransactionBase64({
+        client,
+        walletPublicKey,
+        instructions: [cancelIx],
+      });
+      return {
+        unsignedTransactionBase64: built.unsignedTransactionBase64,
+        lastValidBlockHeight: built.lastValidBlockHeight,
+        market: snapshot,
+        openOrdersAccount: openOrdersAccount.toBase58(),
+        clientOrderId: request.clientOrderId,
+      };
+    },
+    async buildReplaceOrderPlan(request) {
+      const client = buildClient(request);
+      const walletPublicKey = new PublicKey(request.walletPublicKey);
+      const { market, snapshot } = await resolveMarket({
+        client,
+        instrumentId: request.instrumentId,
+      });
+      const openOrdersAccounts = await client.findOpenOrdersForMarket(
+        walletPublicKey,
+        market.pubkey,
+      );
+      const openOrdersAccount = openOrdersAccounts[0];
+      if (!openOrdersAccount) {
+        throw new Error("openbook-open-orders-account-missing");
+      }
+      const openOrdersRecord =
+        await client.deserializeOpenOrderAccount(openOrdersAccount);
+      if (!openOrdersRecord) {
+        throw new Error("openbook-open-orders-account-invalid");
+      }
+      const resolved = resolveOpenBookOrderRequest({
+        market: snapshot,
+        side: request.side,
+        quantityAtomic: request.quantityAtomic,
+        options: request.options,
+      });
+      const remainingAccounts = collectRemainingAccounts({
+        market,
+        side: resolved.side,
+        postOnly: resolved.postOnly,
+      });
+      const userBaseAccount = await getAssociatedTokenAddress(
+        market.account.baseMint,
+        walletPublicKey,
+      );
+      const userQuoteAccount = await getAssociatedTokenAddress(
+        market.account.quoteMint,
+        walletPublicKey,
+      );
+      const userFundingAccount =
+        resolved.side === "buy" ? userQuoteAccount : userBaseAccount;
+      const [cancelIx] = await client.cancelOrderByClientIdIx(
+        openOrdersAccount,
+        openOrdersRecord,
+        market.account,
+        new BN(request.clientOrderId),
+      );
+      const [placeOrderIx] = await client.placeOrderIx(
+        openOrdersAccount,
+        market.pubkey,
+        market.account,
+        userFundingAccount,
+        {
+          side: mapSide(resolved.side),
+          priceLots: market.priceUiToLots(resolved.limitPriceUi),
+          maxBaseLots: market.baseUiToLots(resolved.quantityBaseUi),
+          maxQuoteLotsIncludingFees: computeMaxQuoteLotsIncludingFees({
+            market,
+            request: resolved,
+          }),
+          clientOrderId: new BN(resolved.clientOrderId),
+          orderType: mapPlaceOrderType(resolved),
+          expiryTimestamp: new BN(0),
+          selfTradeBehavior: SelfTradeBehaviorUtils.DecrementTake,
+          limit: 16,
+        },
+        remainingAccounts,
+      );
+      const built = await buildUnsignedTransactionBase64({
+        client,
+        walletPublicKey,
+        instructions: [cancelIx, placeOrderIx],
+      });
+      return {
+        unsignedTransactionBase64: built.unsignedTransactionBase64,
+        lastValidBlockHeight: built.lastValidBlockHeight,
+        market: snapshot,
+        openOrdersAccount: openOrdersAccount.toBase58(),
+        cancelledClientOrderId: request.clientOrderId,
+        replacement: resolved,
+        quotePreview: buildOpenBookSyntheticQuote({
+          market: snapshot,
+          request: resolved,
+        }),
+      };
+    },
+    async listOpenOrders(request) {
+      const client = buildClient(request);
+      const walletPublicKey = new PublicKey(request.walletPublicKey);
+      const { market, snapshot } = await resolveMarket({
+        client,
+        instrumentId: request.instrumentId,
+      });
+      return await loadSummary({
+        client,
+        market,
+        snapshot,
+        walletPublicKey,
+      });
+    },
+  };
+}
+
+export class OpenBookClient {
+  private readonly sdk: OpenBookSdkFacade;
+  private readonly programId: string;
+
+  constructor(
+    private readonly rpcEndpoint: string,
+    programId = OPENBOOK_PROGRAM_ID.toBase58(),
+    deps?: {
+      sdk?: OpenBookSdkFacade;
+    },
+  ) {
+    this.programId = programId;
+    this.sdk = deps?.sdk ?? createOpenBookSdkFacade();
+  }
+
+  async buildPlaceOrderPlan(request: {
+    walletPublicKey: string;
+    instrumentId: string;
+    side: "buy" | "sell";
+    quantityAtomic: string;
+    options?: OpenBookOrderOptions | null;
+  }): Promise<OpenBookPlaceOrderPlan> {
+    return await this.sdk.buildPlaceOrderPlan({
+      rpcEndpoint: this.rpcEndpoint,
+      programId: this.programId,
+      ...request,
+    });
+  }
+
+  async buildCancelOrderPlan(request: {
+    walletPublicKey: string;
+    instrumentId: string;
+    clientOrderId: string;
+  }): Promise<OpenBookCancelOrderPlan> {
+    return await this.sdk.buildCancelOrderPlan({
+      rpcEndpoint: this.rpcEndpoint,
+      programId: this.programId,
+      ...request,
+    });
+  }
+
+  async buildReplaceOrderPlan(request: {
+    walletPublicKey: string;
+    instrumentId: string;
+    clientOrderId: string;
+    side: "buy" | "sell";
+    quantityAtomic: string;
+    options?: OpenBookOrderOptions | null;
+  }): Promise<OpenBookReplaceOrderPlan> {
+    return await this.sdk.buildReplaceOrderPlan({
+      rpcEndpoint: this.rpcEndpoint,
+      programId: this.programId,
+      ...request,
+    });
+  }
+
+  async listOpenOrders(request: {
+    walletPublicKey: string;
+    instrumentId: string;
+  }): Promise<OpenBookOpenOrdersSummary> {
+    return await this.sdk.listOpenOrders({
+      rpcEndpoint: this.rpcEndpoint,
+      programId: this.programId,
+      ...request,
+    });
+  }
+}

--- a/apps/worker/src/openbook.ts
+++ b/apps/worker/src/openbook.ts
@@ -396,8 +396,8 @@ function deriveAggressivePriceUi(input: {
 }): number {
   const anchorPrice =
     input.side === "buy"
-      ? (input.market.bestAskPriceUi ?? input.market.bestBidPriceUi)
-      : (input.market.bestBidPriceUi ?? input.market.bestAskPriceUi);
+      ? input.market.bestAskPriceUi
+      : input.market.bestBidPriceUi;
   if (anchorPrice === null || anchorPrice <= 0) {
     throw new Error("openbook-orderbook-liquidity-missing");
   }

--- a/apps/worker/src/runtime_internal.ts
+++ b/apps/worker/src/runtime_internal.ts
@@ -1328,7 +1328,15 @@ function createRuntimeCostModelFixture(
         : ["shadow", "paper"],
     status: "active",
     assumptions: {
-      feeBps: isPhoenix ? 4 : isMagicBlock ? 6 : isDrift ? 7 : isOpenBook ? 5 : 8,
+      feeBps: isPhoenix
+        ? 4
+        : isMagicBlock
+          ? 6
+          : isDrift
+            ? 7
+            : isOpenBook
+              ? 5
+              : 8,
       slippageBps: isPhoenix
         ? 10
         : isMagicBlock

--- a/apps/worker/src/runtime_internal.ts
+++ b/apps/worker/src/runtime_internal.ts
@@ -1270,6 +1270,18 @@ function createRuntimeAssetFixture(
         minNotionalUsd: "0.01",
         notes: "Paper perps collateral and mark-price mapping.",
       },
+      {
+        venueKey: "openbook",
+        nativeId,
+        venueSymbol: assetKey,
+        decimals: isSol ? 9 : 6,
+        listingState: "paper",
+        quoteAssetKeys: ["USDC"],
+        priceDecimals: 6,
+        sizeDecimals: isSol ? 9 : 6,
+        minNotionalUsd: "0.01",
+        notes: "Paper-only CLOB mapping.",
+      },
     ],
     createdAt: FIXTURE_TIMESTAMP,
     updatedAt: FIXTURE_TIMESTAMP,
@@ -1298,6 +1310,7 @@ function createRuntimeCostModelFixture(
   const isPhoenix = venueKey === "phoenix";
   const isMagicBlock = venueKey === "magicblock";
   const isDrift = venueKey === "drift";
+  const isOpenBook = venueKey === "openbook";
   const pairSymbol = isDrift ? "SOL-PERP" : "SOL/USDC";
   const marketType = isDrift ? "perp" : "spot";
   const instrumentId = isDrift ? "SOL-PERP" : "SOL/USDC";
@@ -1315,43 +1328,89 @@ function createRuntimeCostModelFixture(
         : ["shadow", "paper"],
     status: "active",
     assumptions: {
-      feeBps: isPhoenix ? 4 : isMagicBlock ? 6 : isDrift ? 7 : 8,
-      slippageBps: isPhoenix ? 10 : isMagicBlock ? 18 : isDrift ? 14 : 22,
-      marketImpactBps: isPhoenix ? 6 : isMagicBlock ? 8 : isDrift ? 9 : 12,
-      partialFillRateBps: isPhoenix ? 125 : isDrift ? 175 : 50,
-      partialFillPenaltyBps: isPhoenix ? 10 : isDrift ? 14 : 12,
+      feeBps: isPhoenix ? 4 : isMagicBlock ? 6 : isDrift ? 7 : isOpenBook ? 5 : 8,
+      slippageBps: isPhoenix
+        ? 10
+        : isMagicBlock
+          ? 18
+          : isDrift
+            ? 14
+            : isOpenBook
+              ? 12
+              : 22,
+      marketImpactBps: isPhoenix
+        ? 6
+        : isMagicBlock
+          ? 8
+          : isDrift
+            ? 9
+            : isOpenBook
+              ? 7
+              : 12,
+      partialFillRateBps: isPhoenix
+        ? 125
+        : isDrift
+          ? 175
+          : isOpenBook
+            ? 90
+            : 50,
+      partialFillPenaltyBps: isPhoenix
+        ? 10
+        : isDrift
+          ? 14
+          : isOpenBook
+            ? 8
+            : 12,
     },
     calibration: {
       calibrationId: `calibration_${venueKey}_${isDrift ? "sol_perp" : "sol_usdc_spot"}_seed`,
       methodology: "seed_replay_bootstrap",
       sampleStartAt: "2026-03-07T00:00:00.000Z",
       sampleEndAt: FIXTURE_TIMESTAMP,
-      sampleCount: isPhoenix ? 160 : isMagicBlock ? 180 : isDrift ? 210 : 240,
+      sampleCount: isPhoenix
+        ? 160
+        : isMagicBlock
+          ? 180
+          : isDrift
+            ? 210
+            : isOpenBook
+              ? 200
+              : 240,
       confidenceBps: isPhoenix
         ? 7900
         : isMagicBlock
           ? 8100
           : isDrift
             ? 8350
-            : 8600,
+            : isOpenBook
+              ? 8300
+              : 8600,
       referenceNotionalUsd: "25.00",
       tags: ["seed", "bootstrap"],
       notes: "Stubbed execution cost model calibration.",
     },
     driftGuard: {
-      maxCostDriftBps: isPhoenix ? 70 : isMagicBlock ? 80 : isDrift ? 75 : 90,
+      maxCostDriftBps: isPhoenix
+        ? 70
+        : isMagicBlock
+          ? 80
+          : isDrift || isOpenBook
+            ? 75
+            : 90,
       maxLatencyDriftMs: isPhoenix
         ? 5000
         : isMagicBlock
           ? 6000
           : isDrift
             ? 4500
-            : 8000,
+            : isOpenBook
+              ? 5500
+              : 8000,
       maxReconciliationDriftUsd: isPhoenix
         ? "1.00"
         : isMagicBlock
           ? "1.25"
-          : isDrift
+          : isDrift || isOpenBook
             ? "1.10"
             : "1.50",
     },
@@ -1360,7 +1419,7 @@ function createRuntimeCostModelFixture(
         ? 150
         : isMagicBlock
           ? 200
-          : isDrift
+          : isDrift || isOpenBook
             ? 180
             : 250,
       expectedSubmitMs: isPhoenix
@@ -1369,14 +1428,18 @@ function createRuntimeCostModelFixture(
           ? 400
           : isDrift
             ? 450
-            : 750,
+            : isOpenBook
+              ? 420
+              : 750,
       expectedSettlementMs: isPhoenix
         ? 4000
         : isMagicBlock
           ? 3000
           : isDrift
             ? 4000
-            : 5000,
+            : isOpenBook
+              ? 3500
+              : 5000,
     },
     datasetSnapshots: [
       {
@@ -1414,6 +1477,7 @@ function createRuntimeCostModelRegistryFixture() {
     costModels: [
       createRuntimeCostModelFixture("jupiter"),
       createRuntimeCostModelFixture("magicblock"),
+      createRuntimeCostModelFixture("openbook"),
       createRuntimeCostModelFixture("drift"),
       createRuntimeCostModelFixture("phoenix"),
     ],
@@ -1426,6 +1490,7 @@ function createRuntimeCostObservationFixture(
   const isPhoenix = venueKey === "phoenix";
   const isMagicBlock = venueKey === "magicblock";
   const isDrift = venueKey === "drift";
+  const isOpenBook = venueKey === "openbook";
   const pairSymbol = isDrift ? "SOL-PERP" : "SOL/USDC";
   const marketType = isDrift ? "perp" : "spot";
   return parseRuntimeExecutionCostObservationRecord({
@@ -1442,27 +1507,49 @@ function createRuntimeCostObservationFixture(
     mode: "paper",
     observedAt: FIXTURE_TIMESTAMP,
     evaluatedNotionalUsd: "25.00",
-    modeledTotalCostUsd: isPhoenix ? "0.05" : isDrift ? "0.08" : "0.11",
-    observedTotalCostUsd: isPhoenix ? "0.06" : isDrift ? "0.09" : "0.13",
-    costDriftUsd: isPhoenix ? "0.01" : isDrift ? "0.01" : "0.02",
-    costDriftBps: isPhoenix ? 40 : isDrift ? 55 : 80,
+    modeledTotalCostUsd: isPhoenix
+      ? "0.05"
+      : isDrift || isOpenBook
+        ? "0.08"
+        : "0.11",
+    observedTotalCostUsd: isPhoenix
+      ? "0.06"
+      : isDrift || isOpenBook
+        ? "0.09"
+        : "0.13",
+    costDriftUsd: isPhoenix ? "0.01" : isDrift || isOpenBook ? "0.01" : "0.02",
+    costDriftBps: isPhoenix ? 40 : isDrift || isOpenBook ? 55 : 80,
     expectedEndToEndLatencyMs: isPhoenix
       ? 4350
       : isMagicBlock
         ? 3400
         : isDrift
           ? 4050
-          : 5750,
+          : isOpenBook
+            ? 3950
+            : 5750,
     observedEndToEndLatencyMs: isPhoenix
       ? 4525
       : isMagicBlock
         ? 3625
         : isDrift
           ? 4275
-          : 6125,
-    latencyDriftMs: isPhoenix ? 175 : isMagicBlock ? 225 : isDrift ? 225 : 375,
+          : isOpenBook
+            ? 4175
+            : 6125,
+    latencyDriftMs: isPhoenix
+      ? 175
+      : isMagicBlock
+        ? 225
+        : isDrift || isOpenBook
+          ? 225
+          : 375,
     reconciliationStatus: "passed",
-    reconciliationDriftUsd: isPhoenix ? "0.01" : isDrift ? "0.01" : "0.02",
+    reconciliationDriftUsd: isPhoenix
+      ? "0.01"
+      : isDrift || isOpenBook
+        ? "0.01"
+        : "0.02",
     tags: ["cost-observation", marketType],
     notes: "Stubbed modeled-versus-observed execution cost observation.",
   });
@@ -1473,6 +1560,7 @@ function createRuntimeCostObservationRegistryFixture() {
     costObservations: [
       createRuntimeCostObservationFixture("jupiter"),
       createRuntimeCostObservationFixture("magicblock"),
+      createRuntimeCostObservationFixture("openbook"),
       createRuntimeCostObservationFixture("drift"),
       createRuntimeCostObservationFixture("phoenix"),
     ],
@@ -1511,7 +1599,7 @@ function createRuntimeFeatureDefinitionFixture(
     summary: "Stubbed runtime feature catalog definition.",
     status: "active",
     marketType: "spot",
-    venueKeys: ["jupiter", "magicblock", "phoenix"],
+    venueKeys: ["jupiter", "magicblock", "openbook", "phoenix"],
     assetKeys: ["SOL", "USDC"],
     pairSymbols: ["SOL/USDC"],
     inputRequirements: (
@@ -1586,7 +1674,7 @@ function createRuntimeRegimeTagFixture(
     dimension: dimensionByRegimeKey[regimeKey] ?? "trend",
     value: "classified",
     marketType: "spot",
-    venueKeys: ["jupiter", "magicblock", "phoenix"],
+    venueKeys: ["jupiter", "magicblock", "openbook", "phoenix"],
     assetKeys: ["SOL", "USDC"],
     pairSymbols: ["SOL/USDC"],
     sourceFeatureKeys: sourceFeaturesByRegimeKey[regimeKey] ?? [

--- a/bun.lock
+++ b/bun.lock
@@ -66,6 +66,7 @@
       "dependencies": {
         "@coral-xyz/anchor": "^0.32.1",
         "@noble/hashes": "^1.8.0",
+        "@openbook-dex/openbook-v2": "^0.2.10",
         "@orca-so/common-sdk": "^0.7.0",
         "@orca-so/whirlpools-sdk": "^0.20.0",
         "@solana/web3.js": "^1.98.4",

--- a/src/harness/manager.ts
+++ b/src/harness/manager.ts
@@ -15,7 +15,7 @@ const PORTAL_PORT_BASE = 3000;
 const RUNTIME_PORT_BASE = 8080;
 const WORKER_PORT_BASE = 8800;
 const PORT_SCAN_WINDOW = 400;
-const STARTUP_TIMEOUT_MS = 90_000;
+const DEFAULT_STARTUP_TIMEOUT_MS = 180_000;
 const POLL_INTERVAL_MS = 1_000;
 const DEFAULT_RUNTIME_INTERNAL_SERVICE_TOKEN = "runtime-service-secret";
 const DEFAULT_RUNTIME_INTERNAL_SERVICE_NAME = "runtime-rs";
@@ -131,6 +131,38 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolvePromise) => {
     setTimeout(resolvePromise, ms);
   });
+}
+
+function parsePositiveIntegerEnv(
+  value: string | null | undefined,
+  fallback: number,
+): number {
+  const normalized = String(value ?? "").trim();
+  if (!/^[0-9]+$/.test(normalized)) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(normalized, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function resolveStartupTimeoutMs(): number {
+  return parsePositiveIntegerEnv(
+    process.env.HARNESS_STARTUP_TIMEOUT_MS,
+    DEFAULT_STARTUP_TIMEOUT_MS,
+  );
+}
+
+function readLogTail(path: string, maxLines = 40): string {
+  if (!existsSync(path)) {
+    return "<log file not created>";
+  }
+  const lines = readFileSync(path, "utf8")
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0);
+  if (lines.length < 1) {
+    return "<log file is empty>";
+  }
+  return lines.slice(-maxLines).join("\n");
 }
 
 async function isPortAvailable(port: number): Promise<boolean> {
@@ -444,6 +476,7 @@ export async function startHarness(root = resolveRepoRoot()): Promise<void> {
   let workerPid: number | undefined;
   let portalPid: number | undefined;
   let runtimePid: number | undefined;
+  const startupTimeoutMs = resolveStartupTimeoutMs();
 
   try {
     workerPid = startProcess({
@@ -470,10 +503,16 @@ export async function startHarness(root = resolveRepoRoot()): Promise<void> {
 
     const workerHealthy = await waitForHttp(
       `http://127.0.0.1:${workerPort}/api/health`,
-      STARTUP_TIMEOUT_MS,
+      startupTimeoutMs,
     );
     if (!workerHealthy) {
-      throw new Error(`worker failed to become healthy on port ${workerPort}`);
+      throw new Error(
+        [
+          `worker failed to become healthy on port ${workerPort} within ${startupTimeoutMs}ms`,
+          "worker log tail:",
+          readLogTail(paths.workerLog),
+        ].join("\n"),
+      );
     }
 
     if (runtimeEnabled) {
@@ -496,11 +535,15 @@ export async function startHarness(root = resolveRepoRoot()): Promise<void> {
 
       const runtimeHealthy = await waitForHttp(
         `http://127.0.0.1:${runtimePort}/health`,
-        STARTUP_TIMEOUT_MS,
+        startupTimeoutMs,
       );
       if (!runtimeHealthy) {
         throw new Error(
-          `runtime-rs failed to become healthy on port ${runtimePort}`,
+          [
+            `runtime-rs failed to become healthy on port ${runtimePort} within ${startupTimeoutMs}ms`,
+            "runtime-rs log tail:",
+            readLogTail(paths.runtimeLog),
+          ].join("\n"),
         );
       }
     }
@@ -525,10 +568,16 @@ export async function startHarness(root = resolveRepoRoot()): Promise<void> {
 
     const portalHealthy = await waitForHttp(
       `http://localhost:${portalPort}/login`,
-      STARTUP_TIMEOUT_MS,
+      startupTimeoutMs,
     );
     if (!portalHealthy) {
-      throw new Error(`portal failed to become healthy on port ${portalPort}`);
+      throw new Error(
+        [
+          `portal failed to become healthy on port ${portalPort} within ${startupTimeoutMs}ms`,
+          "portal log tail:",
+          readLogTail(paths.portalLog),
+        ].join("\n"),
+      );
     }
 
     saveHarnessState({

--- a/src/runtime/venues/catalog.ts
+++ b/src/runtime/venues/catalog.ts
@@ -227,6 +227,43 @@ const BUILTIN_RUNTIME_VENUE_CAPABILITIES = [
     notes:
       "Stubbed non-current venue proving the runtime can add a new venue through the shared capability and adapter abstractions.",
   },
+  {
+    schemaVersion: "v1",
+    venueKey: "openbook",
+    displayName: "OpenBook v2",
+    adapterKeys: ["openbook_v2"],
+    marketTypes: ["spot"],
+    orderTypes: ["market", "limit"],
+    intentFamilies: ["clob_order"],
+    authModel: "privy_solana_wallet",
+    feeModel: "maker_taker_bps",
+    precision: {
+      priceDecimals: 6,
+      sizeDecimals: 9,
+      minOrderIncrement: "0.000001",
+      minQuoteNotionalUsd: "0.01",
+    },
+    sizeLimits: {
+      minNotionalUsd: "0.01",
+    },
+    latencyProfile: {
+      expectedQuoteMs: 150,
+      expectedSubmitMs: 350,
+      expectedSettlementMs: 4000,
+    },
+    settlementBehavior: "orderbook_atomic",
+    lifecycle: {
+      supportsOrderLifecycle: true,
+      supportsPositionLifecycle: false,
+      requiresExternalOracle: false,
+      settlementModel: "resting_order",
+    },
+    oracleRequirements: ["venue_reference"],
+    supportedModes: ["shadow", "paper"],
+    onboardingState: "integrated",
+    notes:
+      "Bounded OpenBook v2 spot CLOB integration for shadow and paper only; live stays blocked until venue-specific canary notes and kill controls land.",
+  },
 ] as const satisfies readonly RuntimeVenueCapability[];
 
 const CAPABILITY_INDEX = new Map<string, RuntimeVenueCapability>(

--- a/tests/unit/worker_execution_openbook.test.ts
+++ b/tests/unit/worker_execution_openbook.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, mock, test } from "bun:test";
+import { normalizePolicy } from "../../apps/worker/src/policy";
+import type { Env } from "../../apps/worker/src/types";
+
+const { executeOpenBookClobOrder } = await import(
+  "../../apps/worker/src/execution/openbook_executor"
+);
+
+function buildPlan() {
+  return {
+    unsignedTransactionBase64: "unsigned-openbook",
+    lastValidBlockHeight: 55,
+    market: {
+      instrumentId: "SOL/USDC",
+      marketAddress: "market-1",
+      baseMint: "mint-base",
+      quoteMint: "mint-quote",
+      baseDecimals: 9,
+      quoteDecimals: 6,
+      bestBidPriceUi: 149.5,
+      bestAskPriceUi: 150,
+      bestBidSizeUi: 2,
+      bestAskSizeUi: 3,
+      spreadBps: 33,
+      tickSizeUi: "0.01",
+      minOrderSizeUi: "0.001",
+      openOrdersAdminRequired: false,
+      consumeEventsAdminRequired: false,
+      closeMarketAdminRequired: false,
+    },
+    prerequisites: {
+      openOrdersIndexer: "indexer-1",
+      openOrdersAccount: "oo-1",
+      userBaseAccount: "base-ata",
+      userQuoteAccount: "quote-ata",
+      userFundingAccount: "quote-ata",
+      createdOpenOrdersIndexer: true,
+      createdOpenOrdersAccount: true,
+    },
+    request: {
+      side: "buy",
+      quantityAtomic: "1000000000",
+      quantityBaseUi: 1,
+      orderType: "limit",
+      timeInForce: "gtc",
+      postOnly: false,
+      limitPriceAtomic: "151000000",
+      limitPriceUi: 151,
+      clientOrderId: "42",
+      estimatedQuoteUi: 151,
+      estimatedQuoteAtomic: "151000000",
+    },
+    quotePreview: {
+      inputMint: "mint-quote",
+      outputMint: "mint-base",
+      inAmount: "151000000",
+      outAmount: "1000000000",
+      priceImpactPct: 0,
+      routePlan: [{ poolId: "market-1", swapInfo: { label: "OpenBook v2" } }],
+    },
+  };
+}
+
+function buildIntent() {
+  return {
+    family: "clob_order" as const,
+    wallet: "11111111111111111111111111111111",
+    venueKey: "openbook" as const,
+    marketType: "spot" as const,
+    instrumentId: "SOL/USDC",
+    side: "buy",
+    quantityAtomic: "1000000000",
+    params: {
+      orderType: "limit",
+      timeInForce: "gtc",
+      limitPriceAtomic: "151000000",
+      clientOrderId: "42",
+    },
+  };
+}
+
+describe("worker OpenBook execution adapter", () => {
+  test("returns dry_run for bounded OpenBook orders", async () => {
+    const buildPlaceOrderPlan = mock(async () => buildPlan());
+
+    const result = await executeOpenBookClobOrder({
+      env: { RPC_ENDPOINT: "https://rpc.test" } as Env,
+      runtimeMode: "paper",
+      policy: normalizePolicy({ dryRun: true }),
+      rpc: {} as never,
+      jupiter: {} as never,
+      openbook: { buildPlaceOrderPlan } as never,
+      intent: buildIntent(),
+      log: () => {},
+    });
+
+    expect(result.status).toBe("dry_run");
+    expect(result.executionMeta?.route).toBe("openbook_v2");
+    expect(buildPlaceOrderPlan).toHaveBeenCalledTimes(1);
+  });
+
+  test("simulates OpenBook orders in paper mode with Privy signing", async () => {
+    const buildPlaceOrderPlan = mock(async () => buildPlan());
+    const simulateTransactionBase64 = mock(async () => ({ err: null }));
+
+    const result = await executeOpenBookClobOrder(
+      {
+        env: { RPC_ENDPOINT: "https://rpc.test" } as Env,
+        runtimeMode: "paper",
+        policy: normalizePolicy({}),
+        rpc: {
+          simulateTransactionBase64,
+        } as never,
+        jupiter: {} as never,
+        openbook: { buildPlaceOrderPlan } as never,
+        intent: buildIntent(),
+        privyWalletId: "wallet-1",
+        log: () => {},
+      },
+      {
+        signTransactionWithPrivyById: mock(async () => "signed-openbook"),
+      },
+    );
+
+    expect(result.status).toBe("simulated");
+    expect(result.executionMeta?.lifecycle?.orderState).toBe("open");
+    expect(simulateTransactionBase64).toHaveBeenCalledTimes(1);
+  });
+
+  test("fails closed when safe-lane guardrails reject an OpenBook order", async () => {
+    const buildPlaceOrderPlan = mock(async () => buildPlan());
+
+    const result = await executeOpenBookClobOrder(
+      {
+        env: { RPC_ENDPOINT: "https://rpc.test" } as Env,
+        runtimeMode: "paper",
+        execution: {
+          params: { lane: "safe" },
+        },
+        policy: normalizePolicy({}),
+        rpc: {
+          simulateTransactionBase64: mock(async () => ({ err: null })),
+        } as never,
+        jupiter: {} as never,
+        openbook: { buildPlaceOrderPlan } as never,
+        intent: buildIntent(),
+        privyWalletId: "wallet-1",
+        log: () => {},
+      },
+      {
+        signTransactionWithPrivyById: mock(async () => "signed-openbook"),
+        evaluateSafeLaneTransaction: mock(() => ({
+          ok: false,
+          reason: "tx-account-keys-exceeds-safe-limit",
+          profile: "safe",
+          limits: {},
+        })),
+      },
+    );
+
+    expect(result.status).toBe("simulate_error");
+    expect(result.executionMeta?.classification).toBe("error");
+    expect(result.executionMeta?.lifecycle?.orderState).toBe("rejected");
+  });
+
+  test("rejects live mode for OpenBook rollout", async () => {
+    await expect(
+      executeOpenBookClobOrder({
+        env: { RPC_ENDPOINT: "https://rpc.test" } as Env,
+        runtimeMode: "live",
+        policy: normalizePolicy({}),
+        rpc: {} as never,
+        jupiter: {} as never,
+        intent: buildIntent(),
+        log: () => {},
+      }),
+    ).rejects.toThrow(/openbook-live-mode-not-supported/);
+  });
+});

--- a/tests/unit/worker_execution_router.test.ts
+++ b/tests/unit/worker_execution_router.test.ts
@@ -283,6 +283,87 @@ describe("worker execution router", () => {
     expect(result.executionMeta?.lifecycle?.orderState).toBe("open");
   });
 
+  test("routes OpenBook clob orders through the OpenBook executor in paper mode", async () => {
+    const result = await executeIntentViaRouter({
+      env: { RPC_ENDPOINT: "https://rpc.test" } as never,
+      venueKey: "openbook",
+      runtimeMode: "paper",
+      execution: { adapter: "openbook_v2" },
+      policy: normalizePolicy({ dryRun: true }),
+      rpc: {} as never,
+      jupiter: {} as never,
+      openbook: {
+        buildPlaceOrderPlan: async () => ({
+          unsignedTransactionBase64: "unsigned",
+          lastValidBlockHeight: 42,
+          market: {
+            instrumentId: "SOL/USDC",
+            marketAddress: "market-1",
+            baseMint: "mint-base",
+            quoteMint: "mint-quote",
+            baseDecimals: 9,
+            quoteDecimals: 6,
+            bestBidPriceUi: 149.5,
+            bestAskPriceUi: 150,
+            bestBidSizeUi: 2,
+            bestAskSizeUi: 3,
+            spreadBps: 33,
+            tickSizeUi: "0.01",
+            minOrderSizeUi: "0.001",
+            openOrdersAdminRequired: false,
+            consumeEventsAdminRequired: false,
+            closeMarketAdminRequired: false,
+          },
+          prerequisites: {
+            openOrdersIndexer: "indexer-1",
+            openOrdersAccount: "oo-1",
+            userBaseAccount: "base-ata",
+            userQuoteAccount: "quote-ata",
+            userFundingAccount: "quote-ata",
+            createdOpenOrdersIndexer: true,
+            createdOpenOrdersAccount: true,
+          },
+          request: {
+            side: "buy",
+            quantityAtomic: "1000000000",
+            quantityBaseUi: 1,
+            orderType: "limit",
+            timeInForce: "gtc",
+            postOnly: false,
+            limitPriceAtomic: "151000000",
+            limitPriceUi: 151,
+            clientOrderId: "42",
+            estimatedQuoteUi: 151,
+            estimatedQuoteAtomic: "151000000",
+          },
+          quotePreview: {
+            inputMint: "mint-quote",
+            outputMint: "mint-base",
+            inAmount: "151000000",
+            outAmount: "1000000000",
+          },
+        }),
+      } as never,
+      intent: {
+        family: "clob_order",
+        wallet: "11111111111111111111111111111111",
+        venueKey: "openbook",
+        marketType: "spot",
+        instrumentId: "SOL/USDC",
+        side: "buy",
+        quantityAtomic: "1000000000",
+        params: {
+          orderType: "limit",
+          limitPriceAtomic: "151000000",
+        },
+      },
+      log: () => {},
+    });
+
+    expect(result.status).toBe("dry_run");
+    expect(result.executionMeta?.route).toBe("openbook_v2");
+  });
+
   test("routes Drift perp intents through the Drift executor in paper mode", async () => {
     const result = await executeIntentViaRouter({
       env: {} as never,

--- a/tests/unit/worker_openbook.test.ts
+++ b/tests/unit/worker_openbook.test.ts
@@ -75,6 +75,22 @@ describe("worker openbook helpers", () => {
     expect(quote.routePlan?.[0]?.swapInfo?.label).toBe("OpenBook v2");
   });
 
+  test("fails closed when the opposite side of book is missing", () => {
+    expect(() =>
+      resolveOpenBookOrderRequest({
+        market: {
+          ...MARKET,
+          bestAskPriceUi: null,
+        },
+        side: "buy",
+        quantityAtomic: "1000000000",
+        options: {
+          orderType: "market",
+        },
+      }),
+    ).toThrow(/openbook-orderbook-liquidity-missing/);
+  });
+
   test("delegates place-order plan building through the injected SDK facade", async () => {
     const buildPlaceOrderPlan = mock(async () => ({
       unsignedTransactionBase64: "unsigned",

--- a/tests/unit/worker_openbook.test.ts
+++ b/tests/unit/worker_openbook.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  buildOpenBookSyntheticQuote,
+  OpenBookClient,
+  resolveOpenBookOrderRequest,
+} from "../../apps/worker/src/openbook";
+
+const MARKET = {
+  instrumentId: "SOL/USDC",
+  marketAddress: "market-1",
+  baseMint: "mint-base",
+  quoteMint: "mint-quote",
+  baseDecimals: 9,
+  quoteDecimals: 6,
+  bestBidPriceUi: 149.5,
+  bestAskPriceUi: 150,
+  bestBidSizeUi: 2,
+  bestAskSizeUi: 3,
+  spreadBps: 33,
+  tickSizeUi: "0.01",
+  minOrderSizeUi: "0.001",
+  openOrdersAdminRequired: false,
+  consumeEventsAdminRequired: false,
+  closeMarketAdminRequired: false,
+} as const;
+
+describe("worker openbook helpers", () => {
+  test("resolves limit buy requests into normalized order parameters", () => {
+    const request = resolveOpenBookOrderRequest({
+      market: MARKET,
+      side: "buy",
+      quantityAtomic: "250000000",
+      options: {
+        orderType: "limit",
+        timeInForce: "gtc",
+        limitPriceAtomic: "150000000",
+        clientOrderId: "42",
+      },
+    });
+
+    expect(request).toMatchObject({
+      side: "buy",
+      orderType: "limit",
+      timeInForce: "gtc",
+      postOnly: false,
+      quantityAtomic: "250000000",
+      limitPriceAtomic: "150000000",
+      clientOrderId: "42",
+    });
+    expect(request.quantityBaseUi).toBe(0.25);
+    expect(request.estimatedQuoteUi).toBe(37.5);
+    expect(request.estimatedQuoteAtomic).toBe("37500000");
+  });
+
+  test("builds a synthetic quote preview for OpenBook buy orders", () => {
+    const request = resolveOpenBookOrderRequest({
+      market: MARKET,
+      side: "buy",
+      quantityAtomic: "1000000000",
+      options: {
+        orderType: "limit",
+        limitPriceAtomic: "151000000",
+      },
+    });
+    const quote = buildOpenBookSyntheticQuote({
+      market: MARKET,
+      request,
+    });
+
+    expect(quote).toMatchObject({
+      inputMint: "mint-quote",
+      outputMint: "mint-base",
+      outAmount: "1000000000",
+    });
+    expect(quote.routePlan?.[0]?.swapInfo?.label).toBe("OpenBook v2");
+  });
+
+  test("delegates place-order plan building through the injected SDK facade", async () => {
+    const buildPlaceOrderPlan = mock(async () => ({
+      unsignedTransactionBase64: "unsigned",
+      lastValidBlockHeight: 55,
+      market: MARKET,
+      prerequisites: {
+        openOrdersIndexer: "indexer-1",
+        openOrdersAccount: "oo-1",
+        userBaseAccount: "base-ata",
+        userQuoteAccount: "quote-ata",
+        userFundingAccount: "quote-ata",
+        createdOpenOrdersIndexer: true,
+        createdOpenOrdersAccount: true,
+      },
+      request: resolveOpenBookOrderRequest({
+        market: MARKET,
+        side: "buy",
+        quantityAtomic: "1000000000",
+        options: { orderType: "limit", limitPriceAtomic: "151000000" },
+      }),
+      quotePreview: {
+        inputMint: "mint-quote",
+        outputMint: "mint-base",
+        inAmount: "151000000",
+        outAmount: "1000000000",
+      },
+    }));
+
+    const client = new OpenBookClient("https://rpc.test", "program-1", {
+      sdk: {
+        buildPlaceOrderPlan,
+        buildCancelOrderPlan: mock(async () => {
+          throw new Error("unused");
+        }),
+        buildReplaceOrderPlan: mock(async () => {
+          throw new Error("unused");
+        }),
+        listOpenOrders: mock(async () => {
+          throw new Error("unused");
+        }),
+      },
+    });
+
+    const plan = await client.buildPlaceOrderPlan({
+      walletPublicKey: "11111111111111111111111111111111",
+      instrumentId: "SOL/USDC",
+      side: "buy",
+      quantityAtomic: "1000000000",
+      options: { orderType: "limit", limitPriceAtomic: "151000000" },
+    });
+
+    expect(plan.prerequisites.openOrdersAccount).toBe("oo-1");
+    expect(buildPlaceOrderPlan).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/worker_runtime_internal_routes.test.ts
+++ b/tests/unit/worker_runtime_internal_routes.test.ts
@@ -1364,6 +1364,11 @@ describe("worker runtime internal routes", () => {
             venueKey: "jupiter",
             marketType: "spot",
           }),
+          expect.objectContaining({
+            modelId: "cost_model_openbook_sol_usdc_spot",
+            venueKey: "openbook",
+            marketType: "spot",
+          }),
         ]),
       },
     });
@@ -1518,6 +1523,7 @@ describe("worker runtime internal routes", () => {
           assetKey: "SOL",
           venueMappings: expect.arrayContaining([
             expect.objectContaining({ venueKey: "jupiter" }),
+            expect.objectContaining({ venueKey: "openbook" }),
           ]),
         }),
       ]),

--- a/tests/unit/worker_terminal_open_orders_route.test.ts
+++ b/tests/unit/worker_terminal_open_orders_route.test.ts
@@ -368,6 +368,144 @@ function seedExecutionRequestOnly(
   );
 }
 
+function seedOpenBookOrder(
+  db: Database,
+  input?: {
+    requestId?: string;
+    actorId?: string;
+    side?: "buy" | "sell";
+    status?: string;
+    instrumentId?: string;
+  },
+): string {
+  const requestId = input?.requestId ?? "execreq_openbook_1234567890";
+  const actorId = input?.actorId ?? "user_1";
+  const side = input?.side ?? "buy";
+  const status = input?.status ?? "dispatched";
+  const instrumentId = input?.instrumentId ?? "SOL/USDC";
+  const metadata = {
+    source: "TERMINAL",
+    reason: "OpenBook paper order",
+    intent: {
+      family: "clob_order",
+      marketType: "spot",
+      venueKey: "openbook",
+      instrumentId,
+      side,
+      quantityAtomic: "1000000000",
+    },
+  };
+  const providerResponse = {
+    route: "openbook_v2",
+    lane: "safe",
+    mode: "privy_execute",
+    quality: {
+      orderType: "limit",
+      timeInForce: "gtc",
+      limitPriceAtomic: "151000000",
+    },
+    executionStatus: "simulated",
+    executionMeta: {
+      route: "openbook_v2",
+      classification: "simulated",
+      venueSessionId: "oo-1",
+      intentId: "42",
+      lifecycle: {
+        orderState: "open",
+        fillState: "pending",
+        settlementState: "confirmed",
+        notes: ["openbook-limit"],
+      },
+    },
+  };
+
+  db.query(
+    `INSERT INTO execution_requests (
+      request_id,
+      idempotency_scope,
+      idempotency_key,
+      payload_hash,
+      actor_type,
+      actor_id,
+      mode,
+      lane,
+      status,
+      status_reason,
+      metadata_json,
+      received_at,
+      validated_at,
+      terminal_at
+    ) VALUES (?1, 'authenticated', ?2, ?3, 'privy_user', ?4, 'privy_execute', 'safe', ?5, NULL, ?6, ?7, ?8, NULL)`,
+  ).run(
+    requestId,
+    `idem-${requestId}`,
+    `hash-${requestId}`,
+    actorId,
+    status,
+    JSON.stringify(metadata),
+    "2026-03-05T02:00:00.000Z",
+    "2026-03-05T02:00:01.000Z",
+  );
+  db.query(
+    `INSERT INTO execution_attempts (
+      attempt_id,
+      request_id,
+      attempt_no,
+      lane,
+      provider,
+      status,
+      provider_request_id,
+      provider_response_json,
+      error_code,
+      error_message,
+      started_at,
+      completed_at,
+      created_at,
+      updated_at
+    ) VALUES (?1, ?2, 1, 'safe', 'openbook_v2', 'simulated', 'openbook_req_1', ?3, NULL, NULL, ?4, ?5, ?4, ?5)`,
+  ).run(
+    `attempt_${requestId}`,
+    requestId,
+    JSON.stringify(providerResponse),
+    "2026-03-05T02:00:02.000Z",
+    "2026-03-05T02:00:03.000Z",
+  );
+  db.query(
+    `INSERT INTO execution_status_events (
+      event_id,
+      request_id,
+      seq,
+      status,
+      reason,
+      details_json,
+      created_at
+    ) VALUES (?1, ?2, 1, 'received', NULL, NULL, '2026-03-05T02:00:00.000Z')`,
+  ).run(`event_received_${requestId}`, requestId);
+  db.query(
+    `INSERT INTO execution_status_events (
+      event_id,
+      request_id,
+      seq,
+      status,
+      reason,
+      details_json,
+      created_at
+    ) VALUES (?1, ?2, 2, 'validated', NULL, NULL, '2026-03-05T02:00:01.000Z')`,
+  ).run(`event_validated_${requestId}`, requestId);
+  db.query(
+    `INSERT INTO execution_status_events (
+      event_id,
+      request_id,
+      seq,
+      status,
+      reason,
+      details_json,
+      created_at
+    ) VALUES (?1, ?2, 3, 'dispatched', NULL, NULL, '2026-03-05T02:00:03.000Z')`,
+  ).run(`event_dispatched_${requestId}`, requestId);
+  return requestId;
+}
+
 function responseJson(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -711,6 +849,44 @@ describe("worker terminal open orders and Trigger lifecycle routes", () => {
     }
   });
 
+  test("open-orders route includes active OpenBook paper orders", async () => {
+    const { env, sqlite } = createExecEnv();
+    try {
+      seedOpenBookOrder(sqlite, {
+        requestId: "execreq_openbook_list_123456",
+      });
+
+      const response = await worker.fetch(
+        new Request("http://localhost/api/terminal/open-orders", {
+          headers: {
+            authorization: "Bearer test-token",
+          },
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        orders?: Array<{
+          requestId?: string;
+          pairId?: string;
+          status?: string;
+          orderType?: string;
+          clientOrderId?: string;
+          openOrdersAccount?: string;
+        }>;
+      };
+      expect(body.orders?.[0]?.requestId).toBe("execreq_openbook_list_123456");
+      expect(body.orders?.[0]?.pairId).toBe("SOL/USDC");
+      expect(body.orders?.[0]?.status).toBe("working");
+      expect(body.orders?.[0]?.orderType).toBe("limit");
+      expect(body.orders?.[0]?.clientOrderId).toBe("42");
+      expect(body.orders?.[0]?.openOrdersAccount).toBe("oo-1");
+    } finally {
+      sqlite.close();
+    }
+  });
+
   test("open-orders route still returns older active conditional orders behind newer executions", async () => {
     const { env, sqlite } = createExecEnv();
     try {
@@ -764,6 +940,56 @@ describe("worker terminal open orders and Trigger lifecycle routes", () => {
           (order) => order.requestId === "execreq_trigger_oldest_open",
         ),
       ).toBe(true);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("cancel route terminalizes active OpenBook paper orders", async () => {
+    const { env, sqlite } = createExecEnv();
+    try {
+      const requestId = seedOpenBookOrder(sqlite, {
+        requestId: "execreq_openbook_cancel_123456",
+      });
+
+      const response = await worker.fetch(
+        new Request(
+          `http://localhost/api/terminal/open-orders/${requestId}/cancel`,
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer test-token",
+            },
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        cancelled?: boolean;
+        lifecycle?: { orderState?: string };
+        signature?: string | null;
+        status?: { state?: string; terminal?: boolean };
+      };
+      expect(body.cancelled).toBe(true);
+      expect(body.lifecycle?.orderState).toBe("cancelled");
+      expect(body.signature).toBeNull();
+      expect(body.status?.state).toBe("failed");
+      expect(body.status?.terminal).toBe(true);
+      const requestRow = sqlite
+        .query("SELECT status FROM execution_requests WHERE request_id = ?1")
+        .get(requestId) as { status?: string } | undefined;
+      expect(requestRow?.status).toBe("failed");
+      const receiptRow = sqlite
+        .query(
+          "SELECT finalized_status as finalizedStatus, error_code as errorCode FROM execution_receipts WHERE request_id = ?1",
+        )
+        .get(requestId) as
+        | { finalizedStatus?: string; errorCode?: string }
+        | undefined;
+      expect(receiptRow?.finalizedStatus).toBe("failed");
+      expect(receiptRow?.errorCode).toBe("order-cancelled");
     } finally {
       sqlite.close();
     }


### PR DESCRIPTION
## Summary
- add a bounded OpenBook v2 CLOB client and `openbook_v2` paper or shadow execution adapter for `clob_order`
- thread OpenBook lifecycle into terminal open-order read and cancel flows, and expose venue presence in runtime cost and readiness fixtures
- add focused order planning, executor, router, terminal, and runtime fixture regression coverage while keeping live routing fail-closed

## Issue
- closes #369

## Proof
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit`
- `cargo test --workspace`

## Notes
- live OpenBook routing remains blocked by design; the adapter fails closed in live mode and the runtime venue catalog marks rollout as paper-only
- terminal OpenBook cancellation is synthetic for paper or shadow lifecycle tracking and does not pretend a live on-chain order was resting
- local worktree `node_modules` symlinks were used for validation only and are not part of the commit