### PR TITLE
Add bounded Raydium and Orca live smoke proofs

### DIFF
--- a/apps/worker/src/execution/orca_executor.ts
+++ b/apps/worker/src/execution/orca_executor.ts
@@ -55,6 +55,8 @@ export async function executeOrcaSwap(
   const route = "orca";
   const { policy, rpc, quoteResponse, log, guardEnabled } = input;
   const safeLane = isSafeLaneExecution(input);
+  const preflightCommitment =
+    policy.commitment === "finalized" ? "confirmed" : policy.commitment;
 
   if (policy.dryRun) {
     return {
@@ -151,7 +153,7 @@ export async function executeOrcaSwap(
   let simulatedAt: string | undefined;
   if (requiresSimulation) {
     const simulation = await rpc.simulateTransactionBase64(signedBase64, {
-      commitment: policy.commitment,
+      commitment: preflightCommitment,
       sigVerify: true,
     });
     simulatedAt = nowIso();
@@ -234,7 +236,7 @@ export async function executeOrcaSwap(
 
   const signature = await rpc.sendTransactionBase64(signedBase64, {
     skipPreflight: policy.skipPreflight,
-    preflightCommitment: policy.commitment,
+    preflightCommitment,
   });
   const sentAt = nowIso();
   log("info", "orca tx submitted", {

--- a/apps/worker/src/execution/raydium_executor.ts
+++ b/apps/worker/src/execution/raydium_executor.ts
@@ -1,3 +1,4 @@
+import { PublicKey } from "@solana/web3.js";
 import { SOL_MINT } from "../defaults";
 import { signTransactionWithPrivyById } from "../privy";
 import type { RaydiumApiEnvelope, RaydiumQuoteResponse } from "../raydium";
@@ -8,6 +9,13 @@ type RaydiumExecutorDeps = {
   signTransactionWithPrivyById?: typeof signTransactionWithPrivyById;
   evaluateSafeLaneTransaction?: typeof evaluateSafeLaneTransaction;
 };
+
+const TOKEN_PROGRAM_ID = new PublicKey(
+  "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+);
+const ASSOCIATED_TOKEN_PROGRAM_ID = new PublicKey(
+  "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+);
 
 function nowIso(): string {
   return new Date().toISOString();
@@ -62,6 +70,23 @@ function readRaydiumQuoteEnvelope(
   return envelope as RaydiumApiEnvelope<RaydiumQuoteResponse>;
 }
 
+function maybeDeriveAssociatedTokenAccount(input: {
+  wallet: string;
+  mint: string;
+}): string | undefined {
+  try {
+    const wallet = new PublicKey(input.wallet);
+    const mint = new PublicKey(input.mint);
+    const [ata] = PublicKey.findProgramAddressSync(
+      [wallet.toBuffer(), TOKEN_PROGRAM_ID.toBuffer(), mint.toBuffer()],
+      ASSOCIATED_TOKEN_PROGRAM_ID,
+    );
+    return ata.toBase58();
+  } catch {
+    return undefined;
+  }
+}
+
 export async function executeRaydiumSwap(
   input: ExecuteSwapInput,
   deps: RaydiumExecutorDeps = {},
@@ -103,6 +128,22 @@ export async function executeRaydiumSwap(
     wallet: input.userPublicKey,
     wrapSol: input.quoteResponse.inputMint === SOL_MINT,
     unwrapSol: input.quoteResponse.outputMint === SOL_MINT,
+    ...(input.quoteResponse.inputMint !== SOL_MINT
+      ? {
+          inputAccount: maybeDeriveAssociatedTokenAccount({
+            wallet: input.userPublicKey,
+            mint: input.quoteResponse.inputMint,
+          }),
+        }
+      : {}),
+    ...(input.quoteResponse.outputMint !== SOL_MINT
+      ? {
+          outputAccount: maybeDeriveAssociatedTokenAccount({
+            wallet: input.userPublicKey,
+            mint: input.quoteResponse.outputMint,
+          }),
+        }
+      : {}),
     computeUnitPriceMicroLamports,
     txVersion: "V0",
   });

--- a/apps/worker/src/execution/router.ts
+++ b/apps/worker/src/execution/router.ts
@@ -257,11 +257,30 @@ async function enforceStrategyLabSubjectControls(input: {
   }
 }
 
+function allowsVenueTxSmokeLiveBypass(input: {
+  venueKey: string;
+  runtimeMode?: RuntimeMode;
+  intentFamily: ExecutionIntentFamily;
+  experimentalLiveModeBypass?: "venue_tx_smoke";
+  subjectControlBypassReason?: ExecuteIntentInput["subjectControlBypassReason"];
+}): boolean {
+  if (
+    input.runtimeMode !== "live" ||
+    input.intentFamily !== "spot_swap" ||
+    input.experimentalLiveModeBypass !== "venue_tx_smoke" ||
+    input.subjectControlBypassReason !== "strategy_lab_readiness_canary"
+  ) {
+    return false;
+  }
+  return input.venueKey === "raydium" || input.venueKey === "orca";
+}
+
 async function resolveExecutionAdapterForIntent(input: {
   env: ExecuteIntentInput["env"];
   execution: ExecuteIntentInput["execution"];
   venueKey: string;
   runtimeMode?: RuntimeMode;
+  experimentalLiveModeBypass?: ExecuteIntentInput["experimentalLiveModeBypass"];
   requireVenueRouting?: boolean;
   subjectControlBypassReason?: ExecuteIntentInput["subjectControlBypassReason"];
   intentFamily: ExecutionIntentFamily;
@@ -288,6 +307,13 @@ async function resolveExecutionAdapterForIntent(input: {
   if (runtimeMode && !venueKey) {
     throw new Error("runtime-venue-required");
   }
+  const allowSmokeLiveBypass = allowsVenueTxSmokeLiveBypass({
+    venueKey,
+    runtimeMode,
+    intentFamily: input.intentFamily,
+    experimentalLiveModeBypass: input.experimentalLiveModeBypass,
+    subjectControlBypassReason: input.subjectControlBypassReason,
+  });
   if (venueKey) {
     const capability = requireRuntimeVenueCapability(venueKey);
     if (registration.venueKey !== venueKey) {
@@ -305,7 +331,11 @@ async function resolveExecutionAdapterForIntent(input: {
         `runtime-venue-intent-family-not-supported:${venueKey}:${input.intentFamily}`,
       );
     }
-    if (runtimeMode && !runtimeVenueSupportsMode(capability, runtimeMode)) {
+    if (
+      runtimeMode &&
+      !runtimeVenueSupportsMode(capability, runtimeMode) &&
+      !(allowSmokeLiveBypass && runtimeMode === "live")
+    ) {
       throw new Error(
         `runtime-venue-mode-not-supported:${venueKey}:${runtimeMode}`,
       );
@@ -320,7 +350,11 @@ async function resolveExecutionAdapterForIntent(input: {
       });
     }
   }
-  if (runtimeMode && !registration.supportedModes.includes(runtimeMode)) {
+  if (
+    runtimeMode &&
+    !registration.supportedModes.includes(runtimeMode) &&
+    !(allowSmokeLiveBypass && runtimeMode === "live")
+  ) {
     throw new Error(
       `execution-adapter-mode-unsupported:${adapterName}:${runtimeMode}`,
     );
@@ -347,6 +381,7 @@ export async function executeIntentViaRouter(
     execution: input.execution,
     venueKey,
     runtimeMode: input.runtimeMode,
+    experimentalLiveModeBypass: input.experimentalLiveModeBypass,
     requireVenueRouting: input.requireVenueRouting,
     subjectControlBypassReason: input.subjectControlBypassReason,
     intentFamily: input.intent.family,
@@ -409,6 +444,7 @@ export async function executeIntentViaRouter(
     env: input.env,
     venueKey,
     runtimeMode: input.runtimeMode,
+    experimentalLiveModeBypass: input.experimentalLiveModeBypass,
     requireVenueRouting: input.requireVenueRouting,
     subjectControlBypassReason: input.subjectControlBypassReason,
     execution: input.execution,

--- a/apps/worker/src/execution/types.ts
+++ b/apps/worker/src/execution/types.ts
@@ -96,6 +96,7 @@ type ExecuteIntentInputBase = {
   env: Env;
   venueKey?: string;
   runtimeMode?: RuntimeMode;
+  experimentalLiveModeBypass?: "venue_tx_smoke";
   requireVenueRouting?: boolean;
   subjectControlBypassReason?: "strategy_lab_readiness_canary";
   execution?: ExecutionConfig;
@@ -129,6 +130,7 @@ export type ExecuteSwapInput = {
   env: Env;
   venueKey?: string;
   runtimeMode?: RuntimeMode;
+  experimentalLiveModeBypass?: "venue_tx_smoke";
   requireVenueRouting?: boolean;
   subjectControlBypassReason?: "strategy_lab_readiness_canary";
   execution?: ExecutionConfig;

--- a/apps/worker/src/orca.ts
+++ b/apps/worker/src/orca.ts
@@ -1,3 +1,10 @@
+import { BN } from "@coral-xyz/anchor";
+import { Percentage, ReadOnlyWallet } from "@orca-so/common-sdk";
+import {
+  buildWhirlpoolClient,
+  swapQuoteByInputToken,
+  WhirlpoolContext,
+} from "@orca-so/whirlpools-sdk";
 import {
   Connection,
   PublicKey,
@@ -97,10 +104,6 @@ export type OrcaSdkFacade = {
     walletPublicKey: string;
   }): Promise<OrcaBuiltSwapTransaction>;
 };
-
-async function importOrcaRuntimeModule<T>(specifier: string): Promise<T> {
-  return (await import(specifier)) as T;
-}
 
 function normalizeOrcaPath(pathname: string): string {
   return pathname.startsWith("/") ? pathname : `/${pathname}`;
@@ -292,20 +295,6 @@ export function createOrcaSdkFacade(): OrcaSdkFacade {
     slippageBps: number;
     walletPublicKey: string;
   }) {
-    const [{ BN }, { Percentage, ReadOnlyWallet }, whirlpoolSdk] =
-      await Promise.all([
-        importOrcaRuntimeModule<typeof import("@coral-xyz/anchor")>(
-          "@coral-xyz/anchor",
-        ),
-        importOrcaRuntimeModule<typeof import("@orca-so/common-sdk")>(
-          "@orca-so/common-sdk",
-        ),
-        importOrcaRuntimeModule<typeof import("@orca-so/whirlpools-sdk")>(
-          "@orca-so/whirlpools-sdk",
-        ),
-      ]);
-    const { buildWhirlpoolClient, swapQuoteByInputToken, WhirlpoolContext } =
-      whirlpoolSdk;
     const connection = new Connection(input.rpcEndpoint, "confirmed");
     const wallet = new ReadOnlyWallet(new PublicKey(input.walletPublicKey));
     const ctx = WhirlpoolContext.from(connection, wallet);
@@ -377,7 +366,10 @@ export class OrcaClient {
       sdk?: OrcaSdkFacade;
     },
   ) {
-    this.fetchImpl = deps?.fetch ?? fetch;
+    const fetchImpl = deps?.fetch;
+    this.fetchImpl = fetchImpl
+      ? (input, init) => fetchImpl(input, init)
+      : (input, init) => fetch(input, init);
     this.sdk = deps?.sdk ?? createOrcaSdkFacade();
   }
 

--- a/apps/worker/src/strategy_lab_readiness_canary.ts
+++ b/apps/worker/src/strategy_lab_readiness_canary.ts
@@ -23,6 +23,7 @@ import {
   executeSwapViaRouter,
   resolveExecutionAdapterRegistration,
 } from "./execution/router";
+import { quoteSpotSwap } from "./execution/spot_venues";
 import type { JupiterQuoteResponse } from "./jupiter";
 import { JupiterClient } from "./jupiter";
 import {
@@ -30,8 +31,10 @@ import {
   readOpsControlSnapshot,
 } from "./ops_controls";
 import { evaluateOracleReferencePriceGuard } from "./oracle_reference";
+import { OrcaClient } from "./orca";
 import { enforcePolicy, normalizePolicy } from "./policy";
 import { createPrivySolanaWallet, getPrivyWalletAddressById } from "./privy";
+import { RaydiumClient } from "./raydium";
 import { SolanaRpc } from "./solana_rpc";
 import {
   createStrategyLabReadinessCanaryRun,
@@ -283,6 +286,16 @@ function readProofMode(
     : "readiness_canary";
 }
 
+function allowsVenueTxSmokeLiveBypass(
+  request: RuntimeResearchReadinessCanaryRequest,
+  venueKey: string,
+): boolean {
+  if (readProofMode(request) !== "venue_tx_smoke") {
+    return false;
+  }
+  return venueKey === "raydium" || venueKey === "orca";
+}
+
 function readFailureControlMode(
   request: RuntimeResearchReadinessCanaryRequest | Record<string, unknown>,
 ): "disable_live" | "engage_kill_switch" {
@@ -395,7 +408,8 @@ function resolveCanaryPairContext(
   }
 
   const capability = requireRuntimeVenueCapability(venueKey);
-  if (!runtimeVenueSupportsMode(capability, "live")) {
+  const allowSmokeLiveBypass = allowsVenueTxSmokeLiveBypass(request, venueKey);
+  if (!runtimeVenueSupportsMode(capability, "live") && !allowSmokeLiveBypass) {
     throw new Error(`strategy-lab-readiness-canary-venue-not-live:${venueKey}`);
   }
 
@@ -406,7 +420,7 @@ function resolveCanaryPairContext(
       return (
         registration !== null &&
         registration.venueKey === venueKey &&
-        registration.supportedModes.includes("live")
+        (registration.supportedModes.includes("live") || allowSmokeLiveBypass)
       );
     });
   if (!adapterKey) {
@@ -449,6 +463,8 @@ async function readBalances(input: {
 
 async function fetchCanaryQuote(input: {
   jupiter: JupiterClient;
+  orca?: OrcaClient;
+  raydium?: RaydiumClient;
   context: CanaryPairContext;
   config: StrategyLabReadinessCanaryConfig;
   targetNotionalUsd: string;
@@ -459,12 +475,15 @@ async function fetchCanaryQuote(input: {
   minExpectedOutAtomic: string;
 }> {
   const amountAtomic = parseUsdAtomic(input.targetNotionalUsd).toString();
-  const quoteResponse = await input.jupiter.quote({
+  const { quoteResponse } = await quoteSpotSwap({
+    venueKey: input.context.venueKey,
     inputMint: input.context.inputMint,
     outputMint: input.context.outputMint,
-    amount: amountAtomic,
+    amountAtomic,
     slippageBps: input.config.maxSlippageBps,
-    swapMode: "ExactIn",
+    jupiter: input.jupiter,
+    orca: input.orca,
+    raydium: input.raydium,
   });
   const quotedOutAtomic = parseBigIntLike(quoteResponse.outAmount);
   if (!quotedOutAtomic || quotedOutAtomic <= 0n) {
@@ -839,7 +858,7 @@ export async function runRuntimeResearchReadinessCanaryWorkflow(input: {
     venueKey: context.venueKey,
     adapterKey: context.adapterKey,
     lane: laneResolution.lane,
-    adapter: laneResolution.adapter,
+    adapter: context.adapterKey,
   };
 
   const rpc = SolanaRpc.fromEnv(input.env);
@@ -848,11 +867,19 @@ export async function runRuntimeResearchReadinessCanaryWorkflow(input: {
       "https://lite-api.jup.ag",
     input.env.JUPITER_API_KEY,
   );
+  const raydium =
+    context.venueKey === "raydium" ? new RaydiumClient() : undefined;
+  const orca =
+    context.venueKey === "orca"
+      ? new OrcaClient(String(input.env.RPC_ENDPOINT ?? "").trim())
+      : undefined;
 
   let quoteSummary: Awaited<ReturnType<typeof fetchCanaryQuote>>;
   try {
     quoteSummary = await fetchCanaryQuote({
       jupiter,
+      raydium,
+      orca,
       context,
       config,
       targetNotionalUsd,
@@ -959,10 +986,14 @@ export async function runRuntimeResearchReadinessCanaryWorkflow(input: {
       env: input.env,
       venueKey: context.venueKey,
       runtimeMode: "live",
+      experimentalLiveModeBypass:
+        readProofMode(input.request) === "venue_tx_smoke"
+          ? "venue_tx_smoke"
+          : undefined,
       requireVenueRouting: true,
       subjectControlBypassReason: "strategy_lab_readiness_canary",
       execution: {
-        adapter: laneResolution.adapter,
+        adapter: context.adapterKey,
         params: {
           lane: laneResolution.lane,
           requireSimulation: true,
@@ -971,6 +1002,8 @@ export async function runRuntimeResearchReadinessCanaryWorkflow(input: {
       policy,
       rpc,
       jupiter,
+      raydium,
+      orca,
       quoteResponse: quoteSummary.quoteResponse,
       userPublicKey: wallet.walletAddress,
       privyWalletId: wallet.walletId,

--- a/tests/unit/worker_execution_orca.test.ts
+++ b/tests/unit/worker_execution_orca.test.ts
@@ -119,6 +119,72 @@ describe("worker orca execution adapter", () => {
     expect(confirmSignature).toHaveBeenCalledTimes(1);
   });
 
+  test("uses confirmed preflight when the policy commitment is finalized", async () => {
+    const buildSwapTransaction = mock(async () => ({
+      unsignedTransactionBase64: "unsigned",
+      additionalSignerCount: 1,
+      lastValidBlockHeight: 42,
+    }));
+    const simulateTransactionBase64 = mock(async () => ({ err: null }));
+    const sendTransactionBase64 = mock(async () => "sig-finalized");
+    const confirmSignature = mock(async () => ({
+      ok: true,
+      status: "finalized",
+    }));
+
+    const result = await executeOrcaSwap(
+      {
+        env: {} as Env,
+        policy: normalizePolicy({ commitment: "finalized" }),
+        execution: { params: { lane: "safe" } },
+        rpc: {
+          simulateTransactionBase64,
+          sendTransactionBase64,
+          confirmSignature,
+        } as never,
+        jupiter: {} as never,
+        orca: { buildSwapTransaction } as never,
+        quoteResponse: buildQuoteResponse(),
+        userPublicKey: "11111111111111111111111111111111",
+        privyWalletId: "wallet-id",
+        log: () => {},
+      },
+      {
+        signTransactionWithPrivyById: mock(async () => "signed"),
+        evaluateSafeLaneTransaction: mock(() => ({
+          ok: true,
+          profile: {
+            txSizeBytes: 512,
+            instructionCount: 4,
+            accountKeyCount: 12,
+            addressTableLookupCount: 0,
+            signatureCount: 2,
+            computeUnitLimit: null,
+            computeUnitPriceMicroLamports: null,
+            estimatedFeeLamports: "10000",
+          },
+          limits: {
+            maxTxBytes: 1232,
+            maxInstructionCount: 24,
+            maxAccountKeys: 96,
+            maxComputeUnitLimit: 1_400_000,
+            maxEstimatedFeeLamports: "2000000",
+          },
+        })),
+      },
+    );
+
+    expect(result.status).toBe("finalized");
+    expect(simulateTransactionBase64).toHaveBeenCalledWith("signed", {
+      commitment: "confirmed",
+      sigVerify: true,
+    });
+    expect(sendTransactionBase64).toHaveBeenCalledWith("signed", {
+      skipPreflight: false,
+      preflightCommitment: "confirmed",
+    });
+  });
+
   test("fails closed when Orca simulation fails", async () => {
     const buildSwapTransaction = mock(async () => ({
       unsignedTransactionBase64: "unsigned",

--- a/tests/unit/worker_execution_raydium.test.ts
+++ b/tests/unit/worker_execution_raydium.test.ts
@@ -166,4 +166,46 @@ describe("worker raydium execution adapter", () => {
     expect(result.signature).toBeNull();
     expect(result.executionMeta?.classification).toBe("error");
   });
+
+  test("passes the associated token account for non-SOL inputs", async () => {
+    const buildSwapTransactions = mock(
+      async (request: { inputAccount?: string; outputAccount?: string }) => {
+        expect(request.inputAccount).toBe(
+          "2Rjjtn1VxWg7oJn6ys5oNFxqwEv2QakUr4HBtizhi7zu",
+        );
+        expect(request.outputAccount).toBeUndefined();
+        return {
+          envelope: { success: true, data: [{ transaction: "unsigned-1" }] },
+          transactions: ["unsigned-1"],
+          computeUnitPriceMicroLamports: "10000",
+        };
+      },
+    );
+
+    const result = await executeRaydiumSwap(
+      {
+        env: {} as Env,
+        policy: normalizePolicy({ dryRun: false, simulateOnly: true }),
+        rpc: {
+          simulateTransactionBase64: mock(async () => ({ err: null })),
+        } as never,
+        jupiter: {} as never,
+        raydium: { buildSwapTransactions } as never,
+        quoteResponse: {
+          ...buildQuoteResponse(),
+          inputMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          outputMint: "So11111111111111111111111111111111111111112",
+        },
+        userPublicKey: "BxWgMM6mmfskJyN8r8jWdSb5uSmqkCsqxHjb97RmjcQk",
+        privyWalletId: "wallet-id",
+        log: () => {},
+      },
+      {
+        signTransactionWithPrivyById: mock(async () => "signed-1"),
+      },
+    );
+
+    expect(result.status).toBe("simulated");
+    expect(buildSwapTransactions).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/unit/worker_execution_router.test.ts
+++ b/tests/unit/worker_execution_router.test.ts
@@ -737,6 +737,47 @@ describe("worker execution router", () => {
     ).rejects.toThrow(/runtime-venue-mode-not-supported:raydium:live/);
   });
 
+  test("allows Raydium live venue smoke only through the bounded readiness bypass", async () => {
+    const { env, sqlite } = await createLiveRouterEnv();
+    try {
+      const result = await executeSwapViaRouter({
+        env,
+        venueKey: "raydium",
+        runtimeMode: "live",
+        experimentalLiveModeBypass: "venue_tx_smoke",
+        requireVenueRouting: true,
+        subjectControlBypassReason: "strategy_lab_readiness_canary",
+        execution: { adapter: "raydium" },
+        policy: normalizePolicy({ dryRun: true }),
+        rpc: {} as never,
+        jupiter: {} as never,
+        quoteResponse: {
+          inputMint: "A",
+          outputMint: "B",
+          inAmount: "1",
+          outAmount: "2",
+          raydiumQuoteEnvelope: {
+            id: "quote-1",
+            success: true,
+            data: {
+              inputMint: "A",
+              outputMint: "B",
+              inputAmount: "1",
+              outputAmount: "2",
+            },
+          },
+        },
+        userPublicKey: "11111111111111111111111111111111",
+        log: () => {},
+      });
+
+      expect(result.status).toBe("dry_run");
+      expect(result.executionMeta?.route).toBe("raydium");
+    } finally {
+      sqlite.close();
+    }
+  });
+
   test("fails closed when Orca spot swaps are requested in live mode", async () => {
     await expect(
       executeSwapViaRouter({
@@ -761,6 +802,40 @@ describe("worker execution router", () => {
         log: () => {},
       }),
     ).rejects.toThrow(/runtime-venue-mode-not-supported:orca:live/);
+  });
+
+  test("allows Orca live venue smoke only through the bounded readiness bypass", async () => {
+    const { env, sqlite } = await createLiveRouterEnv();
+    try {
+      const result = await executeSwapViaRouter({
+        env,
+        venueKey: "orca",
+        runtimeMode: "live",
+        experimentalLiveModeBypass: "venue_tx_smoke",
+        requireVenueRouting: true,
+        subjectControlBypassReason: "strategy_lab_readiness_canary",
+        execution: { adapter: "orca" },
+        policy: normalizePolicy({ dryRun: true }),
+        rpc: {} as never,
+        jupiter: {} as never,
+        quoteResponse: {
+          inputMint: "A",
+          outputMint: "B",
+          inAmount: "1",
+          outAmount: "2",
+          orcaPoolSnapshot: {
+            address: "orca-pool-1",
+          },
+        },
+        userPublicKey: "11111111111111111111111111111111",
+        log: () => {},
+      });
+
+      expect(result.status).toBe("dry_run");
+      expect(result.executionMeta?.route).toBe("orca");
+    } finally {
+      sqlite.close();
+    }
   });
 
   test("fails closed when adapter is not allowlisted for the runtime venue", async () => {

--- a/tests/unit/worker_runtime_research_readiness_route.test.ts
+++ b/tests/unit/worker_runtime_research_readiness_route.test.ts
@@ -311,6 +311,104 @@ describe("worker runtime research readiness routes", () => {
     }
   });
 
+  test("allows bounded Raydium venue smoke even though the venue is not generally live-enabled", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/research/readiness/smoke",
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              subjectKind: "venue",
+              subjectKey: "raydium",
+              requestedBy: "codex",
+              venueKey: "raydium",
+              assetKey: "SOL",
+              pairSymbol: "SOL/USDC",
+              proofMode: "venue_tx_smoke",
+              tightenOnFailure: true,
+              failureControlMode: "disable_live",
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(200);
+      const payload = (await response.json()) as {
+        ok: boolean;
+        status: string;
+        run: {
+          venueKey: string;
+          metadata?: Record<string, unknown>;
+          evidenceRefs: Array<{ kind: string }>;
+        };
+      };
+      expect(payload.ok).toBe(true);
+      expect(payload.status).toBe("success");
+      expect(payload.run.venueKey).toBe("raydium");
+      expect(payload.run.evidenceRefs[0]?.kind).toBe("live_canary");
+      expect(payload.run.metadata?.proofMode).toBe("venue_tx_smoke");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("allows bounded Orca venue smoke even though the venue is not generally live-enabled", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/research/readiness/smoke",
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              subjectKind: "venue",
+              subjectKey: "orca",
+              requestedBy: "codex",
+              venueKey: "orca",
+              assetKey: "SOL",
+              pairSymbol: "SOL/USDC",
+              proofMode: "venue_tx_smoke",
+              tightenOnFailure: true,
+              failureControlMode: "disable_live",
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(200);
+      const payload = (await response.json()) as {
+        ok: boolean;
+        status: string;
+        run: {
+          venueKey: string;
+          metadata?: Record<string, unknown>;
+          evidenceRefs: Array<{ kind: string }>;
+        };
+      };
+      expect(payload.ok).toBe(true);
+      expect(payload.status).toBe("success");
+      expect(payload.run.venueKey).toBe("orca");
+      expect(payload.run.evidenceRefs[0]?.kind).toBe("live_canary");
+      expect(payload.run.metadata?.proofMode).toBe("venue_tx_smoke");
+    } finally {
+      sqlite.close();
+    }
+  });
+
   test("tightens the venue on tx smoke failure", async () => {
     const { env, sqlite } = createOpsEnv({
       STRATEGY_LAB_READINESS_CANARY_DAILY_CAP_USD: "1",


### PR DESCRIPTION
## Summary
- add a tightly-scoped `venue_tx_smoke` live bypass for manual readiness canaries on Raydium and Orca spot swaps only
- route venue smoke through venue-native Raydium and Orca quote/execution clients instead of the Jupiter default path
- add regression coverage for Raydium ATA derivation, Orca confirmed preflight on finalized policy, and bounded live-smoke routing

## Validation
- `bun test tests/unit/worker_execution_orca.test.ts tests/unit/worker_orca.test.ts tests/unit/worker_execution_raydium.test.ts tests/unit/worker_execution_router.test.ts tests/unit/worker_runtime_research_readiness_route.test.ts`
- `bun run typecheck`

## Live Proofs
- Raydium run `readinesscanary_60fcee24a0484903a6b12493e89fbba8`
  - signature `3rNYgqH46ryDmh7DzHDPSunjkTF3ra7NpcUv2vonVRy6VohnZG2kDCeqGbZDrdhuyUfgvJ1TTQByR3sc5grjwCPK`
  - finalized, reconciliation passed
- Orca run `readinesscanary_848882606ee4460e9049023b29c9a665`
  - signature `3GwicGYf17xE4bQFXMfsm1JFqnG5Pa3Z6vuonpYfhzdz8WqLtqK8UJmA5xetLadKVdPo2RrmtTJ9ZCBaZWWM9u4o`
  - finalized, reconciliation passed

Closes #413
Closes #414
