### PR TITLE
[Phase 2] Gate Raydium Perps readiness as candidate-only

### DIFF
--- a/docs/strategy-lab/pilots/raydium-perps-readiness/README.md
+++ b/docs/strategy-lab/pilots/raydium-perps-readiness/README.md
@@ -1,0 +1,80 @@
+# Raydium Perps Readiness Pilot
+
+This pilot records why Raydium Perps remains a separate blocked venue candidate
+instead of being treated like a normal Solana program-only adapter.
+
+## Goal
+
+- Venue: `raydium_perps`
+- Instrument class: `perp`
+- Highest justified state on 2026-03-13: `candidate`
+- Stop state: do not advance beyond `candidate`
+
+## Official Sources Reviewed On 2026-03-13
+
+- [Raydium Perps](https://docs.raydium.io/raydium/traders/raydium-perps)
+  - Documents Raydium Perps as a gasless CLOB product powered by Orderly
+    Network infrastructure and states it is not available to residents of the
+    United States of America and other prohibited jurisdictions.
+- [API Perps](https://docs.raydium.io/raydium/build/resources/apis/api-perps)
+  - Documents the public Raydium Perps API as market-data and protocol-state
+    surface only.
+- [Trading fees](https://docs.raydium.io/raydium/for-traders/raydium-perps/trading-fees)
+  - Explicitly states that Orderly infrastructure is included in the taker fee.
+- [API Authentication](https://orderly.network/docs/build-on-omnichain/evm-api/api-authentication)
+  - Documents `orderly-key`, `orderly-secret`, and `orderly-account-id`
+    requirements for private Orderly API access.
+- [Wallet Authentication](https://orderly.network/docs/build-on-omnichain/user-flows/wallet-authentication)
+  - Documents Orderly key generation and the account-linking flow needed before
+    trading APIs can be used.
+
+## Verdict
+
+`raydium_perps` is credible enough to model as a distinct venue candidate with
+a fail-closed control surface. It is not justified for `integrated` yet because
+the execution path depends on an external Orderly account and private API auth
+model that Trader Ralph does not yet represent.
+
+## Why This Stops At `candidate`
+
+- Raydium's public Perps API is read-only market data, not an order-entry
+  surface.
+- Private trading access depends on Orderly authentication headers and account
+  state that are not yet represented in Trader Ralph's execution contract.
+- The venue is explicitly unavailable to U.S. residents according to Raydium's
+  docs reviewed on 2026-03-13.
+- No checked-in adapter validation, replay fixtures, or dependency health model
+  exists for the Orderly-backed flow.
+
+## Follow-Up Gates
+
+- `integrated`
+  - encode the Orderly account, key, and signature model into a dedicated
+    adapter contract and add mapping coverage evidence.
+- `shadow_ready`
+  - add adapter validation, replay fixtures, and external dependency health or
+    rate-limit handling.
+- `paper_ready`
+  - add paper lifecycle coverage, fee or funding observations, and
+    reconciliation against the private user data stream.
+- `limited_live_ready`
+  - only after jurisdiction, operator controls, and venue-specific canary
+    posture are explicitly approved.
+
+## Harness Sequence
+
+1. Keep the venue live-disabled:
+
+```bash
+bun run strategy-lab:readiness \
+  --operation control \
+  --request-file docs/strategy-lab/pilots/raydium-perps-readiness/control.venue.request.json
+```
+
+2. Validate that the current promotion request remains blocked:
+
+```bash
+bun test \
+  tests/unit/runtime_research_promotion.test.ts \
+  tests/unit/runtime_venue_catalog.test.ts
+```

--- a/docs/strategy-lab/pilots/raydium-perps-readiness/control.venue.request.json
+++ b/docs/strategy-lab/pilots/raydium-perps-readiness/control.venue.request.json
@@ -1,0 +1,13 @@
+{
+  "subjectKind": "venue",
+  "subjectKey": "raydium_perps",
+  "liveAllowed": false,
+  "killSwitchEnabled": false,
+  "updatedBy": "codex",
+  "metadata": {
+    "pilot": "raydium-perps-readiness",
+    "issueNumber": 375,
+    "reviewedAt": "2026-03-13",
+    "reason": "orderly-auth-and-jurisdiction-gated"
+  }
+}

--- a/docs/strategy-lab/pilots/raydium-perps-readiness/promotion.request.json
+++ b/docs/strategy-lab/pilots/raydium-perps-readiness/promotion.request.json
@@ -1,0 +1,25 @@
+{
+  "subjectKind": "venue",
+  "subjectKey": "raydium_perps",
+  "currentState": "candidate",
+  "targetState": "integrated",
+  "requestedBy": "codex",
+  "issueNumber": 375,
+  "evidenceRefs": [
+    {
+      "kind": "metadata_draft",
+      "ref": "docs/strategy-lab/pilots/raydium-perps-readiness/README.md"
+    }
+  ],
+  "metadata": {
+    "pilot": "raydium-perps-readiness",
+    "reviewedAt": "2026-03-13",
+    "highestJustifiedState": "candidate",
+    "blockedOn": [
+      "orderly-private-api-auth",
+      "orderly-account-creation",
+      "jurisdiction-controls",
+      "external-dependency-health"
+    ]
+  }
+}

--- a/src/runtime/venues/catalog.ts
+++ b/src/runtime/venues/catalog.ts
@@ -118,6 +118,43 @@ const BUILTIN_RUNTIME_VENUE_CAPABILITIES = [
   },
   {
     schemaVersion: "v1",
+    venueKey: "raydium_perps",
+    displayName: "Raydium Perps",
+    adapterKeys: ["raydium_perps"],
+    marketTypes: ["perp"],
+    orderTypes: ["market", "limit", "trigger"],
+    intentFamilies: ["perp_order"],
+    authModel: "server_signer",
+    feeModel: "maker_taker_bps",
+    precision: {
+      priceDecimals: 6,
+      sizeDecimals: 9,
+      minOrderIncrement: "0.000001",
+      minQuoteNotionalUsd: "0.01",
+    },
+    sizeLimits: {
+      minNotionalUsd: "0.01",
+    },
+    latencyProfile: {
+      expectedQuoteMs: 300,
+      expectedSubmitMs: 700,
+      expectedSettlementMs: 4000,
+    },
+    settlementBehavior: "orderbook_partial",
+    lifecycle: {
+      supportsOrderLifecycle: true,
+      supportsPositionLifecycle: true,
+      requiresExternalOracle: true,
+      settlementModel: "position_account",
+    },
+    oracleRequirements: ["venue_reference"],
+    supportedModes: ["shadow"],
+    onboardingState: "candidate",
+    notes:
+      "Research-gated Raydium Perps candidate. Official Raydium docs route the product through Orderly infrastructure, expose public APIs as read-only market data, and note the venue is not available to U.S. residents as of 2026-03-13. Keep live disabled and fail closed until a later issue models private API auth, account creation, and external dependency health.",
+  },
+  {
+    schemaVersion: "v1",
     venueKey: "orca",
     displayName: "Orca Whirlpools",
     adapterKeys: ["orca"],

--- a/tests/unit/runtime_research_promotion.test.ts
+++ b/tests/unit/runtime_research_promotion.test.ts
@@ -183,6 +183,28 @@ describe("runtime research promotion", () => {
     );
   });
 
+  test("keeps the Raydium Perps integrated promotion request blocked until auth mapping exists", () => {
+    const request = parseRuntimeResearchPromotionRequest(
+      readJson(
+        "docs/strategy-lab/pilots/raydium-perps-readiness/promotion.request.json",
+      ),
+    );
+    const result = buildRuntimeResearchPromotion({ request });
+
+    expect(request.subjectKind).toBe("venue");
+    expect(request.subjectKey).toBe("raydium_perps");
+    expect(request.targetState).toBe("integrated");
+    expect(result.promotion.status).toBe("blocked");
+    expect(
+      result.promotion.checks.find(
+        (check) => check.checkId === "candidate-integrated-mappings",
+      )?.status,
+    ).toBe("blocked");
+    expect(result.promotion.evidenceRefs.map((ref) => ref.kind)).toContain(
+      "metadata_draft",
+    );
+  });
+
   test("promotes candidate strategies into draft with synthesis and triage evidence", () => {
     const { synthesis, triage } = buildCandidateArtifacts();
     const result = buildRuntimeResearchPromotion({

--- a/tests/unit/runtime_venue_catalog.test.ts
+++ b/tests/unit/runtime_venue_catalog.test.ts
@@ -16,19 +16,47 @@ describe("runtime venue catalog", () => {
     if (!perps) {
       throw new Error("expected-jupiter-perps-capability");
     }
+
     expect(spot?.marketTypes).toEqual(["spot"]);
-    expect(perps?.marketTypes).toEqual(["perp"]);
-    expect(perps?.venueKey).toBe("jupiter_perps");
-    expect(perps?.onboardingState).toBe("integrated");
-    expect(perps?.supportedModes).toEqual(["shadow", "paper"]);
+    expect(perps.marketTypes).toEqual(["perp"]);
+    expect(perps.venueKey).toBe("jupiter_perps");
+    expect(perps.onboardingState).toBe("integrated");
+    expect(perps.supportedModes).toEqual(["shadow", "paper"]);
     expect(runtimeVenueSupportsMode(perps, "paper")).toBe(true);
     expect(runtimeVenueSupportsMode(perps, "live")).toBe(false);
     expect(runtimeVenueSupportsIntentFamily(perps, "perp_order")).toBe(true);
     expect(runtimeVenueSupportsIntentFamily(perps, "spot_swap")).toBe(false);
-    expect(perps?.notes).toContain("work in progress");
+    expect(perps.notes).toContain("work in progress");
     expect(
       listRuntimeVenueCapabilities().some(
         (capability) => capability.venueKey === "jupiter_perps",
+      ),
+    ).toBe(true);
+  });
+
+  test("keeps Raydium Perps separate from Raydium spot and blocked to candidate shadow use", () => {
+    const spot = getRuntimeVenueCapability("raydium");
+    const perps = getRuntimeVenueCapability("raydium_perps");
+
+    expect(spot).not.toBeNull();
+    expect(perps).not.toBeNull();
+    if (!perps) {
+      throw new Error("expected-raydium-perps-capability");
+    }
+
+    expect(spot?.marketTypes).toEqual(["spot"]);
+    expect(perps.marketTypes).toEqual(["perp"]);
+    expect(perps.onboardingState).toBe("candidate");
+    expect(perps.supportedModes).toEqual(["shadow"]);
+    expect(runtimeVenueSupportsMode(perps, "shadow")).toBe(true);
+    expect(runtimeVenueSupportsMode(perps, "paper")).toBe(false);
+    expect(runtimeVenueSupportsIntentFamily(perps, "perp_order")).toBe(true);
+    expect(runtimeVenueSupportsIntentFamily(perps, "spot_swap")).toBe(false);
+    expect(perps.notes).toContain("Orderly");
+    expect(perps.notes).toContain("U.S. residents");
+    expect(
+      listRuntimeVenueCapabilities().some(
+        (capability) => capability.venueKey === "raydium_perps",
       ),
     ).toBe(true);
   });


### PR DESCRIPTION
## Summary
- add a separate `raydium_perps` venue capability with a candidate-only, shadow-bounded posture
- add a dated strategy-lab pilot, blocked promotion request, and live-disabled control artifact
- add focused tests proving the venue stays separate from Raydium spot and blocked at the integrated gate

## Validation
- `bun test tests/unit/runtime_venue_catalog.test.ts tests/unit/runtime_research_promotion.test.ts`
- `bun run typecheck`
- `bun run lint`

Closes #375