### PR TITLE
[Phase 2] Integrate Drift perps adapter and Swift execution path

### DIFF
--- a/apps/worker/src/drift.ts
+++ b/apps/worker/src/drift.ts
@@ -1,0 +1,347 @@
+import type { Env } from "./types";
+
+export type DriftOrderOptions = {
+  orderType?: "market" | "limit" | "trigger" | null;
+  timeInForce?: "gtc" | "ioc" | "fok" | null;
+  reduceOnly?: boolean | null;
+  limitPriceAtomic?: string | null;
+  triggerPriceAtomic?: string | null;
+};
+
+export type DriftContractSnapshot = {
+  marketName: string;
+  marketIndex: number | null;
+  oracle: string | null;
+  oracleSource: string | null;
+  status: string | null;
+  contractType: string | null;
+  initialMarginRatio: number | null;
+  maintenanceMarginRatio: number | null;
+};
+
+export type DriftFundingRateSnapshot = {
+  marketName: string;
+  fundingRate1h: number | null;
+  fundingRate1hBps: number | null;
+  oraclePrice: number | null;
+  markPrice: number | null;
+  sourceTs: string | null;
+};
+
+export type DriftPerpIntentPreview = {
+  instrument: DriftContractSnapshot;
+  funding: DriftFundingRateSnapshot | null;
+  side: "long" | "short" | "close_long" | "close_short";
+  direction: "long" | "short";
+  reduceOnly: boolean;
+  orderType: "market" | "limit" | "trigger";
+  timeInForce: "gtc" | "ioc" | "fok";
+  quantityAtomic: string;
+  collateralAtomic: string | null;
+  limitPriceAtomic: string | null;
+  triggerPriceAtomic: string | null;
+  swiftSupported: boolean;
+};
+
+type DriftContractsEnvelope = {
+  contracts?: unknown;
+  data?: unknown;
+};
+
+type DriftFundingRatesEnvelope = {
+  fundingRates?: unknown;
+  data?: unknown;
+};
+
+type DriftClientDeps = {
+  fetch?: typeof fetch;
+};
+
+function readTrimmedString(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return normalized || null;
+}
+
+function readFiniteNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function readPositiveAtomic(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return /^[1-9][0-9]*$/.test(normalized) ? normalized : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeInstrumentId(value: string): string {
+  return value.trim().toUpperCase();
+}
+
+function normalizeMarketName(value: unknown): string | null {
+  const normalized = readTrimmedString(value);
+  return normalized ? normalizeInstrumentId(normalized) : null;
+}
+
+function normalizeOrderType(value: unknown): "market" | "limit" | "trigger" {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  if (normalized === "limit") return "limit";
+  if (normalized === "trigger") return "trigger";
+  return "market";
+}
+
+function normalizeTimeInForce(value: unknown): "gtc" | "ioc" | "fok" {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  if (normalized === "ioc") return "ioc";
+  if (normalized === "fok") return "fok";
+  return "gtc";
+}
+
+function normalizeReduceOnly(side: string, reduceOnly: unknown): boolean {
+  if (side === "close_long" || side === "close_short") return true;
+  return reduceOnly === true;
+}
+
+function readContractsPayload(value: unknown): Record<string, unknown>[] {
+  if (Array.isArray(value)) {
+    return value.filter(isRecord);
+  }
+  if (!isRecord(value)) return [];
+  if (Array.isArray(value.contracts)) {
+    return value.contracts.filter(isRecord);
+  }
+  if (Array.isArray(value.data)) {
+    return value.data.filter(isRecord);
+  }
+  return [];
+}
+
+function readFundingRatesPayload(value: unknown): Record<string, unknown>[] {
+  if (Array.isArray(value)) {
+    return value.filter(isRecord);
+  }
+  if (!isRecord(value)) return [];
+  if (Array.isArray(value.fundingRates)) {
+    return value.fundingRates.filter(isRecord);
+  }
+  if (Array.isArray(value.data)) {
+    return value.data.filter(isRecord);
+  }
+  return [];
+}
+
+function mapContractSnapshot(
+  record: Record<string, unknown>,
+): DriftContractSnapshot | null {
+  const marketName =
+    normalizeMarketName(record.marketName) ??
+    normalizeMarketName(record.symbol) ??
+    normalizeMarketName(record.contractName);
+  if (!marketName) return null;
+  return {
+    marketName,
+    marketIndex:
+      readFiniteNumber(record.marketIndex) ??
+      readFiniteNumber(record.index) ??
+      null,
+    oracle: readTrimmedString(record.oracle),
+    oracleSource:
+      readTrimmedString(record.oracleSource) ??
+      readTrimmedString(record.oracleSourceName),
+    status: readTrimmedString(record.status),
+    contractType:
+      readTrimmedString(record.contractType) ??
+      readTrimmedString(record.marketType),
+    initialMarginRatio:
+      readFiniteNumber(record.initialMarginRatio) ??
+      readFiniteNumber(record.imfFactor),
+    maintenanceMarginRatio:
+      readFiniteNumber(record.maintenanceMarginRatio) ??
+      readFiniteNumber(record.marginRatioMaintenance),
+  };
+}
+
+function mapFundingRateSnapshot(
+  marketName: string,
+  record: Record<string, unknown>,
+): DriftFundingRateSnapshot {
+  const fundingRate1h =
+    readFiniteNumber(record.fundingRate) ??
+    readFiniteNumber(record.fundingRateHour) ??
+    readFiniteNumber(record.hourlyFundingRate);
+  return {
+    marketName,
+    fundingRate1h,
+    fundingRate1hBps:
+      fundingRate1h === null
+        ? null
+        : Number((fundingRate1h * 10_000).toFixed(4)),
+    oraclePrice:
+      readFiniteNumber(record.oraclePrice) ??
+      readFiniteNumber(record.oraclePriceTwap),
+    markPrice:
+      readFiniteNumber(record.markPrice) ??
+      readFiniteNumber(record.markPriceTwap),
+    sourceTs:
+      readTrimmedString(record.ts) ??
+      readTrimmedString(record.timestamp) ??
+      readTrimmedString(record.fundingRateTs),
+  };
+}
+
+function buildSyntheticPerpQuote(preview: DriftPerpIntentPreview): {
+  inputMint: string;
+  outputMint: string;
+  inAmount: string;
+  outAmount: string;
+  priceImpactPct: number;
+  routePlan: Array<{ poolId: string; swapInfo: { label: string } }>;
+} {
+  return {
+    inputMint: preview.instrument.marketName,
+    outputMint: preview.instrument.marketName,
+    inAmount: preview.collateralAtomic ?? preview.quantityAtomic,
+    outAmount: preview.quantityAtomic,
+    priceImpactPct: 0,
+    routePlan: [
+      {
+        poolId: preview.instrument.marketName,
+        swapInfo: {
+          label: preview.swiftSupported ? "Drift Swift" : "Drift",
+        },
+      },
+    ],
+  };
+}
+
+export class DriftClient {
+  private readonly fetchImpl: typeof fetch;
+  private readonly dataApiBase: string;
+  private readonly swiftApiBase: string | null;
+
+  constructor(
+    input:
+      | Env
+      | {
+          dataApiBase?: string;
+          swiftApiBase?: string | null;
+        },
+    deps?: DriftClientDeps,
+  ) {
+    this.fetchImpl = deps?.fetch ?? fetch;
+    this.dataApiBase =
+      readTrimmedString(
+        "DRIFT_DATA_API_BASE" in input
+          ? input.DRIFT_DATA_API_BASE
+          : input.dataApiBase,
+      ) ?? "https://data.api.drift.trade";
+    this.swiftApiBase = readTrimmedString(
+      "DRIFT_SWIFT_API_BASE" in input
+        ? input.DRIFT_SWIFT_API_BASE
+        : input.swiftApiBase,
+    );
+  }
+
+  swiftConfigured(): boolean {
+    return Boolean(this.swiftApiBase);
+  }
+
+  async listContracts(): Promise<DriftContractSnapshot[]> {
+    const url = new URL("/contracts", this.dataApiBase);
+    const response = await this.fetchImpl(url.toString(), {
+      method: "GET",
+      headers: { accept: "application/json" },
+    });
+    if (!response.ok) {
+      throw new Error(`drift-contracts-fetch-failed:${response.status}`);
+    }
+    const payload = (await response.json()) as DriftContractsEnvelope;
+    return readContractsPayload(payload)
+      .map(mapContractSnapshot)
+      .filter((value): value is DriftContractSnapshot => Boolean(value));
+  }
+
+  async getFundingRates(
+    marketName: string,
+  ): Promise<DriftFundingRateSnapshot[]> {
+    const normalizedMarket = normalizeMarketName(marketName);
+    if (!normalizedMarket) throw new Error("drift-market-name-invalid");
+    const url = new URL("/fundingRates", this.dataApiBase);
+    url.searchParams.set("marketName", normalizedMarket);
+    const response = await this.fetchImpl(url.toString(), {
+      method: "GET",
+      headers: { accept: "application/json" },
+    });
+    if (!response.ok) {
+      throw new Error(`drift-funding-rates-fetch-failed:${response.status}`);
+    }
+    const payload = (await response.json()) as DriftFundingRatesEnvelope;
+    return readFundingRatesPayload(payload).map((record) =>
+      mapFundingRateSnapshot(normalizedMarket, record),
+    );
+  }
+
+  async describePerpIntent(input: {
+    instrumentId: string;
+    side: "long" | "short" | "close_long" | "close_short";
+    quantityAtomic: string;
+    collateralAtomic?: string | null;
+    options?: DriftOrderOptions | null;
+    executionAdapter?: string | null;
+  }): Promise<DriftPerpIntentPreview> {
+    const instrumentId = normalizeMarketName(input.instrumentId);
+    if (!instrumentId) {
+      throw new Error("drift-instrument-id-invalid");
+    }
+    const quantityAtomic = readPositiveAtomic(input.quantityAtomic);
+    if (!quantityAtomic) {
+      throw new Error("drift-quantity-atomic-invalid");
+    }
+    const collateralAtomic = input.collateralAtomic
+      ? readPositiveAtomic(input.collateralAtomic)
+      : null;
+    if (input.collateralAtomic && !collateralAtomic) {
+      throw new Error("drift-collateral-atomic-invalid");
+    }
+    const contracts = await this.listContracts();
+    const instrument =
+      contracts.find((record) => record.marketName === instrumentId) ?? null;
+    if (!instrument) {
+      throw new Error(`drift-contract-not-found:${instrumentId}`);
+    }
+    const funding =
+      (await this.getFundingRates(instrument.marketName).catch(() => []))[0] ??
+      null;
+    const options = input.options ?? null;
+    return {
+      instrument,
+      funding,
+      side: input.side,
+      direction:
+        input.side === "short" || input.side === "close_short"
+          ? "short"
+          : "long",
+      reduceOnly: normalizeReduceOnly(input.side, options?.reduceOnly),
+      orderType: normalizeOrderType(options?.orderType),
+      timeInForce: normalizeTimeInForce(options?.timeInForce),
+      quantityAtomic,
+      collateralAtomic,
+      limitPriceAtomic: readPositiveAtomic(options?.limitPriceAtomic),
+      triggerPriceAtomic: readPositiveAtomic(options?.triggerPriceAtomic),
+      swiftSupported:
+        String(input.executionAdapter ?? "").trim() === "drift_swift" &&
+        this.swiftConfigured(),
+    };
+  }
+
+  buildSyntheticQuote(preview: DriftPerpIntentPreview) {
+    return buildSyntheticPerpQuote(preview);
+  }
+}

--- a/apps/worker/src/execution/drift_executor.ts
+++ b/apps/worker/src/execution/drift_executor.ts
@@ -1,0 +1,152 @@
+import { DriftClient, type DriftOrderOptions } from "../drift";
+import type {
+  ExecuteIntentInput,
+  ExecuteSwapResult,
+  NonSwapExecutionIntent,
+} from "./types";
+
+type ExecuteDriftPerpOrderInput = ExecuteIntentInput & {
+  intent: NonSwapExecutionIntent;
+};
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function buildLifecycle(input: {
+  side: string;
+  note: string;
+}): NonNullable<ExecuteSwapResult["executionMeta"]>["lifecycle"] {
+  const closing = input.side === "close_long" || input.side === "close_short";
+  return {
+    orderState: "open",
+    fillState: "pending",
+    positionState: closing ? "closing" : "opening",
+    settlementState: "confirmed",
+    notes: [input.note],
+  };
+}
+
+function readDriftOptions(
+  intent: NonSwapExecutionIntent,
+): DriftOrderOptions | null {
+  const params = intent.params;
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    return null;
+  }
+  return params as DriftOrderOptions;
+}
+
+export async function executeDriftPerpOrder(
+  input: ExecuteDriftPerpOrderInput,
+): Promise<ExecuteSwapResult> {
+  if (input.intent.family !== "perp_order") {
+    throw new Error("invalid-drift-intent-family");
+  }
+  if (input.intent.venueKey !== "drift") {
+    throw new Error("invalid-drift-venue");
+  }
+  if (input.intent.marketType !== "perp") {
+    throw new Error("invalid-drift-market-type");
+  }
+  if (
+    input.intent.side !== "long" &&
+    input.intent.side !== "short" &&
+    input.intent.side !== "close_long" &&
+    input.intent.side !== "close_short"
+  ) {
+    throw new Error("invalid-drift-side");
+  }
+  if (input.runtimeMode === "live") {
+    throw new Error("drift-live-mode-not-supported");
+  }
+
+  const route =
+    String(input.execution?.adapter ?? "").trim() === "drift_swift"
+      ? "drift_swift"
+      : "drift";
+  const drift = input.drift ?? new DriftClient(input.env);
+  if (route === "drift_swift" && !drift.swiftConfigured()) {
+    throw new Error("drift-swift-api-base-missing");
+  }
+
+  const preview = await drift.describePerpIntent({
+    instrumentId: input.intent.instrumentId,
+    side: input.intent.side,
+    quantityAtomic: String(input.intent.quantityAtomic ?? ""),
+    collateralAtomic: input.intent.collateralAtomic ?? null,
+    options: readDriftOptions(input.intent),
+    executionAdapter: route,
+  });
+  const lifecycle = buildLifecycle({
+    side: input.intent.side,
+    note: `${route}:${preview.orderType}:${preview.timeInForce}`,
+  });
+  const usedQuote = drift.buildSyntheticQuote(preview);
+
+  if (input.policy.dryRun) {
+    return {
+      status: "dry_run",
+      signature: null,
+      usedQuote,
+      refreshed: false,
+      lastValidBlockHeight: null,
+      executionMeta: {
+        route,
+        classification: "dry_run",
+        intentId: preview.instrument.marketName,
+        venueSessionId:
+          preview.instrument.marketIndex === null
+            ? null
+            : `perp_market:${preview.instrument.marketIndex}`,
+        lifecycle,
+        trace: {
+          txBuiltAt: nowIso(),
+        },
+      },
+    };
+  }
+
+  if (input.guardEnabled) await input.guardEnabled();
+
+  return {
+    status: "simulated",
+    signature: null,
+    usedQuote,
+    refreshed: false,
+    lastValidBlockHeight: null,
+    executionMeta: {
+      route,
+      classification: "simulated",
+      intentId: preview.instrument.marketName,
+      venueSessionId:
+        preview.instrument.marketIndex === null
+          ? null
+          : `perp_market:${preview.instrument.marketIndex}`,
+      lifecycle,
+      referencePrice: {
+        verdict: "allow",
+        reason: null,
+        executionPrice:
+          preview.funding?.markPrice === null
+            ? null
+            : String(preview.funding.markPrice),
+        executionDivergenceBps: null,
+        snapshot: {
+          marketName: preview.instrument.marketName,
+          marketIndex: preview.instrument.marketIndex,
+          oracle: preview.instrument.oracle,
+          fundingRate1hBps: preview.funding?.fundingRate1hBps ?? null,
+          oraclePrice: preview.funding?.oraclePrice ?? null,
+          markPrice: preview.funding?.markPrice ?? null,
+          reduceOnly: preview.reduceOnly,
+          swiftSupported: preview.swiftSupported,
+        },
+      },
+      trace: {
+        txBuiltAt: nowIso(),
+        simulatedAt: nowIso(),
+      },
+    },
+  };
+}

