### PR TITLE
[Phase T1] Add venue-aware terminal spot workflows

### DIFF
--- a/apps/portal/app/execution-client.ts
+++ b/apps/portal/app/execution-client.ts
@@ -943,7 +943,7 @@ export function createExecutionClient(options: ExecutionClientOptions) {
       method: "POST",
       signal: options?.signal,
       headers: options?.headers,
-      body: JSON.stringify(input),
+      body: input,
     });
     return parseSpotPreviewSnapshot(response);
   }

--- a/apps/portal/app/execution-client.ts
+++ b/apps/portal/app/execution-client.ts
@@ -203,6 +203,17 @@ export type ExecutionOpenOrderSnapshot = {
   } | null;
 };
 
+export type ExecutionSpotPreview = {
+  venueKey: TerminalVenueKey;
+  provider: string;
+  inputMint: string;
+  outputMint: string;
+  inAmountAtomic: string;
+  outAmountAtomic: string;
+  routeSummary: string | null;
+  priceImpactPct: number | null;
+};
+
 export type ExecutionTransportRequest = {
   path: string;
   method: "GET" | "POST";
@@ -633,6 +644,52 @@ function parseOpenOrdersSnapshot(
   return orders;
 }
 
+function parseSpotPreviewSnapshot(payload: unknown): ExecutionSpotPreview {
+  if (!isRecord(payload) || payload.ok !== true || !isRecord(payload.preview)) {
+    throw new ExecutionClientError({
+      message: "invalid-terminal-spot-preview-response",
+      code: "unknown",
+      status: 500,
+      retryable: false,
+      data: payload,
+    });
+  }
+  const preview = payload.preview;
+  const venueKey = parseTerminalVenueKey(preview.venueKey);
+  const provider = parseOptionalString(preview.provider);
+  const inputMint = parseOptionalString(preview.inputMint);
+  const outputMint = parseOptionalString(preview.outputMint);
+  const inAmountAtomic = parseOptionalAtomicString(preview.inAmountAtomic);
+  const outAmountAtomic = parseOptionalAtomicString(preview.outAmountAtomic);
+  if (
+    !venueKey ||
+    !provider ||
+    !inputMint ||
+    !outputMint ||
+    !inAmountAtomic ||
+    !outAmountAtomic
+  ) {
+    throw new ExecutionClientError({
+      message: "invalid-terminal-spot-preview-response",
+      code: "unknown",
+      status: 500,
+      retryable: false,
+      data: payload,
+    });
+  }
+  const priceImpactRaw = Number(preview.priceImpactPct);
+  return {
+    venueKey,
+    provider,
+    inputMint,
+    outputMint,
+    inAmountAtomic,
+    outAmountAtomic,
+    routeSummary: parseOptionalString(preview.routeSummary),
+    priceImpactPct: Number.isFinite(priceImpactRaw) ? priceImpactRaw : null,
+  };
+}
+
 function isExecutionSuccessStatus(status: string | null): boolean {
   if (!status) return false;
   const normalized = status.trim().toLowerCase();
@@ -871,6 +928,26 @@ export function createExecutionClient(options: ExecutionClientOptions) {
     return parseOpenOrdersSnapshot(response);
   }
 
+  async function previewSpotOrder(
+    input: {
+      venueKey: TerminalVenueKey;
+      inputMint: string;
+      outputMint: string;
+      amountAtomic: string;
+      slippageBps: number;
+    },
+    options?: RequestOptions,
+  ): Promise<ExecutionSpotPreview> {
+    const response = await requestJson({
+      path: "/api/terminal/spot-preview",
+      method: "POST",
+      signal: options?.signal,
+      headers: options?.headers,
+      body: JSON.stringify(input),
+    });
+    return parseSpotPreviewSnapshot(response);
+  }
+
   async function cancelOpenOrder(
     requestId: string,
     options?: RequestOptions,
@@ -979,6 +1056,7 @@ export function createExecutionClient(options: ExecutionClientOptions) {
     status,
     receipt,
     listOpenOrders,
+    previewSpotOrder,
     cancelOpenOrder,
     waitForTerminalReceipt,
   };

--- a/apps/portal/app/proof/browser/page.tsx
+++ b/apps/portal/app/proof/browser/page.tsx
@@ -18,12 +18,22 @@ import {
   type TradeTicketCompletion,
   TradeTicketModal,
 } from "../../terminal/components/trade-ticket-modal";
+import type { TerminalVenueRolloutPolicy } from "../../terminal/terminal-venues";
 
 type RuntimeWindow = Window & {
   __TRADER_RALPH_EDGE_API_BASE__?: string;
 };
 
 const PROOF_WALLET = "7YB4proofHarnessWallet111111111111111111111111";
+const PROOF_TERMINAL_VENUE_POLICY: TerminalVenueRolloutPolicy = {
+  enabledVenues: ["jupiter", "raydium", "orca", "openbook"],
+  enabledFamilies: [
+    "spot_swap",
+    "conditional_spot_order",
+    "clob_order",
+    "flash_atomic",
+  ],
+};
 
 function buildProofMarketState(): MarketState {
   const now = Date.now();
@@ -233,6 +243,8 @@ export default function BrowserProofPage() {
         walletAddress={PROOF_WALLET}
         tokenBalancesByMint={tokenBalancesByMint}
         riskSnapshot={riskSnapshot}
+        referencePrice={market.latestPrice}
+        terminalVenueRolloutPolicy={PROOF_TERMINAL_VENUE_POLICY}
         getAccessToken={async () => "proof-access-token"}
         onClose={() => setTradeOpen(false)}
         onTradeComplete={(trade) => {

--- a/apps/portal/app/terminal/components/trade-ticket-modal.tsx
+++ b/apps/portal/app/terminal/components/trade-ticket-modal.tsx
@@ -479,6 +479,44 @@ export function validateExecutionQualityConfig(input: {
   return errors;
 }
 
+export function computeQuoteReferenceDivergenceBps(input: {
+  direction: TradeIntent["direction"];
+  quotedInputAtomic: string | null;
+  quotedOutputAtomic: string | null;
+  inputDecimals: number;
+  outputDecimals: number;
+  referencePrice: number | null | undefined;
+}): number | null {
+  const impliedReference =
+    typeof input.referencePrice === "number" &&
+    Number.isFinite(input.referencePrice) &&
+    input.referencePrice > 0
+      ? input.referencePrice
+      : null;
+  if (impliedReference === null) return null;
+
+  const quotedInput = Number(
+    formatAtomicToUi(input.quotedInputAtomic, input.inputDecimals, 9) ?? "",
+  );
+  const quotedOutput = Number(
+    formatAtomicToUi(input.quotedOutputAtomic, input.outputDecimals, 9) ?? "",
+  );
+  if (
+    !Number.isFinite(quotedInput) ||
+    !Number.isFinite(quotedOutput) ||
+    quotedInput <= 0 ||
+    quotedOutput <= 0
+  ) {
+    return null;
+  }
+
+  const quotedPrice =
+    input.direction === "buy"
+      ? quotedInput / quotedOutput
+      : quotedOutput / quotedInput;
+  return ((quotedPrice - impliedReference) / impliedReference) * 10_000;
+}
+
 export function TradeTicketModal({
   open,
   intent,
@@ -1401,6 +1439,7 @@ export function TradeTicketModal({
             onStopLossPriceChange={setStopLossPriceUi}
           />
           <QuoteSummaryCard
+            direction={intent.direction}
             outputSymbol={intent.outputSymbol}
             inputDecimals={intent.inputDecimals}
             outputDecimals={intent.outputDecimals}
@@ -2164,6 +2203,7 @@ const AdvancedOrderConfigSection = memo(
 );
 
 const QuoteSummaryCard = memo(function QuoteSummaryCard(props: {
+  direction: TradeIntent["direction"];
   outputSymbol: string;
   inputDecimals: number;
   outputDecimals: number;
@@ -2172,6 +2212,7 @@ const QuoteSummaryCard = memo(function QuoteSummaryCard(props: {
   loading: boolean;
 }) {
   const {
+    direction,
     outputSymbol,
     inputDecimals,
     outputDecimals,
@@ -2189,29 +2230,20 @@ const QuoteSummaryCard = memo(function QuoteSummaryCard(props: {
     : loading
       ? "text-muted"
       : "text-transparent";
-  const quotedInput = Number(
-    formatAtomicToUi(quote.inAmountAtomic, inputDecimals, 9) ?? "",
-  );
-  const quotedOutput = Number(
-    formatAtomicToUi(quote.outAmountAtomic, outputDecimals, 9) ?? "",
-  );
   const impliedReference =
     typeof referencePrice === "number" &&
     Number.isFinite(referencePrice) &&
     referencePrice > 0
       ? referencePrice
       : null;
-  const quotedPrice =
-    Number.isFinite(quotedInput) &&
-    Number.isFinite(quotedOutput) &&
-    quotedInput > 0 &&
-    quotedOutput > 0
-      ? quotedInput / quotedOutput
-      : null;
-  const referenceDivergenceBps =
-    quotedPrice !== null && impliedReference !== null
-      ? ((quotedPrice - impliedReference) / impliedReference) * 10_000
-      : null;
+  const referenceDivergenceBps = computeQuoteReferenceDivergenceBps({
+    direction,
+    quotedInputAtomic: quote.inAmountAtomic,
+    quotedOutputAtomic: quote.outAmountAtomic,
+    inputDecimals,
+    outputDecimals,
+    referencePrice,
+  });
 
   return (
     <div className="rounded border border-border bg-subtle px-3 py-2 text-xs space-y-1.5 min-h-[112px]">

--- a/apps/portal/app/terminal/components/trade-ticket-modal.tsx
+++ b/apps/portal/app/terminal/components/trade-ticket-modal.tsx
@@ -16,13 +16,22 @@ import {
   describeExecutionClientError,
   newExecutionIdempotencyKey,
 } from "../../execution-client";
-import { apiBase, BTN_PRIMARY, BTN_SECONDARY, isRecord } from "../../lib";
+import { BTN_PRIMARY, BTN_SECONDARY } from "../../lib";
 import type {
   TerminalIntentFamily,
   TerminalMarketType,
   TerminalOracleStatus,
   TerminalProviderStatus,
+  TerminalSpotVenueDefinition,
   TerminalVenueKey,
+  TerminalVenueRolloutPolicy,
+} from "../terminal-venues";
+import {
+  getTerminalOrderTypeLabel,
+  getTerminalSpotVenueDefinition,
+  getTerminalTimeInForceLabel,
+  getTerminalVenueExecutionReadinessLabel,
+  listTerminalSpotVenueDefinitions,
 } from "../terminal-venues";
 import {
   type AccountRiskSnapshot,
@@ -41,6 +50,8 @@ type TradeTicketModalProps = {
   walletAddress: string | null;
   tokenBalancesByMint?: Record<string, string> | null;
   riskSnapshot?: AccountRiskSnapshot | null;
+  referencePrice?: number | null;
+  terminalVenueRolloutPolicy: TerminalVenueRolloutPolicy;
   riskAcknowledgement?: {
     required: boolean;
     title?: string;
@@ -141,7 +152,6 @@ type PriorityLevel = "normal" | "high" | "urgent";
 
 const MIN_SLIPPAGE_BPS = "1";
 const MAX_SLIPPAGE_BPS = "5000";
-const BEARER_RE = /^bearer\s+/i;
 const EXEC_POLL_INTERVAL_MS = 1200;
 const EXEC_POLL_TIMEOUT_MS = 45000;
 const ORDER_PRICE_DECIMALS = 6;
@@ -234,20 +244,6 @@ function toPositiveAtomic(raw: string | null | undefined): string | null {
   }
 }
 
-function summarizeQuoteRoute(payload: unknown): string | null {
-  if (!isRecord(payload) || !Array.isArray(payload.routePlan)) return null;
-  const labels: string[] = [];
-  for (const hop of payload.routePlan) {
-    if (!isRecord(hop) || !isRecord(hop.swapInfo)) continue;
-    const label = hop.swapInfo.label;
-    if (typeof label === "string" && label.trim()) {
-      labels.push(label.trim());
-    }
-    if (labels.length >= 3) break;
-  }
-  return labels.length > 0 ? labels.join(" -> ") : null;
-}
-
 function toBoundedSlippage(value: string, fallback: number): number {
   const raw = Number(value);
   if (!Number.isFinite(raw)) return fallback;
@@ -283,10 +279,40 @@ const EMPTY_QUOTE: QuoteState = {
   priceImpactPct: null,
 };
 
+function isVenueLiveExecutable(
+  venue: TerminalSpotVenueDefinition | null,
+): boolean {
+  return (
+    venue?.executionReadiness === "bounded_live" ||
+    venue?.executionReadiness === "broad_live"
+  );
+}
+
+function coerceVenueOrderType(
+  venue: TerminalSpotVenueDefinition | null,
+  orderType: OrderType,
+): OrderType {
+  if (!venue) return orderType;
+  return venue.supportedOrderTypes.includes(orderType)
+    ? orderType
+    : (venue.supportedOrderTypes[0] ?? "market");
+}
+
+function coerceVenueTimeInForce(
+  venue: TerminalSpotVenueDefinition | null,
+  timeInForce: TimeInForce,
+): TimeInForce {
+  if (!venue) return timeInForce;
+  return venue.supportedTimeInForce.includes(timeInForce)
+    ? timeInForce
+    : (venue.supportedTimeInForce[0] ?? "gtc");
+}
+
 export function validateOrderConfig(input: {
   orderType: OrderType;
   timeInForce: TimeInForce;
   lane: ExecutionLane;
+  venue?: TerminalSpotVenueDefinition | null;
   reduceOnly: boolean;
   postOnly: boolean;
   quantityMode: QuantityMode;
@@ -298,6 +324,17 @@ export function validateOrderConfig(input: {
   bracketEnabled: boolean;
 }): string[] {
   const errors: string[] = [];
+  const venue = input.venue ?? getTerminalSpotVenueDefinition("jupiter");
+  if (venue && !venue.supportedOrderTypes.includes(input.orderType)) {
+    errors.push(
+      `${venue.label} does not support ${input.orderType.toUpperCase()} spot orders.`,
+    );
+  }
+  if (venue && !venue.supportedTimeInForce.includes(input.timeInForce)) {
+    errors.push(
+      `${venue.label} does not support ${input.timeInForce.toUpperCase()} time-in-force.`,
+    );
+  }
   if (!input.amountAtomic) {
     errors.push("Amount must be greater than zero.");
   }
@@ -325,6 +362,9 @@ export function validateOrderConfig(input: {
   ) {
     errors.push("Post-only cannot be combined with IOC or FOK.");
   }
+  if (input.postOnly && venue && !venue.supportsPostOnly) {
+    errors.push(`${venue.label} does not support post-only spot orders.`);
+  }
   if (
     (input.orderType === "limit" || input.orderType === "trigger") &&
     input.postOnly
@@ -339,6 +379,9 @@ export function validateOrderConfig(input: {
     input.reduceOnly
   ) {
     errors.push("Reduce-only is not supported for Trigger-backed spot orders.");
+  }
+  if (input.reduceOnly && venue && !venue.supportsReduceOnly) {
+    errors.push(`${venue.label} does not support reduce-only spot orders.`);
   }
   if (
     input.bracketEnabled &&
@@ -377,6 +420,9 @@ export function validateOrderConfig(input: {
     input.bracketEnabled
   ) {
     errors.push("Bracket TP/SL is not wired yet for Trigger-backed orders.");
+  }
+  if (input.bracketEnabled && venue && !venue.supportsBracket) {
+    errors.push(`${venue.label} does not support bracket TP/SL controls.`);
   }
   return errors;
 }
@@ -439,6 +485,8 @@ export function TradeTicketModal({
   walletAddress,
   tokenBalancesByMint,
   riskSnapshot,
+  referencePrice,
+  terminalVenueRolloutPolicy,
   riskAcknowledgement,
   hotkeyBindings = DEFAULT_TRADE_TICKET_HOTKEY_BINDINGS,
   getAccessToken,
@@ -456,6 +504,8 @@ export function TradeTicketModal({
   const [priorityLevel, setPriorityLevel] = useState<PriorityLevel>(
     DEFAULT_PRIORITY_LEVEL,
   );
+  const [selectedVenueKey, setSelectedVenueKey] =
+    useState<TerminalVenueKey>("jupiter");
   const [orderType, setOrderType] = useState<OrderType>("market");
   const [timeInForce, setTimeInForce] = useState<TimeInForce>("gtc");
   const [quantityMode, setQuantityMode] = useState<QuantityMode>("quote");
@@ -538,6 +588,7 @@ export function TradeTicketModal({
     setExecutionLane(DEFAULT_EXECUTION_LANE);
     setSimulationPreference(DEFAULT_SIMULATION_PREFERENCE);
     setPriorityLevel(DEFAULT_PRIORITY_LEVEL);
+    setSelectedVenueKey(intent.venueKey);
     setOrderType("market");
     setTimeInForce("gtc");
     setQuantityMode("quote");
@@ -556,6 +607,54 @@ export function TradeTicketModal({
 
   const deferredAmountUi = useDeferredValue(amountUi);
   const deferredSlippageInput = useDeferredValue(slippageInput);
+
+  const spotVenueOptions = useMemo(
+    () =>
+      listTerminalSpotVenueDefinitions({
+        policy: terminalVenueRolloutPolicy,
+        includeDisabled: true,
+      }).filter((definition) => definition.executionReadiness !== "research"),
+    [terminalVenueRolloutPolicy],
+  );
+  const selectedVenue = useMemo(
+    () => getTerminalSpotVenueDefinition(selectedVenueKey),
+    [selectedVenueKey],
+  );
+  const selectedVenueLiveExecutable = useMemo(
+    () => isVenueLiveExecutable(selectedVenue),
+    [selectedVenue],
+  );
+  const selectedVenueEnabled = useMemo(
+    () => terminalVenueRolloutPolicy.enabledVenues.includes(selectedVenueKey),
+    [selectedVenueKey, terminalVenueRolloutPolicy.enabledVenues],
+  );
+
+  useEffect(() => {
+    const nextOrderType = coerceVenueOrderType(selectedVenue, orderType);
+    if (nextOrderType !== orderType) {
+      setOrderType(nextOrderType);
+    }
+    const nextTimeInForce = coerceVenueTimeInForce(selectedVenue, timeInForce);
+    if (nextTimeInForce !== timeInForce) {
+      setTimeInForce(nextTimeInForce);
+    }
+    if (postOnly && !selectedVenue?.supportsPostOnly) {
+      setPostOnly(false);
+    }
+    if (reduceOnly && !selectedVenue?.supportsReduceOnly) {
+      setReduceOnly(false);
+    }
+    if (bracketEnabled && !selectedVenue?.supportsBracket) {
+      setBracketEnabled(false);
+    }
+  }, [
+    bracketEnabled,
+    orderType,
+    postOnly,
+    reduceOnly,
+    selectedVenue,
+    timeInForce,
+  ]);
 
   const amountPresets = useMemo(
     () => intent?.amountPresets ?? [],
@@ -629,6 +728,7 @@ export function TradeTicketModal({
         orderType,
         timeInForce,
         lane: executionLane,
+        venue: selectedVenue,
         reduceOnly,
         postOnly,
         quantityMode,
@@ -648,6 +748,7 @@ export function TradeTicketModal({
       postOnly,
       quantityMode,
       reduceOnly,
+      selectedVenue,
       stopLossPriceAtomic,
       takeProfitPriceAtomic,
       timeInForce,
@@ -681,20 +782,6 @@ export function TradeTicketModal({
       return;
     }
 
-    const base = apiBase();
-    if (!base) {
-      setQuoteTransition({
-        status: "error",
-        error: "missing NEXT_PUBLIC_EDGE_API_BASE",
-        inAmountAtomic,
-        outAmountAtomic: null,
-        outAmountUi: null,
-        route: null,
-        priceImpactPct: null,
-      });
-      return;
-    }
-
     setQuoteTransition({
       status: "loading",
       error: null,
@@ -713,54 +800,24 @@ export function TradeTicketModal({
 
     try {
       const rawToken = String((await getAccessToken()) ?? "").trim();
-      const headers: Record<string, string> = {
-        "content-type": "application/json",
-        "payment-signature": "portal-trade-ticket",
-      };
-      if (rawToken) {
-        headers.authorization = BEARER_RE.test(rawToken)
-          ? rawToken
-          : `Bearer ${rawToken}`;
-      }
-      const response = await fetch(
-        `${base}/api/x402/read/market_jupiter_quote`,
+      const executionClient = createExecutionClient({
+        authToken: rawToken,
+      });
+      const preview = await executionClient.previewSpotOrder(
         {
-          method: "POST",
-          headers,
-          body: JSON.stringify({
-            inputMint: intent.inputMint,
-            outputMint: intent.outputMint,
-            amount: inAmountAtomic,
-            slippageBps: resolvedSlippageBps,
-          }),
-          signal: controller.signal,
+          venueKey: selectedVenueKey,
+          inputMint: intent.inputMint,
+          outputMint: intent.outputMint,
+          amountAtomic: inAmountAtomic,
+          slippageBps: resolvedSlippageBps,
         },
+        { signal: controller.signal },
       );
-      const payload = (await response.json().catch(() => null)) as unknown;
       if (requestId !== quoteRequestIdRef.current) return;
-      if (!response.ok) {
-        const error =
-          isRecord(payload) && typeof payload.error === "string"
-            ? payload.error
-            : `http-${response.status}`;
-        throw new Error(error);
-      }
-      if (
-        !isRecord(payload) ||
-        payload.ok !== true ||
-        !isRecord(payload.quote)
-      ) {
-        throw new Error("invalid-quote-payload");
-      }
 
-      const outAmountAtomic = String(payload.quote.outAmount ?? "").trim();
+      const outAmountAtomic = preview.outAmountAtomic;
       const outAmountUi = formatAtomicToUi(outAmountAtomic, outputDecimals, 6);
       if (!outAmountUi) throw new Error("invalid-quote-out-amount");
-      const priceImpactRaw = payload.quote.priceImpactPct;
-      const priceImpactPct =
-        typeof priceImpactRaw === "number"
-          ? priceImpactRaw
-          : Number(priceImpactRaw);
 
       setQuoteTransition({
         status: "ready",
@@ -768,8 +825,8 @@ export function TradeTicketModal({
         inAmountAtomic,
         outAmountAtomic,
         outAmountUi,
-        route: summarizeQuoteRoute(payload.quote),
-        priceImpactPct: Number.isFinite(priceImpactPct) ? priceImpactPct : null,
+        route: preview.routeSummary,
+        priceImpactPct: preview.priceImpactPct,
       });
     } catch (error) {
       if (controller.signal.aborted) return;
@@ -789,6 +846,7 @@ export function TradeTicketModal({
     intent,
     open,
     resolvedSlippageBps,
+    selectedVenueKey,
     setQuoteTransition,
   ]);
 
@@ -805,6 +863,16 @@ export function TradeTicketModal({
 
   const executeTrade = useCallback(async (): Promise<void> => {
     if (!intent) return;
+    if (!selectedVenueEnabled) {
+      setSubmitStatus("error");
+      setSubmitMessage("selected-venue-rollout-gated");
+      return;
+    }
+    if (!selectedVenueLiveExecutable) {
+      setSubmitStatus("error");
+      setSubmitMessage("selected-venue-preview-only");
+      return;
+    }
     if (orderValidationErrors.length > 0 || executionQualityErrors.length > 0) {
       setSubmitStatus("error");
       setSubmitMessage(
@@ -899,7 +967,7 @@ export function TradeTicketModal({
               wallet: walletAddress,
               intent: {
                 family: "conditional_spot_order",
-                venueKey: intent.venueKey,
+                venueKey: selectedVenueKey,
                 marketType: intent.marketType,
                 instrumentId: intent.instrumentId,
                 side: intent.direction,
@@ -1019,7 +1087,7 @@ export function TradeTicketModal({
         pairId: intent.pairId,
         instrumentId: intent.instrumentId,
         instrumentLabel: intent.instrumentLabel,
-        venueKey: intent.venueKey,
+        venueKey: selectedVenueKey,
         intentFamily: intent.intentFamily,
         marketType: intent.marketType,
         direction: intent.direction,
@@ -1106,6 +1174,9 @@ export function TradeTicketModal({
     quote.outAmountAtomic,
     reduceOnly,
     resolvedSlippageBps,
+    selectedVenueKey,
+    selectedVenueEnabled,
+    selectedVenueLiveExecutable,
     slippageInput,
     stopLossPriceAtomic,
     simulationPreference,
@@ -1152,6 +1223,8 @@ export function TradeTicketModal({
     submitStatus !== "tracking" &&
     quote.status === "ready" &&
     Boolean(quote.inAmountAtomic) &&
+    selectedVenueEnabled &&
+    selectedVenueLiveExecutable &&
     (!riskAcknowledgement?.required || riskConfirmed) &&
     orderValidationErrors.length < 1 &&
     executionQualityErrors.length < 1 &&
@@ -1251,6 +1324,16 @@ export function TradeTicketModal({
 
         <div className="p-6 space-y-4">
           <TradeIdentityCard intent={intent} walletAddress={walletAddress} />
+          <SpotVenueSection
+            venueOptions={spotVenueOptions}
+            selectedVenueKey={selectedVenueKey}
+            selectedVenue={selectedVenue}
+            selectedVenueEnabled={selectedVenueEnabled}
+            selectedVenueLiveExecutable={selectedVenueLiveExecutable}
+            orderType={orderType}
+            timeInForce={timeInForce}
+            onVenueChange={setSelectedVenueKey}
+          />
           <TradeRiskContextCard
             snapshot={riskSnapshot ?? null}
             preSubmitRisk={preSubmitRisk}
@@ -1294,6 +1377,7 @@ export function TradeTicketModal({
             onPriorityLevelChange={setPriorityLevel}
           />
           <AdvancedOrderConfigSection
+            venue={selectedVenue}
             orderType={orderType}
             timeInForce={timeInForce}
             quantityMode={quantityMode}
@@ -1318,7 +1402,10 @@ export function TradeTicketModal({
           />
           <QuoteSummaryCard
             outputSymbol={intent.outputSymbol}
+            inputDecimals={intent.inputDecimals}
+            outputDecimals={intent.outputDecimals}
             quote={quote}
+            referencePrice={referencePrice}
             loading={quote.status === "loading" || isQuoteTransitionPending}
           />
 
@@ -1331,6 +1418,22 @@ export function TradeTicketModal({
               }
             >
               {submitMessage}
+            </p>
+          ) : null}
+          {!selectedVenueEnabled ? (
+            <p className="text-amber-300 text-xs">
+              {selectedVenue?.label ?? "Selected venue"} is rollout-gated for
+              this cohort.
+            </p>
+          ) : null}
+          {selectedVenueEnabled && !selectedVenueLiveExecutable ? (
+            <p className="text-amber-300 text-xs">
+              {selectedVenue?.label ?? "Selected venue"} is preview-only in the
+              current harness. Live terminal execution remains gated to{" "}
+              {getTerminalVenueExecutionReadinessLabel(
+                selectedVenue?.executionReadiness ?? "research",
+              ).toLowerCase()}
+              .
             </p>
           ) : null}
 
@@ -1355,7 +1458,11 @@ export function TradeTicketModal({
                 ? submitStatus === "tracking"
                   ? "Tracking..."
                   : "Submitting..."
-                : `Execute ${intent.direction === "buy" ? "Buy" : "Sell"}`}
+                : !selectedVenueEnabled
+                  ? "Rollout Gated"
+                  : !selectedVenueLiveExecutable
+                    ? "Preview Only"
+                    : `Execute ${intent.direction === "buy" ? "Buy" : "Sell"}`}
             </button>
           </div>
           <p className="text-[10px] text-muted text-right">
@@ -1394,6 +1501,108 @@ const TradeIdentityCard = memo(function TradeIdentityCard(props: {
             : "--"}
         </span>
       </div>
+    </div>
+  );
+});
+
+const SpotVenueSection = memo(function SpotVenueSection(props: {
+  venueOptions: TerminalSpotVenueDefinition[];
+  selectedVenueKey: TerminalVenueKey;
+  selectedVenue: TerminalSpotVenueDefinition | null;
+  selectedVenueEnabled: boolean;
+  selectedVenueLiveExecutable: boolean;
+  orderType: OrderType;
+  timeInForce: TimeInForce;
+  onVenueChange: (value: TerminalVenueKey) => void;
+}) {
+  const {
+    venueOptions,
+    selectedVenueKey,
+    selectedVenue,
+    selectedVenueEnabled,
+    selectedVenueLiveExecutable,
+    orderType,
+    timeInForce,
+    onVenueChange,
+  } = props;
+
+  return (
+    <div className="rounded border border-border bg-subtle px-3 py-2 text-xs space-y-3">
+      <p className="label">SPOT_VENUE_PATH</p>
+      <div className="grid grid-cols-1 sm:grid-cols-[1.2fr_0.8fr_0.8fr] gap-2">
+        <label className="space-y-1">
+          <span className="text-muted text-[10px] uppercase tracking-wider">
+            Venue
+          </span>
+          <select
+            className="input-field !py-2 font-mono"
+            data-testid="trade-ticket-venue-select"
+            value={selectedVenueKey}
+            onChange={(event) =>
+              onVenueChange(event.target.value as TerminalVenueKey)
+            }
+          >
+            {venueOptions.map((venue) => (
+              <option key={venue.venueKey} value={venue.venueKey}>
+                {venue.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div className="rounded border border-border/60 bg-paper/70 px-2 py-1.5 text-[10px] text-muted">
+          <p className="uppercase tracking-wider">Path</p>
+          <p
+            className="mt-1 font-mono text-ink"
+            data-testid="trade-ticket-venue-path"
+          >
+            {selectedVenue?.executionPathLabel ?? "--"}
+          </p>
+        </div>
+        <div className="rounded border border-border/60 bg-paper/70 px-2 py-1.5 text-[10px] text-muted">
+          <p className="uppercase tracking-wider">Readiness</p>
+          <p
+            className="mt-1 font-mono text-ink"
+            data-testid="trade-ticket-venue-readiness"
+          >
+            {selectedVenue
+              ? getTerminalVenueExecutionReadinessLabel(
+                  selectedVenue.executionReadiness,
+                )
+              : "--"}
+          </p>
+        </div>
+      </div>
+      {selectedVenue ? (
+        <div className="rounded border border-border/60 bg-paper/70 px-2 py-1.5 text-[10px] text-muted space-y-0.5">
+          <p>
+            Orders:{" "}
+            {selectedVenue.supportedOrderTypes
+              .map((value) => getTerminalOrderTypeLabel(value) ?? value)
+              .join(", ")}
+          </p>
+          <p>
+            TIF:{" "}
+            {selectedVenue.supportedTimeInForce
+              .map((value) => getTerminalTimeInForceLabel(value) ?? value)
+              .join(", ")}
+          </p>
+          <p>
+            Current path:{" "}
+            {(getTerminalOrderTypeLabel(orderType) ?? orderType).toUpperCase()}{" "}
+            /{" "}
+            {(
+              getTerminalTimeInForceLabel(timeInForce) ?? timeInForce
+            ).toUpperCase()}
+          </p>
+          <p>
+            {selectedVenueEnabled
+              ? selectedVenueLiveExecutable
+                ? "This venue is eligible for live terminal execution."
+                : "This venue is preview-only in the current harness."
+              : "This venue is rollout-gated for the current cohort."}
+          </p>
+        </div>
+      ) : null}
     </div>
   );
 });
@@ -1735,6 +1944,7 @@ const ExecutionQualitySection = memo(function ExecutionQualitySection(props: {
 
 const AdvancedOrderConfigSection = memo(
   function AdvancedOrderConfigSection(props: {
+    venue: TerminalSpotVenueDefinition | null;
     orderType: OrderType;
     timeInForce: TimeInForce;
     quantityMode: QuantityMode;
@@ -1758,6 +1968,7 @@ const AdvancedOrderConfigSection = memo(
     onStopLossPriceChange: (value: string) => void;
   }) {
     const {
+      venue,
       orderType,
       timeInForce,
       quantityMode,
@@ -1798,9 +2009,11 @@ const AdvancedOrderConfigSection = memo(
                 onOrderTypeChange(event.target.value as OrderType)
               }
             >
-              <option value="market">market</option>
-              <option value="limit">limit</option>
-              <option value="trigger">trigger</option>
+              {(venue?.supportedOrderTypes ?? ["market"]).map((value) => (
+                <option key={value} value={value}>
+                  {value}
+                </option>
+              ))}
             </select>
           </label>
           <label className="space-y-1">
@@ -1814,9 +2027,11 @@ const AdvancedOrderConfigSection = memo(
                 onTimeInForceChange(event.target.value as TimeInForce)
               }
             >
-              <option value="gtc">gtc</option>
-              <option value="ioc">ioc</option>
-              <option value="fok">fok</option>
+              {(venue?.supportedTimeInForce ?? ["gtc"]).map((value) => (
+                <option key={value} value={value}>
+                  {value}
+                </option>
+              ))}
             </select>
           </label>
           <label className="space-y-1">
@@ -1843,6 +2058,7 @@ const AdvancedOrderConfigSection = memo(
               checked={reduceOnly}
               onChange={(event) => onReduceOnlyChange(event.target.checked)}
               type="checkbox"
+              disabled={!venue?.supportsReduceOnly}
             />
             <span>Reduce-only</span>
           </label>
@@ -1851,6 +2067,7 @@ const AdvancedOrderConfigSection = memo(
               checked={postOnly}
               onChange={(event) => onPostOnlyChange(event.target.checked)}
               type="checkbox"
+              disabled={!venue?.supportsPostOnly}
             />
             <span>Post-only</span>
           </label>
@@ -1859,6 +2076,7 @@ const AdvancedOrderConfigSection = memo(
               checked={bracketEnabled}
               onChange={(event) => onBracketEnabledChange(event.target.checked)}
               type="checkbox"
+              disabled={!venue?.supportsBracket}
             />
             <span>Bracket TP/SL</span>
           </label>
@@ -1947,10 +2165,20 @@ const AdvancedOrderConfigSection = memo(
 
 const QuoteSummaryCard = memo(function QuoteSummaryCard(props: {
   outputSymbol: string;
+  inputDecimals: number;
+  outputDecimals: number;
   quote: QuoteState;
+  referencePrice: number | null | undefined;
   loading: boolean;
 }) {
-  const { outputSymbol, quote, loading } = props;
+  const {
+    outputSymbol,
+    inputDecimals,
+    outputDecimals,
+    quote,
+    referencePrice,
+    loading,
+  } = props;
   const statusText = quote.error
     ? quote.error
     : loading
@@ -1961,6 +2189,29 @@ const QuoteSummaryCard = memo(function QuoteSummaryCard(props: {
     : loading
       ? "text-muted"
       : "text-transparent";
+  const quotedInput = Number(
+    formatAtomicToUi(quote.inAmountAtomic, inputDecimals, 9) ?? "",
+  );
+  const quotedOutput = Number(
+    formatAtomicToUi(quote.outAmountAtomic, outputDecimals, 9) ?? "",
+  );
+  const impliedReference =
+    Number.isFinite(referencePrice ?? NaN) &&
+    referencePrice !== null &&
+    referencePrice > 0
+      ? referencePrice
+      : null;
+  const quotedPrice =
+    Number.isFinite(quotedInput) &&
+    Number.isFinite(quotedOutput) &&
+    quotedInput > 0 &&
+    quotedOutput > 0
+      ? quotedInput / quotedOutput
+      : null;
+  const referenceDivergenceBps =
+    quotedPrice !== null && impliedReference !== null
+      ? ((quotedPrice - impliedReference) / impliedReference) * 10_000
+      : null;
 
   return (
     <div className="rounded border border-border bg-subtle px-3 py-2 text-xs space-y-1.5 min-h-[112px]">
@@ -1980,8 +2231,25 @@ const QuoteSummaryCard = memo(function QuoteSummaryCard(props: {
       </div>
       <div className="flex items-center justify-between">
         <span className="text-muted">Route</span>
-        <span className="font-mono truncate max-w-[65%] text-right">
+        <span
+          className="font-mono truncate max-w-[65%] text-right"
+          data-testid="trade-ticket-quote-route"
+        >
           {quote.route ?? "--"}
+        </span>
+      </div>
+      <div className="flex items-center justify-between">
+        <span className="text-muted">Reference</span>
+        <span className="font-mono" data-testid="trade-ticket-quote-reference">
+          {impliedReference === null ? "--" : impliedReference.toFixed(4)}
+        </span>
+      </div>
+      <div className="flex items-center justify-between">
+        <span className="text-muted">Vs Ref</span>
+        <span className="font-mono" data-testid="trade-ticket-quote-vs-ref">
+          {referenceDivergenceBps === null
+            ? "--"
+            : `${referenceDivergenceBps >= 0 ? "+" : ""}${referenceDivergenceBps.toFixed(1)} bps`}
         </span>
       </div>
       <p aria-live="polite" className={statusClass}>

--- a/apps/portal/app/terminal/components/trade-ticket-modal.tsx
+++ b/apps/portal/app/terminal/components/trade-ticket-modal.tsx
@@ -2196,8 +2196,8 @@ const QuoteSummaryCard = memo(function QuoteSummaryCard(props: {
     formatAtomicToUi(quote.outAmountAtomic, outputDecimals, 9) ?? "",
   );
   const impliedReference =
-    Number.isFinite(referencePrice ?? NaN) &&
-    referencePrice !== null &&
+    typeof referencePrice === "number" &&
+    Number.isFinite(referencePrice) &&
     referencePrice > 0
       ? referencePrice
       : null;

--- a/apps/portal/app/terminal/page.tsx
+++ b/apps/portal/app/terminal/page.tsx
@@ -1740,6 +1740,8 @@ function ControlRoom() {
           walletAddress={wallet?.walletAddress ?? null}
           tokenBalancesByMint={tokenBalancesByMint}
           riskSnapshot={accountRiskSnapshot}
+          referencePrice={marketFeed.latestPrice}
+          terminalVenueRolloutPolicy={terminalVenueRolloutPolicy}
           riskAcknowledgement={
             isDegenMode
               ? {

--- a/apps/portal/app/terminal/terminal-venues.ts
+++ b/apps/portal/app/terminal/terminal-venues.ts
@@ -4,7 +4,7 @@ export const TERMINAL_VENUE_KEYS = [
   "jupiter",
   "raydium",
   "orca",
-  "openbook_v2",
+  "openbook",
   "phoenix",
   "drift",
   "dflow",
@@ -21,10 +21,15 @@ export const TERMINAL_INTENT_FAMILIES = [
 ] as const;
 
 export const TERMINAL_MARKET_TYPES = ["spot", "perp", "prediction"] as const;
+export const TERMINAL_ORDER_TYPES = ["market", "limit", "trigger"] as const;
+export const TERMINAL_TIME_IN_FORCE_OPTIONS = ["gtc", "ioc", "fok"] as const;
 
 export type TerminalVenueKey = (typeof TERMINAL_VENUE_KEYS)[number];
 export type TerminalIntentFamily = (typeof TERMINAL_INTENT_FAMILIES)[number];
 export type TerminalMarketType = (typeof TERMINAL_MARKET_TYPES)[number];
+export type TerminalOrderType = (typeof TERMINAL_ORDER_TYPES)[number];
+export type TerminalTimeInForce =
+  (typeof TERMINAL_TIME_IN_FORCE_OPTIONS)[number];
 export type TerminalProviderStatus =
   | "healthy"
   | "degraded"
@@ -46,6 +51,17 @@ export type TerminalVenueDefinition = {
   families: readonly TerminalIntentFamily[];
   rolloutFlag: string;
   badges: readonly string[];
+  executionReadiness:
+    | "broad_live"
+    | "bounded_live"
+    | "shadow_paper"
+    | "research";
+  executionPathLabel: string;
+  supportedOrderTypes?: readonly TerminalOrderType[];
+  supportedTimeInForce?: readonly TerminalTimeInForce[];
+  supportsPostOnly?: boolean;
+  supportsReduceOnly?: boolean;
+  supportsBracket?: boolean;
 };
 
 const TERMINAL_VENUE_REGISTRY: Record<
@@ -60,6 +76,13 @@ const TERMINAL_VENUE_REGISTRY: Record<
     families: ["spot_swap", "conditional_spot_order", "flash_atomic"],
     rolloutFlag: "spot_router",
     badges: ["agg", "custody"],
+    executionReadiness: "bounded_live",
+    executionPathLabel: "Routed AMM / Trigger",
+    supportedOrderTypes: ["market", "limit", "trigger"],
+    supportedTimeInForce: ["gtc"],
+    supportsPostOnly: false,
+    supportsReduceOnly: false,
+    supportsBracket: false,
   },
   raydium: {
     venueKey: "raydium",
@@ -69,6 +92,13 @@ const TERMINAL_VENUE_REGISTRY: Record<
     families: ["spot_swap", "flash_atomic"],
     rolloutFlag: "spot_router",
     badges: ["amm", "router"],
+    executionReadiness: "shadow_paper",
+    executionPathLabel: "Direct AMM route",
+    supportedOrderTypes: ["market"],
+    supportedTimeInForce: ["gtc"],
+    supportsPostOnly: false,
+    supportsReduceOnly: false,
+    supportsBracket: false,
   },
   orca: {
     venueKey: "orca",
@@ -78,15 +108,29 @@ const TERMINAL_VENUE_REGISTRY: Record<
     families: ["spot_swap", "flash_atomic"],
     rolloutFlag: "spot_router",
     badges: ["clmm", "lp"],
+    executionReadiness: "shadow_paper",
+    executionPathLabel: "Whirlpool / CLMM",
+    supportedOrderTypes: ["market"],
+    supportedTimeInForce: ["gtc"],
+    supportsPostOnly: false,
+    supportsReduceOnly: false,
+    supportsBracket: false,
   },
-  openbook_v2: {
-    venueKey: "openbook_v2",
+  openbook: {
+    venueKey: "openbook",
     label: "OpenBook v2",
     shortLabel: "OBV2",
     marketTypes: ["spot"],
     families: ["clob_order"],
     rolloutFlag: "spot_clob",
     badges: ["clob", "maker"],
+    executionReadiness: "shadow_paper",
+    executionPathLabel: "CLOB / order book",
+    supportedOrderTypes: ["market", "limit"],
+    supportedTimeInForce: ["gtc", "ioc", "fok"],
+    supportsPostOnly: true,
+    supportsReduceOnly: false,
+    supportsBracket: false,
   },
   phoenix: {
     venueKey: "phoenix",
@@ -96,6 +140,13 @@ const TERMINAL_VENUE_REGISTRY: Record<
     families: ["clob_order"],
     rolloutFlag: "phoenix",
     badges: ["clob", "maker"],
+    executionReadiness: "research",
+    executionPathLabel: "CLOB / maker rail",
+    supportedOrderTypes: ["market", "limit"],
+    supportedTimeInForce: ["gtc", "ioc", "fok"],
+    supportsPostOnly: true,
+    supportsReduceOnly: false,
+    supportsBracket: false,
   },
   drift: {
     venueKey: "drift",
@@ -105,6 +156,8 @@ const TERMINAL_VENUE_REGISTRY: Record<
     families: ["perp_order"],
     rolloutFlag: "perps",
     badges: ["perps", "margin"],
+    executionReadiness: "shadow_paper",
+    executionPathLabel: "Perp order book",
   },
   dflow: {
     venueKey: "dflow",
@@ -114,6 +167,8 @@ const TERMINAL_VENUE_REGISTRY: Record<
     families: ["prediction_order"],
     rolloutFlag: "prediction",
     badges: ["events", "tokenized"],
+    executionReadiness: "research",
+    executionPathLabel: "Tokenized event market",
   },
   monaco: {
     venueKey: "monaco",
@@ -123,12 +178,23 @@ const TERMINAL_VENUE_REGISTRY: Record<
     families: ["prediction_order"],
     rolloutFlag: "prediction",
     badges: ["events", "native"],
+    executionReadiness: "research",
+    executionPathLabel: "Native prediction venue",
   },
 };
 
 export type TerminalVenueRolloutPolicy = {
   enabledVenues: readonly TerminalVenueKey[];
   enabledFamilies: readonly TerminalIntentFamily[];
+};
+
+export type TerminalSpotVenueDefinition = TerminalVenueDefinition & {
+  marketTypes: readonly ["spot"];
+  supportedOrderTypes: readonly TerminalOrderType[];
+  supportedTimeInForce: readonly TerminalTimeInForce[];
+  supportsPostOnly: boolean;
+  supportsReduceOnly: boolean;
+  supportsBracket: boolean;
 };
 
 function parseEnumList<T extends string>(
@@ -169,6 +235,84 @@ export function getTerminalVenueDefinition(
 ): TerminalVenueDefinition | null {
   if (!venueKey) return null;
   return TERMINAL_VENUE_REGISTRY[venueKey] ?? null;
+}
+
+export function getTerminalSpotVenueDefinition(
+  venueKey: TerminalVenueKey | null | undefined,
+): TerminalSpotVenueDefinition | null {
+  const definition = getTerminalVenueDefinition(venueKey);
+  if (!definition || !definition.marketTypes.includes("spot")) {
+    return null;
+  }
+  const supportedOrderTypes = definition.supportedOrderTypes;
+  const supportedTimeInForce = definition.supportedTimeInForce;
+  if (!supportedOrderTypes || !supportedTimeInForce) {
+    return null;
+  }
+  return definition as TerminalSpotVenueDefinition;
+}
+
+export function listTerminalSpotVenueDefinitions(input: {
+  policy: TerminalVenueRolloutPolicy;
+  includeDisabled?: boolean;
+}): TerminalSpotVenueDefinition[] {
+  const definitions = TERMINAL_VENUE_KEYS.map((venueKey) =>
+    getTerminalSpotVenueDefinition(venueKey),
+  ).filter(
+    (definition): definition is TerminalSpotVenueDefinition =>
+      definition !== null,
+  );
+  if (input.includeDisabled) return definitions;
+  return definitions.filter((definition) =>
+    input.policy.enabledVenues.includes(definition.venueKey),
+  );
+}
+
+export function getTerminalVenueExecutionReadinessLabel(
+  readiness: TerminalVenueDefinition["executionReadiness"],
+): string {
+  switch (readiness) {
+    case "broad_live":
+      return "Broad live";
+    case "bounded_live":
+      return "Bounded live";
+    case "shadow_paper":
+      return "Shadow / paper";
+    case "research":
+      return "Research";
+    default:
+      return "Unknown";
+  }
+}
+
+export function getTerminalOrderTypeLabel(
+  orderType: TerminalOrderType | null | undefined,
+): string | null {
+  switch (orderType) {
+    case "market":
+      return "Market";
+    case "limit":
+      return "Limit";
+    case "trigger":
+      return "Trigger";
+    default:
+      return null;
+  }
+}
+
+export function getTerminalTimeInForceLabel(
+  timeInForce: TerminalTimeInForce | null | undefined,
+): string | null {
+  switch (timeInForce) {
+    case "gtc":
+      return "GTC";
+    case "ioc":
+      return "IOC";
+    case "fok":
+      return "FOK";
+    default:
+      return null;
+  }
 }
 
 export function getTerminalIntentFamilyLabel(
@@ -282,6 +426,7 @@ export function parseTerminalVenueKey(value: unknown): TerminalVenueKey | null {
   const normalized = String(value ?? "")
     .trim()
     .toLowerCase();
+  if (normalized === "openbook_v2") return "openbook";
   return (TERMINAL_VENUE_KEYS as readonly string[]).includes(normalized)
     ? (normalized as TerminalVenueKey)
     : null;

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -6963,7 +6963,6 @@ function resolveTerminalProviderStatus(input: {
   return input.latest?.receipt?.errorCode ? "degraded" : "healthy";
 }
 
-<<<<<<< HEAD
 function readPersistedExecutionLifecycle(input: {
   latest: Awaited<ReturnType<typeof getExecutionLatestStatus>>;
 }): Record<string, unknown> | null {

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -155,6 +155,7 @@ import {
   writeOpsControlSnapshot,
 } from "./ops_controls";
 import { evaluateOracleReferencePriceGuard } from "./oracle_reference";
+import { OrcaClient } from "./orca";
 import {
   fetchPerpsFundingSurface,
   fetchPerpsOpenInterestSurface,
@@ -164,6 +165,7 @@ import {
 } from "./perps_sources";
 import { enforcePolicy, normalizePolicy } from "./policy";
 import { createPrivySolanaWallet, signTransactionWithPrivyById } from "./privy";
+import { RaydiumClient } from "./raydium";
 import { gatherMarketSnapshot } from "./research";
 import { json, okCors, withCors } from "./response";
 import {
@@ -5462,6 +5464,135 @@ const worker = {
       }
 
       if (
+        request.method === "POST" &&
+        url.pathname === "/api/terminal/spot-preview"
+      ) {
+        await requireOnboardedUser(request, env);
+        const payload = await readPayload(request);
+        const venueKey = readTrimmedString(payload.venueKey)?.toLowerCase();
+        const inputMint = readTrimmedString(payload.inputMint);
+        const outputMint = readTrimmedString(payload.outputMint);
+        const amountAtomic = readTrimmedString(payload.amountAtomic);
+        const slippageBps = toBoundedInt(payload.slippageBps, 50, 1, 5_000);
+        if (
+          !venueKey ||
+          !inputMint ||
+          !outputMint ||
+          !amountAtomic ||
+          !SUPPORTED_TRADING_MINT_SET.has(inputMint) ||
+          !SUPPORTED_TRADING_MINT_SET.has(outputMint) ||
+          !SUPPORTED_TRADING_PAIR_MINT_SET.has(`${inputMint}:${outputMint}`)
+        ) {
+          return withCors(
+            json(
+              { ok: false, error: "invalid-terminal-spot-preview" },
+              { status: 400 },
+            ),
+            env,
+          );
+        }
+
+        try {
+          const rpcEndpoint = String(env.RPC_ENDPOINT ?? "").trim();
+          if (!rpcEndpoint) {
+            return withCors(
+              json(
+                { ok: false, error: "rpc-endpoint-missing" },
+                { status: 503 },
+              ),
+              env,
+            );
+          }
+          const jupiter = new JupiterClient(
+            String(env.JUPITER_BASE_URL ?? "").trim() ||
+              X402_READ_JUPITER_BASE_URL,
+            env.JUPITER_API_KEY,
+          );
+
+          let provider = venueKey;
+          let normalizedQuote: Record<string, unknown> | null = null;
+          if (venueKey === "jupiter") {
+            normalizedQuote = (await jupiter.quote({
+              inputMint,
+              outputMint,
+              amount: amountAtomic,
+              slippageBps,
+              swapMode: "ExactIn",
+            })) as unknown as Record<string, unknown>;
+          } else if (venueKey === "raydium") {
+            const raydium = new RaydiumClient();
+            const preview = await raydium.quoteBaseIn({
+              inputMint,
+              outputMint,
+              amount: amountAtomic,
+              slippageBps,
+            });
+            normalizedQuote = preview.normalizedQuote as unknown as Record<
+              string,
+              unknown
+            >;
+            provider = "raydium";
+          } else if (venueKey === "orca") {
+            const orca = new OrcaClient(rpcEndpoint);
+            const preview = await orca.quoteBaseIn({
+              inputMint,
+              outputMint,
+              amount: amountAtomic,
+              slippageBps,
+            });
+            normalizedQuote = preview.normalizedQuote as unknown as Record<
+              string,
+              unknown
+            >;
+            provider = "orca";
+          } else {
+            return withCors(
+              json(
+                {
+                  ok: false,
+                  error: `unsupported-terminal-spot-preview:${venueKey}`,
+                },
+                { status: 400 },
+              ),
+              env,
+            );
+          }
+
+          const previewProvider =
+            readTrimmedString(normalizedQuote?.quoteProvider) ?? provider;
+          const routeSummary =
+            summarizeTerminalRoutePlan(normalizedQuote) ?? previewProvider;
+          return withCors(
+            json({
+              ok: true,
+              preview: {
+                venueKey,
+                provider: previewProvider,
+                inputMint,
+                outputMint,
+                inAmountAtomic:
+                  readTrimmedString(normalizedQuote?.inAmount) ?? amountAtomic,
+                outAmountAtomic:
+                  readTrimmedString(normalizedQuote?.outAmount) ?? "0",
+                priceImpactPct: Number(normalizedQuote?.priceImpactPct),
+                routeSummary,
+              },
+            }),
+            env,
+          );
+        } catch (error) {
+          const message =
+            error instanceof Error
+              ? error.message
+              : "terminal-spot-preview-failed";
+          return withCors(
+            json({ ok: false, error: message }, { status: 503 }),
+            env,
+          );
+        }
+      }
+
+      if (
         request.method === "GET" &&
         url.pathname === "/api/terminal/open-orders"
       ) {
@@ -6832,6 +6963,7 @@ function resolveTerminalProviderStatus(input: {
   return input.latest?.receipt?.errorCode ? "degraded" : "healthy";
 }
 
+<<<<<<< HEAD
 function readPersistedExecutionLifecycle(input: {
   latest: Awaited<ReturnType<typeof getExecutionLatestStatus>>;
 }): Record<string, unknown> | null {
@@ -6850,6 +6982,24 @@ function readPersistedExecutionLifecycle(input: {
     ? executionMeta?.lifecycle
     : null;
   return executionLifecycle ?? null;
+}
+
+function summarizeTerminalRoutePlan(
+  quote: Record<string, unknown> | null,
+): string | null {
+  if (!quote || !Array.isArray(quote.routePlan)) return null;
+  const labels: string[] = [];
+  for (const hop of quote.routePlan) {
+    if (!isRecord(hop)) continue;
+    const swapInfo = isRecord(hop.swapInfo) ? hop.swapInfo : null;
+    const label =
+      readTrimmedString(swapInfo?.label) ??
+      readTrimmedString(hop.poolId) ??
+      readTrimmedString(hop.marketId);
+    if (!label || labels.includes(label)) continue;
+    labels.push(label);
+  }
+  return labels.length > 0 ? labels.join(" -> ") : null;
 }
 
 function resolveTerminalOpenOrderStatus(

--- a/tests/browser/harness-proof.spec.ts
+++ b/tests/browser/harness-proof.spec.ts
@@ -22,16 +22,42 @@ async function captureCheckpoint(page: Page, name: string): Promise<void> {
 test.describe.configure({ mode: "serial" });
 
 test.beforeEach(async ({ page }) => {
-  await page.route("**/api/x402/read/market_jupiter_quote", async (route) => {
+  await page.route("**/api/terminal/spot-preview", async (route) => {
+    const payload = (route.request().postDataJSON() ?? {}) as {
+      venueKey?: string;
+      amountAtomic?: string;
+    };
+    const venueKey = String(payload.venueKey ?? "jupiter");
+    const outAmountAtomicByVenue: Record<string, string> = {
+      jupiter: "2000000000",
+      raydium: "1985000000",
+      orca: "1979000000",
+    };
+    const routeSummaryByVenue: Record<string, string> = {
+      jupiter: "Jupiter routed spot swap",
+      raydium: "Raydium direct route",
+      orca: "Orca whirlpool path",
+    };
+    const priceImpactByVenue: Record<string, number> = {
+      jupiter: 0.0018,
+      raydium: 0.0026,
+      orca: 0.0031,
+    };
     await route.fulfill({
       status: 200,
       contentType: "application/json",
       body: JSON.stringify({
         ok: true,
-        quote: {
-          outAmount: "2000000000",
-          priceImpactPct: 0.0018,
-          routePlan: [{ swapInfo: { label: "Jupiter" } }],
+        preview: {
+          venueKey,
+          provider: venueKey,
+          inputMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          outputMint: "So11111111111111111111111111111111111111112",
+          inAmountAtomic: String(payload.amountAtomic ?? "50000000"),
+          outAmountAtomic: outAmountAtomicByVenue[venueKey] ?? "1950000000",
+          priceImpactPct: priceImpactByVenue[venueKey] ?? 0.004,
+          routeSummary:
+            routeSummaryByVenue[venueKey] ?? "Unsupported venue preview",
         },
       }),
     });
@@ -69,6 +95,19 @@ test.beforeEach(async ({ page }) => {
           receivedAt: "2026-03-06T20:45:00.000Z",
           updatedAt: "2026-03-06T20:45:02.000Z",
           terminalAt: "2026-03-06T20:45:03.000Z",
+        },
+        intent: {
+          family: "spot_swap",
+          venueKey: "jupiter",
+          marketType: "spot",
+          instrumentId: "SOL/USDC",
+          instrumentLabel: "SOL / USDC",
+        },
+        lifecycle: {
+          orderState: "filled",
+          fillState: "complete",
+          settlementState: "finalized",
+          notes: ["spot_swap", "proof-harness"],
         },
         events: [
           {
@@ -143,6 +182,18 @@ test("proof route exercises market render, trade validation, and receipt drilldo
 
   await page.getByTestId("proof-open-trade").click();
   await expect(page.getByTestId("trade-ticket-modal")).toBeVisible();
+  await expect(page.getByTestId("trade-ticket-venue-select")).toHaveValue(
+    "jupiter",
+  );
+  await expect(page.getByTestId("trade-ticket-venue-path")).toContainText(
+    "Routed AMM / Trigger",
+  );
+  await expect(page.getByTestId("trade-ticket-quote-route")).toContainText(
+    "Jupiter routed spot swap",
+  );
+  await expect(page.getByTestId("trade-ticket-quote-reference")).not.toHaveText(
+    "--",
+  );
 
   await page.getByTestId("trade-ticket-order-type").selectOption("trigger");
   await expect(
@@ -150,7 +201,25 @@ test("proof route exercises market render, trade validation, and receipt drilldo
   ).toBeVisible();
   await captureCheckpoint(page, "trade-validation.png");
 
+  await page.getByTestId("trade-ticket-venue-select").selectOption("raydium");
+  await expect(page.getByTestId("trade-ticket-venue-path")).toContainText(
+    "Direct AMM route",
+  );
+  await expect(page.getByTestId("trade-ticket-venue-readiness")).toContainText(
+    "Shadow / paper",
+  );
+  await expect(page.getByTestId("trade-ticket-submit")).toHaveText(
+    "Preview Only",
+  );
+  await expect(page.getByText(/Raydium is preview-only/i)).toBeVisible();
+  await expect(page.getByTestId("trade-ticket-submit")).toBeDisabled();
+  await captureCheckpoint(page, "trade-venue-preview.png");
+
+  await page.getByTestId("trade-ticket-venue-select").selectOption("jupiter");
   await page.getByTestId("trade-ticket-order-type").selectOption("market");
+  await expect(page.getByTestId("trade-ticket-submit")).toContainText(
+    "Execute Buy",
+  );
   await expect(page.getByText("2 SOL")).toBeVisible();
 
   await page.getByTestId("trade-ticket-submit").click();
@@ -164,6 +233,7 @@ test("proof route exercises market render, trade validation, and receipt drilldo
   await expect(inspector).toBeVisible();
   await expect(inspector.getByText(`receipt ${RECEIPT_ID}`)).toBeVisible();
   await expect(inspector.getByText(`signature: ${SIGNATURE}`)).toBeVisible();
+  await expect(inspector.getByText(/venue Jupiter/i)).toBeVisible();
   await captureCheckpoint(page, "receipt-drawer.png");
 });
 

--- a/tests/unit/portal_execution_client.test.ts
+++ b/tests/unit/portal_execution_client.test.ts
@@ -173,6 +173,13 @@ describe("portal execution client", () => {
     const client = createExecutionClient({
       transport: async (input) => {
         expect(input.path).toBe("/api/terminal/spot-preview");
+        expect(JSON.parse(String(input.body ?? ""))).toEqual({
+          venueKey: "raydium",
+          inputMint: "mint-in",
+          outputMint: "mint-out",
+          amountAtomic: "1000000",
+          slippageBps: 50,
+        });
         return {
           status: 200,
           payload: {

--- a/tests/unit/portal_execution_client.test.ts
+++ b/tests/unit/portal_execution_client.test.ts
@@ -169,6 +169,43 @@ describe("portal execution client", () => {
     }
   });
 
+  test("parses terminal spot preview responses", async () => {
+    const client = createExecutionClient({
+      transport: async (input) => {
+        expect(input.path).toBe("/api/terminal/spot-preview");
+        return {
+          status: 200,
+          payload: {
+            ok: true,
+            preview: {
+              venueKey: "raydium",
+              provider: "raydium",
+              inputMint: "mint-in",
+              outputMint: "mint-out",
+              inAmountAtomic: "1000000",
+              outAmountAtomic: "250000",
+              routeSummary: "Raydium",
+              priceImpactPct: 0.0025,
+            },
+          },
+        };
+      },
+    });
+
+    const preview = await client.previewSpotOrder({
+      venueKey: "raydium",
+      inputMint: "mint-in",
+      outputMint: "mint-out",
+      amountAtomic: "1000000",
+      slippageBps: 50,
+    });
+
+    expect(preview.venueKey).toBe("raydium");
+    expect(preview.provider).toBe("raydium");
+    expect(preview.routeSummary).toBe("Raydium");
+    expect(preview.priceImpactPct).toBe(0.0025);
+  });
+
   test("waitForTerminalReceipt retries transient failures", async () => {
     let statusCalls = 0;
     let receiptCalls = 0;

--- a/tests/unit/portal_terminal_trade_ticket_validation.test.ts
+++ b/tests/unit/portal_terminal_trade_ticket_validation.test.ts
@@ -3,6 +3,7 @@ import {
   validateExecutionQualityConfig,
   validateOrderConfig,
 } from "../../apps/portal/app/terminal/components/trade-ticket-modal";
+import { getTerminalSpotVenueDefinition } from "../../apps/portal/app/terminal/terminal-venues";
 
 describe("portal terminal advanced trade ticket validation", () => {
   test("rejects invalid limit and post-only combinations", () => {
@@ -29,6 +30,7 @@ describe("portal terminal advanced trade ticket validation", () => {
       orderType: "trigger",
       timeInForce: "gtc",
       lane: "safe",
+      venue: getTerminalSpotVenueDefinition("jupiter"),
       reduceOnly: false,
       postOnly: false,
       quantityMode: "quote",
@@ -47,6 +49,7 @@ describe("portal terminal advanced trade ticket validation", () => {
       orderType: "trigger",
       timeInForce: "gtc",
       lane: "safe",
+      venue: getTerminalSpotVenueDefinition("jupiter"),
       reduceOnly: false,
       postOnly: false,
       quantityMode: "quote",
@@ -59,6 +62,27 @@ describe("portal terminal advanced trade ticket validation", () => {
     });
     expect(errors).toContain(
       "Bracket TP/SL is not wired yet for Trigger-backed orders.",
+    );
+  });
+
+  test("fails closed for unsupported OpenBook trigger controls", () => {
+    const errors = validateOrderConfig({
+      orderType: "trigger",
+      timeInForce: "gtc",
+      lane: "safe",
+      venue: getTerminalSpotVenueDefinition("openbook"),
+      reduceOnly: false,
+      postOnly: false,
+      quantityMode: "quote",
+      amountAtomic: "1000",
+      limitPriceAtomic: null,
+      triggerPriceAtomic: "900000",
+      takeProfitPriceAtomic: null,
+      stopLossPriceAtomic: null,
+      bracketEnabled: false,
+    });
+    expect(errors).toContain(
+      "OpenBook v2 does not support TRIGGER spot orders.",
     );
   });
 

--- a/tests/unit/portal_terminal_trade_ticket_validation.test.ts
+++ b/tests/unit/portal_terminal_trade_ticket_validation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  computeQuoteReferenceDivergenceBps,
   validateExecutionQualityConfig,
   validateOrderConfig,
 } from "../../apps/portal/app/terminal/components/trade-ticket-modal";
@@ -106,5 +107,31 @@ describe("portal terminal advanced trade ticket validation", () => {
       priorityMicroLamports: 200000,
     });
     expect(errors).toHaveLength(0);
+  });
+
+  test("computes quote divergence against reference price for buys", () => {
+    const divergence = computeQuoteReferenceDivergenceBps({
+      direction: "buy",
+      quotedInputAtomic: "155000000",
+      quotedOutputAtomic: "1000000",
+      inputDecimals: 6,
+      outputDecimals: 6,
+      referencePrice: 155,
+    });
+
+    expect(divergence).toBe(0);
+  });
+
+  test("computes quote divergence against reference price for sells without inverting the quote", () => {
+    const divergence = computeQuoteReferenceDivergenceBps({
+      direction: "sell",
+      quotedInputAtomic: "1000000",
+      quotedOutputAtomic: "155000000",
+      inputDecimals: 6,
+      outputDecimals: 6,
+      referencePrice: 155,
+    });
+
+    expect(divergence).toBe(0);
   });
 });

--- a/tests/unit/portal_terminal_venues.test.ts
+++ b/tests/unit/portal_terminal_venues.test.ts
@@ -2,18 +2,31 @@ import { describe, expect, test } from "bun:test";
 import {
   formatTerminalOracleFreshness,
   getTerminalIntentFamilyLabel,
+  getTerminalOrderTypeLabel,
+  getTerminalSpotVenueDefinition,
   getTerminalVenueDefinition,
+  getTerminalVenueExecutionReadinessLabel,
   isTerminalIntentFamilyEnabled,
   isTerminalVenueEnabled,
+  listTerminalSpotVenueDefinitions,
   parseTerminalOracleStatus,
+  parseTerminalVenueKey,
   resolveTerminalVenueRolloutPolicy,
 } from "../../apps/portal/app/terminal/terminal-venues";
 
 describe("portal terminal venue substrate", () => {
   test("resolves venue registry metadata", () => {
     expect(getTerminalVenueDefinition("jupiter")?.label).toBe("Jupiter");
-    expect(getTerminalVenueDefinition("openbook_v2")?.badges).toContain("clob");
+    expect(getTerminalVenueDefinition("openbook")?.badges).toContain("clob");
     expect(getTerminalIntentFamilyLabel("prediction_order")).toBe("Prediction");
+    expect(
+      getTerminalSpotVenueDefinition("openbook")?.supportedOrderTypes,
+    ).toEqual(["market", "limit"]);
+    expect(parseTerminalVenueKey("openbook_v2")).toBe("openbook");
+    expect(getTerminalVenueExecutionReadinessLabel("shadow_paper")).toBe(
+      "Shadow / paper",
+    );
+    expect(getTerminalOrderTypeLabel("trigger")).toBe("Trigger");
   });
 
   test("parses venue and family rollout policy from profile and env", () => {
@@ -67,5 +80,26 @@ describe("portal terminal venue substrate", () => {
       source: "pyth",
       stale: false,
     });
+  });
+
+  test("lists spot venues from rollout policy and excludes gated rails by default", () => {
+    const policy = resolveTerminalVenueRolloutPolicy({
+      profile: {
+        terminal: {
+          enabledVenues: ["jupiter", "raydium", "orca", "openbook"],
+          enabledFamilies: [
+            "spot_swap",
+            "conditional_spot_order",
+            "clob_order",
+          ],
+        },
+      },
+    });
+
+    expect(
+      listTerminalSpotVenueDefinitions({ policy }).map(
+        (definition) => definition.venueKey,
+      ),
+    ).toEqual(["jupiter", "raydium", "orca", "openbook"]);
   });
 });

--- a/tests/unit/worker_terminal_open_orders_route.test.ts
+++ b/tests/unit/worker_terminal_open_orders_route.test.ts
@@ -8,6 +8,8 @@ import {
   SystemProgram,
   Transaction,
 } from "@solana/web3.js";
+import { OrcaClient } from "../../apps/worker/src/orca";
+import { RaydiumClient } from "../../apps/worker/src/raydium";
 import type { Env } from "../../apps/worker/src/types";
 import {
   createExecutionContextStub,
@@ -551,6 +553,122 @@ afterAll(() => {
 });
 
 describe("worker terminal open orders and Trigger lifecycle routes", () => {
+  test("terminal spot preview route returns bounded Raydium previews", async () => {
+    const { env, sqlite } = createExecEnv();
+    const original = RaydiumClient.prototype.quoteBaseIn;
+    RaydiumClient.prototype.quoteBaseIn = (async () => ({
+      envelope: { success: true },
+      normalizedQuote: {
+        inputMint: SOL_MINT,
+        outputMint: MAINNET_USDC_MINT,
+        inAmount: "1000000",
+        outAmount: "150000000",
+        priceImpactPct: 0.0012,
+        routePlan: [{ poolId: "ray-pool-1", swapInfo: { label: "Raydium" } }],
+        quoteProvider: "raydium",
+      },
+    })) as never;
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/terminal/spot-preview", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer mock-token",
+          },
+          body: JSON.stringify({
+            venueKey: "raydium",
+            inputMint: SOL_MINT,
+            outputMint: MAINNET_USDC_MINT,
+            amountAtomic: "1000000",
+            slippageBps: 50,
+          }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        preview?: {
+          provider?: string;
+          routeSummary?: string;
+          outAmountAtomic?: string;
+        };
+      };
+      expect(body.preview?.provider).toBe("raydium");
+      expect(body.preview?.routeSummary).toBe("Raydium");
+      expect(body.preview?.outAmountAtomic).toBe("150000000");
+    } finally {
+      RaydiumClient.prototype.quoteBaseIn = original;
+      sqlite.close();
+    }
+  });
+
+  test("terminal spot preview route returns bounded Orca previews", async () => {
+    const { env, sqlite } = createExecEnv();
+    const original = OrcaClient.prototype.quoteBaseIn;
+    OrcaClient.prototype.quoteBaseIn = (async () => ({
+      pool: { address: "orca-pool-1" },
+      sdkQuote: {
+        estimatedAmountInAtomic: "1000000",
+        estimatedAmountOutAtomic: "149500000",
+        otherAmountThresholdAtomic: "149000000",
+        estimatedFeeAmountAtomic: "1000",
+        sqrtPriceLimit: "1",
+        tickArrayAddresses: [],
+        aToB: true,
+        amountSpecifiedIsInput: true,
+      },
+      normalizedQuote: {
+        inputMint: SOL_MINT,
+        outputMint: MAINNET_USDC_MINT,
+        inAmount: "1000000",
+        outAmount: "149500000",
+        priceImpactPct: 0.0025,
+        routePlan: [
+          { poolId: "orca-pool-1", swapInfo: { label: "Orca Whirlpool" } },
+        ],
+        quoteProvider: "orca",
+      },
+    })) as never;
+    try {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/terminal/spot-preview", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer mock-token",
+          },
+          body: JSON.stringify({
+            venueKey: "orca",
+            inputMint: SOL_MINT,
+            outputMint: MAINNET_USDC_MINT,
+            amountAtomic: "1000000",
+            slippageBps: 50,
+          }),
+        }),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        preview?: {
+          provider?: string;
+          routeSummary?: string;
+          outAmountAtomic?: string;
+        };
+      };
+      expect(body.preview?.provider).toBe("orca");
+      expect(body.preview?.routeSummary).toBe("Orca Whirlpool");
+      expect(body.preview?.outAmountAtomic).toBe("149500000");
+    } finally {
+      OrcaClient.prototype.quoteBaseIn = original;
+      sqlite.close();
+    }
+  });
+
   test("status route exposes live Trigger lifecycle for conditional spot orders", async () => {
     const { env, sqlite } = createExecEnv();
     try {


### PR DESCRIPTION
## Summary
- add venue-aware terminal spot selectors, readiness labels, preview routing, and execution gating
- add bounded worker spot preview support for Raydium and Orca with route/reference telemetry
- extend the browser proof to exercise preview-only venue UX alongside the bounded Jupiter execution path

## Validation
- bun test tests/unit/portal_terminal_venues.test.ts tests/unit/portal_terminal_trade_ticket_validation.test.ts tests/unit/portal_execution_client.test.ts tests/unit/worker_terminal_open_orders_route.test.ts
- bun run typecheck
- bun run harness:proof --output-dir .tmp/browser-proof-388-final

## Notes
- Resolves #388
- Phoenix remains deferred by design.
- Non-Jupiter spot rails stay preview-only in the public terminal until broader money-state promotion is justified through the harness.
- This draft should be rebased once #369 merges so the OpenBook dependency is on main before final merge.