### PR TITLE
Add operator readiness surfaces for terminal rollout

### DIFF
--- a/apps/portal/app/api/runtime/operator/route.ts
+++ b/apps/portal/app/api/runtime/operator/route.ts
@@ -235,6 +235,7 @@ function normalizeRuntimeSnapshot(payload: Record<string, unknown>) {
     source: readString(runtime.source) ?? "worker",
     integration: isRecord(runtime.integration) ? runtime.integration : {},
     health: isRecord(runtime.health) ? runtime.health : null,
+    routes: isRecord(runtime.routes) ? runtime.routes : null,
     deployments: parseDeployments(runtime.deployments),
     controls: normalizeControls(runtime.controls),
     canary: isRecord(runtime.canary) ? runtime.canary : null,

--- a/apps/portal/app/proof/runtime/page.tsx
+++ b/apps/portal/app/proof/runtime/page.tsx
@@ -102,6 +102,11 @@ function buildPayload(selectedDeploymentId: string): RuntimeOperatorApiPayload {
           maxFeatureAgeMs: 2600,
         },
       },
+      routes: {
+        health: "/api/internal/runtime/health",
+        deployments: "/api/internal/runtime/deployments",
+        research: "/api/internal/runtime/research",
+      },
       deployments: [...DEPLOYMENTS],
       controls: {
         enabled: true,

--- a/apps/portal/app/terminal/runtime/runtime-operator-view.tsx
+++ b/apps/portal/app/terminal/runtime/runtime-operator-view.tsx
@@ -2,6 +2,15 @@
 
 import Link from "next/link";
 import { BTN_PRIMARY, BTN_SECONDARY, formatTick } from "../../lib";
+import {
+  getTerminalIntentFamilyLabel,
+  getTerminalVenueDefinition,
+  getTerminalVenueExecutionReadinessLabel,
+  isTerminalVenueEnabled,
+  resolveTerminalVenueRolloutPolicy,
+  TERMINAL_INTENT_FAMILIES,
+  TERMINAL_VENUE_KEYS,
+} from "../terminal-venues";
 import type {
   RuntimeControlAction,
   RuntimeOperatorApiPayload,
@@ -149,6 +158,317 @@ function renderCanarySummary(snapshot: RuntimeOperatorSnapshot | null) {
         "Reconciliation",
         readString(latestRun.reconciliationStatus) ?? "n/a",
       )}
+    </div>
+  );
+}
+
+function renderInfrastructureReadiness(
+  snapshot: RuntimeOperatorSnapshot | null,
+) {
+  const integration = isRecord(snapshot?.integration)
+    ? snapshot.integration
+    : {};
+  const health = isRecord(snapshot?.health) ? snapshot.health : {};
+  const routes = isRecord(snapshot?.routes) ? snapshot.routes : {};
+  const routeEntries = Object.entries(routes);
+  const feedGateway = isRecord(health.feedGateway) ? health.feedGateway : {};
+  const featureCache = isRecord(health.featureCache) ? health.featureCache : {};
+  const oracleRegistry = isRecord(health.oracleRegistry)
+    ? health.oracleRegistry
+    : {};
+  const strategyRegistry = isRecord(health.strategyRegistry)
+    ? health.strategyRegistry
+    : {};
+  const researchRegistry = isRecord(health.researchRegistry)
+    ? health.researchRegistry
+    : {};
+  const cards = [
+    {
+      key: "feed-gateway",
+      label: "Feed gateway",
+      status: readString(feedGateway.status) ?? "unknown",
+      detail: `${readString(feedGateway.maxMarketAgeMs) ?? String(feedGateway.maxMarketAgeMs ?? "n/a")} ms max market age`,
+    },
+    {
+      key: "feature-cache",
+      label: "Feature cache",
+      status: readString(featureCache.status) ?? "unknown",
+      detail: `${readString(featureCache.maxFeatureAgeMs) ?? String(featureCache.maxFeatureAgeMs ?? "n/a")} ms max feature age`,
+    },
+    {
+      key: "oracle-registry",
+      label: "Oracle registry",
+      status: readString(oracleRegistry.status) ?? "unknown",
+      detail: `${readString(oracleRegistry.staleInstrumentCount) ?? String(oracleRegistry.staleInstrumentCount ?? "0")} stale instruments`,
+    },
+    {
+      key: "strategy-registry",
+      label: "Strategy registry",
+      status: readString(strategyRegistry.status) ?? "unknown",
+      detail: `${readString(strategyRegistry.deploymentCount) ?? String(strategyRegistry.deploymentCount ?? "0")} deployments`,
+    },
+    {
+      key: "research-registry",
+      label: "Research registry",
+      status: readString(researchRegistry.status) ?? "unknown",
+      detail: `${readString(researchRegistry.experimentCount) ?? String(researchRegistry.experimentCount ?? "0")} experiments`,
+    },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {summaryItem(
+          "Runtime service",
+          readString(integration.serviceName) ?? "runtime-rs",
+        )}
+        {summaryItem(
+          "Runtime base",
+          readString(integration.runtimeBaseUrl) ?? "not configured",
+        )}
+        {summaryItem(
+          "Stub mode",
+          readBoolean(integration.stubModeEnabled, false) ? "enabled" : "off",
+        )}
+        {summaryItem("Route inventory", String(routeEntries.length))}
+      </div>
+      <div className="grid gap-3 xl:grid-cols-5">
+        {cards.map((card) => (
+          <article
+            key={card.key}
+            className="rounded border border-border bg-surface/80 p-3"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                {card.label}
+              </p>
+              {renderBadge(card.status)}
+            </div>
+            <p className="mt-3 text-sm text-muted">{card.detail}</p>
+          </article>
+        ))}
+      </div>
+      <div className="rounded border border-border bg-surface/70 p-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+              Route availability
+            </p>
+            <p className="mt-2 text-sm text-muted">
+              Runtime health and deployment routes currently advertised by the
+              worker bridge.
+            </p>
+          </div>
+          {renderBadge(
+            routeEntries.length > 0 ? "healthy" : "blocked",
+            routeEntries.length > 0 ? "available" : "missing",
+          )}
+        </div>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {routeEntries.length > 0 ? (
+            routeEntries.map(([routeKey, routeValue]) => (
+              <span
+                key={routeKey}
+                className="rounded border border-border px-2 py-1 text-[10px] uppercase tracking-[0.24em] text-muted"
+              >
+                {routeKey}: {String(routeValue)}
+              </span>
+            ))
+          ) : (
+            <p className="text-sm text-muted">No runtime routes advertised.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function renderTerminalRollout(detail: RuntimeOperatorDetail | null) {
+  const rolloutPolicy = resolveTerminalVenueRolloutPolicy();
+  const selectedVenueKey = readString(detail?.deployment?.venueKey);
+  const readinessVenue = detail?.lab?.readiness?.venue ?? null;
+  const readinessArtifacts = readRecordArray(readinessVenue?.artifacts);
+  const readinessCanaries = readRecordArray(readinessVenue?.canaryRuns);
+  const latestVenueArtifact = readinessArtifacts[0] ?? null;
+  const latestVenueCanary = readinessCanaries[0] ?? null;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {summaryItem(
+          "Enabled venues",
+          String(rolloutPolicy.enabledVenues.length),
+        )}
+        {summaryItem(
+          "Enabled families",
+          String(rolloutPolicy.enabledFamilies.length),
+        )}
+        {summaryItem("Selected venue", selectedVenueKey ?? "n/a")}
+        {summaryItem(
+          "Selected canary",
+          readString(latestVenueCanary?.status) ??
+            readString(latestVenueArtifact?.status) ??
+            "n/a",
+        )}
+      </div>
+      <div className="grid gap-3 xl:grid-cols-2">
+        {TERMINAL_VENUE_KEYS.map((venueKey) => {
+          const definition = getTerminalVenueDefinition(venueKey);
+          if (!definition) return null;
+          const rolloutEnabled = isTerminalVenueEnabled(venueKey);
+          const enabledFamilies = definition.families.filter((family) =>
+            rolloutPolicy.enabledFamilies.includes(family),
+          );
+          const selected = venueKey === selectedVenueKey;
+          return (
+            <article
+              key={venueKey}
+              className={`rounded border p-4 ${
+                selected
+                  ? "border-ink bg-surface"
+                  : "border-border bg-surface/80"
+              }`}
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                    {definition.executionPathLabel}
+                  </p>
+                  <h3 className="mt-2 text-sm font-medium text-ink">
+                    {definition.label}
+                  </h3>
+                </div>
+                {renderBadge(
+                  rolloutEnabled ? "healthy" : "blocked",
+                  rolloutEnabled ? "rollout enabled" : "rollout gated",
+                )}
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {renderBadge(
+                  definition.executionReadiness,
+                  getTerminalVenueExecutionReadinessLabel(
+                    definition.executionReadiness,
+                  ),
+                )}
+                {selected && latestVenueCanary
+                  ? renderBadge(
+                      readString(latestVenueCanary.status) ?? "pending",
+                      "selected canary",
+                    )
+                  : null}
+              </div>
+              <p className="mt-3 text-sm text-muted">
+                Families in rollout:{" "}
+                {enabledFamilies.length > 0
+                  ? enabledFamilies
+                      .map((family) => getTerminalIntentFamilyLabel(family))
+                      .filter(Boolean)
+                      .join(", ")
+                  : "none enabled"}
+              </p>
+            </article>
+          );
+        })}
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        {TERMINAL_INTENT_FAMILIES.map((family) => {
+          const label = getTerminalIntentFamilyLabel(family) ?? family;
+          const enabled = rolloutPolicy.enabledFamilies.includes(family);
+          const supportedVenueCount = TERMINAL_VENUE_KEYS.filter((venueKey) => {
+            const definition = getTerminalVenueDefinition(venueKey);
+            return Boolean(definition?.families.includes(family));
+          }).length;
+          return (
+            <article
+              key={family}
+              className="rounded border border-border bg-surface/80 p-4"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-sm font-medium text-ink">{label}</p>
+                {renderBadge(
+                  enabled ? "healthy" : "blocked",
+                  enabled ? "enabled" : "gated",
+                )}
+              </div>
+              <p className="mt-3 text-sm text-muted">
+                {supportedVenueCount} venue rail
+                {supportedVenueCount === 1 ? "" : "s"} support this family.
+              </p>
+            </article>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function renderProofSurfaces(detail: RuntimeOperatorDetail | null) {
+  const readiness = detail?.lab?.readiness ?? null;
+  const subjects = [readiness?.venue, readiness?.asset].filter(
+    (entry): entry is NonNullable<typeof entry> => entry !== null,
+  );
+
+  return (
+    <div className="grid gap-4 xl:grid-cols-[0.9fr_1.1fr]">
+      <div className="rounded border border-border bg-surface/80 p-4">
+        <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+          Proof surfaces
+        </p>
+        <p className="mt-2 text-sm text-muted">
+          Open deterministic browser and runtime proof surfaces directly from
+          the operator page.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <Link className={BTN_PRIMARY} href="/proof/runtime">
+            Runtime proof
+          </Link>
+          <Link className={BTN_SECONDARY} href="/proof/browser">
+            Browser proof
+          </Link>
+        </div>
+      </div>
+      <div className="rounded border border-border bg-surface/80 p-4">
+        <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+          Readiness artifacts
+        </p>
+        <div className="mt-3 space-y-3">
+          {subjects.length > 0 ? (
+            subjects.map((subject) => {
+              const artifact = readRecordArray(subject.artifacts)[0] ?? null;
+              const canary = readRecordArray(subject.canaryRuns)[0] ?? null;
+              const label =
+                readString(subject.subjectKind) === "asset" ? "Asset" : "Venue";
+              return (
+                <div
+                  key={`${readString(subject.subjectKind)}:${readString(subject.subjectKey)}`}
+                  className="rounded border border-border bg-paper/70 p-3"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="text-sm font-medium text-ink">
+                      {label}: {readString(subject.subjectKey) ?? "unknown"}
+                    </p>
+                    {renderBadge(
+                      readString(artifact?.status) ??
+                        readString(canary?.status) ??
+                        "candidate",
+                    )}
+                  </div>
+                  <div className="mt-3 grid gap-2 text-sm text-muted">
+                    <p>
+                      readiness id: {readString(artifact?.readinessId) ?? "n/a"}
+                    </p>
+                    <p>canary id: {readString(canary?.runId) ?? "n/a"}</p>
+                  </div>
+                </div>
+              );
+            })
+          ) : (
+            <p className="text-sm text-muted">
+              No readiness artifacts are attached to the selected deployment.
+            </p>
+          )}
+        </div>
+      </div>
     </div>
   );
 }
@@ -1223,6 +1543,39 @@ export function RuntimeOperatorView({
         <div className="space-y-6">
           <section className="card p-4">{renderHealthSummary(runtime)}</section>
           <section className="card p-4">{renderCanarySummary(runtime)}</section>
+          <section className="card p-5">
+            <div className="mb-4">
+              <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                Infrastructure readiness
+              </p>
+              <h2 className="mt-2 text-lg font-semibold text-ink">
+                Feed, oracle, registry, and route health
+              </h2>
+            </div>
+            {renderInfrastructureReadiness(runtime)}
+          </section>
+          <section className="card p-5">
+            <div className="mb-4">
+              <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                Terminal rollout
+              </p>
+              <h2 className="mt-2 text-lg font-semibold text-ink">
+                Venue and family exposure tied to rollout state
+              </h2>
+            </div>
+            {renderTerminalRollout(detail)}
+          </section>
+          <section className="card p-5">
+            <div className="mb-4">
+              <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                Proof and readiness
+              </p>
+              <h2 className="mt-2 text-lg font-semibold text-ink">
+                Proof surfaces and latest readiness artifacts
+              </h2>
+            </div>
+            {renderProofSurfaces(detail)}
+          </section>
           <section className="card p-5">
             <div className="mb-4">
               <p className="text-[10px] uppercase tracking-[0.28em] text-muted">

--- a/apps/portal/app/terminal/runtime/types.ts
+++ b/apps/portal/app/terminal/runtime/types.ts
@@ -37,6 +37,7 @@ export type RuntimeOperatorSnapshot = {
   source: string;
   integration: Record<string, unknown>;
   health: Record<string, unknown> | null;
+  routes: Record<string, unknown> | null;
   deployments: RuntimeDeploymentRecord[];
   controls: RuntimeOperatorControls;
   canary: Record<string, unknown> | null;

--- a/apps/worker/src/runtime_internal.ts
+++ b/apps/worker/src/runtime_internal.ts
@@ -94,6 +94,7 @@ export type RuntimeAdminSnapshot = {
     serviceName: string;
   };
   health: Record<string, unknown> | null;
+  routes: Record<string, unknown> | null;
   deployments: RuntimeDeploymentRecord[];
   leaderboard: Record<string, unknown> | null;
   error: string | null;
@@ -2086,6 +2087,7 @@ export async function readRuntimeAdminSnapshot(
       source: "worker",
       integration,
       health: null,
+      routes: null,
       deployments: [],
       leaderboard: null,
       error: runtimeErrorFromPayload(
@@ -2100,6 +2102,9 @@ export async function readRuntimeAdminSnapshot(
     : integration.stubModeEnabled
       ? createRuntimeHealthFixture()
       : null;
+  const routes = isRecord(healthResult.payload.routes)
+    ? healthResult.payload.routes
+    : null;
   const source =
     readStringOrNull(healthResult.payload.source) ??
     (integration.stubModeEnabled ? "stub" : "runtime-rs");
@@ -2115,6 +2120,7 @@ export async function readRuntimeAdminSnapshot(
       source,
       integration,
       health,
+      routes,
       deployments: [],
       leaderboard: isRecord(leaderboardResult.payload.leaderboard)
         ? leaderboardResult.payload.leaderboard
@@ -2133,6 +2139,7 @@ export async function readRuntimeAdminSnapshot(
     source: readStringOrNull(deploymentsResult.payload.source) ?? source,
     integration,
     health,
+    routes,
     deployments: parseRuntimeDeploymentList(
       deploymentsResult.payload.deployments,
     ),

--- a/tests/unit/portal_runtime_operator_route.test.ts
+++ b/tests/unit/portal_runtime_operator_route.test.ts
@@ -229,6 +229,10 @@ describe("portal runtime operator route", () => {
               health: {
                 status: "healthy",
               },
+              routes: {
+                health: "/api/internal/runtime/health",
+                deployments: "/api/internal/runtime/deployments",
+              },
               deployments: [runtimeDeploymentFixture()],
               controls: {
                 enabled: true,
@@ -473,6 +477,10 @@ describe("portal runtime operator route", () => {
       selectedDeploymentId: "runtime_canary_live_dca",
       runtime: {
         ok: true,
+        routes: {
+          health: "/api/internal/runtime/health",
+          deployments: "/api/internal/runtime/deployments",
+        },
         deployments: [
           {
             deploymentId: "runtime_canary_live_dca",

--- a/tests/unit/worker_ops_controls_route.test.ts
+++ b/tests/unit/worker_ops_controls_route.test.ts
@@ -287,6 +287,9 @@ describe("worker ops controls routes", () => {
               maxFeatureAgeMs: expect.any(Number),
             },
           },
+          routes: {
+            health: "/api/internal/runtime/health",
+          },
           deployments: [
             {
               deploymentId: "deployment_shadow_fixture",


### PR DESCRIPTION
## Summary
- carry runtime route inventory through the admin snapshot and portal operator route
- add infrastructure, rollout, and proof/readiness sections to the runtime operator UI
- extend route coverage for the operator snapshot and runtime admin dashboard

## Testing
- bun run lint
- bun test tests/unit/portal_runtime_operator_route.test.ts tests/unit/worker_ops_controls_route.test.ts
- bun run typecheck

Closes #391