--- a/apps/worker/src/execution/router.ts
+++ b/apps/worker/src/execution/router.ts
@@ -7,6 +7,7 @@ import {
 import { TRADING_TOKEN_BY_MINT } from "../defaults";
 import type { RuntimeMode } from "../runtime_contracts";
 import { getStrategyLabSubjectControl } from "../strategy_lab_readiness_repository";
+import { executeDriftPerpOrder } from "./drift_executor";
 import { executeHeliusSenderSwap } from "./helius_sender_executor";
 import { executeJitoBundleSwap } from "./jito_bundle_executor";
 import { executeJupiterSwap } from "./jupiter_executor";
@@ -46,6 +47,30 @@ const DEFAULT_SUPPORTED_INTENT_FAMILIES: ExecutionIntentFamily[] = [
 ];
 
 const ADAPTERS = new Map<string, ExecutionAdapterRegistration>([
+  [
+    "drift",
+    {
+      adapterKey: "drift",
+      venueKey: "drift",
+      supportedModes: ["shadow", "paper"],
+      supportedIntentFamilies: ["perp_order"],
+      adapter: async () => {
+        throw new Error("drift-requires-intent-routing");
+      },
+    },
+  ],
+  [
+    "drift_swift",
+    {
+      adapterKey: "drift_swift",
+      venueKey: "drift",
+      supportedModes: ["shadow", "paper"],
+      supportedIntentFamilies: ["perp_order"],
+      adapter: async () => {
+        throw new Error("drift-swift-requires-intent-routing");
+      },
+    },
+  ],
   [
     "jupiter",
     {
@@ -285,6 +310,13 @@ export async function executeIntentViaRouter(
   });
 
   if (input.intent.family !== "spot_swap") {
+    if (
+      input.intent.family === "perp_order" &&
+      (registration.adapterKey === "drift" ||
+        registration.adapterKey === "drift_swift")
+    ) {
+      return await executeDriftPerpOrder(input);
+    }
     if (
       input.intent.family === "conditional_spot_order" &&
       registration.adapterKey === "jupiter"

--- a/apps/worker/src/execution/types.ts
+++ b/apps/worker/src/execution/types.ts
@@ -1,3 +1,4 @@
+import type { DriftClient } from "../drift";
 import type { JupiterClient, JupiterQuoteResponse } from "../jupiter";
 import type { OrcaClient } from "../orca";
 import type { NormalizedPolicy } from "../policy";
@@ -71,6 +72,7 @@ export type NonSwapExecutionIntent = {
   instrumentId: string;
   side?: string;
   quantityAtomic?: string;
+  collateralAtomic?: string;
   referenceId?: string;
   params?: Record<string, unknown> | null;
   lifecycle?: ExecutionIntentLifecycleSnapshot;
@@ -90,6 +92,7 @@ type ExecuteIntentInputBase = {
   policy: NormalizedPolicy;
   rpc: SolanaRpc;
   jupiter: JupiterClient;
+  drift?: DriftClient;
   orca?: OrcaClient;
   raydium?: RaydiumClient;
   log: ExecutionLogFn;

--- a/apps/worker/src/runtime_internal.ts
+++ b/apps/worker/src/runtime_internal.ts
@@ -1258,6 +1258,18 @@ function createRuntimeAssetFixture(
         minNotionalUsd: "0.01",
         notes: "Native paper routing mapping.",
       },
+      {
+        venueKey: "drift",
+        nativeId,
+        venueSymbol: assetKey,
+        decimals: isSol ? 9 : 6,
+        listingState: "paper",
+        quoteAssetKeys: ["USDC"],
+        priceDecimals: 6,
+        sizeDecimals: isSol ? 9 : 6,
+        minNotionalUsd: "0.01",
+        notes: "Paper perps collateral and mark-price mapping.",
+      },
     ],
     createdAt: FIXTURE_TIMESTAMP,
     updatedAt: FIXTURE_TIMESTAMP,
@@ -1283,13 +1295,19 @@ function createRuntimeAssetRegistryFixture() {
 function createRuntimeCostModelFixture(
   venueKey = "jupiter",
 ): RuntimeExecutionCostModelRecord {
+  const isPhoenix = venueKey === "phoenix";
+  const isMagicBlock = venueKey === "magicblock";
+  const isDrift = venueKey === "drift";
+  const pairSymbol = isDrift ? "SOL-PERP" : "SOL/USDC";
+  const marketType = isDrift ? "perp" : "spot";
+  const instrumentId = isDrift ? "SOL-PERP" : "SOL/USDC";
   return parseRuntimeExecutionCostModelRecord({
     schemaVersion: RUNTIME_PROTOCOL_SCHEMA_VERSION,
-    modelId: `cost_model_${venueKey}_sol_usdc_spot`,
+    modelId: `cost_model_${venueKey}_${isDrift ? "sol_perp" : "sol_usdc_spot"}`,
     venueKey,
-    marketType: "spot",
-    pairSymbol: "SOL/USDC",
-    instrumentId: "SOL/USDC",
+    marketType,
+    pairSymbol,
+    instrumentId,
     assetKeys: ["SOL", "USDC"],
     modeCoverage:
       venueKey === "jupiter"
@@ -1297,66 +1315,96 @@ function createRuntimeCostModelFixture(
         : ["shadow", "paper"],
     status: "active",
     assumptions: {
-      feeBps: venueKey === "phoenix" ? 4 : venueKey === "magicblock" ? 6 : 8,
-      slippageBps:
-        venueKey === "phoenix" ? 10 : venueKey === "magicblock" ? 18 : 22,
-      marketImpactBps:
-        venueKey === "phoenix" ? 6 : venueKey === "magicblock" ? 8 : 12,
-      partialFillRateBps: venueKey === "phoenix" ? 125 : 50,
-      partialFillPenaltyBps: venueKey === "phoenix" ? 10 : 12,
+      feeBps: isPhoenix ? 4 : isMagicBlock ? 6 : isDrift ? 7 : 8,
+      slippageBps: isPhoenix ? 10 : isMagicBlock ? 18 : isDrift ? 14 : 22,
+      marketImpactBps: isPhoenix ? 6 : isMagicBlock ? 8 : isDrift ? 9 : 12,
+      partialFillRateBps: isPhoenix ? 125 : isDrift ? 175 : 50,
+      partialFillPenaltyBps: isPhoenix ? 10 : isDrift ? 14 : 12,
     },
     calibration: {
-      calibrationId: `calibration_${venueKey}_sol_usdc_spot_seed`,
+      calibrationId: `calibration_${venueKey}_${isDrift ? "sol_perp" : "sol_usdc_spot"}_seed`,
       methodology: "seed_replay_bootstrap",
       sampleStartAt: "2026-03-07T00:00:00.000Z",
       sampleEndAt: FIXTURE_TIMESTAMP,
-      sampleCount:
-        venueKey === "phoenix" ? 160 : venueKey === "magicblock" ? 180 : 240,
-      confidenceBps:
-        venueKey === "phoenix" ? 7900 : venueKey === "magicblock" ? 8100 : 8600,
+      sampleCount: isPhoenix ? 160 : isMagicBlock ? 180 : isDrift ? 210 : 240,
+      confidenceBps: isPhoenix
+        ? 7900
+        : isMagicBlock
+          ? 8100
+          : isDrift
+            ? 8350
+            : 8600,
       referenceNotionalUsd: "25.00",
       tags: ["seed", "bootstrap"],
       notes: "Stubbed execution cost model calibration.",
     },
     driftGuard: {
-      maxCostDriftBps:
-        venueKey === "phoenix" ? 70 : venueKey === "magicblock" ? 80 : 90,
-      maxLatencyDriftMs:
-        venueKey === "phoenix" ? 5000 : venueKey === "magicblock" ? 6000 : 8000,
-      maxReconciliationDriftUsd:
-        venueKey === "phoenix"
-          ? "1.00"
-          : venueKey === "magicblock"
-            ? "1.25"
+      maxCostDriftBps: isPhoenix ? 70 : isMagicBlock ? 80 : isDrift ? 75 : 90,
+      maxLatencyDriftMs: isPhoenix
+        ? 5000
+        : isMagicBlock
+          ? 6000
+          : isDrift
+            ? 4500
+            : 8000,
+      maxReconciliationDriftUsd: isPhoenix
+        ? "1.00"
+        : isMagicBlock
+          ? "1.25"
+          : isDrift
+            ? "1.10"
             : "1.50",
     },
     latencyProfile: {
-      expectedQuoteMs:
-        venueKey === "phoenix" ? 150 : venueKey === "magicblock" ? 200 : 250,
-      expectedSubmitMs:
-        venueKey === "phoenix" ? 350 : venueKey === "magicblock" ? 400 : 750,
-      expectedSettlementMs:
-        venueKey === "phoenix" ? 4000 : venueKey === "magicblock" ? 3000 : 5000,
+      expectedQuoteMs: isPhoenix
+        ? 150
+        : isMagicBlock
+          ? 200
+          : isDrift
+            ? 180
+            : 250,
+      expectedSubmitMs: isPhoenix
+        ? 350
+        : isMagicBlock
+          ? 400
+          : isDrift
+            ? 450
+            : 750,
+      expectedSettlementMs: isPhoenix
+        ? 4000
+        : isMagicBlock
+          ? 3000
+          : isDrift
+            ? 4000
+            : 5000,
     },
     datasetSnapshots: [
       {
-        datasetId: "dataset_feed_replay_sol_usdc_market_events",
+        datasetId: isDrift
+          ? "dataset_feed_replay_sol_perp_market_events"
+          : "dataset_feed_replay_sol_usdc_market_events",
         snapshotId: "snapshot_2026_03_07_seed",
         capturedAt: FIXTURE_TIMESTAMP,
-        uri: "repo://services/runtime-rs/fixtures/runtime-feed-replay.sol_usdc.v1.json#marketEvents",
+        uri: isDrift
+          ? "repo://services/runtime-rs/fixtures/runtime-feed-replay.sol_perp.v1.json#marketEvents"
+          : "repo://services/runtime-rs/fixtures/runtime-feed-replay.sol_usdc.v1.json#marketEvents",
         contentDigest: "sha256:fixture",
       },
       {
-        datasetId: "dataset_feed_replay_sol_usdc_slot_events",
+        datasetId: isDrift
+          ? "dataset_feed_replay_sol_perp_slot_events"
+          : "dataset_feed_replay_sol_usdc_slot_events",
         snapshotId: "snapshot_2026_03_07_seed",
         capturedAt: FIXTURE_TIMESTAMP,
-        uri: "repo://services/runtime-rs/fixtures/runtime-feed-replay.sol_usdc.v1.json#slotEvents",
+        uri: isDrift
+          ? "repo://services/runtime-rs/fixtures/runtime-feed-replay.sol_perp.v1.json#slotEvents"
+          : "repo://services/runtime-rs/fixtures/runtime-feed-replay.sol_usdc.v1.json#slotEvents",
         contentDigest: "sha256:fixture",
       },
     ],
     createdAt: FIXTURE_TIMESTAMP,
     updatedAt: FIXTURE_TIMESTAMP,
-    tags: ["seed", "spot"],
+    tags: ["seed", marketType],
     notes: "Stubbed execution cost model fixture.",
   });
 }
@@ -1366,6 +1414,7 @@ function createRuntimeCostModelRegistryFixture() {
     costModels: [
       createRuntimeCostModelFixture("jupiter"),
       createRuntimeCostModelFixture("magicblock"),
+      createRuntimeCostModelFixture("drift"),
       createRuntimeCostModelFixture("phoenix"),
     ],
   };
@@ -1374,33 +1423,47 @@ function createRuntimeCostModelRegistryFixture() {
 function createRuntimeCostObservationFixture(
   venueKey = "jupiter",
 ): RuntimeExecutionCostObservationRecord {
+  const isPhoenix = venueKey === "phoenix";
+  const isMagicBlock = venueKey === "magicblock";
+  const isDrift = venueKey === "drift";
+  const pairSymbol = isDrift ? "SOL-PERP" : "SOL/USDC";
+  const marketType = isDrift ? "perp" : "spot";
   return parseRuntimeExecutionCostObservationRecord({
     schemaVersion: RUNTIME_PROTOCOL_SCHEMA_VERSION,
     observationId: `costobs_${venueKey}_deployment_shadow_fixture_run_1`,
-    modelId: `cost_model_${venueKey}_sol_usdc_spot`,
+    modelId: `cost_model_${venueKey}_${isDrift ? "sol_perp" : "sol_usdc_spot"}`,
     deploymentId: "deployment_shadow_fixture",
     runId: "deployment_shadow_fixture_run_1",
     receiptId: `receipt_${venueKey}_deployment_shadow_fixture_run_1`,
     venueKey,
-    marketType: "spot",
-    pairSymbol: "SOL/USDC",
+    marketType,
+    pairSymbol,
     assetKeys: ["SOL", "USDC"],
     mode: "paper",
     observedAt: FIXTURE_TIMESTAMP,
     evaluatedNotionalUsd: "25.00",
-    modeledTotalCostUsd: venueKey === "phoenix" ? "0.05" : "0.11",
-    observedTotalCostUsd: venueKey === "phoenix" ? "0.06" : "0.13",
-    costDriftUsd: venueKey === "phoenix" ? "0.01" : "0.02",
-    costDriftBps: venueKey === "phoenix" ? 40 : 80,
-    expectedEndToEndLatencyMs:
-      venueKey === "phoenix" ? 4350 : venueKey === "magicblock" ? 3400 : 5750,
-    observedEndToEndLatencyMs:
-      venueKey === "phoenix" ? 4525 : venueKey === "magicblock" ? 3625 : 6125,
-    latencyDriftMs:
-      venueKey === "phoenix" ? 175 : venueKey === "magicblock" ? 225 : 375,
+    modeledTotalCostUsd: isPhoenix ? "0.05" : isDrift ? "0.08" : "0.11",
+    observedTotalCostUsd: isPhoenix ? "0.06" : isDrift ? "0.09" : "0.13",
+    costDriftUsd: isPhoenix ? "0.01" : isDrift ? "0.01" : "0.02",
+    costDriftBps: isPhoenix ? 40 : isDrift ? 55 : 80,
+    expectedEndToEndLatencyMs: isPhoenix
+      ? 4350
+      : isMagicBlock
+        ? 3400
+        : isDrift
+          ? 4050
+          : 5750,
+    observedEndToEndLatencyMs: isPhoenix
+      ? 4525
+      : isMagicBlock
+        ? 3625
+        : isDrift
+          ? 4275
+          : 6125,
+    latencyDriftMs: isPhoenix ? 175 : isMagicBlock ? 225 : isDrift ? 225 : 375,
     reconciliationStatus: "passed",
-    reconciliationDriftUsd: venueKey === "phoenix" ? "0.01" : "0.02",
-    tags: ["cost-observation", "paper"],
+    reconciliationDriftUsd: isPhoenix ? "0.01" : isDrift ? "0.01" : "0.02",
+    tags: ["cost-observation", marketType],
     notes: "Stubbed modeled-versus-observed execution cost observation.",
   });
 }
@@ -1410,6 +1473,7 @@ function createRuntimeCostObservationRegistryFixture() {
     costObservations: [
       createRuntimeCostObservationFixture("jupiter"),
       createRuntimeCostObservationFixture("magicblock"),
+      createRuntimeCostObservationFixture("drift"),
       createRuntimeCostObservationFixture("phoenix"),
     ],
   };

--- a/apps/worker/src/types.ts
+++ b/apps/worker/src/types.ts
@@ -70,6 +70,8 @@ export type Env = {
   JUPITER_BASE_URL?: string;
   JUPITER_PRICE_BASE_URL?: string;
   JUPITER_API_KEY?: string;
+  DRIFT_DATA_API_BASE?: string;
+  DRIFT_SWIFT_API_BASE?: string;
   ORCA_API_BASE_URL?: string;
   RAYDIUM_API_BASE_URL?: string;
   RAYDIUM_TRANSACTION_BASE_URL?: string;

--- a/src/runtime/venues/catalog.ts
+++ b/src/runtime/venues/catalog.ts
@@ -155,6 +155,43 @@ const BUILTIN_RUNTIME_VENUE_CAPABILITIES = [
   },
   {
     schemaVersion: "v1",
+    venueKey: "drift",
+    displayName: "Drift",
+    adapterKeys: ["drift", "drift_swift"],
+    marketTypes: ["perp"],
+    orderTypes: ["market", "limit", "trigger"],
+    intentFamilies: ["perp_order"],
+    authModel: "privy_solana_wallet",
+    feeModel: "maker_taker_bps",
+    precision: {
+      priceDecimals: 6,
+      sizeDecimals: 9,
+      minOrderIncrement: "0.000001",
+      minQuoteNotionalUsd: "0.01",
+    },
+    sizeLimits: {
+      minNotionalUsd: "0.01",
+    },
+    latencyProfile: {
+      expectedQuoteMs: 200,
+      expectedSubmitMs: 450,
+      expectedSettlementMs: 4000,
+    },
+    settlementBehavior: "orderbook_partial",
+    lifecycle: {
+      supportsOrderLifecycle: true,
+      supportsPositionLifecycle: true,
+      requiresExternalOracle: true,
+      settlementModel: "position_account",
+    },
+    oracleRequirements: ["pyth", "switchboard", "venue_reference"],
+    supportedModes: ["shadow", "paper"],
+    onboardingState: "integrated",
+    notes:
+      "Bounded Drift perps substrate for shadow and paper; live stays blocked until oracle, margin, and Swift canary evidence land.",
+  },
+  {
+    schemaVersion: "v1",
     venueKey: "phoenix",
     displayName: "Phoenix",
     adapterKeys: ["phoenix_orderbook"],

--- a/tests/unit/worker_drift.test.ts
+++ b/tests/unit/worker_drift.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, mock, test } from "bun:test";
+import { DriftClient } from "../../apps/worker/src/drift";
+
+describe("worker Drift client", () => {
+  test("describes perp intents from the Drift data API and preserves Swift availability", async () => {
+    const fetchMock = mock(async (input: string | URL) => {
+      const url = String(input);
+      if (url === "https://drift.test/contracts") {
+        return new Response(
+          JSON.stringify({
+            contracts: [
+              {
+                marketName: "SOL-PERP",
+                marketIndex: 2,
+                oracle: "oracle-sol",
+                oracleSource: "pyth",
+                status: "active",
+                contractType: "perp",
+                initialMarginRatio: 1000,
+                maintenanceMarginRatio: 500,
+              },
+            ],
+          }),
+        );
+      }
+      if (url === "https://drift.test/fundingRates?marketName=SOL-PERP") {
+        return new Response(
+          JSON.stringify({
+            fundingRates: [
+              {
+                marketName: "SOL-PERP",
+                fundingRate: 0.00012,
+                oraclePrice: 153.25,
+                markPrice: 153.3,
+                ts: "2026-03-13T23:59:00.000Z",
+              },
+            ],
+          }),
+        );
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+
+    const client = new DriftClient(
+      {
+        dataApiBase: "https://drift.test",
+        swiftApiBase: "https://swift.test",
+      },
+      { fetch: fetchMock as typeof fetch },
+    );
+    const preview = await client.describePerpIntent({
+      instrumentId: "sol-perp",
+      side: "long",
+      quantityAtomic: "1000000",
+      collateralAtomic: "250000",
+      options: {
+        orderType: "limit",
+        timeInForce: "gtc",
+        limitPriceAtomic: "155000000",
+      },
+      executionAdapter: "drift_swift",
+    });
+
+    expect(preview.instrument.marketName).toBe("SOL-PERP");
+    expect(preview.instrument.marketIndex).toBe(2);
+    expect(preview.funding?.fundingRate1hBps).toBe(1.2);
+    expect(preview.limitPriceAtomic).toBe("155000000");
+    expect(preview.swiftSupported).toBe(true);
+  });
+});

--- a/tests/unit/worker_execution_drift.test.ts
+++ b/tests/unit/worker_execution_drift.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "bun:test";
+import { normalizePolicy } from "../../apps/worker/src/policy";
+import type { Env } from "../../apps/worker/src/types";
+
+const { executeDriftPerpOrder } = await import(
+  "../../apps/worker/src/execution/drift_executor"
+);
+
+function buildIntent() {
+  return {
+    family: "perp_order" as const,
+    wallet: "11111111111111111111111111111111",
+    venueKey: "drift" as const,
+    marketType: "perp" as const,
+    instrumentId: "SOL-PERP",
+    side: "long" as const,
+    quantityAtomic: "1000000",
+    collateralAtomic: "250000",
+    params: {
+      orderType: "limit",
+      timeInForce: "gtc",
+      limitPriceAtomic: "155000000",
+    },
+  };
+}
+
+function buildPreview() {
+  return {
+    instrument: {
+      marketName: "SOL-PERP",
+      marketIndex: 2,
+      oracle: "oracle-sol",
+      oracleSource: "pyth",
+      status: "active",
+      contractType: "perp",
+      initialMarginRatio: 1000,
+      maintenanceMarginRatio: 500,
+    },
+    funding: {
+      marketName: "SOL-PERP",
+      fundingRate1h: 0.00012,
+      fundingRate1hBps: 1.2,
+      oraclePrice: 153.25,
+      markPrice: 153.3,
+      sourceTs: "2026-03-13T23:59:00.000Z",
+    },
+    side: "long" as const,
+    direction: "long" as const,
+    reduceOnly: false,
+    orderType: "limit" as const,
+    timeInForce: "gtc" as const,
+    quantityAtomic: "1000000",
+    collateralAtomic: "250000",
+    limitPriceAtomic: "155000000",
+    triggerPriceAtomic: null,
+    swiftSupported: false,
+  };
+}
+
+describe("worker Drift perp execution adapter", () => {
+  test("returns dry_run for bounded Drift perp intents", async () => {
+    const result = await executeDriftPerpOrder({
+      env: {} as Env,
+      runtimeMode: "paper",
+      policy: normalizePolicy({ dryRun: true }),
+      rpc: {} as never,
+      jupiter: {} as never,
+      drift: {
+        swiftConfigured: () => false,
+        describePerpIntent: async () => buildPreview(),
+        buildSyntheticQuote: () => ({
+          inputMint: "SOL-PERP",
+          outputMint: "SOL-PERP",
+          inAmount: "250000",
+          outAmount: "1000000",
+          priceImpactPct: 0,
+          routePlan: [{ poolId: "SOL-PERP", swapInfo: { label: "Drift" } }],
+        }),
+      } as never,
+      intent: buildIntent(),
+      log: () => {},
+    });
+
+    expect(result.status).toBe("dry_run");
+    expect(result.executionMeta?.route).toBe("drift");
+    expect(result.executionMeta?.lifecycle?.positionState).toBe("opening");
+  });
+
+  test("simulates Drift perp intents in paper mode", async () => {
+    const result = await executeDriftPerpOrder({
+      env: {} as Env,
+      runtimeMode: "paper",
+      policy: normalizePolicy({}),
+      rpc: {} as never,
+      jupiter: {} as never,
+      drift: {
+        swiftConfigured: () => false,
+        describePerpIntent: async () => buildPreview(),
+        buildSyntheticQuote: () => ({
+          inputMint: "SOL-PERP",
+          outputMint: "SOL-PERP",
+          inAmount: "250000",
+          outAmount: "1000000",
+          priceImpactPct: 0,
+          routePlan: [{ poolId: "SOL-PERP", swapInfo: { label: "Drift" } }],
+        }),
+      } as never,
+      intent: buildIntent(),
+      log: () => {},
+    });
+
+    expect(result.status).toBe("simulated");
+    expect(result.executionMeta?.referencePrice?.snapshot?.marketName).toBe(
+      "SOL-PERP",
+    );
+  });
+
+  test("fails closed when the Swift route is requested without a Swift endpoint", async () => {
+    await expect(
+      executeDriftPerpOrder({
+        env: {
+          DRIFT_DATA_API_BASE: "https://drift.test",
+        } as Env,
+        runtimeMode: "paper",
+        execution: { adapter: "drift_swift" },
+        policy: normalizePolicy({}),
+        rpc: {} as never,
+        jupiter: {} as never,
+        intent: buildIntent(),
+        log: () => {},
+      }),
+    ).rejects.toThrow(/drift-swift-api-base-missing/);
+  });
+
+  test("rejects live mode for Drift rollout", async () => {
+    await expect(
+      executeDriftPerpOrder({
+        env: {} as Env,
+        runtimeMode: "live",
+        policy: normalizePolicy({}),
+        rpc: {} as never,
+        jupiter: {} as never,
+        intent: buildIntent(),
+        log: () => {},
+      }),
+    ).rejects.toThrow(/drift-live-mode-not-supported/);
+  });
+});

--- a/tests/unit/worker_execution_router.test.ts
+++ b/tests/unit/worker_execution_router.test.ts
@@ -283,6 +283,78 @@ describe("worker execution router", () => {
     expect(result.executionMeta?.lifecycle?.orderState).toBe("open");
   });
 
+  test("routes Drift perp intents through the Drift executor in paper mode", async () => {
+    const result = await executeIntentViaRouter({
+      env: {} as never,
+      venueKey: "drift",
+      runtimeMode: "paper",
+      execution: { adapter: "drift" },
+      policy: normalizePolicy({}),
+      rpc: {} as never,
+      jupiter: {} as never,
+      drift: {
+        swiftConfigured: () => false,
+        describePerpIntent: async () => ({
+          instrument: {
+            marketName: "SOL-PERP",
+            marketIndex: 2,
+            oracle: "oracle-sol",
+            oracleSource: "pyth",
+            status: "active",
+            contractType: "perp",
+            initialMarginRatio: 1000,
+            maintenanceMarginRatio: 500,
+          },
+          funding: {
+            marketName: "SOL-PERP",
+            fundingRate1h: 0.00012,
+            fundingRate1hBps: 1.2,
+            oraclePrice: 153.25,
+            markPrice: 153.3,
+            sourceTs: "2026-03-13T23:59:00.000Z",
+          },
+          side: "long",
+          direction: "long",
+          reduceOnly: false,
+          orderType: "limit",
+          timeInForce: "gtc",
+          quantityAtomic: "1000000",
+          collateralAtomic: "250000",
+          limitPriceAtomic: "155000000",
+          triggerPriceAtomic: null,
+          swiftSupported: false,
+        }),
+        buildSyntheticQuote: () => ({
+          inputMint: "SOL-PERP",
+          outputMint: "SOL-PERP",
+          inAmount: "250000",
+          outAmount: "1000000",
+          priceImpactPct: 0,
+          routePlan: [{ poolId: "SOL-PERP", swapInfo: { label: "Drift" } }],
+        }),
+      } as never,
+      intent: {
+        family: "perp_order",
+        wallet: "11111111111111111111111111111111",
+        venueKey: "drift",
+        marketType: "perp",
+        instrumentId: "SOL-PERP",
+        side: "long",
+        quantityAtomic: "1000000",
+        collateralAtomic: "250000",
+        params: {
+          orderType: "limit",
+          limitPriceAtomic: "155000000",
+        },
+      },
+      log: () => {},
+    });
+
+    expect(result.status).toBe("simulated");
+    expect(result.executionMeta?.route).toBe("drift");
+    expect(result.executionMeta?.lifecycle?.positionState).toBe("opening");
+  });
+
   test("fails closed when the runtime venue does not support the requested intent family", async () => {
     registerExecutionAdapter(
       "phoenix_orderbook",

--- a/tests/unit/worker_runtime_internal_routes.test.ts
+++ b/tests/unit/worker_runtime_internal_routes.test.ts
@@ -1369,6 +1369,47 @@ describe("worker runtime internal routes", () => {
     });
   });
 
+  test("returns stubbed Drift runtime cost model registry", async () => {
+    const env = createWorkerLiveEnv();
+
+    const response = await worker.fetch(
+      new Request(
+        "http://localhost/api/internal/runtime/cost-models?venueKey=drift&assetKey=SOL&pairSymbol=SOL-PERP&marketType=perp&mode=paper",
+        {
+          headers: {
+            authorization: "Bearer runtime-service-secret",
+          },
+        },
+      ),
+      env,
+      createExecutionContextStub(),
+    );
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload).toMatchObject({
+      ok: true,
+      source: "stub",
+      filters: {
+        venueKey: "drift",
+        assetKey: "SOL",
+        pairSymbol: "SOL-PERP",
+        marketType: "perp",
+        mode: "paper",
+      },
+      registry: {
+        costModels: expect.arrayContaining([
+          expect.objectContaining({
+            modelId: "cost_model_drift_sol_perp",
+            venueKey: "drift",
+            marketType: "perp",
+            pairSymbol: "SOL-PERP",
+          }),
+        ]),
+      },
+    });
+  });
+
   test("accepts stubbed runtime research writes", async () => {
     const env = createWorkerLiveEnv();
 
@@ -1477,6 +1518,45 @@ describe("worker runtime internal routes", () => {
           assetKey: "SOL",
           venueMappings: expect.arrayContaining([
             expect.objectContaining({ venueKey: "jupiter" }),
+          ]),
+        }),
+      ]),
+    );
+  });
+
+  test("returns stubbed runtime asset registry entries for Drift", async () => {
+    const env = createWorkerLiveEnv();
+
+    const response = await worker.fetch(
+      new Request(
+        "http://localhost/api/internal/runtime/assets?assetKey=SOL&venueKey=drift&listingState=paper",
+        {
+          headers: {
+            authorization: "Bearer runtime-service-secret",
+          },
+        },
+      ),
+      env,
+      createExecutionContextStub(),
+    );
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload).toMatchObject({
+      ok: true,
+      source: "stub",
+      filters: {
+        assetKey: "SOL",
+        venueKey: "drift",
+        listingState: "paper",
+      },
+    });
+    expect(payload.registry.assets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          assetKey: "SOL",
+          venueMappings: expect.arrayContaining([
+            expect.objectContaining({ venueKey: "drift" }),
           ]),
         }),
       ]),


### PR DESCRIPTION
## Summary
- add a bounded Drift perps adapter family for perp_order intents in shadow and paper
- support both drift and drift_swift routing with Data API-backed intent previews and fail-closed Swift/live behavior
- extend stubbed runtime asset and cost-model registries so Drift appears in the internal harness surfaces

Closes #372

## Proof
- bun test tests/unit/worker_drift.test.ts tests/unit/worker_execution_drift.test.ts tests/unit/worker_execution_router.test.ts tests/unit/worker_runtime_internal_routes.test.ts
- bun run typecheck
- bun run lint
