### PR TITLE
[Phase T0] Build terminal multi-venue substrate for venue-aware trading

### DIFF
--- a/apps/portal/app/execution-client.ts
+++ b/apps/portal/app/execution-client.ts
@@ -1,4 +1,16 @@
 import { apiBase, isRecord } from "./lib";
+import {
+  parseTerminalIntentFamily,
+  parseTerminalMarketType,
+  parseTerminalOracleStatus,
+  parseTerminalProviderStatus,
+  parseTerminalVenueKey,
+  type TerminalIntentFamily,
+  type TerminalMarketType,
+  type TerminalOracleStatus,
+  type TerminalProviderStatus,
+  type TerminalVenueKey,
+} from "./terminal/terminal-venues";
 
 const BEARER_RE = /^bearer\s+/i;
 
@@ -77,12 +89,15 @@ export type ExecutionSubmitPayload =
       privyExecute: {
         wallet: string;
         intent: {
-          family: "conditional_spot_order";
-          venueKey: "jupiter";
-          marketType: "spot";
+          family: TerminalIntentFamily;
+          venueKey: TerminalVenueKey;
+          marketType: TerminalMarketType;
           instrumentId: string;
-          side: "buy" | "sell";
-          quantityAtomic: string;
+          instrumentLabel?: string;
+          side: "buy" | "sell" | "long" | "short";
+          quantityAtomic?: string;
+          collateralAtomic?: string;
+          notionalAtomic?: string;
         };
         options?: {
           commitment?: "processed" | "confirmed" | "finalized";
@@ -146,7 +161,12 @@ export type ExecutionOpenOrderSnapshot = {
   receivedAt: string | null;
   updatedAt: string | null;
   terminalAt: string | null;
+  intentFamily: TerminalIntentFamily | null;
+  venueKey: TerminalVenueKey | null;
+  marketType: TerminalMarketType | null;
   pairId: string | null;
+  instrumentId: string | null;
+  instrumentLabel: string | null;
   direction: "buy" | "sell" | null;
   source: string | null;
   reason: string | null;
@@ -167,14 +187,18 @@ export type ExecutionOpenOrderSnapshot = {
   limitPriceAtomic: string | null;
   triggerPriceAtomic: string | null;
   provider: string | null;
+  providerStatus: TerminalProviderStatus | null;
   signature: string | null;
   errorCode: string | null;
   errorMessage: string | null;
   status: string | null;
+  oracleStatus: TerminalOracleStatus | null;
   lifecycle: {
     orderState?: string;
     fillState?: string;
     settlementState?: string;
+    positionState?: string;
+    riskState?: string;
     notes?: string[];
   } | null;
 };
@@ -510,7 +534,12 @@ function parseOpenOrderSnapshot(
     receivedAt: parseOptionalString(value.receivedAt),
     updatedAt: parseOptionalString(value.updatedAt),
     terminalAt: parseOptionalString(value.terminalAt),
+    intentFamily: parseTerminalIntentFamily(value.intentFamily),
+    venueKey: parseTerminalVenueKey(value.venueKey),
+    marketType: parseTerminalMarketType(value.marketType),
     pairId: parseOptionalString(value.pairId),
+    instrumentId: parseOptionalString(value.instrumentId),
+    instrumentLabel: parseOptionalString(value.instrumentLabel),
     direction:
       value.direction === "buy" || value.direction === "sell"
         ? value.direction
@@ -559,16 +588,25 @@ function parseOpenOrderSnapshot(
     limitPriceAtomic: parseOptionalAtomicString(value.limitPriceAtomic),
     triggerPriceAtomic: parseOptionalAtomicString(value.triggerPriceAtomic),
     provider: parseOptionalString(value.provider),
+    providerStatus: parseTerminalProviderStatus(value.providerStatus),
     signature: parseOptionalString(value.signature),
     errorCode: parseOptionalString(value.errorCode),
     errorMessage: parseOptionalString(value.errorMessage),
     status: parseOptionalString(value.status),
+    oracleStatus: parseTerminalOracleStatus({
+      freshnessMs: value.oracleFreshnessMs,
+      source: value.oracleSource,
+      stale: value.oracleStale,
+    }),
     lifecycle: lifecycleRaw
       ? {
           orderState: parseOptionalString(lifecycleRaw.orderState) ?? undefined,
           fillState: parseOptionalString(lifecycleRaw.fillState) ?? undefined,
           settlementState:
             parseOptionalString(lifecycleRaw.settlementState) ?? undefined,
+          positionState:
+            parseOptionalString(lifecycleRaw.positionState) ?? undefined,
+          riskState: parseOptionalString(lifecycleRaw.riskState) ?? undefined,
           notes: parseStringArray(lifecycleRaw.notes) ?? undefined,
         }
       : null,

--- a/apps/portal/app/terminal/components/execution-inspector-drawer.tsx
+++ b/apps/portal/app/terminal/components/execution-inspector-drawer.tsx
@@ -3,6 +3,16 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "../../cn";
 import { apiBase, BTN_SECONDARY, isRecord } from "../../lib";
+import {
+  getTerminalIntentFamilyLabel,
+  getTerminalVenueDefinition,
+  parseTerminalIntentFamily,
+  parseTerminalMarketType,
+  parseTerminalVenueKey,
+  type TerminalIntentFamily,
+  type TerminalMarketType,
+  type TerminalVenueKey,
+} from "../terminal-venues";
 
 type ExecutionInspectorEvent = {
   state: string;
@@ -31,6 +41,21 @@ export type ExecutionInspectorSnapshot = {
     updatedAt: string | null;
     terminalAt: string | null;
   };
+  intent: {
+    family: TerminalIntentFamily | null;
+    venueKey: TerminalVenueKey | null;
+    marketType: TerminalMarketType | null;
+    instrumentId: string | null;
+    instrumentLabel: string | null;
+  } | null;
+  lifecycle: {
+    orderState?: string;
+    fillState?: string;
+    settlementState?: string;
+    positionState?: string;
+    riskState?: string;
+    notes?: string[];
+  } | null;
   events: ExecutionInspectorEvent[];
   attempts: ExecutionInspectorAttempt[];
   receipt: {
@@ -69,6 +94,8 @@ function parseOptionalInteger(value: unknown): number | null {
 export function parseStatusPayload(payload: unknown): {
   requestId: string;
   status: ExecutionInspectorSnapshot["status"];
+  intent: ExecutionInspectorSnapshot["intent"];
+  lifecycle: ExecutionInspectorSnapshot["lifecycle"];
   events: ExecutionInspectorEvent[];
   attempts: ExecutionInspectorAttempt[];
 } {
@@ -90,6 +117,35 @@ export function parseStatusPayload(payload: unknown): {
     updatedAt: parseOptionalString(statusRaw.updatedAt),
     terminalAt: parseOptionalString(statusRaw.terminalAt),
   };
+  const intentRaw = isRecord(payload.intent) ? payload.intent : null;
+  const lifecycleRaw = isRecord(payload.lifecycle) ? payload.lifecycle : null;
+  const intent = intentRaw
+    ? {
+        family: parseTerminalIntentFamily(intentRaw.family),
+        venueKey: parseTerminalVenueKey(intentRaw.venueKey),
+        marketType: parseTerminalMarketType(intentRaw.marketType),
+        instrumentId: parseOptionalString(intentRaw.instrumentId),
+        instrumentLabel:
+          parseOptionalString(intentRaw.instrumentLabel) ??
+          parseOptionalString(intentRaw.instrumentId),
+      }
+    : null;
+  const lifecycle = lifecycleRaw
+    ? {
+        orderState: parseOptionalString(lifecycleRaw.orderState) ?? undefined,
+        fillState: parseOptionalString(lifecycleRaw.fillState) ?? undefined,
+        settlementState:
+          parseOptionalString(lifecycleRaw.settlementState) ?? undefined,
+        positionState:
+          parseOptionalString(lifecycleRaw.positionState) ?? undefined,
+        riskState: parseOptionalString(lifecycleRaw.riskState) ?? undefined,
+        notes: Array.isArray(lifecycleRaw.notes)
+          ? lifecycleRaw.notes
+              .map((note) => parseOptionalString(note))
+              .filter((note): note is string => note !== null)
+          : undefined,
+      }
+    : null;
 
   const events: ExecutionInspectorEvent[] = Array.isArray(payload.events)
     ? payload.events
@@ -127,7 +183,7 @@ export function parseStatusPayload(payload: unknown): {
         )
     : [];
 
-  return { requestId, status, events, attempts };
+  return { requestId, status, intent, lifecycle, events, attempts };
 }
 
 export function parseReceiptPayload(
@@ -219,6 +275,8 @@ async function fetchExecutionInspectorSnapshot(
   return {
     requestId: status.requestId,
     status: status.status,
+    intent: status.intent,
+    lifecycle: status.lifecycle,
     events: status.events,
     attempts: status.attempts,
     receipt,
@@ -383,11 +441,43 @@ export const ExecutionInspectorDrawer = memo(function ExecutionInspectorDrawer(
                   {snapshot.status.lane ?? "--"} • actor{" "}
                   {snapshot.status.actorType ?? "--"}
                 </p>
+                {snapshot.intent ? (
+                  <p className="text-[11px] text-muted">
+                    venue{" "}
+                    {getTerminalVenueDefinition(snapshot.intent.venueKey)
+                      ?.label ??
+                      snapshot.intent.venueKey ??
+                      "--"}{" "}
+                    • family{" "}
+                    {getTerminalIntentFamilyLabel(snapshot.intent.family) ??
+                      snapshot.intent.family ??
+                      "--"}{" "}
+                    • market {snapshot.intent.marketType ?? "--"} • instrument{" "}
+                    {snapshot.intent.instrumentLabel ??
+                      snapshot.intent.instrumentId ??
+                      "--"}
+                  </p>
+                ) : null}
                 <p className="text-[11px] text-muted">
                   received {formatTimestamp(snapshot.status.receivedAt)} •
                   updated {formatTimestamp(snapshot.status.updatedAt)} •
                   terminal {formatTimestamp(snapshot.status.terminalAt)}
                 </p>
+                {snapshot.lifecycle ? (
+                  <p className="text-[11px] text-muted">
+                    order {snapshot.lifecycle.orderState ?? "--"} • fill{" "}
+                    {snapshot.lifecycle.fillState ?? "--"} • settle{" "}
+                    {snapshot.lifecycle.settlementState ?? "--"} • position{" "}
+                    {snapshot.lifecycle.positionState ?? "--"} • risk{" "}
+                    {snapshot.lifecycle.riskState ?? "--"}
+                  </p>
+                ) : null}
+                {snapshot.lifecycle?.notes &&
+                snapshot.lifecycle.notes.length > 0 ? (
+                  <p className="text-[11px] text-muted">
+                    notes: {snapshot.lifecycle.notes.join(" • ")}
+                  </p>
+                ) : null}
                 {normalizedError ? (
                   <p className="mt-1 text-[11px] text-red-300">
                     {normalizedError}

--- a/apps/portal/app/terminal/components/open-orders.ts
+++ b/apps/portal/app/terminal/components/open-orders.ts
@@ -1,3 +1,13 @@
+import {
+  formatTerminalOracleFreshness,
+  getTerminalIntentFamilyLabel,
+  getTerminalVenueDefinition,
+  type TerminalIntentFamily,
+  type TerminalMarketType,
+  type TerminalOracleStatus,
+  type TerminalProviderStatus,
+  type TerminalVenueKey,
+} from "../terminal-venues";
 import { type PairId, SUPPORTED_PAIRS, TOKEN_BY_MINT } from "./trade-pairs";
 import type { QueuedTerminalOrder } from "./trade-ticket-modal";
 
@@ -17,7 +27,12 @@ export type TerminalOpenOrderSnapshot = {
   receivedAt: string | null;
   updatedAt: string | null;
   terminalAt: string | null;
+  intentFamily: TerminalIntentFamily | null;
+  venueKey: TerminalVenueKey | null;
+  marketType: TerminalMarketType | null;
   pairId: string | null;
+  instrumentId: string | null;
+  instrumentLabel: string | null;
   direction: "buy" | "sell" | null;
   source: string | null;
   reason: string | null;
@@ -38,19 +53,34 @@ export type TerminalOpenOrderSnapshot = {
   limitPriceAtomic: string | null;
   triggerPriceAtomic: string | null;
   provider: string | null;
+  providerStatus: TerminalProviderStatus | null;
   signature: string | null;
   errorCode: string | null;
   errorMessage: string | null;
   status: string | null;
+  oracleStatus: TerminalOracleStatus | null;
   lifecycle: {
     orderState?: string;
     fillState?: string;
     settlementState?: string;
+    positionState?: string;
+    riskState?: string;
     notes?: string[];
   } | null;
 };
 
-export type OpenOrderRow = QueuedTerminalOrder & {
+export type OpenOrderRow = Omit<QueuedTerminalOrder, "pairId"> & {
+  pairId: PairId | null;
+  instrumentId: string;
+  instrumentLabel: string;
+  venueKey: TerminalVenueKey;
+  intentFamily: TerminalIntentFamily;
+  marketType: TerminalMarketType;
+  venueLabel: string;
+  familyLabel: string;
+  providerStatus: TerminalProviderStatus | null;
+  oracleStatus: TerminalOracleStatus | null;
+  oracleFreshnessLabel: string | null;
   requestId?: string | null;
   status: OpenOrderStatus;
   initialAmountUi: string;
@@ -147,9 +177,20 @@ export function mapTerminalOpenOrderSnapshot(
     snapshot.pairId && isSupportedPairId(snapshot.pairId)
       ? snapshot.pairId
       : null;
-  if (!pairId || !snapshot.direction || !snapshot.orderType || !snapshot.lane) {
+  if (!snapshot.direction || !snapshot.orderType || !snapshot.lane) {
     return null;
   }
+  const instrumentId = snapshot.instrumentId ?? pairId ?? snapshot.requestId;
+  if (!instrumentId) return null;
+  const instrumentLabel =
+    snapshot.instrumentLabel ?? pairId ?? snapshot.instrumentId ?? instrumentId;
+  const venueKey = snapshot.venueKey ?? "jupiter";
+  const intentFamily = snapshot.intentFamily ?? "conditional_spot_order";
+  const marketType = snapshot.marketType ?? "spot";
+  const venueLabel =
+    getTerminalVenueDefinition(venueKey)?.label ?? venueKey.toUpperCase();
+  const familyLabel =
+    getTerminalIntentFamilyLabel(intentFamily) ?? intentFamily;
   const inputToken = snapshot.inputMint
     ? TOKEN_BY_MINT[snapshot.inputMint]
     : null;
@@ -168,6 +209,18 @@ export function mapTerminalOpenOrderSnapshot(
     createdAt,
     updatedAt,
     pairId,
+    instrumentId,
+    instrumentLabel,
+    venueKey,
+    intentFamily,
+    marketType,
+    venueLabel,
+    familyLabel,
+    providerStatus: snapshot.providerStatus,
+    oracleStatus: snapshot.oracleStatus,
+    oracleFreshnessLabel: formatTerminalOracleFreshness(
+      snapshot.oracleStatus?.freshnessMs,
+    ),
     direction: snapshot.direction,
     source: snapshot.source ?? "TERMINAL",
     reason: snapshot.reason ?? "Conditional order",
@@ -213,8 +266,27 @@ export function queueOpenOrder(
   current: readonly OpenOrderRow[],
   order: QueuedTerminalOrder,
 ): OpenOrderRow[] {
+  const venueKey = order.venueKey ?? "jupiter";
+  const intentFamily = order.intentFamily ?? "conditional_spot_order";
+  const venueLabel =
+    getTerminalVenueDefinition(venueKey)?.label ?? venueKey.toUpperCase();
+  const familyLabel =
+    getTerminalIntentFamilyLabel(intentFamily) ?? intentFamily;
   const nextOrder: OpenOrderRow = {
     ...order,
+    pairId: order.pairId,
+    instrumentId: order.instrumentId ?? order.pairId,
+    instrumentLabel: order.instrumentLabel ?? order.pairId,
+    venueKey,
+    intentFamily,
+    marketType: order.marketType ?? "spot",
+    venueLabel,
+    familyLabel,
+    providerStatus: order.providerStatus ?? null,
+    oracleStatus: order.oracleStatus ?? null,
+    oracleFreshnessLabel: formatTerminalOracleFreshness(
+      order.oracleStatus?.freshnessMs,
+    ),
     status: "pending",
     initialAmountUi: order.amountUi,
     lastError: null,

--- a/apps/portal/app/terminal/components/trade-intent.ts
+++ b/apps/portal/app/terminal/components/trade-intent.ts
@@ -1,3 +1,8 @@
+import type {
+  TerminalIntentFamily,
+  TerminalMarketType,
+  TerminalVenueKey,
+} from "../terminal-venues";
 import {
   DEFAULT_PAIR_ID,
   getPairConfig,
@@ -10,6 +15,11 @@ export type TradeDirection = "buy" | "sell";
 
 export type TradeIntent = {
   pairId: PairId;
+  instrumentId: string;
+  instrumentLabel: string;
+  venueKey: TerminalVenueKey;
+  intentFamily: TerminalIntentFamily;
+  marketType: TerminalMarketType;
   source: string;
   reason: string;
   direction: TradeDirection;
@@ -44,6 +54,11 @@ export function createTradeIntent(
 
   return {
     pairId: pair.id,
+    instrumentId: pair.id,
+    instrumentLabel: pair.id,
+    venueKey: "jupiter",
+    intentFamily: "spot_swap",
+    marketType: "spot",
     source,
     reason:
       opts?.reason ?? (buy ? `Buy ${outputSymbol}` : `Sell ${inputSymbol}`),

--- a/apps/portal/app/terminal/components/trade-ticket-modal.tsx
+++ b/apps/portal/app/terminal/components/trade-ticket-modal.tsx
@@ -17,6 +17,13 @@ import {
   newExecutionIdempotencyKey,
 } from "../../execution-client";
 import { apiBase, BTN_PRIMARY, BTN_SECONDARY, isRecord } from "../../lib";
+import type {
+  TerminalIntentFamily,
+  TerminalMarketType,
+  TerminalOracleStatus,
+  TerminalProviderStatus,
+  TerminalVenueKey,
+} from "../terminal-venues";
 import {
   type AccountRiskSnapshot,
   evaluatePreSubmitRisk,
@@ -57,6 +64,11 @@ type TradeTicketHotkeyBindings = {
 
 export type TradeTicketCompletion = {
   pairId: TradeIntent["pairId"];
+  instrumentId: string;
+  instrumentLabel: string;
+  venueKey: TradeIntent["venueKey"];
+  intentFamily: TradeIntent["intentFamily"];
+  marketType: TradeIntent["marketType"];
   direction: TradeIntent["direction"];
   source: string;
   reason: string;
@@ -88,6 +100,13 @@ export type QueuedTerminalOrder = {
   createdAt: number;
   updatedAt: number;
   pairId: TradeIntent["pairId"];
+  instrumentId?: string;
+  instrumentLabel?: string;
+  venueKey?: TerminalVenueKey;
+  intentFamily?: TerminalIntentFamily;
+  marketType?: TerminalMarketType;
+  providerStatus?: TerminalProviderStatus | null;
+  oracleStatus?: TerminalOracleStatus | null;
   direction: TradeIntent["direction"];
   source: string;
   reason: string;
@@ -880,9 +899,9 @@ export function TradeTicketModal({
               wallet: walletAddress,
               intent: {
                 family: "conditional_spot_order",
-                venueKey: "jupiter",
-                marketType: "spot",
-                instrumentId: intent.pairId,
+                venueKey: intent.venueKey,
+                marketType: intent.marketType,
+                instrumentId: intent.instrumentId,
                 side: intent.direction,
                 quantityAtomic: quote.inAmountAtomic,
               },
@@ -902,7 +921,7 @@ export function TradeTicketModal({
         closeModal();
         onOrderQueued?.(submitAck.requestId);
         toast.success(`${orderType.toUpperCase()} order submitted`, {
-          description: `${intent.pairId} • ${amountUi.trim()} ${intent.inputSymbol}`,
+          description: `${intent.instrumentLabel} • ${amountUi.trim()} ${intent.inputSymbol}`,
           position: "bottom-right",
           duration: 3500,
         });
@@ -998,6 +1017,11 @@ export function TradeTicketModal({
 
       onTradeComplete?.({
         pairId: intent.pairId,
+        instrumentId: intent.instrumentId,
+        instrumentLabel: intent.instrumentLabel,
+        venueKey: intent.venueKey,
+        intentFamily: intent.intentFamily,
+        marketType: intent.marketType,
         direction: intent.direction,
         source: intent.source,
         reason: intent.reason,

--- a/apps/portal/app/terminal/page.tsx
+++ b/apps/portal/app/terminal/page.tsx
@@ -136,6 +136,13 @@ import {
   type TerminalModule,
   writeLocalTerminalMode,
 } from "./terminal-modes";
+import {
+  resolveTerminalVenueRolloutPolicy,
+  type TerminalIntentFamily,
+  type TerminalMarketType,
+  type TerminalProviderStatus,
+  type TerminalVenueKey,
+} from "./terminal-venues";
 
 type Balances = BalanceResponse;
 type ExecutionActivityRow = {
@@ -143,7 +150,12 @@ type ExecutionActivityRow = {
   ts: number;
   requestId: string;
   receiptId: string | null;
-  pairId: PairId;
+  pairId: PairId | null;
+  instrumentId: string;
+  instrumentLabel: string;
+  venueKey: TerminalVenueKey;
+  intentFamily: TerminalIntentFamily;
+  marketType: TerminalMarketType;
   direction: "buy" | "sell";
   leg: string;
   lane: "fast" | "protected" | "safe";
@@ -154,6 +166,7 @@ type ExecutionActivityRow = {
   feeSymbol: string | null;
   status: string;
   provider: string | null;
+  providerStatus: TerminalProviderStatus | null;
   signature: string | null;
   qualitySummary: string;
 };
@@ -311,25 +324,31 @@ function isSupportedPairId(value: string): value is PairId {
 function buildConditionalOrderExecutionEntry(
   snapshot: ExecutionOpenOrderSnapshot,
 ): ExecutionActivityRow | null {
-  if (
-    !snapshot.requestId ||
-    !snapshot.pairId ||
-    !isSupportedPairId(snapshot.pairId)
-  ) {
-    return null;
-  }
+  if (!snapshot.requestId) return null;
   if (snapshot.direction !== "buy" && snapshot.direction !== "sell") {
     return null;
   }
-  const pair = getPairConfig(snapshot.pairId);
+  const pairId =
+    snapshot.pairId && isSupportedPairId(snapshot.pairId)
+      ? snapshot.pairId
+      : null;
+  const pair = pairId ? getPairConfig(pairId) : null;
   const fallbackInputToken =
     snapshot.direction === "buy"
-      ? TOKEN_CONFIGS[pair.quoteSymbol]
-      : TOKEN_CONFIGS[pair.baseSymbol];
+      ? pair
+        ? TOKEN_CONFIGS[pair.quoteSymbol]
+        : null
+      : pair
+        ? TOKEN_CONFIGS[pair.baseSymbol]
+        : null;
   const fallbackOutputToken =
     snapshot.direction === "buy"
-      ? TOKEN_CONFIGS[pair.baseSymbol]
-      : TOKEN_CONFIGS[pair.quoteSymbol];
+      ? pair
+        ? TOKEN_CONFIGS[pair.baseSymbol]
+        : null
+      : pair
+        ? TOKEN_CONFIGS[pair.quoteSymbol]
+        : null;
   const inputToken =
     (snapshot.inputMint ? TOKEN_BY_MINT[snapshot.inputMint] : null) ??
     fallbackInputToken;
@@ -339,14 +358,14 @@ function buildConditionalOrderExecutionEntry(
   const inputFilledUi = Number(
     formatAtomicTokenBalance(
       snapshot.filledInputAtomic,
-      inputToken.decimals,
+      inputToken?.decimals ?? 0,
       9,
     ),
   );
   const outputFilledUi = Number(
     formatAtomicTokenBalance(
       snapshot.filledOutputAtomic,
-      outputToken.decimals,
+      outputToken?.decimals ?? 0,
       9,
     ),
   );
@@ -372,9 +391,21 @@ function buildConditionalOrderExecutionEntry(
     ts: Number.isFinite(tsRaw) ? tsRaw : Date.now(),
     requestId: snapshot.requestId,
     receiptId: null,
-    pairId: snapshot.pairId,
+    pairId,
+    instrumentId: snapshot.instrumentId ?? pairId ?? snapshot.requestId,
+    instrumentLabel:
+      snapshot.instrumentLabel ??
+      pairId ??
+      snapshot.instrumentId ??
+      "Instrument",
+    venueKey: snapshot.venueKey ?? "jupiter",
+    intentFamily: snapshot.intentFamily ?? "conditional_spot_order",
+    marketType: snapshot.marketType ?? "spot",
     direction: snapshot.direction,
-    leg: `${inputToken.symbol} -> ${outputToken.symbol}`,
+    leg:
+      inputToken && outputToken
+        ? `${inputToken.symbol} -> ${outputToken.symbol}`
+        : (snapshot.instrumentLabel ?? snapshot.instrumentId ?? "instrument"),
     lane: snapshot.lane ?? "safe",
     baseFilledUi,
     quoteFilledUi,
@@ -383,6 +414,7 @@ function buildConditionalOrderExecutionEntry(
     feeSymbol: null,
     status: snapshot.status ?? snapshot.requestStatus,
     provider: snapshot.provider,
+    providerStatus: snapshot.providerStatus,
     signature: snapshot.signature,
     qualitySummary: `lane ${snapshot.lane ?? "safe"} • sim ${snapshot.simulationPreference ?? "auto"} • slip ${snapshot.slippageBps ?? 50} bps • prio ${snapshot.priorityLevel ?? "normal"}`,
   };
@@ -546,6 +578,13 @@ function ControlRoom() {
         context: terminalRolloutContext,
       }),
     [terminalRolloutContext],
+  );
+  const terminalVenueRolloutPolicy = useMemo(
+    () =>
+      resolveTerminalVenueRolloutPolicy({
+        profile: userProfile,
+      }),
+    [userProfile],
   );
   const modeCapabilities = getTerminalModeCapabilities(terminalMode);
   const activeCustomWorkspace = useMemo(
@@ -1466,6 +1505,11 @@ function ControlRoom() {
           requestId: trade.requestId,
           receiptId: trade.receiptId,
           pairId: trade.pairId,
+          instrumentId: trade.instrumentId,
+          instrumentLabel: trade.instrumentLabel,
+          venueKey: trade.venueKey,
+          intentFamily: trade.intentFamily,
+          marketType: trade.marketType,
           direction: trade.direction,
           leg: `${trade.inputSymbol} -> ${trade.outputSymbol}`,
           lane: trade.lane,
@@ -1476,6 +1520,7 @@ function ControlRoom() {
           feeSymbol: trade.feeSymbol,
           status: trade.status,
           provider: trade.provider,
+          providerStatus: null,
           signature: trade.signature,
           qualitySummary: `lane ${trade.lane} • sim ${trade.simulationPreference} • slip ${trade.slippageBps} bps • prio ${trade.priorityLevel}`,
         };
@@ -1978,6 +2023,7 @@ function ControlRoom() {
                       <PositionsOrdersFillsPanel
                         entries={recentExecutions}
                         openOrders={openOrders}
+                        terminalVenueRolloutPolicy={terminalVenueRolloutPolicy}
                         selectedPairId={selectedPairId}
                         selectedPairMark={marketFeed.latestPrice}
                         tokenBalancesByMint={tokenBalancesByMint}
@@ -2838,6 +2884,9 @@ const PositionsOrdersFillsPanel = memo(
   function PositionsOrdersFillsPanel(props: {
     entries: ExecutionActivityRow[];
     openOrders: OpenOrderRow[];
+    terminalVenueRolloutPolicy: ReturnType<
+      typeof resolveTerminalVenueRolloutPolicy
+    >;
     selectedPairId: PairId;
     selectedPairMark: number | null;
     tokenBalancesByMint: Record<string, string>;
@@ -2849,6 +2898,7 @@ const PositionsOrdersFillsPanel = memo(
     const {
       entries,
       openOrders,
+      terminalVenueRolloutPolicy,
       selectedPairId,
       selectedPairMark,
       tokenBalancesByMint,
@@ -2879,18 +2929,24 @@ const PositionsOrdersFillsPanel = memo(
     }, [tokenBalancesByMint]);
     const fills = useMemo<PositionFill[]>(
       () =>
-        entries.map((entry) => ({
-          id: entry.id,
-          ts: entry.ts,
-          pairId: entry.pairId,
-          direction: entry.direction,
-          status: entry.status,
-          signature: entry.signature,
-          baseFilledUi: entry.baseFilledUi,
-          quoteFilledUi: entry.quoteFilledUi,
-          fillPrice: entry.fillPrice,
-          qualitySummary: entry.qualitySummary,
-        })),
+        entries.flatMap((entry) =>
+          entry.pairId
+            ? [
+                {
+                  id: entry.id,
+                  ts: entry.ts,
+                  pairId: entry.pairId,
+                  direction: entry.direction,
+                  status: entry.status,
+                  signature: entry.signature,
+                  baseFilledUi: entry.baseFilledUi,
+                  quoteFilledUi: entry.quoteFilledUi,
+                  fillPrice: entry.fillPrice,
+                  qualitySummary: entry.qualitySummary,
+                },
+              ]
+            : [],
+        ),
       [entries],
     );
     const positions = useMemo(
@@ -2989,22 +3045,28 @@ const PositionsOrdersFillsPanel = memo(
     );
     const ledgerRows = useMemo<FillLedgerRow[]>(
       () =>
-        entries.map((entry) => ({
-          id: entry.id,
-          ts: entry.ts,
-          requestId: entry.requestId,
-          receiptId: entry.receiptId,
-          pairId: entry.pairId,
-          side: entry.direction,
-          sizeBaseUi: entry.baseFilledUi,
-          quoteFilledUi: entry.quoteFilledUi,
-          price: entry.fillPrice,
-          feeUi: entry.feeUi,
-          feeSymbol: entry.feeSymbol,
-          status: entry.status,
-          provider: entry.provider,
-          signature: entry.signature,
-        })),
+        entries.flatMap((entry) =>
+          entry.pairId
+            ? [
+                {
+                  id: entry.id,
+                  ts: entry.ts,
+                  requestId: entry.requestId,
+                  receiptId: entry.receiptId,
+                  pairId: entry.pairId,
+                  side: entry.direction,
+                  sizeBaseUi: entry.baseFilledUi,
+                  quoteFilledUi: entry.quoteFilledUi,
+                  price: entry.fillPrice,
+                  feeUi: entry.feeUi,
+                  feeSymbol: entry.feeSymbol,
+                  status: entry.status,
+                  provider: entry.provider,
+                  signature: entry.signature,
+                },
+              ]
+            : [],
+        ),
       [entries],
     );
     const filteredLedgerRows = useMemo(
@@ -3112,7 +3174,8 @@ const PositionsOrdersFillsPanel = memo(
                   <div className="flex items-start justify-between gap-2">
                     <div className="min-w-0">
                       <p className="font-mono text-[11px] text-ink truncate">
-                        {order.pairId} • {order.direction.toUpperCase()} •{" "}
+                        {order.instrumentLabel} •{" "}
+                        {order.direction.toUpperCase()} •{" "}
                         {order.orderType.toUpperCase()}
                       </p>
                       <p className="text-[10px] text-muted">
@@ -3127,6 +3190,34 @@ const PositionsOrdersFillsPanel = memo(
                           Request {shortExecutionId(order.requestId)}
                         </p>
                       ) : null}
+                      <div className="mt-1 flex flex-wrap gap-1">
+                        <span className="rounded border border-sky-500/30 bg-sky-500/10 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-sky-200">
+                          {order.venueLabel}
+                        </span>
+                        <span className="rounded border border-emerald-500/30 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-emerald-200">
+                          {order.familyLabel}
+                        </span>
+                        {order.providerStatus ? (
+                          <span className="rounded border border-border px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-muted">
+                            provider {order.providerStatus}
+                          </span>
+                        ) : null}
+                        {order.oracleFreshnessLabel ? (
+                          <span className="rounded border border-border px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-muted">
+                            oracle {order.oracleFreshnessLabel}
+                          </span>
+                        ) : null}
+                        {!terminalVenueRolloutPolicy.enabledVenues.includes(
+                          order.venueKey,
+                        ) ||
+                        !terminalVenueRolloutPolicy.enabledFamilies.includes(
+                          order.intentFamily,
+                        ) ? (
+                          <span className="rounded border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-amber-200">
+                            rollout gated
+                          </span>
+                        ) : null}
+                      </div>
                     </div>
                     <span
                       className={cn(

--- a/apps/portal/app/terminal/terminal-venues.ts
+++ b/apps/portal/app/terminal/terminal-venues.ts
@@ -1,0 +1,326 @@
+import { isRecord } from "../lib";
+
+export const TERMINAL_VENUE_KEYS = [
+  "jupiter",
+  "raydium",
+  "orca",
+  "openbook_v2",
+  "phoenix",
+  "drift",
+  "dflow",
+  "monaco",
+] as const;
+
+export const TERMINAL_INTENT_FAMILIES = [
+  "spot_swap",
+  "conditional_spot_order",
+  "clob_order",
+  "perp_order",
+  "prediction_order",
+  "flash_atomic",
+] as const;
+
+export const TERMINAL_MARKET_TYPES = ["spot", "perp", "prediction"] as const;
+
+export type TerminalVenueKey = (typeof TERMINAL_VENUE_KEYS)[number];
+export type TerminalIntentFamily = (typeof TERMINAL_INTENT_FAMILIES)[number];
+export type TerminalMarketType = (typeof TERMINAL_MARKET_TYPES)[number];
+export type TerminalProviderStatus =
+  | "healthy"
+  | "degraded"
+  | "pending"
+  | "disabled"
+  | "unknown";
+
+export type TerminalOracleStatus = {
+  freshnessMs: number | null;
+  source: string | null;
+  stale: boolean;
+};
+
+export type TerminalVenueDefinition = {
+  venueKey: TerminalVenueKey;
+  label: string;
+  shortLabel: string;
+  marketTypes: readonly TerminalMarketType[];
+  families: readonly TerminalIntentFamily[];
+  rolloutFlag: string;
+  badges: readonly string[];
+};
+
+const TERMINAL_VENUE_REGISTRY: Record<
+  TerminalVenueKey,
+  TerminalVenueDefinition
+> = {
+  jupiter: {
+    venueKey: "jupiter",
+    label: "Jupiter",
+    shortLabel: "JUP",
+    marketTypes: ["spot"],
+    families: ["spot_swap", "conditional_spot_order", "flash_atomic"],
+    rolloutFlag: "spot_router",
+    badges: ["agg", "custody"],
+  },
+  raydium: {
+    venueKey: "raydium",
+    label: "Raydium",
+    shortLabel: "RAYD",
+    marketTypes: ["spot"],
+    families: ["spot_swap", "flash_atomic"],
+    rolloutFlag: "spot_router",
+    badges: ["amm", "router"],
+  },
+  orca: {
+    venueKey: "orca",
+    label: "Orca",
+    shortLabel: "ORCA",
+    marketTypes: ["spot"],
+    families: ["spot_swap", "flash_atomic"],
+    rolloutFlag: "spot_router",
+    badges: ["clmm", "lp"],
+  },
+  openbook_v2: {
+    venueKey: "openbook_v2",
+    label: "OpenBook v2",
+    shortLabel: "OBV2",
+    marketTypes: ["spot"],
+    families: ["clob_order"],
+    rolloutFlag: "spot_clob",
+    badges: ["clob", "maker"],
+  },
+  phoenix: {
+    venueKey: "phoenix",
+    label: "Phoenix",
+    shortLabel: "PHNX",
+    marketTypes: ["spot"],
+    families: ["clob_order"],
+    rolloutFlag: "phoenix",
+    badges: ["clob", "maker"],
+  },
+  drift: {
+    venueKey: "drift",
+    label: "Drift",
+    shortLabel: "DRFT",
+    marketTypes: ["perp"],
+    families: ["perp_order"],
+    rolloutFlag: "perps",
+    badges: ["perps", "margin"],
+  },
+  dflow: {
+    venueKey: "dflow",
+    label: "DFlow",
+    shortLabel: "DFLW",
+    marketTypes: ["prediction"],
+    families: ["prediction_order"],
+    rolloutFlag: "prediction",
+    badges: ["events", "tokenized"],
+  },
+  monaco: {
+    venueKey: "monaco",
+    label: "Monaco",
+    shortLabel: "MONA",
+    marketTypes: ["prediction"],
+    families: ["prediction_order"],
+    rolloutFlag: "prediction",
+    badges: ["events", "native"],
+  },
+};
+
+export type TerminalVenueRolloutPolicy = {
+  enabledVenues: readonly TerminalVenueKey[];
+  enabledFamilies: readonly TerminalIntentFamily[];
+};
+
+function parseEnumList<T extends string>(
+  raw: unknown,
+  allowed: readonly T[],
+): T[] | null {
+  if (Array.isArray(raw)) {
+    const normalized = raw
+      .map((entry) =>
+        String(entry ?? "")
+          .trim()
+          .toLowerCase(),
+      )
+      .filter((entry): entry is T =>
+        (allowed as readonly string[]).includes(entry),
+      );
+    return normalized.length > 0 ? Array.from(new Set(normalized)) : null;
+  }
+  const normalized = String(raw ?? "")
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry): entry is T =>
+      (allowed as readonly string[]).includes(entry),
+    );
+  return normalized.length > 0 ? Array.from(new Set(normalized)) : null;
+}
+
+function readTerminalProfile(
+  profile: Record<string, unknown> | null,
+): Record<string, unknown> | null {
+  if (!isRecord(profile)) return null;
+  const terminal = profile.terminal;
+  return isRecord(terminal) ? terminal : null;
+}
+
+export function getTerminalVenueDefinition(
+  venueKey: TerminalVenueKey | null | undefined,
+): TerminalVenueDefinition | null {
+  if (!venueKey) return null;
+  return TERMINAL_VENUE_REGISTRY[venueKey] ?? null;
+}
+
+export function getTerminalIntentFamilyLabel(
+  family: TerminalIntentFamily | null | undefined,
+): string | null {
+  switch (family) {
+    case "spot_swap":
+      return "Spot Swap";
+    case "conditional_spot_order":
+      return "Conditional";
+    case "clob_order":
+      return "CLOB";
+    case "perp_order":
+      return "Perps";
+    case "prediction_order":
+      return "Prediction";
+    case "flash_atomic":
+      return "Flash";
+    default:
+      return null;
+  }
+}
+
+export function resolveTerminalVenueRolloutPolicy(
+  input: {
+    env?: Record<string, unknown>;
+    profile?: Record<string, unknown> | null;
+  } = {},
+): TerminalVenueRolloutPolicy {
+  const env = input.env ?? process.env;
+  const terminalProfile = readTerminalProfile(input.profile ?? null);
+  const enabledVenues = parseEnumList(
+    terminalProfile?.enabledVenues ?? env.NEXT_PUBLIC_TERMINAL_ENABLED_VENUES,
+    TERMINAL_VENUE_KEYS,
+  ) ?? ["jupiter"];
+  const enabledFamilies = parseEnumList(
+    terminalProfile?.enabledFamilies ??
+      env.NEXT_PUBLIC_TERMINAL_ENABLED_FAMILIES,
+    TERMINAL_INTENT_FAMILIES,
+  ) ?? ["spot_swap", "conditional_spot_order"];
+
+  return {
+    enabledVenues,
+    enabledFamilies,
+  };
+}
+
+export function isTerminalVenueEnabled(
+  venueKey: TerminalVenueKey,
+  input: {
+    env?: Record<string, unknown>;
+    profile?: Record<string, unknown> | null;
+  } = {},
+): boolean {
+  const policy = resolveTerminalVenueRolloutPolicy(input);
+  if (!policy.enabledVenues.includes(venueKey)) return false;
+  if (venueKey === "phoenix") {
+    const env = input.env ?? process.env;
+    const terminalProfile = readTerminalProfile(input.profile ?? null);
+    const phoenixEnabled =
+      terminalProfile?.enablePhoenix ??
+      env.NEXT_PUBLIC_TERMINAL_ENABLE_PHOENIX ??
+      "0";
+    return String(phoenixEnabled).trim() === "1";
+  }
+  return true;
+}
+
+export function isTerminalIntentFamilyEnabled(
+  family: TerminalIntentFamily,
+  input: {
+    env?: Record<string, unknown>;
+    profile?: Record<string, unknown> | null;
+  } = {},
+): boolean {
+  return resolveTerminalVenueRolloutPolicy(input).enabledFamilies.includes(
+    family,
+  );
+}
+
+export function parseTerminalProviderStatus(
+  value: unknown,
+): TerminalProviderStatus | null {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  if (
+    normalized === "healthy" ||
+    normalized === "degraded" ||
+    normalized === "pending" ||
+    normalized === "disabled" ||
+    normalized === "unknown"
+  ) {
+    return normalized;
+  }
+  return null;
+}
+
+export function parseTerminalMarketType(
+  value: unknown,
+): TerminalMarketType | null {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  return (TERMINAL_MARKET_TYPES as readonly string[]).includes(normalized)
+    ? (normalized as TerminalMarketType)
+    : null;
+}
+
+export function parseTerminalVenueKey(value: unknown): TerminalVenueKey | null {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  return (TERMINAL_VENUE_KEYS as readonly string[]).includes(normalized)
+    ? (normalized as TerminalVenueKey)
+    : null;
+}
+
+export function parseTerminalIntentFamily(
+  value: unknown,
+): TerminalIntentFamily | null {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  return (TERMINAL_INTENT_FAMILIES as readonly string[]).includes(normalized)
+    ? (normalized as TerminalIntentFamily)
+    : null;
+}
+
+export function parseTerminalOracleStatus(input: {
+  freshnessMs: unknown;
+  source: unknown;
+  stale: unknown;
+}): TerminalOracleStatus | null {
+  const freshnessMs = Number(input.freshnessMs);
+  const source = String(input.source ?? "").trim() || null;
+  const stale = input.stale === true;
+  if (!Number.isFinite(freshnessMs) && !source && stale === false) {
+    return null;
+  }
+  return {
+    freshnessMs: Number.isFinite(freshnessMs) ? Math.max(0, freshnessMs) : null,
+    source,
+    stale,
+  };
+}
+
+export function formatTerminalOracleFreshness(
+  freshnessMs: number | null | undefined,
+): string | null {
+  if (!Number.isFinite(freshnessMs)) return null;
+  if ((freshnessMs ?? 0) < 1000) return `${Math.round(freshnessMs ?? 0)}ms`;
+  const seconds = Math.round((freshnessMs ?? 0) / 100) / 10;
+  return `${seconds}s`;
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -6654,6 +6654,24 @@ function resolveTerminalPriorityLevel(
   return "high";
 }
 
+function resolveTerminalProviderStatus(input: {
+  latest: Awaited<ReturnType<typeof getExecutionLatestStatus>>;
+  terminal: boolean;
+}): "healthy" | "degraded" | "pending" {
+  const latestAttemptStatus = readTrimmedString(
+    input.latest?.latestAttempt?.status,
+  )?.toLowerCase();
+  if (
+    latestAttemptStatus === "failed" ||
+    latestAttemptStatus === "rejected" ||
+    latestAttemptStatus === "expired"
+  ) {
+    return "degraded";
+  }
+  if (!input.terminal) return "pending";
+  return input.latest?.receipt?.errorCode ? "degraded" : "healthy";
+}
+
 function resolveTerminalOpenOrderStatus(
   lifecycle: Record<string, unknown> | null,
   terminal: boolean,
@@ -6703,6 +6721,10 @@ function buildTerminalConditionalOrderView(input: {
   const filledOutputAtomic = input.summary?.filledOutputAtomic ?? "0";
   const terminal = Boolean(latest.request.terminalAt);
   const notes = readStringArray(lifecycle?.notes);
+  const providerStatus = resolveTerminalProviderStatus({
+    latest,
+    terminal,
+  });
   return {
     requestId: latest.request.requestId,
     requestStatus: latest.request.status,
@@ -6710,7 +6732,14 @@ function buildTerminalConditionalOrderView(input: {
     receivedAt: latest.request.receivedAt,
     updatedAt: latest.request.updatedAt,
     terminalAt: latest.request.terminalAt,
+    intentFamily: readTrimmedString(intent?.family) ?? "conditional_spot_order",
+    venueKey: readTrimmedString(intent?.venueKey) ?? "jupiter",
+    marketType: readTrimmedString(intent?.marketType) ?? "spot",
     pairId:
+      trackedOrder?.instrumentId ?? readTrimmedString(intent?.instrumentId),
+    instrumentId:
+      trackedOrder?.instrumentId ?? readTrimmedString(intent?.instrumentId),
+    instrumentLabel:
       trackedOrder?.instrumentId ?? readTrimmedString(intent?.instrumentId),
     direction: trackedOrder?.side ?? readTrimmedString(intent?.side),
     source: readTrimmedString(latest.request.metadata?.source) ?? "TERMINAL",
@@ -6743,10 +6772,14 @@ function buildTerminalConditionalOrderView(input: {
     triggerPriceAtomic: readTrimmedString(quality?.triggerPriceAtomic),
     provider:
       latest.receipt?.provider ?? latest.latestAttempt?.provider ?? null,
+    providerStatus,
     signature: latest.receipt?.signature ?? input.summary?.signature ?? null,
     errorCode: latest.receipt?.errorCode ?? null,
     errorMessage: latest.receipt?.errorMessage ?? null,
     status: resolveTerminalOpenOrderStatus(lifecycle, terminal),
+    oracleFreshnessMs: null,
+    oracleSource: null,
+    oracleStale: false,
     lifecycle:
       lifecycle && Object.keys(lifecycle).length > 0
         ? {

--- a/tests/unit/portal_terminal_open_orders.test.ts
+++ b/tests/unit/portal_terminal_open_orders.test.ts
@@ -186,6 +186,70 @@ describe("portal terminal open orders lifecycle", () => {
     expect(row?.amountUi).toBe("1");
     expect(row?.remainingAmountUi).toBe("0.75");
     expect(row?.limitPriceUi).toBe("150");
+    expect(row?.venueKey).toBe("jupiter");
+    expect(row?.intentFamily).toBe("conditional_spot_order");
     expect(row?.lifecycle?.orderState).toBe("open");
+  });
+
+  test("hydrates venue-aware non-pair snapshots without forcing pair support", () => {
+    const row = mapTerminalOpenOrderSnapshot({
+      requestId: "execreq_drift_row_123456",
+      requestStatus: "dispatched",
+      terminal: false,
+      receivedAt: "2026-03-03T02:00:00.000Z",
+      updatedAt: "2026-03-03T02:00:03.000Z",
+      terminalAt: null,
+      intentFamily: "perp_order",
+      venueKey: "drift",
+      marketType: "perp",
+      pairId: null,
+      instrumentId: "SOL-PERP",
+      instrumentLabel: "SOL-PERP",
+      direction: "sell",
+      source: "TERMINAL",
+      reason: "Hydrated perp order",
+      orderType: "limit",
+      timeInForce: "gtc",
+      lane: "safe",
+      simulationPreference: "always",
+      priorityLevel: "high",
+      priorityMicroLamports: 50_000,
+      slippageBps: 25,
+      inputMint: null,
+      outputMint: null,
+      amountAtomic: "10",
+      remainingAmountAtomic: "4",
+      takingAmountAtomic: null,
+      filledInputAtomic: "6",
+      filledOutputAtomic: "0",
+      limitPriceAtomic: "150000000",
+      triggerPriceAtomic: null,
+      provider: "drift",
+      providerStatus: "healthy",
+      signature: null,
+      errorCode: null,
+      errorMessage: null,
+      status: "working",
+      oracleStatus: {
+        freshnessMs: 450,
+        source: "pyth",
+        stale: false,
+      },
+      lifecycle: {
+        orderState: "open",
+        fillState: "pending",
+        settlementState: "confirmed",
+        positionState: "opening",
+        riskState: "healthy",
+        notes: ["Perp order accepted"],
+      },
+    });
+
+    expect(row?.pairId).toBeNull();
+    expect(row?.instrumentLabel).toBe("SOL-PERP");
+    expect(row?.venueKey).toBe("drift");
+    expect(row?.familyLabel).toBe("Perps");
+    expect(row?.providerStatus).toBe("healthy");
+    expect(row?.oracleFreshnessLabel).toBe("450ms");
   });
 });

--- a/tests/unit/portal_terminal_venues.test.ts
+++ b/tests/unit/portal_terminal_venues.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import {
+  formatTerminalOracleFreshness,
+  getTerminalIntentFamilyLabel,
+  getTerminalVenueDefinition,
+  isTerminalIntentFamilyEnabled,
+  isTerminalVenueEnabled,
+  parseTerminalOracleStatus,
+  resolveTerminalVenueRolloutPolicy,
+} from "../../apps/portal/app/terminal/terminal-venues";
+
+describe("portal terminal venue substrate", () => {
+  test("resolves venue registry metadata", () => {
+    expect(getTerminalVenueDefinition("jupiter")?.label).toBe("Jupiter");
+    expect(getTerminalVenueDefinition("openbook_v2")?.badges).toContain("clob");
+    expect(getTerminalIntentFamilyLabel("prediction_order")).toBe("Prediction");
+  });
+
+  test("parses venue and family rollout policy from profile and env", () => {
+    const policy = resolveTerminalVenueRolloutPolicy({
+      env: {
+        NEXT_PUBLIC_TERMINAL_ENABLED_VENUES: "jupiter,drift,phoenix",
+        NEXT_PUBLIC_TERMINAL_ENABLED_FAMILIES:
+          "spot_swap,conditional_spot_order,perp_order",
+        NEXT_PUBLIC_TERMINAL_ENABLE_PHOENIX: "0",
+      },
+      profile: {
+        terminal: {
+          enabledVenues: ["jupiter", "drift"],
+          enabledFamilies: ["spot_swap", "perp_order"],
+        },
+      },
+    });
+
+    expect(policy.enabledVenues).toEqual(["jupiter", "drift"]);
+    expect(policy.enabledFamilies).toEqual(["spot_swap", "perp_order"]);
+    expect(
+      isTerminalVenueEnabled("phoenix", {
+        env: {
+          NEXT_PUBLIC_TERMINAL_ENABLED_VENUES: "phoenix",
+          NEXT_PUBLIC_TERMINAL_ENABLE_PHOENIX: "0",
+        },
+      }),
+    ).toBe(false);
+    expect(
+      isTerminalIntentFamilyEnabled("perp_order", {
+        profile: {
+          terminal: {
+            enabledFamilies: ["spot_swap", "perp_order"],
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  test("formats oracle freshness and parses oracle status", () => {
+    expect(formatTerminalOracleFreshness(450)).toBe("450ms");
+    expect(formatTerminalOracleFreshness(2_450)).toBe("2.5s");
+    expect(
+      parseTerminalOracleStatus({
+        freshnessMs: 850,
+        source: "pyth",
+        stale: false,
+      }),
+    ).toEqual({
+      freshnessMs: 850,
+      source: "pyth",
+      stale: false,
+    });
+  });
+});

--- a/tests/unit/worker_terminal_open_orders_route.test.ts
+++ b/tests/unit/worker_terminal_open_orders_route.test.ts
@@ -687,15 +687,25 @@ describe("worker terminal open orders and Trigger lifecycle routes", () => {
       const body = (await response.json()) as {
         orders?: Array<{
           requestId?: string;
+          intentFamily?: string;
+          venueKey?: string;
+          marketType?: string;
           pairId?: string;
+          instrumentId?: string;
           status?: string;
           orderType?: string;
+          providerStatus?: string;
         }>;
       };
       expect(body.orders?.[0]?.requestId).toBe("execreq_trigger_list_123456");
+      expect(body.orders?.[0]?.intentFamily).toBe("conditional_spot_order");
+      expect(body.orders?.[0]?.venueKey).toBe("jupiter");
+      expect(body.orders?.[0]?.marketType).toBe("spot");
       expect(body.orders?.[0]?.pairId).toBe("SOL/USDC");
+      expect(body.orders?.[0]?.instrumentId).toBe("SOL/USDC");
       expect(body.orders?.[0]?.status).toBe("working");
       expect(body.orders?.[0]?.orderType).toBe("limit");
+      expect(body.orders?.[0]?.providerStatus).toBe("pending");
     } finally {
       sqlite.close();
     }


### PR DESCRIPTION
## Summary
- add a terminal venue and intent-family registry with rollout policy helpers for venue and instrument-family gating
- generalize terminal execution and open-order contracts to carry venue, market-type, provider-status, and oracle metadata
- surface the new substrate in shared terminal components and worker terminal payloads without changing the current Jupiter-first trade path

## Validation
- bun test tests/unit/portal_terminal_venues.test.ts tests/unit/portal_terminal_open_orders.test.ts tests/unit/portal_terminal_modes.test.ts tests/unit/worker_terminal_open_orders_route.test.ts
- bun run typecheck
- ./node_modules/.bin/biome check apps/portal/app/execution-client.ts apps/portal/app/terminal/page.tsx apps/portal/app/terminal/components/open-orders.ts apps/portal/app/terminal/components/trade-intent.ts apps/portal/app/terminal/components/trade-ticket-modal.tsx apps/portal/app/terminal/components/execution-inspector-drawer.tsx apps/portal/app/terminal/terminal-venues.ts apps/worker/src/index.ts tests/unit/portal_terminal_venues.test.ts tests/unit/portal_terminal_open_orders.test.ts tests/unit/worker_terminal_open_orders_route.test.ts

Closes #387