### PR TITLE
Add Monaco prediction-market contract verdict

### DIFF
--- a/docs/strategy-lab/pilots/monaco-readiness/README.md
+++ b/docs/strategy-lab/pilots/monaco-readiness/README.md
@@ -1,0 +1,73 @@
+# Monaco Protocol Readiness
+
+- Reviewed on: `2026-03-14`
+- Issue: `#377`
+- Venue: `monaco`
+- Instrument class: `prediction`
+- Verdict: `candidate`
+- Highest justified state: `candidate`
+- Stop before: `integrated`
+
+## Official Sources Reviewed
+
+- [Monaco Protocol main repo](https://github.com/MonacoProtocol/protocol)
+- [Monaco Protocol SDK repo](https://github.com/MonacoProtocol/sdk)
+- [Monaco client order docs](https://github.com/MonacoProtocol/protocol/blob/develop/npm-client/docs/types/order.md)
+- [Monaco client trade docs](https://github.com/MonacoProtocol/protocol/blob/develop/npm-client/docs/types/trade.md)
+- [Monaco client market-position docs](https://github.com/MonacoProtocol/protocol/blob/develop/npm-client/docs/types/market_position.md)
+
+## What The Official Material Supports
+
+The official Monaco materials are strong enough to model a real prediction-market
+adapter contract in Trader Ralph.
+
+- The active `protocol` repo publishes stable mainnet releases through `0.15.5`
+  and explicitly ships JavaScript clients alongside the on-chain program.
+- The client docs expose order creation and cancellation, trade accounts,
+  market-position queries, matching pools, market outcomes, and settlement
+  instructions.
+- The order type docs show venue-native fields that matter for Ralph:
+  `marketOutcomeIndex`, `forOutcome`, `stake`, `expectedPrice`,
+  `stakeUnmatched`, `payout`, and `orderStatus`.
+- The market-position docs show Monaco is not a swap-like venue. Positions carry
+  `outcomePositions`, `unmatchedExposures`, and `matchedRisk`, so Ralph must
+  treat position lifecycle and unmatched risk as first-class state.
+- The SDK README still documents partial matching, cancellation of unmatched
+  amounts, in-play betting delay, and settlement to the winning wallet.
+
+## Repo-Owned Contract Decision
+
+Monaco should be treated as a dedicated `prediction_order` venue with:
+
+- market discovery over markets, outcomes, matching pools, and price ladders
+- stateful order lifecycle for create, query, cancel, and unmatched-risk updates
+- stateful position lifecycle for market positions and settlement or void flows
+- a separate admin or operator path for market creation, status changes, and
+  settlement authority that remains outside the public Worker boundary
+
+That contract is strong enough for a `candidate` venue capability in Ralph.
+
+## Why It Stops At Candidate
+
+The official materials still leave integration decisions unresolved for a safe
+implementation PR.
+
+- The previously prominent `sdk` repo is archived and marked as `v1`, while the
+  maintained client surface now lives inside the active `protocol` repo.
+- The venue depends on operator-managed market lifecycle, resolution, and
+  product-commission behavior. Ralph needs an explicit boundary for those
+  privileged flows before claiming `integrated`.
+- The repo does not yet have Monaco-specific fixtures for market discovery,
+  order lifecycle, market positions, unmatched risk, settlement, and voids.
+
+## Next Implementation Slice
+
+The follow-on implementation issue should stay to one PR and do only this:
+
+1. Add a Monaco worker client targeting the maintained `protocol` npm-client
+   surface.
+2. Support read discovery for markets, outcomes, and matching pools.
+3. Add bounded `prediction_order` paper or shadow execution scaffolding for
+   create and cancel.
+4. Add reconciliation fixtures for market positions, unmatched exposure, and
+   settlement or void outcomes.

--- a/docs/strategy-lab/pilots/monaco-readiness/control.venue.request.json
+++ b/docs/strategy-lab/pilots/monaco-readiness/control.venue.request.json
@@ -1,0 +1,13 @@
+{
+  "subjectKind": "venue",
+  "subjectKey": "monaco",
+  "liveAllowed": false,
+  "killSwitchEnabled": false,
+  "updatedBy": "codex",
+  "metadata": {
+    "pilot": "monaco-readiness",
+    "issueNumber": 377,
+    "reviewedAt": "2026-03-14",
+    "reason": "archived-sdk-and-operator-lifecycle-gated"
+  }
+}

--- a/docs/strategy-lab/pilots/monaco-readiness/promotion.request.json
+++ b/docs/strategy-lab/pilots/monaco-readiness/promotion.request.json
@@ -1,0 +1,32 @@
+{
+  "subjectKind": "venue",
+  "subjectKey": "monaco",
+  "currentState": "candidate",
+  "targetState": "integrated",
+  "requestedBy": "codex",
+  "issueNumber": 377,
+  "evidenceRefs": [
+    {
+      "kind": "metadata_draft",
+      "ref": "docs/strategy-lab/pilots/monaco-readiness/README.md"
+    }
+  ],
+  "metadata": {
+    "pilot": "monaco-readiness",
+    "reviewedAt": "2026-03-14",
+    "highestJustifiedState": "candidate",
+    "blockedOn": [
+      "maintained-client-selection",
+      "operator-market-lifecycle-boundary",
+      "settlement-and-void-fixtures",
+      "commission-reconciliation"
+    ],
+    "sourceUrls": [
+      "https://github.com/MonacoProtocol/protocol",
+      "https://github.com/MonacoProtocol/sdk",
+      "https://github.com/MonacoProtocol/protocol/blob/develop/npm-client/docs/types/order.md",
+      "https://github.com/MonacoProtocol/protocol/blob/develop/npm-client/docs/types/trade.md",
+      "https://github.com/MonacoProtocol/protocol/blob/develop/npm-client/docs/types/market_position.md"
+    ]
+  }
+}

--- a/src/runtime/venues/catalog.ts
+++ b/src/runtime/venues/catalog.ts
@@ -266,6 +266,43 @@ const BUILTIN_RUNTIME_VENUE_CAPABILITIES = [
   },
   {
     schemaVersion: "v1",
+    venueKey: "monaco",
+    displayName: "Monaco Protocol",
+    adapterKeys: ["monaco"],
+    marketTypes: ["prediction"],
+    orderTypes: ["market", "limit"],
+    intentFamilies: ["prediction_order"],
+    authModel: "privy_solana_wallet",
+    feeModel: "maker_taker_bps",
+    precision: {
+      priceDecimals: 4,
+      sizeDecimals: 6,
+      minOrderIncrement: "0.000001",
+      minQuoteNotionalUsd: "0.01",
+    },
+    sizeLimits: {
+      minNotionalUsd: "0.01",
+    },
+    latencyProfile: {
+      expectedQuoteMs: 250,
+      expectedSubmitMs: 600,
+      expectedSettlementMs: 5000,
+    },
+    settlementBehavior: "orderbook_partial",
+    lifecycle: {
+      supportsOrderLifecycle: true,
+      supportsPositionLifecycle: true,
+      requiresExternalOracle: false,
+      settlementModel: "position_account",
+    },
+    oracleRequirements: ["none"],
+    supportedModes: ["shadow"],
+    onboardingState: "candidate",
+    notes:
+      "Monaco has an active protocol repo with order, trade, matching-pool, and market-position client docs, but the previously prominent SDK repo is archived and the venue still depends on operator-managed market lifecycle and settlement flows. Keep it candidate-only until a later issue locks the maintained client path, operator authority model, and reconciliation fixtures.",
+  },
+  {
+    schemaVersion: "v1",
     venueKey: "phoenix",
     displayName: "Phoenix",
     adapterKeys: ["phoenix_orderbook"],

--- a/tests/unit/runtime_research_promotion.test.ts
+++ b/tests/unit/runtime_research_promotion.test.ts
@@ -205,6 +205,28 @@ describe("runtime research promotion", () => {
     );
   });
 
+  test("keeps the Monaco integrated promotion request blocked until the maintained client path is fixed", () => {
+    const request = parseRuntimeResearchPromotionRequest(
+      readJson(
+        "docs/strategy-lab/pilots/monaco-readiness/promotion.request.json",
+      ),
+    );
+    const result = buildRuntimeResearchPromotion({ request });
+
+    expect(request.subjectKind).toBe("venue");
+    expect(request.subjectKey).toBe("monaco");
+    expect(request.targetState).toBe("integrated");
+    expect(result.promotion.status).toBe("blocked");
+    expect(
+      result.promotion.checks.find(
+        (check) => check.checkId === "candidate-integrated-mappings",
+      )?.status,
+    ).toBe("blocked");
+    expect(result.promotion.evidenceRefs.map((ref) => ref.kind)).toContain(
+      "metadata_draft",
+    );
+  });
+
   test("promotes candidate strategies into draft with synthesis and triage evidence", () => {
     const { synthesis, triage } = buildCandidateArtifacts();
     const result = buildRuntimeResearchPromotion({

--- a/tests/unit/runtime_venue_catalog.test.ts
+++ b/tests/unit/runtime_venue_catalog.test.ts
@@ -60,4 +60,31 @@ describe("runtime venue catalog", () => {
       ),
     ).toBe(true);
   });
+
+  test("adds Monaco as a candidate prediction-market venue with order and position lifecycle", () => {
+    const venue = getRuntimeVenueCapability("monaco");
+
+    expect(venue).not.toBeNull();
+    if (!venue) {
+      throw new Error("expected-monaco-capability");
+    }
+
+    expect(venue.marketTypes).toEqual(["prediction"]);
+    expect(venue.intentFamilies).toEqual(["prediction_order"]);
+    expect(venue.onboardingState).toBe("candidate");
+    expect(venue.supportedModes).toEqual(["shadow"]);
+    expect(runtimeVenueSupportsMode(venue, "shadow")).toBe(true);
+    expect(runtimeVenueSupportsMode(venue, "paper")).toBe(false);
+    expect(runtimeVenueSupportsIntentFamily(venue, "prediction_order")).toBe(
+      true,
+    );
+    expect(runtimeVenueSupportsIntentFamily(venue, "perp_order")).toBe(false);
+    expect(venue.notes).toContain("archived");
+    expect(venue.notes).toContain("market lifecycle");
+    expect(
+      listRuntimeVenueCapabilities().some(
+        (capability) => capability.venueKey === "monaco",
+      ),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary\n- add a candidate Monaco venue capability for prediction-market contracts\n- add strategy-lab pilot artifacts with a dated official-source readiness verdict\n- cover the candidate verdict with venue catalog and promotion tests\n\n## Testing\n- bun test tests/unit/runtime_venue_catalog.test.ts tests/unit/runtime_research_promotion.test.ts\n- bun run typecheck\n- bun run lint\n\nCloses #377