### PR TITLE
Add Drift BET contract verdict

### DIFF
--- a/docs/strategy-lab/pilots/drift-bet-readiness/README.md
+++ b/docs/strategy-lab/pilots/drift-bet-readiness/README.md
@@ -1,0 +1,69 @@
+# Drift BET Readiness
+
+- Reviewed on: `2026-03-14`
+- Issue: `#378`
+- Venue: `drift_bet`
+- Instrument class: `prediction`
+- Verdict: `candidate`
+- Highest justified state: `candidate`
+- Stop before: `integrated`
+
+## Official Sources Reviewed
+
+- [Drift update: raising the stakes with BET](https://www.drift.trade/updates)
+- [Drift v2 teacher prediction-market docs](https://github.com/drift-labs/v2-teacher/blob/master/source/includes/_prediction_markets.md)
+- [Drift common prediction-market constants](https://github.com/drift-labs/drift-common/blob/master/common-ts/src/constants/predictionMarket.ts)
+- [Drift protocol v2 repo](https://github.com/drift-labs/protocol-v2)
+
+## What The Official Material Supports
+
+The official Drift materials are strong enough to conclude that BET is a
+prediction-market extension of the Drift venue family, not a brand-new custody
+or margin venue.
+
+- Drift's own prediction-market docs state that prediction markets are perp
+  markets with `contract_type` set as `Prediction`.
+- The same docs say the instrument follows the perp account model with extra
+  rules: prices stay between `0` and `1`, funding is paused, margin ratios are
+  pinned to `1`, short valuation uses `1 - oracle price`, and the oracle is a
+  prelaunch-style mark TWAP.
+- The official `drift-common` repo exports prediction-market constants derived
+  from `@drift-labs/sdk`, which shows the SDK surface already models the
+  instrument type at the code level.
+
+## Repo-Owned Contract Decision
+
+Drift BET should be modeled as:
+
+- a separate `prediction_order` venue capability in Ralph
+- a follow-on of the Drift adapter family rather than a new venue stack
+- shared custody, account, and margin semantics with Drift perps
+- prediction-specific risk and validation rules layered on top of the Drift
+  account model
+
+That means BET should not be forced into `perp_order`, even though it shares
+the same account substrate.
+
+## Why It Stops At Candidate
+
+The official developer surface is still too fragmented to justify an
+implementation PR right now.
+
+- The explicit prediction-market docs are discoverable through the older
+  `v2-teacher` repo, not through the main `docs.drift.trade` developer flow.
+- The repo does not yet have maintained examples for BET market discovery,
+  order placement, cancellation, settlement, or replay fixtures.
+- Ralph still needs a venue-specific mapping for prediction-market settlement
+  and outcome resolution within the Worker-owned reconciliation layer.
+
+## Next Implementation Slice
+
+The follow-on implementation issue should stay to one PR and do only this:
+
+1. Add Drift prediction-market discovery and instrument metadata reads.
+2. Reuse the Drift account client path while routing BET through
+   `prediction_order` intent handling.
+3. Add bounded shadow fixtures for order lifecycle, position lifecycle, and
+   prediction settlement.
+4. Add oracle and price-band guards for `0..1` pricing plus fully collateralized
+   margin checks.

--- a/docs/strategy-lab/pilots/drift-bet-readiness/control.venue.request.json
+++ b/docs/strategy-lab/pilots/drift-bet-readiness/control.venue.request.json
@@ -1,0 +1,13 @@
+{
+  "subjectKind": "venue",
+  "subjectKey": "drift_bet",
+  "liveAllowed": false,
+  "killSwitchEnabled": false,
+  "updatedBy": "codex",
+  "metadata": {
+    "pilot": "drift-bet-readiness",
+    "issueNumber": 378,
+    "reviewedAt": "2026-03-14",
+    "reason": "prediction-market-docs-surface-gated"
+  }
+}

--- a/docs/strategy-lab/pilots/drift-bet-readiness/promotion.request.json
+++ b/docs/strategy-lab/pilots/drift-bet-readiness/promotion.request.json
@@ -1,0 +1,31 @@
+{
+  "subjectKind": "venue",
+  "subjectKey": "drift_bet",
+  "currentState": "candidate",
+  "targetState": "integrated",
+  "requestedBy": "codex",
+  "issueNumber": 378,
+  "evidenceRefs": [
+    {
+      "kind": "metadata_draft",
+      "ref": "docs/strategy-lab/pilots/drift-bet-readiness/README.md"
+    }
+  ],
+  "metadata": {
+    "pilot": "drift-bet-readiness",
+    "reviewedAt": "2026-03-14",
+    "highestJustifiedState": "candidate",
+    "blockedOn": [
+      "main-docs-developer-surface",
+      "market-discovery-fixtures",
+      "prediction-settlement-reconciliation",
+      "maintained-order-examples"
+    ],
+    "sourceUrls": [
+      "https://www.drift.trade/updates",
+      "https://github.com/drift-labs/v2-teacher/blob/master/source/includes/_prediction_markets.md",
+      "https://github.com/drift-labs/drift-common/blob/master/common-ts/src/constants/predictionMarket.ts",
+      "https://github.com/drift-labs/protocol-v2"
+    ]
+  }
+}

--- a/src/runtime/venues/catalog.ts
+++ b/src/runtime/venues/catalog.ts
@@ -303,6 +303,43 @@ const BUILTIN_RUNTIME_VENUE_CAPABILITIES = [
   },
   {
     schemaVersion: "v1",
+    venueKey: "drift_bet",
+    displayName: "Drift BET",
+    adapterKeys: ["drift_prediction"],
+    marketTypes: ["prediction"],
+    orderTypes: ["market", "limit"],
+    intentFamilies: ["prediction_order"],
+    authModel: "privy_solana_wallet",
+    feeModel: "maker_taker_bps",
+    precision: {
+      priceDecimals: 6,
+      sizeDecimals: 9,
+      minOrderIncrement: "0.000001",
+      minQuoteNotionalUsd: "0.01",
+    },
+    sizeLimits: {
+      minNotionalUsd: "0.01",
+    },
+    latencyProfile: {
+      expectedQuoteMs: 250,
+      expectedSubmitMs: 650,
+      expectedSettlementMs: 5000,
+    },
+    settlementBehavior: "orderbook_partial",
+    lifecycle: {
+      supportsOrderLifecycle: true,
+      supportsPositionLifecycle: true,
+      requiresExternalOracle: true,
+      settlementModel: "position_account",
+    },
+    oracleRequirements: ["pyth", "venue_reference"],
+    supportedModes: ["shadow"],
+    onboardingState: "candidate",
+    notes:
+      "Drift BET is a Drift-family prediction market rather than a separate custody venue. Official Drift materials describe prediction markets as perp markets with `contract_type=Prediction`, fully collateralized margin, and prelaunch-oracle valuation, but the current developer surface is still fragmented across older docs repos instead of the main docs site. Keep it candidate-only until a later issue lands maintained discovery, order, and settlement fixtures.",
+  },
+  {
+    schemaVersion: "v1",
     venueKey: "monaco",
     displayName: "Monaco Protocol",
     adapterKeys: ["monaco"],

--- a/tests/unit/runtime_research_promotion.test.ts
+++ b/tests/unit/runtime_research_promotion.test.ts
@@ -205,6 +205,28 @@ describe("runtime research promotion", () => {
     );
   });
 
+  test("keeps the Drift BET integrated promotion request blocked until the maintained developer surface stabilizes", () => {
+    const request = parseRuntimeResearchPromotionRequest(
+      readJson(
+        "docs/strategy-lab/pilots/drift-bet-readiness/promotion.request.json",
+      ),
+    );
+    const result = buildRuntimeResearchPromotion({ request });
+
+    expect(request.subjectKind).toBe("venue");
+    expect(request.subjectKey).toBe("drift_bet");
+    expect(request.targetState).toBe("integrated");
+    expect(result.promotion.status).toBe("blocked");
+    expect(
+      result.promotion.checks.find(
+        (check) => check.checkId === "candidate-integrated-mappings",
+      )?.status,
+    ).toBe("blocked");
+    expect(result.promotion.evidenceRefs.map((ref) => ref.kind)).toContain(
+      "metadata_draft",
+    );
+  });
+
   test("keeps the Monaco integrated promotion request blocked until the maintained client path is fixed", () => {
     const request = parseRuntimeResearchPromotionRequest(
       readJson(

--- a/tests/unit/runtime_venue_catalog.test.ts
+++ b/tests/unit/runtime_venue_catalog.test.ts
@@ -61,6 +61,33 @@ describe("runtime venue catalog", () => {
     ).toBe(true);
   });
 
+  test("adds Drift BET as a candidate prediction-market follow-on of Drift", () => {
+    const venue = getRuntimeVenueCapability("drift_bet");
+
+    expect(venue).not.toBeNull();
+    if (!venue) {
+      throw new Error("expected-drift-bet-capability");
+    }
+
+    expect(venue.marketTypes).toEqual(["prediction"]);
+    expect(venue.intentFamilies).toEqual(["prediction_order"]);
+    expect(venue.onboardingState).toBe("candidate");
+    expect(venue.supportedModes).toEqual(["shadow"]);
+    expect(runtimeVenueSupportsMode(venue, "shadow")).toBe(true);
+    expect(runtimeVenueSupportsMode(venue, "paper")).toBe(false);
+    expect(runtimeVenueSupportsIntentFamily(venue, "prediction_order")).toBe(
+      true,
+    );
+    expect(runtimeVenueSupportsIntentFamily(venue, "perp_order")).toBe(false);
+    expect(venue.notes).toContain("contract_type=Prediction");
+    expect(venue.notes).toContain("main docs site");
+    expect(
+      listRuntimeVenueCapabilities().some(
+        (capability) => capability.venueKey === "drift_bet",
+      ),
+    ).toBe(true);
+  });
+
   test("adds Monaco as a candidate prediction-market venue with order and position lifecycle", () => {
     const venue = getRuntimeVenueCapability("monaco");
 


### PR DESCRIPTION
## Summary\n- add a candidate Drift BET venue capability as a prediction-market follow-on of Drift\n- add strategy-lab pilot artifacts with a dated official-source verdict and blockers\n- cover the candidate verdict with venue catalog and promotion tests\n\n## Testing\n- bun test tests/unit/runtime_venue_catalog.test.ts tests/unit/runtime_research_promotion.test.ts\n- bun run typecheck\n- bun run lint\n\nCloses #378