### PR TITLE
Add venue readiness matrix and canary templates (#380)

### DIFF
--- a/apps/portal/app/api/runtime/operator/route.ts
+++ b/apps/portal/app/api/runtime/operator/route.ts
@@ -7,6 +7,10 @@ import {
   safeParseRuntimeLedgerSnapshot,
   safeParseRuntimeRunRecord,
 } from "../../../../lib/runtime-contracts";
+import {
+  listRuntimeVenueProgramMatrix,
+  RUNTIME_VENUE_PROGRAM_NEXT_ISSUES,
+} from "../../../terminal/runtime/program-matrix";
 
 const LOCAL_EDGE_API_BASE = "http://127.0.0.1:8888";
 const BEARER_RE = /^bearer\s+/i;
@@ -603,6 +607,10 @@ export async function GET(request: Request) {
   return NextResponse.json({
     ok: true,
     runtime,
+    program: {
+      matrix: listRuntimeVenueProgramMatrix(),
+      nextIssueOrder: [...RUNTIME_VENUE_PROGRAM_NEXT_ISSUES],
+    },
     selectedDeploymentId,
     detail,
     detailError,

--- a/apps/portal/app/proof/runtime/page.tsx
+++ b/apps/portal/app/proof/runtime/page.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { useState } from "react";
+import {
+  listRuntimeVenueProgramMatrix,
+  RUNTIME_VENUE_PROGRAM_NEXT_ISSUES,
+} from "../../terminal/runtime/program-matrix";
 import { RuntimeOperatorView } from "../../terminal/runtime/runtime-operator-view";
 import type { RuntimeOperatorApiPayload } from "../../terminal/runtime/types";
 
@@ -145,6 +149,10 @@ function buildPayload(selectedDeploymentId: string): RuntimeOperatorApiPayload {
         ],
       },
       error: null,
+    },
+    program: {
+      matrix: listRuntimeVenueProgramMatrix(),
+      nextIssueOrder: [...RUNTIME_VENUE_PROGRAM_NEXT_ISSUES],
     },
     selectedDeploymentId: deployment.deploymentId,
     detail: {

--- a/apps/portal/app/terminal/runtime/program-matrix.ts
+++ b/apps/portal/app/terminal/runtime/program-matrix.ts
@@ -1,0 +1,321 @@
+export type RuntimeOperatorProgramMatrixEntry = {
+  subjectKey: string;
+  displayName: string;
+  programFamily: "spot" | "clob" | "perp" | "prediction" | "flash";
+  marketLabels: string[];
+  currentState: string;
+  targetState: string;
+  evidenceTarget: string;
+  canaryPlan: string;
+  disableDrill: string;
+  integrationIssueNumber: number;
+  terminalIssueNumber: number | null;
+  liveSmokeIssueNumber: number | null;
+  nextReadyIssueNumbers: number[];
+  notes: string;
+  adapterKeys: string[];
+  supportedModes: string[];
+};
+
+const PROGRAM_MATRIX: RuntimeOperatorProgramMatrixEntry[] = [
+  {
+    subjectKey: "jupiter",
+    displayName: "Jupiter",
+    programFamily: "spot",
+    marketLabels: ["spot"],
+    currentState: "broad_live_ready",
+    targetState: "broad_live_ready",
+    evidenceTarget:
+      "Real spot swap receipt plus Trigger lifecycle evidence with fill-or-cancel reconciliation.",
+    canaryPlan:
+      "Run a tiny-notional SOL/USDC swap and one Trigger order from the operator surface, then persist signatures, fees, and reconciliation output.",
+    disableDrill:
+      "Disable Jupiter live subject controls and engage the venue kill switch without changing Raydium or Orca posture.",
+    integrationIssueNumber: 366,
+    terminalIssueNumber: 388,
+    liveSmokeIssueNumber: 412,
+    nextReadyIssueNumbers: [412],
+    notes:
+      "Primary bounded live venue and baseline for later venue smoke proofs.",
+    adapterKeys: ["jupiter", "helius_sender", "jito_bundle"],
+    supportedModes: ["shadow", "paper", "live"],
+  },
+  {
+    subjectKey: "raydium",
+    displayName: "Raydium",
+    programFamily: "spot",
+    marketLabels: ["spot"],
+    currentState: "paper_ready",
+    targetState: "limited_live_ready",
+    evidenceTarget:
+      "Dedicated Raydium live swap receipt proving venue-native routing instead of aggregator fallback.",
+    canaryPlan:
+      "Run one tiny-notional Raydium swap and, if needed, a bounded reverse trade to neutralize inventory.",
+    disableDrill:
+      "Pause only the Raydium venue path and confirm Jupiter remains available for the same asset pair.",
+    integrationIssueNumber: 370,
+    terminalIssueNumber: 388,
+    liveSmokeIssueNumber: 413,
+    nextReadyIssueNumbers: [411, 413],
+    notes:
+      "Keep live blocked until the shared venue smoke harness is merged and the bounded real swap proof exists.",
+    adapterKeys: ["raydium"],
+    supportedModes: ["shadow", "paper"],
+  },
+  {
+    subjectKey: "orca",
+    displayName: "Orca Whirlpools",
+    programFamily: "spot",
+    marketLabels: ["spot"],
+    currentState: "paper_ready",
+    targetState: "limited_live_ready",
+    evidenceTarget:
+      "Real Orca pool-specific swap evidence with route, pool context, fees, and reconciliation.",
+    canaryPlan:
+      "Run one tiny-notional Whirlpool swap against an allowlisted pool and capture pool-level route details.",
+    disableDrill:
+      "Disable Orca independently and verify other spot venues remain enabled for the same deployment.",
+    integrationIssueNumber: 371,
+    terminalIssueNumber: 388,
+    liveSmokeIssueNumber: 414,
+    nextReadyIssueNumbers: [411, 414],
+    notes:
+      "Pool quality and routing proofs remain required before any live allowlist discussion.",
+    adapterKeys: ["orca"],
+    supportedModes: ["shadow", "paper"],
+  },
+  {
+    subjectKey: "openbook",
+    displayName: "OpenBook v2",
+    programFamily: "clob",
+    marketLabels: ["spot"],
+    currentState: "integrated",
+    targetState: "limited_live_ready",
+    evidenceTarget:
+      "Real order-placement evidence with order id, tx signature, bounded lifecycle, and reconciliation.",
+    canaryPlan:
+      "Use IOC or place-and-cancel behavior so the live proof stays bounded and does not require a maker loop.",
+    disableDrill:
+      "Engage the OpenBook venue kill switch and confirm routed spot venues remain unaffected.",
+    integrationIssueNumber: 369,
+    terminalIssueNumber: 388,
+    liveSmokeIssueNumber: 415,
+    nextReadyIssueNumbers: [411, 415],
+    notes:
+      "CLOB live proof must distinguish placement success from later fill or cancel outcomes.",
+    adapterKeys: ["openbook_v2"],
+    supportedModes: ["shadow", "paper"],
+  },
+  {
+    subjectKey: "phoenix",
+    displayName: "Phoenix",
+    programFamily: "clob",
+    marketLabels: ["spot"],
+    currentState: "candidate",
+    targetState: "limited_live_ready",
+    evidenceTarget:
+      "Phoenix-specific order-placement proof with any seat prerequisites, lifecycle evidence, and isolated disable drill.",
+    canaryPlan:
+      "Resume Phoenix only after the deferred terminal slice is complete, then run one bounded IOC or cancelable live order.",
+    disableDrill:
+      "Pause Phoenix independently from OpenBook and document any seat-related rollback steps.",
+    integrationIssueNumber: 368,
+    terminalIssueNumber: 392,
+    liveSmokeIssueNumber: 416,
+    nextReadyIssueNumbers: [392, 405, 411, 416],
+    notes:
+      "Deferred venue. Keep Phoenix behind the later-phase terminal issue and smoke harness rollout.",
+    adapterKeys: ["phoenix_orderbook"],
+    supportedModes: ["shadow", "paper"],
+  },
+  {
+    subjectKey: "drift",
+    displayName: "Drift",
+    programFamily: "perp",
+    marketLabels: ["perp"],
+    currentState: "integrated",
+    targetState: "limited_live_ready",
+    evidenceTarget:
+      "Real perp position lifecycle evidence covering open, bounded reduce-or-close, margin context, and reconciliation.",
+    canaryPlan:
+      "Run one tiny-notional live position action from the operator surface, then reduce or close it in the same bounded session.",
+    disableDrill:
+      "Kill the Drift venue path and verify spot venues and prediction venues remain controllable.",
+    integrationIssueNumber: 372,
+    terminalIssueNumber: 389,
+    liveSmokeIssueNumber: 417,
+    nextReadyIssueNumbers: [389, 411, 417],
+    notes:
+      "Perp live proof must capture position state, margin posture, and fees rather than only tx submission.",
+    adapterKeys: ["drift", "drift_swift"],
+    supportedModes: ["shadow", "paper"],
+  },
+  {
+    subjectKey: "mango",
+    displayName: "Mango v4",
+    programFamily: "perp",
+    marketLabels: ["spot", "perp"],
+    currentState: "integrated",
+    targetState: "limited_live_ready",
+    evidenceTarget:
+      "Real Mango account or order lifecycle evidence showing account-state change plus bounded residual exposure.",
+    canaryPlan:
+      "Run the smallest live Mango action that proves account-state mutation, then flatten or cancel any residual risk.",
+    disableDrill:
+      "Disable Mango controls without touching Drift or Jupiter readiness state.",
+    integrationIssueNumber: 374,
+    terminalIssueNumber: 389,
+    liveSmokeIssueNumber: 418,
+    nextReadyIssueNumbers: [389, 411, 418],
+    notes:
+      "Cross-margin venues need account-state reconciliation evidence before any readiness widening.",
+    adapterKeys: ["mango"],
+    supportedModes: ["shadow", "paper"],
+  },
+  {
+    subjectKey: "jupiter_perps",
+    displayName: "Jupiter Perps",
+    programFamily: "perp",
+    marketLabels: ["perp"],
+    currentState: "integrated",
+    targetState: "paper_ready",
+    evidenceTarget:
+      "Position-account replay, paper lifecycle coverage, and reconciliation artifacts that prove the WIP API surface is stable enough for paper use.",
+    canaryPlan:
+      "No live venue smoke until a direct execution adapter and stable operator controls exist.",
+    disableDrill:
+      "If enabled for research, disable Jupiter Perps without affecting spot Jupiter execution.",
+    integrationIssueNumber: 373,
+    terminalIssueNumber: 389,
+    liveSmokeIssueNumber: null,
+    nextReadyIssueNumbers: [389, 380],
+    notes:
+      "Research-gated. Treat live discussion as blocked until the API surface is no longer explicitly WIP.",
+    adapterKeys: ["jupiter_perps"],
+    supportedModes: ["shadow", "paper"],
+  },
+  {
+    subjectKey: "raydium_perps",
+    displayName: "Raydium Perps",
+    programFamily: "perp",
+    marketLabels: ["perp"],
+    currentState: "candidate",
+    targetState: "integrated",
+    evidenceTarget:
+      "Confirmed auth model, external dependency health, and account creation behavior for the Orderly-backed path.",
+    canaryPlan:
+      "No live venue smoke until the venue exits candidate and the external dependency path is operator-controlled.",
+    disableDrill:
+      "If later enabled, pause the Orderly-backed rail without affecting Drift or Mango.",
+    integrationIssueNumber: 375,
+    terminalIssueNumber: 389,
+    liveSmokeIssueNumber: 419,
+    nextReadyIssueNumbers: [380, 411, 419],
+    notes:
+      "Candidate-only because private auth, venue policy, and external dependency behavior are still unresolved.",
+    adapterKeys: ["raydium_perps"],
+    supportedModes: ["shadow"],
+  },
+  {
+    subjectKey: "dflow",
+    displayName: "DFlow Prediction Markets",
+    programFamily: "prediction",
+    marketLabels: ["prediction"],
+    currentState: "integrated",
+    targetState: "limited_live_ready",
+    evidenceTarget:
+      "Real outcome-token purchase evidence with resulting position state, settlement posture, fees, and reconciliation.",
+    canaryPlan:
+      "Run one tiny-notional live outcome purchase from the operator surface and preserve or flatten bounded inventory per venue constraints.",
+    disableDrill:
+      "Disable DFlow independently from perps and spot venues while preserving prediction-market audit history.",
+    integrationIssueNumber: 376,
+    terminalIssueNumber: 390,
+    liveSmokeIssueNumber: 420,
+    nextReadyIssueNumbers: [411, 420],
+    notes:
+      "Prediction-market live scope needs explicit policy review even for tiny-notional venue smokes.",
+    adapterKeys: ["dflow"],
+    supportedModes: ["shadow", "paper"],
+  },
+  {
+    subjectKey: "drift_bet",
+    displayName: "Drift BET",
+    programFamily: "prediction",
+    marketLabels: ["prediction"],
+    currentState: "candidate",
+    targetState: "integrated",
+    evidenceTarget:
+      "Cross-margin prediction-market contract model, account semantics, and operator controls documented well enough to implement safely.",
+    canaryPlan:
+      "No live venue smoke until a direct venue adapter exists and generic prediction controls prove out on DFlow first.",
+    disableDrill:
+      "If later enabled, isolate Drift BET from Drift perps controls and evidence.",
+    integrationIssueNumber: 378,
+    terminalIssueNumber: 390,
+    liveSmokeIssueNumber: null,
+    nextReadyIssueNumbers: [380],
+    notes:
+      "Still a candidate expansion of the Drift family, not a live-capable venue path.",
+    adapterKeys: ["drift_prediction"],
+    supportedModes: ["shadow"],
+  },
+  {
+    subjectKey: "monaco",
+    displayName: "Monaco Protocol",
+    programFamily: "prediction",
+    marketLabels: ["prediction"],
+    currentState: "candidate",
+    targetState: "integrated",
+    evidenceTarget:
+      "SDK contract, market discovery, and settlement behavior documented with enough fidelity to implement bounded paper flows.",
+    canaryPlan:
+      "No live venue smoke until Monaco exits candidate and a direct venue adapter exists.",
+    disableDrill:
+      "If Monaco is later enabled, keep its controls isolated from DFlow and Drift BET.",
+    integrationIssueNumber: 377,
+    terminalIssueNumber: 390,
+    liveSmokeIssueNumber: null,
+    nextReadyIssueNumbers: [380],
+    notes:
+      "Research-established candidate only; no direct execution path is ready yet.",
+    adapterKeys: ["monaco"],
+    supportedModes: ["shadow"],
+  },
+  {
+    subjectKey: "flash_liquidity",
+    displayName: "Flash Liquidity",
+    programFamily: "flash",
+    marketLabels: ["flash"],
+    currentState: "integrated",
+    targetState: "limited_live_ready",
+    evidenceTarget:
+      "Atomic borrow-and-repay evidence proving bounded real execution without depending on a profit-seeking strategy.",
+    canaryPlan:
+      "Run one tiny bounded flash transaction on the enabled rail and persist tx, fees, and repayment evidence.",
+    disableDrill:
+      "Disable flash rails without affecting spot, perps, or prediction venue controls.",
+    integrationIssueNumber: 379,
+    terminalIssueNumber: null,
+    liveSmokeIssueNumber: 421,
+    nextReadyIssueNumbers: [411, 421],
+    notes:
+      "Treat flash liquidity as a reusable substrate with its own real-TX proof requirement.",
+    adapterKeys: [],
+    supportedModes: [],
+  },
+];
+
+export const RUNTIME_VENUE_PROGRAM_NEXT_ISSUES = [
+  389, 380, 392, 411, 412, 413, 414, 415, 417, 418, 420, 421, 416, 419,
+] as const;
+
+export function listRuntimeVenueProgramMatrix(): RuntimeOperatorProgramMatrixEntry[] {
+  return PROGRAM_MATRIX.map((entry) => ({
+    ...entry,
+    marketLabels: [...entry.marketLabels],
+    nextReadyIssueNumbers: [...entry.nextReadyIssueNumbers],
+    adapterKeys: [...entry.adapterKeys],
+    supportedModes: [...entry.supportedModes],
+  }));
+}

--- a/apps/portal/app/terminal/runtime/runtime-operator-view.tsx
+++ b/apps/portal/app/terminal/runtime/runtime-operator-view.tsx
@@ -15,6 +15,7 @@ import type {
   RuntimeControlAction,
   RuntimeOperatorApiPayload,
   RuntimeOperatorDetail,
+  RuntimeOperatorProgramMatrixEntry,
   RuntimeOperatorReadinessCanaryInput,
   RuntimeOperatorSnapshot,
   RuntimeOperatorSubjectControlInput,
@@ -114,6 +115,108 @@ function renderBadge(status: string, label?: string) {
     >
       {(label ?? status).replaceAll("_", " ")}
     </span>
+  );
+}
+
+function renderProgramMatrix(
+  matrix: RuntimeOperatorProgramMatrixEntry[],
+  nextIssueOrder: number[],
+) {
+  if (matrix.length === 0) {
+    return (
+      <div className="rounded border border-dashed border-border p-4 text-sm text-muted">
+        Venue program matrix is not available yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4" data-testid="runtime-operator-program-matrix">
+      <div className="rounded border border-border bg-paper/70 p-4">
+        <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+          Next issue order
+        </p>
+        <p className="mt-2 text-sm text-muted">
+          {nextIssueOrder.length > 0
+            ? nextIssueOrder
+                .map((issueNumber) => `#${issueNumber}`)
+                .join(" -> ")
+            : "No queued follow-up issues."}
+        </p>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        {matrix.map((entry) => (
+          <article
+            key={entry.subjectKey}
+            className="rounded border border-border bg-surface/80 p-4"
+            data-testid={`runtime-program-${entry.subjectKey}`}
+          >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                  {entry.programFamily} venue
+                </p>
+                <h3 className="mt-2 text-sm font-medium text-ink">
+                  {entry.displayName}
+                </h3>
+              </div>
+              {renderBadge(entry.currentState, entry.currentState)}
+            </div>
+            <div className="mt-3 grid gap-3 sm:grid-cols-2">
+              {summaryItem("Current state", entry.currentState)}
+              {summaryItem("Target state", entry.targetState)}
+            </div>
+            <div className="mt-4 grid gap-3 md:grid-cols-[1.1fr_0.9fr]">
+              <div className="rounded border border-border bg-paper/70 p-3">
+                <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                  Evidence target
+                </p>
+                <p className="mt-2 text-sm text-muted">
+                  {entry.evidenceTarget}
+                </p>
+                <p className="mt-3 text-xs text-muted">
+                  Markets: {entry.marketLabels.join(", ")}. Modes:{" "}
+                  {entry.supportedModes.length > 0
+                    ? entry.supportedModes.join(", ")
+                    : "n/a"}
+                  .
+                </p>
+              </div>
+              <div className="rounded border border-border bg-paper/70 p-3">
+                <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                  Controls
+                </p>
+                <p className="mt-2 text-sm text-muted">{entry.disableDrill}</p>
+                <p className="mt-3 text-xs text-muted">
+                  Canary: {entry.canaryPlan}
+                </p>
+              </div>
+            </div>
+            <div className="mt-4 grid gap-3 text-xs text-muted sm:grid-cols-2">
+              <p>
+                Issues #{entry.integrationIssueNumber}
+                {entry.terminalIssueNumber
+                  ? ` · #${entry.terminalIssueNumber}`
+                  : ""}
+                {entry.liveSmokeIssueNumber
+                  ? ` · #${entry.liveSmokeIssueNumber}`
+                  : ""}
+              </p>
+              <p>
+                Agent-ready after{" "}
+                {entry.nextReadyIssueNumbers.length > 0
+                  ? entry.nextReadyIssueNumbers
+                      .map((issueNumber) => `#${issueNumber}`)
+                      .join(", ")
+                  : "current queue"}
+              </p>
+            </div>
+            <p className="mt-3 text-sm text-muted">{entry.notes}</p>
+          </article>
+        ))}
+      </div>
+    </div>
   );
 }
 
@@ -1586,6 +1689,21 @@ export function RuntimeOperatorView({
               </h2>
             </div>
             {renderLeaderboard(runtime)}
+          </section>
+
+          <section className="card p-5">
+            <div className="mb-4">
+              <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                Venue program matrix
+              </p>
+              <h2 className="mt-2 text-lg font-semibold text-ink">
+                Readiness targets, canary posture, and disable drills by venue
+              </h2>
+            </div>
+            {renderProgramMatrix(
+              payload?.program.matrix ?? [],
+              payload?.program.nextIssueOrder ?? [],
+            )}
           </section>
 
           <section className="card p-5">

--- a/apps/portal/app/terminal/runtime/types.ts
+++ b/apps/portal/app/terminal/runtime/types.ts
@@ -3,6 +3,9 @@ import type {
   RuntimeLedgerSnapshot,
   RuntimeRunRecord,
 } from "../../../lib/runtime-contracts";
+import type { RuntimeOperatorProgramMatrixEntry } from "./program-matrix";
+
+export type { RuntimeOperatorProgramMatrixEntry } from "./program-matrix";
 
 export type RuntimeControlAction = "pause" | "resume" | "kill";
 export type RuntimeSubjectKind = "venue" | "asset";
@@ -97,6 +100,10 @@ export type RuntimeOperatorDetail = {
 export type RuntimeOperatorApiPayload = {
   ok: boolean;
   runtime: RuntimeOperatorSnapshot;
+  program: {
+    matrix: RuntimeOperatorProgramMatrixEntry[];
+    nextIssueOrder: number[];
+  };
   selectedDeploymentId: string | null;
   detail: RuntimeOperatorDetail | null;
   detailError: string | null;

--- a/docs/strategy-lab/request-templates/venue-readiness/venue.canary.request.json
+++ b/docs/strategy-lab/request-templates/venue-readiness/venue.canary.request.json
@@ -1,0 +1,16 @@
+{
+  "subjectKind": "venue",
+  "subjectKey": "raydium",
+  "requestedBy": "operator@example.com",
+  "venueKey": "raydium",
+  "assetKey": "SOL",
+  "pairSymbol": "SOL/USDC",
+  "adapterKey": "raydium",
+  "triggerSource": "manual",
+  "targetNotionalUsd": "5.00",
+  "metadata": {
+    "issueNumber": 413,
+    "purpose": "venue-live-smoke",
+    "notes": "Manual tiny-notional venue landing proof without enabling a strategy loop."
+  }
+}

--- a/docs/strategy-lab/request-templates/venue-readiness/venue.control.request.json
+++ b/docs/strategy-lab/request-templates/venue-readiness/venue.control.request.json
@@ -1,0 +1,13 @@
+{
+  "subjectKind": "venue",
+  "subjectKey": "raydium",
+  "liveAllowed": false,
+  "killSwitchEnabled": true,
+  "disabledReason": "operator-drill-raydium-disable",
+  "updatedBy": "operator@example.com",
+  "metadata": {
+    "issueNumber": 380,
+    "drill": "isolated-venue-disable",
+    "notes": "Disable Raydium without affecting Jupiter, Orca, or runtime-wide controls."
+  }
+}

--- a/docs/strategy-lab/request-templates/venue-readiness/venue.readiness.request.json
+++ b/docs/strategy-lab/request-templates/venue-readiness/venue.readiness.request.json
@@ -1,0 +1,24 @@
+{
+  "subjectKind": "venue",
+  "subjectKey": "raydium",
+  "targetState": "limited_live_ready",
+  "requestedBy": "operator@example.com",
+  "venueKey": "raydium",
+  "assetKey": "SOL",
+  "pairSymbol": "SOL/USDC",
+  "adapterKey": "raydium",
+  "evidenceRefs": [
+    {
+      "kind": "paper_scorecard",
+      "ref": "scorecard:raydium_sol_usdc_paper"
+    },
+    {
+      "kind": "bounded_canary_plan",
+      "ref": "plan:raydium_sol_usdc_live_smoke"
+    }
+  ],
+  "metadata": {
+    "issueNumber": 413,
+    "notes": "Bounded venue readiness evaluation ahead of venue-specific live smoke proof."
+  }
+}

--- a/docs/strategy-lab/venue-readiness-matrix.md
+++ b/docs/strategy-lab/venue-readiness-matrix.md
@@ -1,0 +1,66 @@
+# Multi-Venue Readiness Matrix
+
+This matrix is the shared readiness reference for the multi-venue harness
+program tracked by `#381`, `#386`, and `#380`.
+
+It exists to keep venue onboarding, terminal rollout, and later real-TX smoke
+proofs on one explicit path instead of scattering readiness assumptions across
+issue bodies and PR notes.
+
+## How To Use It
+
+- Treat venue readiness as separate from strategy readiness.
+- Use the request templates in
+  [`docs/strategy-lab/request-templates/venue-readiness`](/Users/guillaumebibeau-laviolette/github/serious-trader-ralph-380/docs/strategy-lab/request-templates/venue-readiness)
+  for manual readiness, canary, and control operations.
+- A venue is not meaningfully ready for `limited_live_ready` unless the matrix
+  names both an evidence target and an isolated disable drill.
+- Real-TX landing proof without a full strategy runtime is tracked separately in
+  `#410` through `#421`.
+
+## Execution Order
+
+The remaining harness queue for this program is:
+
+1. `#389` perps terminal workflows
+2. `#380` shared matrix, templates, and operator visibility
+3. `#392` deferred Phoenix terminal workflows
+4. `#411` shared venue live-smoke harness
+5. venue live-smoke proofs `#412`, `#413`, `#414`, `#415`, `#417`, `#418`, `#420`, `#421`
+6. deferred venue proofs `#416` and `#419` once their blocked dependencies are cleared
+
+## Matrix
+
+| Subject | Family | Current | Target | Evidence target | Issues |
+| --- | --- | --- | --- | --- | --- |
+| Jupiter | spot | `broad_live_ready` | `broad_live_ready` | Real spot swap receipt plus Trigger fill-or-cancel reconciliation | `#366`, `#388`, `#412` |
+| Raydium | spot | `paper_ready` | `limited_live_ready` | Venue-native live swap proof, not aggregator fallback | `#370`, `#388`, `#413` |
+| Orca Whirlpools | spot | `paper_ready` | `limited_live_ready` | Pool-specific live swap proof with route and reconciliation | `#371`, `#388`, `#414` |
+| OpenBook v2 | clob | `integrated` | `limited_live_ready` | Real order placement plus bounded lifecycle and reconciliation | `#369`, `#388`, `#415` |
+| Phoenix | clob | `candidate` | `limited_live_ready` | Seat-aware live order proof after deferred terminal support resumes | `#368`, `#392`, `#416` |
+| Drift | perp | `integrated` | `limited_live_ready` | Real position open plus bounded reduce-or-close with margin evidence | `#372`, `#389`, `#417` |
+| Mango v4 | perp | `integrated` | `limited_live_ready` | Real account-state mutation with bounded residual exposure | `#374`, `#389`, `#418` |
+| Jupiter Perps | perp | `integrated` | `paper_ready` | Position-account replay and paper reconciliation coverage | `#373`, `#389` |
+| Raydium Perps / Orderly | perp | `candidate` | `integrated` | External auth and dependency behavior documented well enough to integrate safely | `#375`, `#389`, `#419` |
+| DFlow | prediction | `integrated` | `limited_live_ready` | Real outcome-token purchase with resulting position and settlement posture | `#376`, `#390`, `#420` |
+| Drift BET | prediction | `candidate` | `integrated` | Cross-margin prediction contract model and controls specified for implementation | `#378`, `#390` |
+| Monaco | prediction | `candidate` | `integrated` | SDK contract and settlement behavior documented for bounded paper use | `#377`, `#390` |
+| Flash Liquidity | flash | `integrated` | `limited_live_ready` | Atomic borrow-and-repay proof without a profit-seeking strategy | `#379`, `#421` |
+
+## Disable Drills
+
+- Jupiter: disable live subject control and engage kill switch without affecting Raydium or Orca.
+- Raydium and Orca: disable each venue independently while Jupiter stays available.
+- OpenBook and Phoenix: disable one CLOB venue without affecting the other or routed spot flows.
+- Drift and Mango: disable one perp venue without affecting spot or prediction venues.
+- DFlow, Drift BET, and Monaco: isolate prediction-market controls from perps.
+- Flash liquidity: disable flash rails without touching spot, perp, or prediction execution controls.
+
+## Notes
+
+- Candidate-state venues stay blocked from live-smoke issues even when the
+  smoke issue exists as a placeholder.
+- `#410` and its child issues are evidence-producing issues, not automatic
+  readiness promotions.
+- Merging an implementation PR still does not authorize real-money promotion by
+  itself.

--- a/tests/browser/harness-proof.spec.ts
+++ b/tests/browser/harness-proof.spec.ts
@@ -251,6 +251,14 @@ test("runtime operator proof shows deployment detail and control affordances", a
       name: /Latest hypotheses, sources, experiments, and evidence bundles/i,
     }),
   ).toBeVisible();
+  await expect(
+    page.getByRole("heading", {
+      name: /Readiness targets, canary posture, and disable drills by venue/i,
+    }),
+  ).toBeVisible();
+  await expect(page.getByTestId("runtime-program-jupiter")).toContainText(
+    "Jupiter",
+  );
   await captureCheckpoint(page, "runtime-operator-home.png");
 
   await page.getByRole("button", { name: /mean_reversion/i }).click();

--- a/tests/unit/portal_runtime_operator_route.test.ts
+++ b/tests/unit/portal_runtime_operator_route.test.ts
@@ -472,7 +472,8 @@ describe("portal runtime operator route", () => {
     );
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toMatchObject({
+    const payload = (await response.json()) as Record<string, unknown>;
+    expect(payload).toMatchObject({
       ok: true,
       selectedDeploymentId: "runtime_canary_live_dca",
       runtime: {
@@ -526,6 +527,23 @@ describe("portal runtime operator route", () => {
         },
       },
     });
+    const program = payload.program as {
+      matrix?: Array<Record<string, unknown>>;
+      nextIssueOrder?: number[];
+    };
+    expect(program.nextIssueOrder?.slice(0, 3)).toEqual([389, 380, 392]);
+    expect(
+      program.matrix?.some(
+        (entry) =>
+          entry.subjectKey === "jupiter" && entry.liveSmokeIssueNumber === 412,
+      ),
+    ).toBe(true);
+    expect(
+      program.matrix?.some(
+        (entry) =>
+          entry.subjectKey === "drift" && entry.terminalIssueNumber === 389,
+      ),
+    ).toBe(true);
     expect(seenAuthHeaders[0]).toBe("Bearer user-token");
     expect(seenAuthHeaders.slice(1)).toHaveLength(12);
     expect(


### PR DESCRIPTION
## Summary\n- add a runtime operator venue readiness matrix with issue sequencing and rollout metadata\n- surface the matrix in the operator API, runtime proof page, and terminal runtime view\n- add venue readiness request templates and proof coverage for the operator surface\n\n## Validation\n- bun test ./tests/unit/portal_runtime_operator_route.test.ts ./tests/unit/worker_runtime_research_readiness_route.test.ts\n- bun run lint\n- bun run typecheck\n- (cd apps/portal && bun run build)\n- bun run harness:proof --output-dir .tmp/harness-proof-380\n\nCloses #380