### PR TITLE
[Phase 2] Gate Jupiter Perps readiness as integrated-only

### DIFF
--- a/apps/worker/src/orca.ts
+++ b/apps/worker/src/orca.ts
@@ -98,6 +98,10 @@ export type OrcaSdkFacade = {
   }): Promise<OrcaBuiltSwapTransaction>;
 };
 
+async function importOrcaRuntimeModule<T>(specifier: string): Promise<T> {
+  return (await import(specifier)) as T;
+}
+
 function normalizeOrcaPath(pathname: string): string {
   return pathname.startsWith("/") ? pathname : `/${pathname}`;
 }
@@ -290,9 +294,15 @@ export function createOrcaSdkFacade(): OrcaSdkFacade {
   }) {
     const [{ BN }, { Percentage, ReadOnlyWallet }, whirlpoolSdk] =
       await Promise.all([
-        import("@coral-xyz/anchor"),
-        import("@orca-so/common-sdk"),
-        import("@orca-so/whirlpools-sdk"),
+        importOrcaRuntimeModule<typeof import("@coral-xyz/anchor")>(
+          "@coral-xyz/anchor",
+        ),
+        importOrcaRuntimeModule<typeof import("@orca-so/common-sdk")>(
+          "@orca-so/common-sdk",
+        ),
+        importOrcaRuntimeModule<typeof import("@orca-so/whirlpools-sdk")>(
+          "@orca-so/whirlpools-sdk",
+        ),
       ]);
     const { buildWhirlpoolClient, swapQuoteByInputToken, WhirlpoolContext } =
       whirlpoolSdk;

--- a/docs/strategy-lab/pilots/jupiter-perps-readiness/README.md
+++ b/docs/strategy-lab/pilots/jupiter-perps-readiness/README.md
@@ -1,0 +1,79 @@
+# Jupiter Perps Readiness Pilot
+
+This pilot records the current Jupiter Perps readiness verdict without
+pretending the venue is ready for live use.
+
+## Goal
+
+- Venue: `jupiter_perps`
+- Instrument class: `perp`
+- Highest justified state on 2026-03-13: `integrated`
+- Stop state: do not advance beyond `integrated`
+
+## Official Sources Reviewed On 2026-03-13
+
+- [About Perps API](https://dev.jup.ag/docs/perps/about-perps-api)
+  - The official docs still describe the Perps API as a work in progress.
+- [Position Account](https://dev.jup.ag/docs/perps/position-account)
+  - Documents wallet and custody derived position accounts plus long and short
+    position slots.
+- [Pool Account](https://dev.jup.ag/docs/perps/pool-account)
+  - Documents pool state, AUM, custody relationships, and fee accounting.
+- [Custody Account](https://dev.jup.ag/docs/perps/custody-account)
+  - Documents collateral and target custody accounts, pricing fields, and
+    funding or borrow style accounting inputs.
+
+## Verdict
+
+`jupiter_perps` is strong enough to model as a separate venue capability with a
+separate subject-control surface from Jupiter spot. It is not strong enough to
+claim `shadow_ready`, `paper_ready`, or any live-readiness state.
+
+The current repo changes justify `integrated` only because:
+
+- the official docs expose a concrete position-account settlement model,
+- the venue can be represented as a first-class `perp_order` venue in the
+  runtime catalog,
+- the venue now has a dedicated control key so its live posture can stay
+  blocked independently of Jupiter spot.
+
+## Why This Stops At `integrated`
+
+- The official docs still frame the API as work in progress.
+- Trader Ralph does not yet have a Jupiter Perps execution adapter.
+- The repo does not yet contain replay fixtures or adapter validation for
+  Jupiter Perps lifecycle events.
+- The repo does not yet contain paper lifecycle coverage, venue-specific cost
+  models, or oracle reconciliation for Jupiter Perps positions.
+- No bounded canary plan or allowlist change is justified while the surface is
+  still WIP and unintegrated at the adapter layer.
+
+## Follow-Up Gates
+
+- `shadow_ready`
+  - add adapter validation and deterministic replay fixtures for account,
+    order, and position reconciliation.
+- `paper_ready`
+  - add paper lifecycle coverage, venue-specific cost models, and oracle sanity
+    checks.
+- `limited_live_ready`
+  - add a bounded canary plan, explicit allowlist change, and human approval
+    after paper evidence is stable.
+
+## Harness Sequence
+
+1. Keep the venue live-disabled:
+
+```bash
+bun run strategy-lab:readiness \
+  --operation control \
+  --request-file docs/strategy-lab/pilots/jupiter-perps-readiness/control.venue.request.json
+```
+
+2. Validate the promotion verdict and venue metadata:
+
+```bash
+bun test \
+  tests/unit/runtime_research_promotion.test.ts \
+  tests/unit/runtime_venue_catalog.test.ts
+```

--- a/docs/strategy-lab/pilots/jupiter-perps-readiness/control.venue.request.json
+++ b/docs/strategy-lab/pilots/jupiter-perps-readiness/control.venue.request.json
@@ -1,0 +1,13 @@
+{
+  "subjectKind": "venue",
+  "subjectKey": "jupiter_perps",
+  "liveAllowed": false,
+  "killSwitchEnabled": false,
+  "updatedBy": "codex",
+  "metadata": {
+    "pilot": "jupiter-perps-readiness",
+    "issueNumber": 373,
+    "reviewedAt": "2026-03-13",
+    "reason": "perps-api-wip"
+  }
+}

--- a/docs/strategy-lab/pilots/jupiter-perps-readiness/promotion.request.json
+++ b/docs/strategy-lab/pilots/jupiter-perps-readiness/promotion.request.json
@@ -1,0 +1,30 @@
+{
+  "subjectKind": "venue",
+  "subjectKey": "jupiter_perps",
+  "currentState": "candidate",
+  "targetState": "integrated",
+  "requestedBy": "codex",
+  "issueNumber": 373,
+  "evidenceRefs": [
+    {
+      "kind": "metadata_draft",
+      "ref": "docs/strategy-lab/pilots/jupiter-perps-readiness/README.md"
+    },
+    {
+      "kind": "mapping_coverage",
+      "ref": "src/runtime/venues/catalog.ts"
+    }
+  ],
+  "metadata": {
+    "pilot": "jupiter-perps-readiness",
+    "reviewedAt": "2026-03-13",
+    "highestJustifiedState": "integrated",
+    "stopBefore": "shadow_ready",
+    "sourceUrls": [
+      "https://dev.jup.ag/docs/perps/about-perps-api",
+      "https://dev.jup.ag/docs/perps/position-account",
+      "https://dev.jup.ag/docs/perps/pool-account",
+      "https://dev.jup.ag/docs/perps/custody-account"
+    ]
+  }
+}

--- a/src/runtime/venues/catalog.ts
+++ b/src/runtime/venues/catalog.ts
@@ -155,6 +155,43 @@ const BUILTIN_RUNTIME_VENUE_CAPABILITIES = [
   },
   {
     schemaVersion: "v1",
+    venueKey: "jupiter_perps",
+    displayName: "Jupiter Perps",
+    adapterKeys: ["jupiter_perps"],
+    marketTypes: ["perp"],
+    orderTypes: ["market", "limit", "trigger"],
+    intentFamilies: ["perp_order"],
+    authModel: "privy_solana_wallet",
+    feeModel: "maker_taker_bps",
+    precision: {
+      priceDecimals: 6,
+      sizeDecimals: 9,
+      minOrderIncrement: "0.000001",
+      minQuoteNotionalUsd: "0.01",
+    },
+    sizeLimits: {
+      minNotionalUsd: "0.01",
+    },
+    latencyProfile: {
+      expectedQuoteMs: 250,
+      expectedSubmitMs: 700,
+      expectedSettlementMs: 4000,
+    },
+    settlementBehavior: "orderbook_partial",
+    lifecycle: {
+      supportsOrderLifecycle: true,
+      supportsPositionLifecycle: true,
+      requiresExternalOracle: true,
+      settlementModel: "position_account",
+    },
+    oracleRequirements: ["pyth", "switchboard", "venue_reference"],
+    supportedModes: ["shadow", "paper"],
+    onboardingState: "integrated",
+    notes:
+      "Dated research-gated Jupiter Perps capability kept separate from Jupiter spot. The official docs still describe the Perps API as work in progress, so live stays disabled until a later issue lands replay fixtures, paper lifecycle evidence, and venue-specific canary controls.",
+  },
+  {
+    schemaVersion: "v1",
     venueKey: "drift",
     displayName: "Drift",
     adapterKeys: ["drift", "drift_swift"],

--- a/tests/unit/runtime_research_promotion.test.ts
+++ b/tests/unit/runtime_research_promotion.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import {
   parseRuntimeAssetRecord,
   parseRuntimeDeploymentRecord,
@@ -50,6 +52,11 @@ const briefFixture = {
     },
   ],
 } as const;
+
+function readJson(path: string): unknown {
+  const absolute = resolve(import.meta.dir, "..", "..", path);
+  return JSON.parse(readFileSync(absolute, "utf8")) as unknown;
+}
 
 function buildCandidateArtifacts() {
   const synthesis = buildRuntimeResearchSynthesis({
@@ -154,6 +161,26 @@ describe("runtime research promotion", () => {
 
     expect(request.subjectKind).toBe("strategy");
     expect(request.targetState).toBe("draft");
+  });
+
+  test("passes the Jupiter Perps integrated promotion gate from the checked-in pilot artifact", () => {
+    const request = parseRuntimeResearchPromotionRequest(
+      readJson(
+        "docs/strategy-lab/pilots/jupiter-perps-readiness/promotion.request.json",
+      ),
+    );
+    const result = buildRuntimeResearchPromotion({ request });
+
+    expect(request.subjectKind).toBe("venue");
+    expect(request.subjectKey).toBe("jupiter_perps");
+    expect(request.targetState).toBe("integrated");
+    expect(result.promotion.status).toBe("pass");
+    expect(
+      result.promotion.checks.every((check) => check.status === "pass"),
+    ).toBe(true);
+    expect(result.promotion.evidenceRefs.map((ref) => ref.kind)).toEqual(
+      expect.arrayContaining(["metadata_draft", "mapping_coverage"]),
+    );
   });
 
   test("promotes candidate strategies into draft with synthesis and triage evidence", () => {

--- a/tests/unit/runtime_venue_catalog.test.ts
+++ b/tests/unit/runtime_venue_catalog.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import {
+  getRuntimeVenueCapability,
+  listRuntimeVenueCapabilities,
+  runtimeVenueSupportsIntentFamily,
+  runtimeVenueSupportsMode,
+} from "../../src/runtime/venues/catalog.js";
+
+describe("runtime venue catalog", () => {
+  test("keeps Jupiter Perps separate from Jupiter spot with bounded modes", () => {
+    const spot = getRuntimeVenueCapability("jupiter");
+    const perps = getRuntimeVenueCapability("jupiter_perps");
+
+    expect(spot).not.toBeNull();
+    expect(perps).not.toBeNull();
+    if (!perps) {
+      throw new Error("expected-jupiter-perps-capability");
+    }
+    expect(spot?.marketTypes).toEqual(["spot"]);
+    expect(perps?.marketTypes).toEqual(["perp"]);
+    expect(perps?.venueKey).toBe("jupiter_perps");
+    expect(perps?.onboardingState).toBe("integrated");
+    expect(perps?.supportedModes).toEqual(["shadow", "paper"]);
+    expect(runtimeVenueSupportsMode(perps, "paper")).toBe(true);
+    expect(runtimeVenueSupportsMode(perps, "live")).toBe(false);
+    expect(runtimeVenueSupportsIntentFamily(perps, "perp_order")).toBe(true);
+    expect(runtimeVenueSupportsIntentFamily(perps, "spot_swap")).toBe(false);
+    expect(perps?.notes).toContain("work in progress");
+    expect(
+      listRuntimeVenueCapabilities().some(
+        (capability) => capability.venueKey === "jupiter_perps",
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a separate `jupiter_perps` venue capability so perps stays distinct from Jupiter spot
- add a dated strategy-lab pilot, subject-control artifact, and promotion request that stop the venue at `integrated`
- add focused tests for the catalog split and the integrated promotion gate

## Validation
- `bun test tests/unit/runtime_venue_catalog.test.ts tests/unit/runtime_research_promotion.test.ts`
- `bun run typecheck`
- `bun run lint`

Closes #373