### PR TITLE
Add venue tx smoke readiness harness (#411)

### DIFF
--- a/apps/portal/app/api/runtime/operator/route.ts
+++ b/apps/portal/app/api/runtime/operator/route.ts
@@ -749,6 +749,7 @@ export async function POST(request: Request) {
         subjectKey,
         requestedBy: operatorActor,
         triggerSource: "manual",
+        proofMode: "venue_tx_smoke",
         ...(readString(payload.venueKey)
           ? { venueKey: readString(payload.venueKey) }
           : {}),
@@ -763,6 +764,59 @@ export async function POST(request: Request) {
           : {}),
         ...(readString(payload.targetNotionalUsd)
           ? { targetNotionalUsd: readString(payload.targetNotionalUsd) }
+          : {}),
+      },
+    });
+    return NextResponse.json(result.payload, { status: result.status });
+  }
+
+  if (action === "run_venue_tx_smoke") {
+    const subjectKind = payload.subjectKind === "venue" ? "venue" : null;
+    const subjectKey = readString(payload.subjectKey);
+    if (!subjectKind || !subjectKey) {
+      return NextResponse.json(
+        { ok: false, error: "invalid-runtime-operator-action" },
+        { status: 400 },
+      );
+    }
+    const result = await requestWorkerJson({
+      path: "/api/admin/ops/runtime/research/readiness/smoke",
+      method: "POST",
+      authHeader: `Bearer ${adminToken}`,
+      body: {
+        subjectKind,
+        subjectKey,
+        requestedBy: operatorActor,
+        triggerSource: "manual",
+        proofMode: "venue_tx_smoke",
+        ...(readString(payload.venueKey)
+          ? { venueKey: readString(payload.venueKey) }
+          : {}),
+        ...(readString(payload.assetKey)
+          ? { assetKey: readString(payload.assetKey) }
+          : {}),
+        ...(readString(payload.pairSymbol)
+          ? { pairSymbol: readString(payload.pairSymbol) }
+          : {}),
+        ...(readString(payload.adapterKey)
+          ? { adapterKey: readString(payload.adapterKey) }
+          : {}),
+        ...(readString(payload.targetNotionalUsd)
+          ? { targetNotionalUsd: readString(payload.targetNotionalUsd) }
+          : {}),
+        ...(typeof payload.tightenOnFailure === "boolean"
+          ? { tightenOnFailure: payload.tightenOnFailure }
+          : {}),
+        ...(payload.failureControlMode === "disable_live" ||
+        payload.failureControlMode === "engage_kill_switch"
+          ? { failureControlMode: payload.failureControlMode }
+          : {}),
+        ...(Array.isArray(payload.killDrillNotes)
+          ? {
+              killDrillNotes: payload.killDrillNotes
+                .map((entry) => readString(entry))
+                .filter((entry): entry is string => Boolean(entry)),
+            }
           : {}),
       },
     });

--- a/apps/portal/app/api/runtime/operator/route.ts
+++ b/apps/portal/app/api/runtime/operator/route.ts
@@ -749,7 +749,6 @@ export async function POST(request: Request) {
         subjectKey,
         requestedBy: operatorActor,
         triggerSource: "manual",
-        proofMode: "venue_tx_smoke",
         ...(readString(payload.venueKey)
           ? { venueKey: readString(payload.venueKey) }
           : {}),

--- a/apps/portal/app/terminal/runtime/runtime-operator-client.tsx
+++ b/apps/portal/app/terminal/runtime/runtime-operator-client.tsx
@@ -8,6 +8,7 @@ import type {
   RuntimeOperatorApiPayload,
   RuntimeOperatorReadinessCanaryInput,
   RuntimeOperatorSubjectControlInput,
+  RuntimeOperatorVenueTxSmokeInput,
 } from "./types";
 
 async function readJson<T>(response: Response): Promise<T | null> {
@@ -136,6 +137,16 @@ export function RuntimeOperatorClient() {
     );
   }
 
+  async function runVenueTxSmoke(input: RuntimeOperatorVenueTxSmokeInput) {
+    await runOperatorAction(
+      {
+        action: "run_venue_tx_smoke",
+        ...input,
+      },
+      `venue-tx-smoke:${input.subjectKey}`,
+    );
+  }
+
   useEffect(() => {
     if (!ready) return;
     if (!authenticated) {
@@ -234,6 +245,17 @@ export function RuntimeOperatorClient() {
               cause instanceof Error
                 ? cause.message
                 : "runtime-operator-readiness-canary-failed",
+            );
+          });
+        });
+      }}
+      onVenueTxSmoke={(input) => {
+        startTransition(() => {
+          void runVenueTxSmoke(input).catch((cause) => {
+            setError(
+              cause instanceof Error
+                ? cause.message
+                : "runtime-operator-venue-tx-smoke-failed",
             );
           });
         });

--- a/apps/portal/app/terminal/runtime/runtime-operator-view.tsx
+++ b/apps/portal/app/terminal/runtime/runtime-operator-view.tsx
@@ -19,6 +19,7 @@ import type {
   RuntimeOperatorReadinessCanaryInput,
   RuntimeOperatorSnapshot,
   RuntimeOperatorSubjectControlInput,
+  RuntimeOperatorVenueTxSmokeInput,
 } from "./types";
 
 type RuntimeOperatorViewProps = {
@@ -32,6 +33,7 @@ type RuntimeOperatorViewProps = {
   onControl?: (action: RuntimeControlAction) => void;
   onSubjectControl?: (input: RuntimeOperatorSubjectControlInput) => void;
   onReadinessCanary?: (input: RuntimeOperatorReadinessCanaryInput) => void;
+  onVenueTxSmoke?: (input: RuntimeOperatorVenueTxSmokeInput) => void;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -104,6 +106,12 @@ function buildReadinessCanaryActionKey(
   input: RuntimeOperatorReadinessCanaryInput,
 ): string {
   return `readiness-canary:${input.subjectKind}:${input.subjectKey}`;
+}
+
+function buildVenueTxSmokeActionKey(
+  input: RuntimeOperatorVenueTxSmokeInput,
+): string {
+  return `venue-tx-smoke:${input.subjectKey}`;
 }
 
 function renderBadge(status: string, label?: string) {
@@ -1304,6 +1312,7 @@ function renderReadinessControls(
   actionPending: string | null,
   onSubjectControl?: (input: RuntimeOperatorSubjectControlInput) => void,
   onReadinessCanary?: (input: RuntimeOperatorReadinessCanaryInput) => void,
+  onVenueTxSmoke?: (input: RuntimeOperatorVenueTxSmokeInput) => void,
 ) {
   const deployment = detail?.deployment ?? null;
   const readiness = detail?.lab?.readiness ?? null;
@@ -1327,6 +1336,7 @@ function renderReadinessControls(
       {subjects.map((subject) => {
         const subjectKind =
           readString(subject.subjectKind) === "asset" ? "asset" : "venue";
+        const isVenueSubject = subjectKind === "venue";
         const subjectKey = readString(subject.subjectKey) ?? "unknown";
         const controls = readRecordArray(subject.controls);
         const artifacts = readRecordArray(subject.artifacts);
@@ -1362,12 +1372,30 @@ function renderReadinessControls(
           pairSymbol: deployment.pair.symbol,
           targetNotionalUsd: "5.00",
         };
+        const smokeInput: RuntimeOperatorVenueTxSmokeInput | null =
+          isVenueSubject
+            ? {
+                subjectKind: "venue",
+                subjectKey,
+                venueKey: subjectKey,
+                assetKey,
+                pairSymbol: deployment.pair.symbol,
+                targetNotionalUsd: "5.00",
+                tightenOnFailure: true,
+                failureControlMode: "disable_live",
+                killDrillNotes: [
+                  `Tighten ${subjectKey} only; do not widen to runtime-wide pause.`,
+                ],
+              }
+            : null;
         const liveTogglePending =
           actionPending === buildSubjectActionKey(liveToggleInput);
         const killTogglePending =
           actionPending === buildSubjectActionKey(killToggleInput);
         const canaryPending =
-          actionPending === buildReadinessCanaryActionKey(canaryInput);
+          isVenueSubject && smokeInput
+            ? actionPending === buildVenueTxSmokeActionKey(smokeInput)
+            : actionPending === buildReadinessCanaryActionKey(canaryInput);
 
         return (
           <article
@@ -1408,7 +1436,7 @@ function renderReadinessControls(
                 readString(latestArtifact?.targetState) ?? "n/a",
               )}
               {summaryItem(
-                "Latest canary",
+                isVenueSubject ? "Latest tx smoke" : "Latest canary",
                 readString(latestCanary?.status) ?? "not run",
               )}
             </div>
@@ -1468,10 +1496,24 @@ function renderReadinessControls(
                   <button
                     className={BTN_PRIMARY}
                     type="button"
-                    onClick={() => onReadinessCanary?.(canaryInput)}
-                    disabled={!onReadinessCanary}
+                    onClick={() =>
+                      isVenueSubject
+                        ? smokeInput && onVenueTxSmoke?.(smokeInput)
+                        : onReadinessCanary?.(canaryInput)
+                    }
+                    disabled={
+                      isVenueSubject
+                        ? !onVenueTxSmoke || !smokeInput
+                        : !onReadinessCanary
+                    }
                   >
-                    {canaryPending ? "Running canary..." : "Run canary"}
+                    {canaryPending
+                      ? isVenueSubject
+                        ? "Running tx smoke..."
+                        : "Running canary..."
+                      : isVenueSubject
+                        ? "Run tx smoke"
+                        : "Run canary"}
                   </button>
                 </div>
               </div>
@@ -1494,6 +1536,7 @@ export function RuntimeOperatorView({
   onControl,
   onSubjectControl,
   onReadinessCanary,
+  onVenueTxSmoke,
 }: RuntimeOperatorViewProps) {
   const runtime = payload?.runtime ?? null;
   const detail = payload?.detail ?? null;
@@ -1780,6 +1823,7 @@ export function RuntimeOperatorView({
               actionPending,
               onSubjectControl,
               onReadinessCanary,
+              onVenueTxSmoke,
             )}
           </section>
 

--- a/apps/portal/app/terminal/runtime/types.ts
+++ b/apps/portal/app/terminal/runtime/types.ts
@@ -28,6 +28,19 @@ export type RuntimeOperatorReadinessCanaryInput = {
   targetNotionalUsd?: string;
 };
 
+export type RuntimeOperatorVenueTxSmokeInput = {
+  subjectKind: "venue";
+  subjectKey: string;
+  venueKey?: string;
+  assetKey?: string;
+  pairSymbol?: string;
+  adapterKey?: string;
+  targetNotionalUsd?: string;
+  tightenOnFailure?: boolean;
+  failureControlMode?: "disable_live" | "engage_kill_switch";
+  killDrillNotes?: string[];
+};
+
 export type RuntimeOperatorControls = {
   enabled: boolean;
   disabledReason: string | null;

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -7,6 +7,7 @@ import {
   parseRuntimeResearchReadinessCanaryRequest,
   parseRuntimeResearchReadinessRequest,
   parseRuntimeResearchSubjectControlPatch,
+  parseRuntimeResearchVenueTxSmokeRequest,
 } from "../../../src/runtime/research/readiness.js";
 import { parseRuntimeResearchSynthesisRequest } from "../../../src/runtime/research/synthesis.js";
 import { parseRuntimeResearchCandidateTriageRequest } from "../../../src/runtime/research/triage.js";
@@ -3533,6 +3534,53 @@ const worker = {
                   error instanceof Error
                     ? error.message
                     : "runtime-research-readiness-canary-failed",
+              },
+              { status: 400 },
+            ),
+            env,
+          );
+        }
+      }
+
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/admin/ops/runtime/research/readiness/smoke"
+      ) {
+        const auth = authorizeAdminRoute(request, env);
+        if (!auth.ok) {
+          return withCors(
+            json({ ok: false, error: auth.error }, { status: auth.status }),
+            env,
+          );
+        }
+        try {
+          const smokeRequest = parseRuntimeResearchVenueTxSmokeRequest(
+            await request.json(),
+          );
+          const result = await runRuntimeResearchReadinessCanaryWithMarkdown({
+            env,
+            request: smokeRequest,
+          });
+          return withCors(
+            json({
+              ok: result.ok,
+              status: result.status,
+              run: result.run,
+              state: result.state,
+              markdown: result.markdown,
+              ...(result.error ? { error: result.error } : {}),
+            }),
+            env,
+          );
+        } catch (error) {
+          return withCors(
+            json(
+              {
+                ok: false,
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "runtime-research-venue-tx-smoke-failed",
               },
               { status: 400 },
             ),

--- a/apps/worker/src/strategy_lab_readiness_canary.ts
+++ b/apps/worker/src/strategy_lab_readiness_canary.ts
@@ -1,5 +1,6 @@
 import {
   buildRuntimeResearchReadinessCanaryMarkdown,
+  buildRuntimeStrategyLabSubjectControlRecord,
   type RuntimeResearchReadinessCanaryRequest,
 } from "../../../src/runtime/research/readiness.js";
 import {
@@ -37,10 +38,12 @@ import {
   getStrategyLabReadinessCanaryDailySpendUsd,
   getStrategyLabReadinessCanaryRun,
   getStrategyLabReadinessCanaryState,
+  getStrategyLabSubjectControl,
   listStrategyLabReadinessCanaryRuns,
   type ReadinessCanaryStateRecord,
   updateStrategyLabReadinessCanaryRun,
   updateStrategyLabReadinessCanaryState,
+  writeStrategyLabSubjectControl,
 } from "./strategy_lab_readiness_repository";
 import type { Env } from "./types";
 
@@ -112,6 +115,23 @@ function readBooleanEnv(value: unknown, fallback = false): boolean {
     return false;
   }
   return fallback;
+}
+
+function readBoolean(value: unknown, fallback = false): boolean {
+  if (typeof value === "boolean") return value;
+  return readBooleanEnv(value, fallback);
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  const normalized = String(value ?? "").trim();
+  return normalized ? normalized : undefined;
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => readOptionalString(entry))
+    .filter((entry): entry is string => Boolean(entry));
 }
 
 function readNumberEnv(
@@ -253,6 +273,37 @@ function readStrategyLabReadinessCanaryConfig(
       ) ?? 50_000_000n,
     ),
   };
+}
+
+function readProofMode(
+  request: RuntimeResearchReadinessCanaryRequest,
+): "readiness_canary" | "venue_tx_smoke" {
+  return request.proofMode === "venue_tx_smoke"
+    ? "venue_tx_smoke"
+    : "readiness_canary";
+}
+
+function readFailureControlMode(
+  request: RuntimeResearchReadinessCanaryRequest | Record<string, unknown>,
+): "disable_live" | "engage_kill_switch" {
+  const raw =
+    "failureControlMode" in request
+      ? readOptionalString(request.failureControlMode)
+      : undefined;
+  return raw === "engage_kill_switch" ? "engage_kill_switch" : "disable_live";
+}
+
+function shouldTightenOnFailure(
+  request: RuntimeResearchReadinessCanaryRequest | Record<string, unknown>,
+): boolean {
+  const proofMode =
+    "proofMode" in request ? readOptionalString(request.proofMode) : undefined;
+  if (proofMode !== "venue_tx_smoke") {
+    return false;
+  }
+  return "tightenOnFailure" in request
+    ? readBoolean(request.tightenOnFailure, true)
+    : true;
 }
 
 async function ensureReadinessCanaryWallet(
@@ -434,6 +485,83 @@ async function fetchCanaryQuote(input: {
   };
 }
 
+function mergeMetadata(
+  current: unknown,
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    ...(isRecord(current) ? current : {}),
+    ...patch,
+  };
+}
+
+async function applyVenueSmokeFailureControl(input: {
+  env: Env;
+  run: NonNullable<RuntimeResearchReadinessCanaryWorkflowResult["run"]>;
+}): Promise<NonNullable<RuntimeResearchReadinessCanaryWorkflowResult["run"]>> {
+  const metadata = isRecord(input.run.metadata) ? input.run.metadata : {};
+  if (
+    input.run.subjectKind !== "venue" ||
+    !shouldTightenOnFailure(metadata) ||
+    input.run.status === "success"
+  ) {
+    return input.run;
+  }
+
+  const existing = await getStrategyLabSubjectControl(
+    input.env.WAITLIST_DB,
+    "venue",
+    input.run.subjectKey,
+  );
+  const controlMode = readFailureControlMode(metadata);
+  const updatedBy =
+    readOptionalString(metadata.requestedBy) ?? "system:venue-tx-smoke";
+  const disabledReason = `venue-tx-smoke-${input.run.status}:${input.run.runId}`;
+  const control = buildRuntimeStrategyLabSubjectControlRecord({
+    existing,
+    patch: {
+      subjectKind: "venue",
+      subjectKey: input.run.subjectKey,
+      liveAllowed: false,
+      ...(controlMode === "engage_kill_switch"
+        ? { killSwitchEnabled: true }
+        : {}),
+      disabledReason,
+      updatedBy,
+      metadata: {
+        source: "venue_tx_smoke",
+        runId: input.run.runId,
+        mode: controlMode,
+      },
+    },
+  });
+  await writeStrategyLabSubjectControl(input.env.WAITLIST_DB, control);
+
+  return (await updateStrategyLabReadinessCanaryRun(input.env.WAITLIST_DB, {
+    ...input.run,
+    evidenceRefs: [
+      ...input.run.evidenceRefs,
+      {
+        kind: "subject_control_patch",
+        ref: `subject-control:venue:${input.run.subjectKey}:${controlMode}`,
+      },
+    ],
+    metadata: mergeMetadata(input.run.metadata, {
+      smokeFailureControl: {
+        applied: true,
+        mode: controlMode,
+        subjectKind: "venue",
+        subjectKey: input.run.subjectKey,
+        liveAllowed: control.liveAllowed,
+        killSwitchEnabled: control.killSwitchEnabled,
+        disabledReason: control.disabledReason ?? null,
+        updatedAt: control.updatedAt,
+        updatedBy: control.updatedBy ?? null,
+      },
+    }),
+  })) as NonNullable<RuntimeResearchReadinessCanaryWorkflowResult["run"]>;
+}
+
 async function finalizeReadinessCanaryRun(
   env: Env,
   input: {
@@ -452,12 +580,28 @@ async function finalizeReadinessCanaryRun(
     throw new Error("strategy-lab-readiness-canary-run-missing");
   }
   const completedAt = new Date().toISOString();
+  const runPatch =
+    input.runPatch && isRecord(input.runPatch.metadata)
+      ? {
+          ...input.runPatch,
+          metadata: mergeMetadata(current.metadata, input.runPatch.metadata),
+        }
+      : input.runPatch;
   const run = await updateStrategyLabReadinessCanaryRun(env.WAITLIST_DB, {
     ...current,
     status: input.status,
-    ...(input.runPatch ?? {}),
+    ...(runPatch ?? {}),
     completedAt,
   });
+  const nextRun =
+    run && input.status !== "success"
+      ? await applyVenueSmokeFailureControl({
+          env,
+          run: run as NonNullable<
+            RuntimeResearchReadinessCanaryWorkflowResult["run"]
+          >,
+        })
+      : run;
   const state = await updateStrategyLabReadinessCanaryState(env.WAITLIST_DB, {
     canaryKey: STRATEGY_LAB_READINESS_CANARY_KEY,
     lastRunId: input.runId,
@@ -466,15 +610,17 @@ async function finalizeReadinessCanaryRun(
   return {
     ok: input.status === "success",
     status: input.status,
-    run,
+    run: nextRun,
     state,
-    markdown: run ? buildRuntimeResearchReadinessCanaryMarkdown(run) : null,
+    markdown: nextRun
+      ? buildRuntimeResearchReadinessCanaryMarkdown(nextRun)
+      : null,
     ...(input.status === "success"
       ? {}
       : {
           error:
-            input.runPatch && "errorMessage" in input.runPatch
-              ? (input.runPatch.errorMessage as string | undefined)
+            runPatch && "errorMessage" in runPatch
+              ? (runPatch.errorMessage as string | undefined)
               : undefined,
         }),
   };
@@ -495,6 +641,10 @@ function buildStubCanaryMetadata(input: {
   return {
     source: "stub",
     requestedBy: input.request.requestedBy,
+    proofMode: readProofMode(input.request),
+    tightenOnFailure: shouldTightenOnFailure(input.request),
+    failureControlMode: readFailureControlMode(input.request),
+    killDrillNotes: readStringArray(input.request.killDrillNotes),
     pairSymbol: input.context.pairSymbol,
     venueKey: input.context.venueKey,
     assetKey: input.context.assetKey,
@@ -615,6 +765,10 @@ export async function runRuntimeResearchReadinessCanaryWorkflow(input: {
     startedAt,
     metadata: {
       requestedBy: input.request.requestedBy,
+      proofMode: readProofMode(input.request),
+      tightenOnFailure: shouldTightenOnFailure(input.request),
+      failureControlMode: readFailureControlMode(input.request),
+      killDrillNotes: readStringArray(input.request.killDrillNotes),
       ...(input.request.metadata
         ? { requestMetadata: input.request.metadata }
         : {}),
@@ -681,6 +835,12 @@ export async function runRuntimeResearchReadinessCanaryWorkflow(input: {
       },
     });
   }
+  const submissionPath = {
+    venueKey: context.venueKey,
+    adapterKey: context.adapterKey,
+    lane: laneResolution.lane,
+    adapter: laneResolution.adapter,
+  };
 
   const rpc = SolanaRpc.fromEnv(input.env);
   const jupiter = new JupiterClient(
@@ -737,6 +897,7 @@ export async function runRuntimeResearchReadinessCanaryWorkflow(input: {
         errorCode: "policy-denied",
         errorMessage: runtimeBalancePolicy.reason,
         metadata: {
+          submissionPath,
           runtimePolicy: runtimeBalancePolicy.metadata,
         },
       },
@@ -835,6 +996,10 @@ export async function runRuntimeResearchReadinessCanaryWorkflow(input: {
           errorCode: failure.errorCode,
           errorMessage: failure.errorMessage,
           metadata: {
+            submissionPath: {
+              ...submissionPath,
+              landingStatus: result.status,
+            },
             quote: asJsonObject(quoteSummary.quoteResponse),
             executionMeta: asJsonObject(result.executionMeta),
             ...(referenceGuard.enabled
@@ -906,8 +1071,13 @@ export async function runRuntimeResearchReadinessCanaryWorkflow(input: {
           },
         ],
         metadata: {
+          submissionPath: {
+            ...submissionPath,
+            landingStatus: result.status,
+          },
           quote: asJsonObject(quoteSummary.quoteResponse),
           executionMeta: asJsonObject(result.executionMeta),
+          feeLamports: feeLamports.toString(),
           ...(referenceGuard.enabled
             ? {
                 referencePrice: {
@@ -942,6 +1112,9 @@ export async function runRuntimeResearchReadinessCanaryWorkflow(input: {
           fallback: "submission-failed",
         }),
         errorMessage: executionErrorMessage(error),
+        metadata: {
+          submissionPath,
+        },
       },
     });
   }

--- a/docs/strategy-lab/request-templates/venue-readiness/venue.canary.request.json
+++ b/docs/strategy-lab/request-templates/venue-readiness/venue.canary.request.json
@@ -10,7 +10,7 @@
   "targetNotionalUsd": "5.00",
   "metadata": {
     "issueNumber": 413,
-    "purpose": "venue-live-smoke",
-    "notes": "Manual tiny-notional venue landing proof without enabling a strategy loop."
+    "purpose": "venue-readiness-canary",
+    "notes": "Manual readiness canary for venue-scoped promotion evidence without automatic failure tightening."
   }
 }

--- a/docs/strategy-lab/request-templates/venue-readiness/venue.smoke.request.json
+++ b/docs/strategy-lab/request-templates/venue-readiness/venue.smoke.request.json
@@ -1,0 +1,23 @@
+{
+  "subjectKind": "venue",
+  "subjectKey": "raydium",
+  "requestedBy": "operator@example.com",
+  "venueKey": "raydium",
+  "assetKey": "SOL",
+  "pairSymbol": "SOL/USDC",
+  "adapterKey": "raydium",
+  "triggerSource": "manual",
+  "proofMode": "venue_tx_smoke",
+  "targetNotionalUsd": "5.00",
+  "tightenOnFailure": true,
+  "failureControlMode": "disable_live",
+  "killDrillNotes": [
+    "Tighten Raydium only.",
+    "Do not widen to a runtime-wide pause."
+  ],
+  "metadata": {
+    "issueNumber": 413,
+    "purpose": "venue-live-smoke",
+    "notes": "Manual tiny-notional venue landing proof without enabling a strategy loop."
+  }
+}

--- a/docs/strategy-lab/venue-readiness-matrix.md
+++ b/docs/strategy-lab/venue-readiness-matrix.md
@@ -11,12 +11,26 @@ issue bodies and PR notes.
 
 - Treat venue readiness as separate from strategy readiness.
 - Use the request templates in
-  [`docs/strategy-lab/request-templates/venue-readiness`](/Users/guillaumebibeau-laviolette/github/serious-trader-ralph-380/docs/strategy-lab/request-templates/venue-readiness)
-  for manual readiness, canary, and control operations.
+  `docs/strategy-lab/request-templates/venue-readiness`
+  for manual readiness, canary, smoke, and control operations.
 - A venue is not meaningfully ready for `limited_live_ready` unless the matrix
   names both an evidence target and an isolated disable drill.
 - Real-TX landing proof without a full strategy runtime is tracked separately in
   `#410` through `#421`.
+
+## Shared Smoke Workflow
+
+Use the shared operator-invoked smoke harness for venue landing proofs:
+
+```bash
+bun run strategy-lab:readiness \
+  --operation smoke \
+  --request-file docs/strategy-lab/request-templates/venue-readiness/venue.smoke.request.json
+```
+
+The smoke request is distinct from the readiness canary request because it
+records venue-TX landing proof intent and can automatically tighten the single
+venue path on failure.
 
 ## Execution Order
 

--- a/src/bin/strategy_lab_readiness.ts
+++ b/src/bin/strategy_lab_readiness.ts
@@ -4,9 +4,10 @@ import {
   parseRuntimeResearchReadinessCanaryRequest,
   parseRuntimeResearchReadinessRequest,
   parseRuntimeResearchSubjectControlPatch,
+  parseRuntimeResearchVenueTxSmokeRequest,
 } from "../runtime/research/readiness.js";
 
-type Operation = "readiness" | "canary" | "control";
+type Operation = "readiness" | "canary" | "control" | "smoke";
 
 function readArg(flag: string): string | null {
   const index = process.argv.indexOf(flag);
@@ -20,7 +21,12 @@ function readJsonFile(path: string): unknown {
 
 function resolveOperation(): Operation {
   const raw = readArg("--operation") ?? "readiness";
-  if (raw === "readiness" || raw === "canary" || raw === "control") {
+  if (
+    raw === "readiness" ||
+    raw === "canary" ||
+    raw === "control" ||
+    raw === "smoke"
+  ) {
     return raw;
   }
   throw new Error("invalid-arg:--operation");
@@ -48,14 +54,18 @@ async function main(): Promise<void> {
       ? parseRuntimeResearchReadinessRequest(requestPayload)
       : operation === "canary"
         ? parseRuntimeResearchReadinessCanaryRequest(requestPayload)
-        : parseRuntimeResearchSubjectControlPatch(requestPayload);
+        : operation === "smoke"
+          ? parseRuntimeResearchVenueTxSmokeRequest(requestPayload)
+          : parseRuntimeResearchSubjectControlPatch(requestPayload);
 
   const endpoint =
     operation === "readiness"
       ? "/api/admin/ops/runtime/research/readiness"
       : operation === "canary"
         ? "/api/admin/ops/runtime/research/readiness/canary"
-        : "/api/admin/ops/runtime/research/subject-controls";
+        : operation === "smoke"
+          ? "/api/admin/ops/runtime/research/readiness/smoke"
+          : "/api/admin/ops/runtime/research/subject-controls";
 
   const response = await fetch(`${baseUrl.replace(/\/$/, "")}${endpoint}`, {
     method: "POST",

--- a/src/runtime/research/readiness.ts
+++ b/src/runtime/research/readiness.ts
@@ -71,6 +71,10 @@ export type RuntimeResearchReadinessCanaryRequest = {
   adapterKey?: string;
   triggerSource?: "manual" | "promotion";
   targetNotionalUsd?: string;
+  proofMode?: "readiness_canary" | "venue_tx_smoke";
+  tightenOnFailure?: boolean;
+  failureControlMode?: "disable_live" | "engage_kill_switch";
+  killDrillNotes?: string[];
   metadata?: Record<string, unknown>;
 };
 
@@ -116,6 +120,13 @@ function readOptionalString(value: unknown): string | undefined {
 function readOptionalBoolean(value: unknown): boolean | undefined {
   if (typeof value === "boolean") return value;
   return undefined;
+}
+
+function readStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value
+    .map((entry) => readOptionalString(entry))
+    .filter((entry): entry is string => Boolean(entry));
 }
 
 function readStatus(
@@ -340,6 +351,33 @@ export function parseRuntimeResearchReadinessCanaryRequest(
     triggerSourceValue === "manual" || triggerSourceValue === "promotion"
       ? triggerSourceValue
       : undefined;
+  const proofModeValue = readOptionalString(input.proofMode);
+  if (
+    proofModeValue &&
+    proofModeValue !== "readiness_canary" &&
+    proofModeValue !== "venue_tx_smoke"
+  ) {
+    throw new Error("invalid-runtime-research-readiness-canary-proof-mode");
+  }
+  const failureControlModeValue = readOptionalString(input.failureControlMode);
+  if (
+    failureControlModeValue &&
+    failureControlModeValue !== "disable_live" &&
+    failureControlModeValue !== "engage_kill_switch"
+  ) {
+    throw new Error(
+      "invalid-runtime-research-readiness-canary-failure-control-mode",
+    );
+  }
+  const proofMode =
+    proofModeValue === "readiness_canary" || proofModeValue === "venue_tx_smoke"
+      ? proofModeValue
+      : undefined;
+  const failureControlMode =
+    failureControlModeValue === "disable_live" ||
+    failureControlModeValue === "engage_kill_switch"
+      ? failureControlModeValue
+      : undefined;
 
   return {
     subjectKind,
@@ -361,9 +399,34 @@ export function parseRuntimeResearchReadinessCanaryRequest(
     ...(readOptionalString(input.targetNotionalUsd)
       ? { targetNotionalUsd: readOptionalString(input.targetNotionalUsd) }
       : {}),
+    ...(proofMode ? { proofMode } : {}),
+    ...(readOptionalBoolean(input.tightenOnFailure) !== undefined
+      ? { tightenOnFailure: readOptionalBoolean(input.tightenOnFailure) }
+      : {}),
+    ...(failureControlMode ? { failureControlMode } : {}),
+    ...(readStringArray(input.killDrillNotes)
+      ? { killDrillNotes: readStringArray(input.killDrillNotes) }
+      : {}),
     ...(isRecord(input.metadata)
       ? { metadata: input.metadata as Record<string, unknown> }
       : {}),
+  };
+}
+
+export function parseRuntimeResearchVenueTxSmokeRequest(
+  input: unknown,
+): RuntimeResearchReadinessCanaryRequest {
+  const request = parseRuntimeResearchReadinessCanaryRequest(input);
+  if (request.subjectKind !== "venue") {
+    throw new Error("invalid-runtime-research-venue-tx-smoke-subject-kind");
+  }
+
+  return {
+    ...request,
+    proofMode: "venue_tx_smoke",
+    triggerSource: request.triggerSource ?? "manual",
+    tightenOnFailure: request.tightenOnFailure ?? true,
+    failureControlMode: request.failureControlMode ?? "disable_live",
   };
 }
 
@@ -769,8 +832,19 @@ export function buildRuntimeResearchReadinessMarkdown(
 export function buildRuntimeResearchReadinessCanaryMarkdown(
   canaryRun: RuntimeStrategyLabReadinessCanaryRun,
 ): string {
+  const metadata = isRecord(canaryRun.metadata) ? canaryRun.metadata : null;
+  const proofMode = readOptionalString(metadata?.proofMode);
+  const failureControl = isRecord(metadata?.smokeFailureControl)
+    ? metadata.smokeFailureControl
+    : null;
+  const submissionPath = isRecord(metadata?.submissionPath)
+    ? metadata.submissionPath
+    : null;
+  const killDrillNotes = readStringArray(metadata?.killDrillNotes) ?? [];
   const lines = [
-    `# Strategy-lab readiness canary for ${canaryRun.subjectKind}:${canaryRun.subjectKey}`,
+    proofMode === "venue_tx_smoke"
+      ? `# Venue TX smoke for ${canaryRun.subjectKind}:${canaryRun.subjectKey}`
+      : `# Strategy-lab readiness canary for ${canaryRun.subjectKind}:${canaryRun.subjectKey}`,
     "",
     `- Run id: ${canaryRun.runId}`,
     `- Status: ${canaryRun.status}`,
@@ -794,6 +868,11 @@ export function buildRuntimeResearchReadinessCanaryMarkdown(
   }
   if (canaryRun.errorMessage) {
     lines.push(`- Error: ${canaryRun.errorMessage}`);
+  }
+  if (submissionPath) {
+    lines.push(
+      `- Submission path: ${readOptionalString(submissionPath.adapter) ?? "unknown adapter"} on ${readOptionalString(submissionPath.lane) ?? "unknown lane"}`,
+    );
   }
 
   lines.push("", "## Evidence", "");
@@ -820,6 +899,28 @@ export function buildRuntimeResearchReadinessCanaryMarkdown(
     }
     for (const note of canaryRun.reconciliation.notes ?? []) {
       lines.push(`- Note: ${note}`);
+    }
+  }
+
+  if (proofMode === "venue_tx_smoke" && killDrillNotes.length > 0) {
+    lines.push("", "## Kill Drill Notes", "");
+    for (const note of killDrillNotes) {
+      lines.push(`- ${note}`);
+    }
+  }
+
+  if (proofMode === "venue_tx_smoke" && failureControl) {
+    lines.push("", "## Failure Control", "");
+    lines.push(
+      `- Applied: ${String(failureControl.applied ?? false)}`,
+      `- Mode: ${readOptionalString(failureControl.mode) ?? "n/a"}`,
+      `- Live allowed: ${String(failureControl.liveAllowed ?? "n/a")}`,
+      `- Kill switch enabled: ${String(failureControl.killSwitchEnabled ?? "n/a")}`,
+    );
+    if (readOptionalString(failureControl.disabledReason)) {
+      lines.push(
+        `- Disabled reason: ${readOptionalString(failureControl.disabledReason)}`,
+      );
     }
   }
 

--- a/tests/unit/portal_runtime_operator_route.test.ts
+++ b/tests/unit/portal_runtime_operator_route.test.ts
@@ -753,6 +753,87 @@ describe("portal runtime operator route", () => {
     });
   });
 
+  test("forwards venue tx smoke actions with operator identity", async () => {
+    process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
+    process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";
+    process.env.RUNTIME_OPERATOR_USER_ALLOWLIST = "u_1";
+
+    let capturedBody = "";
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url = String(input);
+      if (url.endsWith("/api/me")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            user: { id: "u_1", email: "operator@example.com" },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (url.endsWith("/api/admin/ops/runtime/research/readiness/smoke")) {
+        capturedBody = String(init?.body ?? "");
+        return new Response(
+          JSON.stringify({ ok: true, run: { runId: "smoke_jupiter" } }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const response = await POST(
+      new Request("https://www.trader-ralph.com/api/runtime/operator", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer user-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          action: "run_venue_tx_smoke",
+          subjectKind: "venue",
+          subjectKey: "jupiter",
+          venueKey: "jupiter",
+          assetKey: "SOL",
+          pairSymbol: "SOL/USDC",
+          targetNotionalUsd: "5.00",
+          tightenOnFailure: true,
+          failureControlMode: "disable_live",
+          killDrillNotes: ["Disable Jupiter only."],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(JSON.parse(capturedBody)).toMatchObject({
+      subjectKind: "venue",
+      subjectKey: "jupiter",
+      venueKey: "jupiter",
+      assetKey: "SOL",
+      pairSymbol: "SOL/USDC",
+      targetNotionalUsd: "5.00",
+      requestedBy: "operator@example.com",
+      triggerSource: "manual",
+      proofMode: "venue_tx_smoke",
+      tightenOnFailure: true,
+      failureControlMode: "disable_live",
+      killDrillNotes: ["Disable Jupiter only."],
+    });
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      run: {
+        runId: "smoke_jupiter",
+      },
+    });
+  });
+
   test("forwards deployment evaluation actions", async () => {
     process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
     process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";

--- a/tests/unit/portal_runtime_operator_route.test.ts
+++ b/tests/unit/portal_runtime_operator_route.test.ts
@@ -736,7 +736,8 @@ describe("portal runtime operator route", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(JSON.parse(capturedBody)).toMatchObject({
+    const parsedBody = JSON.parse(capturedBody) as Record<string, unknown>;
+    expect(parsedBody).toMatchObject({
       subjectKind: "asset",
       subjectKey: "SOL",
       venueKey: "jupiter",
@@ -745,6 +746,7 @@ describe("portal runtime operator route", () => {
       requestedBy: "operator@example.com",
       triggerSource: "manual",
     });
+    expect(parsedBody).not.toHaveProperty("proofMode");
     await expect(response.json()).resolves.toMatchObject({
       ok: true,
       run: {

--- a/tests/unit/worker_runtime_research_readiness_route.test.ts
+++ b/tests/unit/worker_runtime_research_readiness_route.test.ts
@@ -258,4 +258,174 @@ describe("worker runtime research readiness routes", () => {
       sqlite.close();
     }
   });
+
+  test("runs a venue tx smoke and returns smoke-scoped evidence", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/research/readiness/smoke",
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              subjectKind: "venue",
+              subjectKey: "jupiter",
+              requestedBy: "codex",
+              venueKey: "jupiter",
+              assetKey: "SOL",
+              pairSymbol: "SOL/USDC",
+              proofMode: "venue_tx_smoke",
+              tightenOnFailure: true,
+              failureControlMode: "disable_live",
+              killDrillNotes: ["Disable Jupiter only."],
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(200);
+      const payload = (await response.json()) as {
+        ok: boolean;
+        status: string;
+        markdown: string;
+        run: {
+          metadata?: Record<string, unknown>;
+          evidenceRefs: Array<{ kind: string }>;
+          reconciliation: { status: string };
+        };
+      };
+      expect(payload.ok).toBe(true);
+      expect(payload.status).toBe("success");
+      expect(payload.markdown).toContain("Venue TX smoke");
+      expect(payload.run.reconciliation.status).toBe("passed");
+      expect(payload.run.evidenceRefs[0]?.kind).toBe("live_canary");
+      expect(payload.run.metadata?.proofMode).toBe("venue_tx_smoke");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("tightens the venue on tx smoke failure", async () => {
+    const { env, sqlite } = createOpsEnv({
+      STRATEGY_LAB_READINESS_CANARY_DAILY_CAP_USD: "1",
+    });
+    try {
+      const warmupResponse = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/research/readiness/smoke",
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              subjectKind: "venue",
+              subjectKey: "jupiter",
+              requestedBy: "codex",
+              venueKey: "jupiter",
+              assetKey: "SOL",
+              pairSymbol: "SOL/USDC",
+              proofMode: "venue_tx_smoke",
+              tightenOnFailure: true,
+              failureControlMode: "disable_live",
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(warmupResponse.status).toBe(200);
+
+      const smokeResponse = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/research/readiness/smoke",
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              subjectKind: "venue",
+              subjectKey: "jupiter",
+              requestedBy: "codex",
+              venueKey: "jupiter",
+              assetKey: "SOL",
+              pairSymbol: "SOL/USDC",
+              proofMode: "venue_tx_smoke",
+              tightenOnFailure: true,
+              failureControlMode: "disable_live",
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(smokeResponse.status).toBe(200);
+      const payload = (await smokeResponse.json()) as {
+        ok: boolean;
+        status: string;
+        run: {
+          evidenceRefs: Array<{ kind: string }>;
+          metadata?: {
+            smokeFailureControl?: {
+              applied?: boolean;
+              liveAllowed?: boolean;
+              killSwitchEnabled?: boolean;
+            };
+          };
+        };
+      };
+      expect(payload.ok).toBe(false);
+      expect(payload.status).toBe("skipped");
+      expect(
+        payload.run.evidenceRefs.some(
+          (ref) => ref.kind === "subject_control_patch",
+        ),
+      ).toBe(true);
+      expect(payload.run.metadata?.smokeFailureControl).toMatchObject({
+        applied: true,
+        liveAllowed: false,
+        killSwitchEnabled: false,
+      });
+
+      const subjectControls = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/research/subject-controls?subjectKind=venue&subjectKey=jupiter",
+          {
+            headers: {
+              authorization: "Bearer admin-secret",
+            },
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(subjectControls.status).toBe(200);
+      const controlPayload = (await subjectControls.json()) as {
+        ok: boolean;
+        controls: Array<{
+          subjectKey: string;
+          liveAllowed: boolean;
+          killSwitchEnabled: boolean;
+        }>;
+      };
+      expect(controlPayload.ok).toBe(true);
+      expect(controlPayload.controls[0]).toMatchObject({
+        subjectKey: "jupiter",
+        liveAllowed: false,
+        killSwitchEnabled: false,
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add a dedicated venue tx smoke request shape and CLI/operator entrypoint
- persist smoke-specific metadata and automatic failure controls in readiness canary evidence
- document the new operator-invoked smoke flow and request template

## Validation
- bun test ./tests/unit/worker_runtime_research_readiness_route.test.ts ./tests/unit/portal_runtime_operator_route.test.ts
- bun run typecheck
- bun run lint

Closes #411