### PR TITLE
Add Drift live venue smoke proof support

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.32.1",
+    "@drift-labs/sdk": "^2.159.0-beta.2",
     "@noble/hashes": "^1.8.0",
     "@openbook-dex/openbook-v2": "^0.2.10",
     "@orca-so/common-sdk": "^0.7.0",

--- a/apps/worker/src/drift.ts
+++ b/apps/worker/src/drift.ts
@@ -68,6 +68,16 @@ function readFiniteNumber(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+function readScaledNumber(
+  value: unknown,
+  threshold: number,
+  scale: number,
+): number | null {
+  const parsed = readFiniteNumber(value);
+  if (parsed === null) return null;
+  return Math.abs(parsed) >= threshold ? parsed / scale : parsed;
+}
+
 function readPositiveAtomic(value: unknown): string | null {
   const normalized = String(value ?? "").trim();
   return /^[1-9][0-9]*$/.test(normalized) ? normalized : null;
@@ -109,6 +119,15 @@ function normalizeReduceOnly(side: string, reduceOnly: unknown): boolean {
   return reduceOnly === true;
 }
 
+function normalizeDirection(
+  side: "long" | "short" | "close_long" | "close_short",
+): "long" | "short" {
+  if (side === "short" || side === "close_long") {
+    return "short";
+  }
+  return "long";
+}
+
 function readContractsPayload(value: unknown): Record<string, unknown>[] {
   if (Array.isArray(value)) {
     return value.filter(isRecord);
@@ -142,6 +161,7 @@ function mapContractSnapshot(
 ): DriftContractSnapshot | null {
   const marketName =
     normalizeMarketName(record.marketName) ??
+    normalizeMarketName(record.ticker_id) ??
     normalizeMarketName(record.symbol) ??
     normalizeMarketName(record.contractName);
   if (!marketName) return null;
@@ -149,15 +169,19 @@ function mapContractSnapshot(
     marketName,
     marketIndex:
       readFiniteNumber(record.marketIndex) ??
+      readFiniteNumber(record.contract_index) ??
       readFiniteNumber(record.index) ??
       null,
     oracle: readTrimmedString(record.oracle),
     oracleSource:
       readTrimmedString(record.oracleSource) ??
       readTrimmedString(record.oracleSourceName),
-    status: readTrimmedString(record.status),
+    status:
+      readTrimmedString(record.status) ??
+      (readTrimmedString(record.end_timestamp) ? "active" : null),
     contractType:
       readTrimmedString(record.contractType) ??
+      readTrimmedString(record.product_type) ??
       readTrimmedString(record.marketType),
     initialMarginRatio:
       readFiniteNumber(record.initialMarginRatio) ??
@@ -173,9 +197,10 @@ function mapFundingRateSnapshot(
   record: Record<string, unknown>,
 ): DriftFundingRateSnapshot {
   const fundingRate1h =
-    readFiniteNumber(record.fundingRate) ??
+    readScaledNumber(record.fundingRate, 100, 1_000_000_000) ??
     readFiniteNumber(record.fundingRateHour) ??
-    readFiniteNumber(record.hourlyFundingRate);
+    readFiniteNumber(record.hourlyFundingRate) ??
+    readFiniteNumber(record.next_funding_rate);
   return {
     marketName,
     fundingRate1h,
@@ -185,10 +210,10 @@ function mapFundingRateSnapshot(
         : Number((fundingRate1h * 10_000).toFixed(4)),
     oraclePrice:
       readFiniteNumber(record.oraclePrice) ??
-      readFiniteNumber(record.oraclePriceTwap),
+      readScaledNumber(record.oraclePriceTwap, 100_000, 1_000_000),
     markPrice:
       readFiniteNumber(record.markPrice) ??
-      readFiniteNumber(record.markPriceTwap),
+      readScaledNumber(record.markPriceTwap, 100_000, 1_000_000),
     sourceTs:
       readTrimmedString(record.ts) ??
       readTrimmedString(record.timestamp) ??
@@ -324,10 +349,7 @@ export class DriftClient {
       instrument,
       funding,
       side: input.side,
-      direction:
-        input.side === "short" || input.side === "close_short"
-          ? "short"
-          : "long",
+      direction: normalizeDirection(input.side),
       reduceOnly: normalizeReduceOnly(input.side, options?.reduceOnly),
       orderType: normalizeOrderType(options?.orderType),
       timeInForce: normalizeTimeInForce(options?.timeInForce),

--- a/apps/worker/src/drift_live.ts
+++ b/apps/worker/src/drift_live.ts
@@ -1,0 +1,720 @@
+import {
+  BN,
+  DriftClient as DriftSdkClient,
+  configs as driftConfigs,
+  getMarketsAndOraclesForSubscription,
+  getUserAccountPublicKeySync,
+  MarketType,
+  OrderTriggerCondition,
+  OrderType,
+  PositionDirection,
+} from "@drift-labs/sdk";
+import {
+  Connection,
+  PublicKey,
+  type Transaction,
+  type TransactionVersion,
+  type VersionedTransaction,
+} from "@solana/web3.js";
+import { SOL_MINT, SUPPORTED_TRADING_TOKENS, USDC_MINT } from "./defaults";
+import type { DriftPerpIntentPreview } from "./drift";
+
+type DriftBuildWallet = {
+  publicKey: PublicKey;
+  signTransaction(tx: Transaction): Promise<Transaction>;
+  signAllTransactions(txs: Transaction[]): Promise<Transaction[]>;
+};
+
+const MAINNET_ENV = "mainnet-beta";
+const TOKEN_PROGRAM_ID = new PublicKey(
+  "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+);
+const ASSOCIATED_TOKEN_PROGRAM_ID = new PublicKey(
+  "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+);
+const QUOTE_PRECISION = 1_000_000n;
+const BASE_PRECISION = 1_000_000_000n;
+
+export type DriftLiveSetupAction = "initialize_and_deposit" | "deposit";
+
+export type DriftLiveAccountSnapshot = {
+  userAccountAddress: string;
+  marketIndex: number;
+  positionDirection: "long" | "short" | "flat";
+  baseAssetAmountAtomic: string;
+  quoteAssetAmountAtomic: string;
+  quoteEntryAmountAtomic: string;
+  quoteBreakEvenAmountAtomic: string;
+  settledPnlAtomic: string;
+  collateralAtomic: string;
+  freeCollateralAtomic: string;
+  totalCollateralAtomic: string;
+  initialMarginRequirementAtomic: string;
+  maintenanceMarginRequirementAtomic: string;
+  leverageTenThousand: string;
+  health: number;
+  openOrders: number;
+};
+
+export type DriftPreparedLivePerpOrder = {
+  marketIndex: number;
+  userAccountAddress: string;
+  spotCollateralMint: string;
+  setupAction: DriftLiveSetupAction | null;
+  setupAmountAtomic: string | null;
+  setupTransactionBase64: string | null;
+  orderTransactionBase64: string | null;
+  lastValidBlockHeight: number | null;
+  snapshotBefore: DriftLiveAccountSnapshot | null;
+};
+
+export type DriftPreparedLiveCancelOrders = {
+  marketIndex: number;
+  userAccountAddress: string;
+  cancelTransactionBase64: string;
+  lastValidBlockHeight: number | null;
+  snapshotBefore: DriftLiveAccountSnapshot;
+};
+
+type DriftSdkBundle = {
+  client: DriftSdkClient;
+  connection: Connection;
+  walletPublicKey: PublicKey;
+  perpMarket: (typeof driftConfigs)[typeof MAINNET_ENV]["PERP_MARKETS"][number];
+};
+
+type LegacyTransactionLike = {
+  feePayer?: PublicKey;
+  recentBlockhash?: string;
+  instructions: unknown[];
+  serialize(config?: {
+    requireAllSignatures?: boolean;
+    verifySignatures?: boolean;
+  }): Uint8Array;
+};
+
+function createBuildWallet(publicKey: PublicKey): DriftBuildWallet {
+  return {
+    publicKey,
+    async signTransaction(tx: Transaction): Promise<Transaction> {
+      return tx;
+    },
+    async signAllTransactions(txs: Transaction[]): Promise<Transaction[]> {
+      return txs;
+    },
+  };
+}
+
+function resolvePerpMarket(instrumentId: string) {
+  const normalized = instrumentId.trim().toUpperCase();
+  const market =
+    driftConfigs[MAINNET_ENV].PERP_MARKETS.find(
+      (entry) => entry.symbol.toUpperCase() === normalized,
+    ) ?? null;
+  if (!market) {
+    throw new Error(`drift-live-market-not-supported:${normalized}`);
+  }
+  return market;
+}
+
+function resolveUnderlyingMint(instrumentId: string): string {
+  const symbol = instrumentId
+    .trim()
+    .toUpperCase()
+    .replace(/-PERP$/, "");
+  if (symbol === "SOL") return SOL_MINT;
+  const token =
+    SUPPORTED_TRADING_TOKENS.find(
+      (entry) => entry.symbol.toUpperCase() === symbol,
+    ) ?? null;
+  if (!token) {
+    throw new Error(`drift-live-underlying-mint-unresolved:${instrumentId}`);
+  }
+  return token.mint;
+}
+
+function deriveAssociatedTokenAddress(input: {
+  owner: PublicKey;
+  mint: PublicKey;
+}): PublicKey {
+  const [associatedTokenAddress] = PublicKey.findProgramAddressSync(
+    [
+      input.owner.toBuffer(),
+      TOKEN_PROGRAM_ID.toBuffer(),
+      input.mint.toBuffer(),
+    ],
+    ASSOCIATED_TOKEN_PROGRAM_ID,
+  );
+  return associatedTokenAddress;
+}
+
+function bigIntToBn(value: bigint): BN {
+  return new BN(value.toString());
+}
+
+function positiveBigIntString(value: string | null | undefined): bigint | null {
+  const normalized = String(value ?? "").trim();
+  if (!/^[1-9][0-9]*$/.test(normalized)) return null;
+  try {
+    return BigInt(normalized);
+  } catch {
+    return null;
+  }
+}
+
+function serializeTransactionToBase64(
+  transaction: Transaction | VersionedTransaction,
+  walletPublicKey: PublicKey,
+): string {
+  // Drift SDK can return legacy Transaction objects from a different
+  // @solana/web3.js instance, so use structural detection instead of instanceof.
+  if (
+    "instructions" in transaction &&
+    Array.isArray(
+      (transaction as Transaction | LegacyTransactionLike).instructions,
+    )
+  ) {
+    transaction.feePayer = walletPublicKey;
+    return Buffer.from(
+      transaction.serialize({
+        requireAllSignatures: false,
+        verifySignatures: false,
+      }),
+    ).toString("base64");
+  }
+  return Buffer.from(transaction.serialize()).toString("base64");
+}
+
+async function refreshLegacyTransactionMetadata(input: {
+  connection: Connection;
+  transaction: Transaction | VersionedTransaction;
+  walletPublicKey: PublicKey;
+}): Promise<number | null> {
+  if (
+    !("instructions" in input.transaction) ||
+    !Array.isArray(
+      (input.transaction as Transaction | LegacyTransactionLike).instructions,
+    )
+  ) {
+    return null;
+  }
+  const latest = await input.connection.getLatestBlockhash("confirmed");
+  input.transaction.feePayer = input.walletPublicKey;
+  input.transaction.recentBlockhash = latest.blockhash;
+  return latest.lastValidBlockHeight;
+}
+
+function readOrderType(preview: DriftPerpIntentPreview): {
+  orderType: ReturnType<typeof mapOrderType>;
+  triggerCondition: typeof OrderTriggerCondition.ABOVE;
+} {
+  return {
+    orderType: mapOrderType(preview),
+    triggerCondition:
+      preview.direction === "long"
+        ? OrderTriggerCondition.ABOVE
+        : OrderTriggerCondition.BELOW,
+  };
+}
+
+function mapOrderType(preview: DriftPerpIntentPreview) {
+  if (preview.orderType === "limit") return OrderType.LIMIT;
+  if (preview.orderType === "trigger") {
+    return preview.limitPriceAtomic
+      ? OrderType.TRIGGER_LIMIT
+      : OrderType.TRIGGER_MARKET;
+  }
+  return OrderType.MARKET;
+}
+
+function mapPositionDirection(preview: DriftPerpIntentPreview) {
+  return preview.direction === "short"
+    ? PositionDirection.SHORT
+    : PositionDirection.LONG;
+}
+
+function readSetupShortfall(input: {
+  preview: DriftPerpIntentPreview;
+  snapshot: DriftLiveAccountSnapshot | null;
+}): bigint | null {
+  const requestedCollateral = positiveBigIntString(
+    input.preview.collateralAtomic,
+  );
+  if (requestedCollateral === null) return null;
+  if (!input.snapshot) return requestedCollateral;
+  const freeCollateral = positiveBigIntString(
+    input.snapshot.freeCollateralAtomic,
+  );
+  if (freeCollateral === null) return requestedCollateral;
+  return requestedCollateral > freeCollateral
+    ? requestedCollateral - freeCollateral
+    : null;
+}
+
+function computeTargetBaseAmountAtomic(input: {
+  targetNotionalUsd: string;
+  referencePrice: number | null;
+}): string {
+  const price = input.referencePrice;
+  if (price === null || !Number.isFinite(price) || price <= 0) {
+    throw new Error("drift-live-reference-price-unavailable");
+  }
+  const priceAtomic = BigInt(Math.floor(price * Number(QUOTE_PRECISION)));
+  if (priceAtomic <= 0n) {
+    throw new Error("drift-live-reference-price-invalid");
+  }
+  const [wholeRaw, fractionRaw = ""] = String(input.targetNotionalUsd ?? "")
+    .trim()
+    .split(".", 2);
+  const whole = /^[0-9]+$/.test(wholeRaw) ? BigInt(wholeRaw) : 0n;
+  const fraction = /^[0-9]*$/.test(fractionRaw)
+    ? BigInt(fractionRaw.padEnd(6, "0").slice(0, 6) || "0")
+    : 0n;
+  const notionalAtomic = whole * QUOTE_PRECISION + fraction;
+  const baseAmount = (notionalAtomic * BASE_PRECISION) / priceAtomic;
+  return (baseAmount > 0n ? baseAmount : 1n).toString();
+}
+
+function buildSdkBundle(input: {
+  rpcEndpoint: string;
+  walletPublicKey: string;
+  instrumentId: string;
+  skipLoadUsers: boolean;
+}): DriftSdkBundle {
+  const walletPublicKey = new PublicKey(input.walletPublicKey);
+  const connection = new Connection(input.rpcEndpoint, "confirmed");
+  const perpMarket = resolvePerpMarket(input.instrumentId);
+  const quoteSpot = driftConfigs[MAINNET_ENV].SPOT_MARKETS.filter(
+    (entry) => entry.marketIndex === 0,
+  );
+  const subscription = getMarketsAndOraclesForSubscription(
+    MAINNET_ENV,
+    [perpMarket],
+    quoteSpot,
+  );
+  const client = new DriftSdkClient({
+    connection,
+    wallet: createBuildWallet(walletPublicKey),
+    env: MAINNET_ENV,
+    accountSubscription: {
+      type: "websocket",
+      commitment: "confirmed",
+    },
+    perpMarketIndexes: subscription.perpMarketIndexes,
+    spotMarketIndexes: subscription.spotMarketIndexes,
+    oracleInfos: subscription.oracleInfos,
+    skipLoadUsers: input.skipLoadUsers,
+    txVersion: "legacy" as TransactionVersion,
+  });
+  return {
+    client,
+    connection,
+    walletPublicKey,
+    perpMarket,
+  };
+}
+
+async function ensureUserLoaded(input: {
+  client: DriftSdkClient;
+  walletPublicKey: PublicKey;
+}): Promise<void> {
+  if (!input.client.hasUser(0, input.walletPublicKey)) {
+    await input.client.addUser(0, input.walletPublicKey);
+  }
+}
+
+function buildSnapshot(input: {
+  client: DriftSdkClient;
+  marketIndex: number;
+}): DriftLiveAccountSnapshot {
+  const user = input.client.getUser();
+  const position = user.getPerpPositionOrEmpty(input.marketIndex);
+  const baseAssetAmount = BigInt(position.baseAssetAmount.toString());
+  return {
+    userAccountAddress: user.getUserAccountPublicKey().toBase58(),
+    marketIndex: input.marketIndex,
+    positionDirection:
+      baseAssetAmount > 0n ? "long" : baseAssetAmount < 0n ? "short" : "flat",
+    baseAssetAmountAtomic: position.baseAssetAmount.toString(),
+    quoteAssetAmountAtomic: position.quoteAssetAmount.toString(),
+    quoteEntryAmountAtomic: position.quoteEntryAmount.toString(),
+    quoteBreakEvenAmountAtomic: position.quoteBreakEvenAmount.toString(),
+    settledPnlAtomic: position.settledPnl.toString(),
+    collateralAtomic: user.getTokenAmount(0).toString(),
+    freeCollateralAtomic: user.getFreeCollateral("Initial").toString(),
+    totalCollateralAtomic: user.getTotalCollateral("Initial").toString(),
+    initialMarginRequirementAtomic: user
+      .getInitialMarginRequirement(false, input.marketIndex)
+      .toString(),
+    maintenanceMarginRequirementAtomic: user
+      .getMaintenanceMarginRequirement(undefined, input.marketIndex)
+      .toString(),
+    leverageTenThousand: user.getLeverage(true, input.marketIndex).toString(),
+    health: user.getHealth(input.marketIndex),
+    openOrders: position.openOrders,
+  };
+}
+
+async function readUserAccountExists(input: {
+  connection: Connection;
+  walletPublicKey: PublicKey;
+}): Promise<{
+  exists: boolean;
+  userAccountAddress: string;
+}> {
+  const userAccountPublicKey = getUserAccountPublicKeySync(
+    new PublicKey(driftConfigs[MAINNET_ENV].DRIFT_PROGRAM_ID),
+    input.walletPublicKey,
+    0,
+  );
+  const account = await input.connection.getAccountInfo(
+    userAccountPublicKey,
+    "confirmed",
+  );
+  return {
+    exists: account !== null,
+    userAccountAddress: userAccountPublicKey.toBase58(),
+  };
+}
+
+async function buildSetupTransaction(input: {
+  client: DriftSdkClient;
+  connection: Connection;
+  walletPublicKey: PublicKey;
+  amountAtomic: bigint;
+  existingUser: boolean;
+}): Promise<{
+  setupAction: DriftLiveSetupAction;
+  transactionBase64: string;
+  lastValidBlockHeight: number | null;
+}> {
+  const usdcMint = new PublicKey(USDC_MINT);
+  const usdcAta = deriveAssociatedTokenAddress({
+    owner: input.walletPublicKey,
+    mint: usdcMint,
+  });
+  if (input.existingUser) {
+    await ensureUserLoaded({
+      client: input.client,
+      walletPublicKey: input.walletPublicKey,
+    });
+  }
+  const transaction = input.existingUser
+    ? await input.client.createDepositTxn(
+        bigIntToBn(input.amountAtomic),
+        0,
+        usdcAta,
+        0,
+      )
+    : (
+        await input.client.createInitializeUserAccountAndDepositCollateral(
+          bigIntToBn(input.amountAtomic),
+          usdcAta,
+          0,
+          0,
+        )
+      )[0];
+  const signatureBlock =
+    "SIGNATURE_BLOCK_AND_EXPIRY" in transaction
+      ? (
+          transaction as Transaction & {
+            SIGNATURE_BLOCK_AND_EXPIRY?: { lastValidBlockHeight?: number };
+          }
+        ).SIGNATURE_BLOCK_AND_EXPIRY
+      : undefined;
+  const refreshedLastValidBlockHeight = await refreshLegacyTransactionMetadata({
+    connection: input.connection,
+    transaction,
+    walletPublicKey: input.walletPublicKey,
+  });
+  return {
+    setupAction: input.existingUser ? "deposit" : "initialize_and_deposit",
+    transactionBase64: serializeTransactionToBase64(
+      transaction,
+      input.walletPublicKey,
+    ),
+    lastValidBlockHeight:
+      refreshedLastValidBlockHeight ??
+      signatureBlock?.lastValidBlockHeight ??
+      null,
+  };
+}
+
+export async function readDriftLiveAccountSnapshot(input: {
+  rpcEndpoint: string;
+  walletPublicKey: string;
+  instrumentId: string;
+}): Promise<DriftLiveAccountSnapshot | null> {
+  const sdk = buildSdkBundle({
+    rpcEndpoint: input.rpcEndpoint,
+    walletPublicKey: input.walletPublicKey,
+    instrumentId: input.instrumentId,
+    skipLoadUsers: false,
+  });
+  try {
+    const exists = await readUserAccountExists({
+      connection: sdk.connection,
+      walletPublicKey: sdk.walletPublicKey,
+    });
+    if (!exists.exists) return null;
+    await sdk.client.subscribe();
+    await ensureUserLoaded({
+      client: sdk.client,
+      walletPublicKey: sdk.walletPublicKey,
+    });
+    await sdk.client.fetchAccounts();
+    return buildSnapshot({
+      client: sdk.client,
+      marketIndex: sdk.perpMarket.marketIndex,
+    });
+  } finally {
+    await sdk.client.unsubscribe().catch(() => {});
+  }
+}
+
+export async function prepareDriftLivePerpOrder(input: {
+  rpcEndpoint: string;
+  walletPublicKey: string;
+  preview: DriftPerpIntentPreview;
+}): Promise<DriftPreparedLivePerpOrder> {
+  const sdk = buildSdkBundle({
+    rpcEndpoint: input.rpcEndpoint,
+    walletPublicKey: input.walletPublicKey,
+    instrumentId: input.preview.instrument.marketName,
+    skipLoadUsers: false,
+  });
+  const existence = await readUserAccountExists({
+    connection: sdk.connection,
+    walletPublicKey: sdk.walletPublicKey,
+  });
+
+  let snapshotBefore: DriftLiveAccountSnapshot | null = null;
+  if (existence.exists) {
+    try {
+      await sdk.client.subscribe();
+      await ensureUserLoaded({
+        client: sdk.client,
+        walletPublicKey: sdk.walletPublicKey,
+      });
+      await sdk.client.fetchAccounts();
+      snapshotBefore = buildSnapshot({
+        client: sdk.client,
+        marketIndex: sdk.perpMarket.marketIndex,
+      });
+    } finally {
+      await sdk.client.unsubscribe().catch(() => {});
+    }
+  }
+
+  const setupShortfall = readSetupShortfall({
+    preview: input.preview,
+    snapshot: snapshotBefore,
+  });
+  if (setupShortfall !== null && setupShortfall > 0n) {
+    const setupSdk = buildSdkBundle({
+      rpcEndpoint: input.rpcEndpoint,
+      walletPublicKey: input.walletPublicKey,
+      instrumentId: input.preview.instrument.marketName,
+      skipLoadUsers: true,
+    });
+    try {
+      await setupSdk.client.subscribe();
+      const setup = await buildSetupTransaction({
+        client: setupSdk.client,
+        connection: setupSdk.connection,
+        walletPublicKey: setupSdk.walletPublicKey,
+        amountAtomic: setupShortfall,
+        existingUser: existence.exists,
+      });
+      return {
+        marketIndex: sdk.perpMarket.marketIndex,
+        userAccountAddress: existence.userAccountAddress,
+        spotCollateralMint: USDC_MINT,
+        setupAction: setup.setupAction,
+        setupAmountAtomic: setupShortfall.toString(),
+        setupTransactionBase64: setup.transactionBase64,
+        orderTransactionBase64: null,
+        lastValidBlockHeight: setup.lastValidBlockHeight,
+        snapshotBefore,
+      };
+    } finally {
+      await setupSdk.client.unsubscribe().catch(() => {});
+    }
+  }
+
+  if (!existence.exists) {
+    throw new Error("drift-live-user-account-missing");
+  }
+
+  const liveSdk = buildSdkBundle({
+    rpcEndpoint: input.rpcEndpoint,
+    walletPublicKey: input.walletPublicKey,
+    instrumentId: input.preview.instrument.marketName,
+    skipLoadUsers: false,
+  });
+  try {
+    await liveSdk.client.subscribe();
+    await ensureUserLoaded({
+      client: liveSdk.client,
+      walletPublicKey: liveSdk.walletPublicKey,
+    });
+    await liveSdk.client.fetchAccounts();
+    const { orderType, triggerCondition } = readOrderType(input.preview);
+    const orderInstruction = await liveSdk.client.getPlaceAndTakePerpOrderIx({
+      marketIndex: liveSdk.perpMarket.marketIndex,
+      marketType: MarketType.PERP,
+      direction: mapPositionDirection(input.preview),
+      baseAssetAmount: bigIntToBn(
+        positiveBigIntString(input.preview.quantityAtomic) ?? 1n,
+      ),
+      orderType,
+      price: bigIntToBn(
+        positiveBigIntString(input.preview.limitPriceAtomic) ?? 0n,
+      ),
+      reduceOnly: input.preview.reduceOnly,
+      triggerPrice:
+        positiveBigIntString(input.preview.triggerPriceAtomic) === null
+          ? null
+          : bigIntToBn(
+              positiveBigIntString(input.preview.triggerPriceAtomic) ?? 0n,
+            ),
+      triggerCondition,
+    });
+    const transaction = await liveSdk.client.buildTransaction([
+      orderInstruction,
+    ]);
+    const signatureBlock =
+      "SIGNATURE_BLOCK_AND_EXPIRY" in transaction
+        ? (
+            transaction as Transaction & {
+              SIGNATURE_BLOCK_AND_EXPIRY?: { lastValidBlockHeight?: number };
+            }
+          ).SIGNATURE_BLOCK_AND_EXPIRY
+        : undefined;
+    const refreshedLastValidBlockHeight =
+      await refreshLegacyTransactionMetadata({
+        connection: liveSdk.connection,
+        transaction,
+        walletPublicKey: liveSdk.walletPublicKey,
+      });
+    return {
+      marketIndex: liveSdk.perpMarket.marketIndex,
+      userAccountAddress: existence.userAccountAddress,
+      spotCollateralMint: USDC_MINT,
+      setupAction: null,
+      setupAmountAtomic: null,
+      setupTransactionBase64: null,
+      orderTransactionBase64: serializeTransactionToBase64(
+        transaction,
+        liveSdk.walletPublicKey,
+      ),
+      lastValidBlockHeight:
+        refreshedLastValidBlockHeight ??
+        signatureBlock?.lastValidBlockHeight ??
+        null,
+      snapshotBefore: buildSnapshot({
+        client: liveSdk.client,
+        marketIndex: liveSdk.perpMarket.marketIndex,
+      }),
+    };
+  } finally {
+    await liveSdk.client.unsubscribe().catch(() => {});
+  }
+}
+
+export async function prepareDriftLiveCancelOrders(input: {
+  rpcEndpoint: string;
+  walletPublicKey: string;
+  instrumentId: string;
+}): Promise<DriftPreparedLiveCancelOrders> {
+  const sdk = buildSdkBundle({
+    rpcEndpoint: input.rpcEndpoint,
+    walletPublicKey: input.walletPublicKey,
+    instrumentId: input.instrumentId,
+    skipLoadUsers: false,
+  });
+  const existence = await readUserAccountExists({
+    connection: sdk.connection,
+    walletPublicKey: sdk.walletPublicKey,
+  });
+  if (!existence.exists) {
+    throw new Error("drift-live-user-account-missing");
+  }
+
+  try {
+    await sdk.client.subscribe();
+    await ensureUserLoaded({
+      client: sdk.client,
+      walletPublicKey: sdk.walletPublicKey,
+    });
+    await sdk.client.fetchAccounts();
+    const snapshotBefore = buildSnapshot({
+      client: sdk.client,
+      marketIndex: sdk.perpMarket.marketIndex,
+    });
+    const cancelIx = await sdk.client.getCancelOrdersIx(
+      MarketType.PERP,
+      sdk.perpMarket.marketIndex,
+      null,
+      0,
+    );
+    const transaction = await sdk.client.buildTransaction([cancelIx]);
+    const signatureBlock =
+      "SIGNATURE_BLOCK_AND_EXPIRY" in transaction
+        ? (
+            transaction as Transaction & {
+              SIGNATURE_BLOCK_AND_EXPIRY?: { lastValidBlockHeight?: number };
+            }
+          ).SIGNATURE_BLOCK_AND_EXPIRY
+        : undefined;
+    const refreshedLastValidBlockHeight =
+      await refreshLegacyTransactionMetadata({
+        connection: sdk.connection,
+        transaction,
+        walletPublicKey: sdk.walletPublicKey,
+      });
+    return {
+      marketIndex: sdk.perpMarket.marketIndex,
+      userAccountAddress: existence.userAccountAddress,
+      cancelTransactionBase64: serializeTransactionToBase64(
+        transaction,
+        sdk.walletPublicKey,
+      ),
+      lastValidBlockHeight:
+        refreshedLastValidBlockHeight ??
+        signatureBlock?.lastValidBlockHeight ??
+        null,
+      snapshotBefore,
+    };
+  } finally {
+    await sdk.client.unsubscribe().catch(() => {});
+  }
+}
+
+export function buildDriftSmokeIntent(input: {
+  instrumentId: string;
+  side: "long" | "short" | "close_long" | "close_short";
+  targetNotionalUsd: string;
+  referencePrice: number | null;
+  collateralAtomic?: string | null;
+}): {
+  instrumentId: string;
+  quantityAtomic: string;
+  collateralAtomic: string | null;
+} {
+  return {
+    instrumentId: input.instrumentId,
+    quantityAtomic: computeTargetBaseAmountAtomic({
+      targetNotionalUsd: input.targetNotionalUsd,
+      referencePrice: input.referencePrice,
+    }),
+    collateralAtomic:
+      input.side === "long" || input.side === "short"
+        ? String(input.collateralAtomic ?? "5000000").trim() || "5000000"
+        : null,
+  };
+}
+
+export function resolveDriftSmokeUnderlyingMint(instrumentId: string): string {
+  return resolveUnderlyingMint(instrumentId);
+}

--- a/apps/worker/src/execution/drift_executor.ts
+++ b/apps/worker/src/execution/drift_executor.ts
@@ -1,4 +1,10 @@
 import { DriftClient, type DriftOrderOptions } from "../drift";
+import {
+  prepareDriftLivePerpOrder,
+  readDriftLiveAccountSnapshot,
+} from "../drift_live";
+import { signTransactionWithPrivyById } from "../privy";
+import { evaluateSafeLaneTransaction } from "./safe_lane_policy";
 import type {
   ExecuteIntentInput,
   ExecuteSwapResult,
@@ -9,21 +15,70 @@ type ExecuteDriftPerpOrderInput = ExecuteIntentInput & {
   intent: NonSwapExecutionIntent;
 };
 
+type DriftExecutorDeps = {
+  prepareDriftLivePerpOrder?: typeof prepareDriftLivePerpOrder;
+  readDriftLiveAccountSnapshot?: typeof readDriftLiveAccountSnapshot;
+  signTransactionWithPrivyById?: typeof signTransactionWithPrivyById;
+  evaluateSafeLaneTransaction?: typeof evaluateSafeLaneTransaction;
+};
+
 function nowIso(): string {
   return new Date().toISOString();
+}
+
+function readsTruthyExecutionParam(value: unknown): boolean {
+  if (value === true) return true;
+  if (typeof value !== "string") return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "on";
+}
+
+function isSafeLaneExecution(input: ExecuteDriftPerpOrderInput): boolean {
+  const lane = String(input.execution?.params?.lane ?? "")
+    .trim()
+    .toLowerCase();
+  return lane === "safe";
+}
+
+function isVenueTxSmokeLiveBypass(input: ExecuteDriftPerpOrderInput): boolean {
+  return (
+    input.runtimeMode === "live" &&
+    input.experimentalLiveModeBypass === "venue_tx_smoke" &&
+    input.subjectControlBypassReason === "strategy_lab_readiness_canary"
+  );
+}
+
+function normalizeConfirmationStatus(
+  status: string | undefined,
+): Extract<
+  ExecuteSwapResult["status"],
+  "processed" | "confirmed" | "finalized" | "error"
+> {
+  if (
+    status === "processed" ||
+    status === "confirmed" ||
+    status === "finalized"
+  ) {
+    return status;
+  }
+  return "error";
 }
 
 function buildLifecycle(input: {
   side: string;
   note: string;
+  positionState?: NonNullable<
+    ExecuteSwapResult["executionMeta"]
+  >["lifecycle"]["positionState"];
+  notes?: string[];
 }): NonNullable<ExecuteSwapResult["executionMeta"]>["lifecycle"] {
   const closing = input.side === "close_long" || input.side === "close_short";
   return {
     orderState: "open",
     fillState: "pending",
-    positionState: closing ? "closing" : "opening",
+    positionState: input.positionState ?? (closing ? "closing" : "opening"),
     settlementState: "confirmed",
-    notes: [input.note],
+    notes: [input.note, ...(input.notes ?? [])],
   };
 }
 
@@ -37,8 +92,43 @@ function readDriftOptions(
   return params as DriftOrderOptions;
 }
 
+function positionStateFromSnapshot(input: {
+  side: string;
+  afterDirection: "long" | "short" | "flat" | null;
+}): NonNullable<
+  ExecuteSwapResult["executionMeta"]
+>["lifecycle"]["positionState"] {
+  if (input.afterDirection === "flat") {
+    return input.side === "close_long" || input.side === "close_short"
+      ? "closed"
+      : "flat";
+  }
+  return input.side === "close_long" || input.side === "close_short"
+    ? "closing"
+    : "open";
+}
+
+function referenceSnapshot(
+  preview: Awaited<ReturnType<DriftClient["describePerpIntent"]>>,
+) {
+  return {
+    marketName: preview.instrument.marketName,
+    marketIndex: preview.instrument.marketIndex,
+    oracle: preview.instrument.oracle,
+    oracleSource: preview.instrument.oracleSource,
+    initialMarginRatio: preview.instrument.initialMarginRatio,
+    maintenanceMarginRatio: preview.instrument.maintenanceMarginRatio,
+    fundingRate1hBps: preview.funding?.fundingRate1hBps ?? null,
+    oraclePrice: preview.funding?.oraclePrice ?? null,
+    markPrice: preview.funding?.markPrice ?? null,
+    reduceOnly: preview.reduceOnly,
+    swiftSupported: preview.swiftSupported,
+  };
+}
+
 export async function executeDriftPerpOrder(
   input: ExecuteDriftPerpOrderInput,
+  deps: DriftExecutorDeps = {},
 ): Promise<ExecuteSwapResult> {
   if (input.intent.family !== "perp_order") {
     throw new Error("invalid-drift-intent-family");
@@ -57,7 +147,9 @@ export async function executeDriftPerpOrder(
   ) {
     throw new Error("invalid-drift-side");
   }
-  if (input.runtimeMode === "live") {
+
+  const allowLiveSmoke = isVenueTxSmokeLiveBypass(input);
+  if (input.runtimeMode === "live" && !allowLiveSmoke) {
     throw new Error("drift-live-mode-not-supported");
   }
 
@@ -78,11 +170,15 @@ export async function executeDriftPerpOrder(
     options: readDriftOptions(input.intent),
     executionAdapter: route,
   });
+  const usedQuote = drift.buildSyntheticQuote(preview);
   const lifecycle = buildLifecycle({
     side: input.intent.side,
     note: `${route}:${preview.orderType}:${preview.timeInForce}`,
   });
-  const usedQuote = drift.buildSyntheticQuote(preview);
+  const routeSessionId =
+    preview.instrument.marketIndex === null
+      ? null
+      : `perp_market:${preview.instrument.marketIndex}`;
 
   if (input.policy.dryRun) {
     return {
@@ -95,10 +191,7 @@ export async function executeDriftPerpOrder(
         route,
         classification: "dry_run",
         intentId: preview.instrument.marketName,
-        venueSessionId:
-          preview.instrument.marketIndex === null
-            ? null
-            : `perp_market:${preview.instrument.marketIndex}`,
+        venueSessionId: routeSessionId,
         lifecycle,
         trace: {
           txBuiltAt: nowIso(),
@@ -107,23 +200,273 @@ export async function executeDriftPerpOrder(
     };
   }
 
+  if (input.runtimeMode !== "live") {
+    if (input.guardEnabled) await input.guardEnabled();
+    return {
+      status: "simulated",
+      signature: null,
+      usedQuote,
+      refreshed: false,
+      lastValidBlockHeight: null,
+      executionMeta: {
+        route,
+        classification: "simulated",
+        intentId: preview.instrument.marketName,
+        venueSessionId: routeSessionId,
+        lifecycle,
+        referencePrice: {
+          verdict: "allow",
+          reason: null,
+          executionPrice:
+            preview.funding?.markPrice === null
+              ? null
+              : String(preview.funding.markPrice),
+          executionDivergenceBps: null,
+          snapshot: referenceSnapshot(preview),
+        },
+        trace: {
+          txBuiltAt: nowIso(),
+          simulatedAt: nowIso(),
+        },
+      },
+    };
+  }
+
+  if (route !== "drift") {
+    throw new Error("drift-swift-live-mode-not-supported");
+  }
+  if (!input.privyWalletId) {
+    throw new Error("missing-privy-wallet-id");
+  }
+  const rpcEndpoint = String(input.env.RPC_ENDPOINT ?? "").trim();
+  if (!rpcEndpoint) {
+    throw new Error("rpc-endpoint-missing");
+  }
+  const prepareLiveOrder =
+    deps.prepareDriftLivePerpOrder ?? prepareDriftLivePerpOrder;
+  const readLiveAccountSnapshot =
+    deps.readDriftLiveAccountSnapshot ?? readDriftLiveAccountSnapshot;
+  const signWithPrivy =
+    deps.signTransactionWithPrivyById ?? signTransactionWithPrivyById;
+  const evaluateSafeLane =
+    deps.evaluateSafeLaneTransaction ?? evaluateSafeLaneTransaction;
+  const safeLane = isSafeLaneExecution(input);
+  const txBuiltAt = nowIso();
+  let setupSignature: string | null = null;
+  let setupAction: string | null = null;
+
+  const submitSignedTransaction = async (
+    signedBase64: string,
+  ): Promise<{
+    status: Extract<
+      ExecuteSwapResult["status"],
+      "processed" | "confirmed" | "finalized" | "error" | "simulate_error"
+    >;
+    signature: string | null;
+    err: unknown;
+    trace: ExecuteSwapResult["executionMeta"]["trace"];
+  }> => {
+    const preflightCommitment =
+      input.runtimeMode === "live" ? "confirmed" : input.policy.commitment;
+    if (safeLane) {
+      const evaluation = evaluateSafeLane({
+        env: input.env,
+        signedTransactionBase64: signedBase64,
+      });
+      if (!evaluation.ok) {
+        const failedAt = nowIso();
+        return {
+          status: "simulate_error",
+          signature: null,
+          err: {
+            code: "policy-denied",
+            reason: evaluation.reason,
+            profile: evaluation.profile,
+            limits: evaluation.limits,
+          },
+          trace: {
+            txBuiltAt,
+            failedAt,
+          },
+        };
+      }
+    }
+
+    const requireSimulation =
+      safeLane ||
+      input.policy.simulateOnly ||
+      readsTruthyExecutionParam(input.execution?.params?.requireSimulation);
+    if (requireSimulation) {
+      const simulation = await input.rpc.simulateTransactionBase64(
+        signedBase64,
+        {
+          commitment: preflightCommitment,
+          sigVerify: true,
+        },
+      );
+      const simulatedAt = nowIso();
+      if (simulation.err) {
+        return {
+          status: "simulate_error",
+          signature: null,
+          err: simulation.err,
+          trace: {
+            txBuiltAt,
+            simulatedAt,
+            failedAt: simulatedAt,
+          },
+        };
+      }
+    }
+
+    const sentAt = nowIso();
+    const signature = await input.rpc.sendTransactionBase64(signedBase64, {
+      preflightCommitment,
+      skipPreflight: false,
+      maxRetries: 2,
+    });
+    const confirmation = await input.rpc.confirmSignature(signature, {
+      commitment: input.policy.commitment,
+      maxWaitMs: 30_000,
+      pollMs: 750,
+    });
+    const terminalAt = nowIso();
+    return {
+      status: confirmation.ok
+        ? normalizeConfirmationStatus(confirmation.status)
+        : "error",
+      signature,
+      err: confirmation.ok ? null : (confirmation.err ?? null),
+      trace: {
+        txBuiltAt,
+        sentAt,
+        ...(confirmation.ok
+          ? {
+              landedAt: terminalAt,
+              ...(confirmation.status === "confirmed" ||
+              confirmation.status === "finalized"
+                ? { confirmedAt: terminalAt }
+                : {}),
+              ...(confirmation.status === "finalized"
+                ? { finalizedAt: terminalAt }
+                : {}),
+            }
+          : { failedAt: terminalAt }),
+      },
+    };
+  };
+
   if (input.guardEnabled) await input.guardEnabled();
+  let plan = await prepareLiveOrder({
+    rpcEndpoint,
+    walletPublicKey: input.intent.wallet,
+    preview,
+  });
+  if (plan.setupTransactionBase64) {
+    const signedSetup = await signWithPrivy(
+      input.env,
+      input.privyWalletId,
+      plan.setupTransactionBase64,
+    );
+    const setupResult = await submitSignedTransaction(signedSetup);
+    if (
+      setupResult.status !== "processed" &&
+      setupResult.status !== "confirmed" &&
+      setupResult.status !== "finalized"
+    ) {
+      return {
+        status: setupResult.status,
+        signature: setupResult.signature,
+        usedQuote,
+        refreshed: false,
+        lastValidBlockHeight: plan.lastValidBlockHeight,
+        err: setupResult.err,
+        executionMeta: {
+          route,
+          classification: "error",
+          intentId: preview.instrument.marketName,
+          venueSessionId: plan.userAccountAddress,
+          lifecycle: buildLifecycle({
+            side: input.intent.side,
+            note: `${route}:setup_failed`,
+            notes: [String(plan.setupAction ?? "setup")],
+          }),
+          referencePrice: {
+            verdict: "allow",
+            reason: null,
+            executionPrice:
+              preview.funding?.markPrice === null
+                ? null
+                : String(preview.funding.markPrice),
+            executionDivergenceBps: null,
+            snapshot: referenceSnapshot(preview),
+          },
+          trace: setupResult.trace,
+        },
+      };
+    }
+    setupSignature = setupResult.signature;
+    setupAction = plan.setupAction;
+    plan = await prepareLiveOrder({
+      rpcEndpoint,
+      walletPublicKey: input.intent.wallet,
+      preview,
+    });
+  }
+
+  if (!plan.orderTransactionBase64) {
+    throw new Error("drift-live-order-transaction-missing");
+  }
+
+  const signedOrder = await signWithPrivy(
+    input.env,
+    input.privyWalletId,
+    plan.orderTransactionBase64,
+  );
+  const orderResult = await submitSignedTransaction(signedOrder);
+  const snapshotAfter =
+    orderResult.signature === null
+      ? null
+      : await readLiveAccountSnapshot({
+          rpcEndpoint,
+          walletPublicKey: input.intent.wallet,
+          instrumentId: preview.instrument.marketName,
+        });
+  const afterDirection = snapshotAfter?.positionDirection ?? null;
+  const classification =
+    orderResult.status === "finalized"
+      ? "finalized"
+      : orderResult.status === "confirmed"
+        ? "confirmed"
+        : orderResult.status === "processed"
+          ? "landed"
+          : "error";
 
   return {
-    status: "simulated",
-    signature: null,
+    status: orderResult.status,
+    signature: orderResult.signature,
     usedQuote,
     refreshed: false,
-    lastValidBlockHeight: null,
+    lastValidBlockHeight: plan.lastValidBlockHeight,
+    ...(orderResult.err ? { err: orderResult.err } : {}),
     executionMeta: {
       route,
-      classification: "simulated",
+      classification,
       intentId: preview.instrument.marketName,
-      venueSessionId:
-        preview.instrument.marketIndex === null
-          ? null
-          : `perp_market:${preview.instrument.marketIndex}`,
-      lifecycle,
+      venueSessionId: plan.userAccountAddress,
+      lifecycle: buildLifecycle({
+        side: input.intent.side,
+        note: `${route}:${preview.orderType}:${preview.timeInForce}`,
+        positionState: positionStateFromSnapshot({
+          side: input.intent.side,
+          afterDirection,
+        }),
+        notes: [
+          `marketIndex:${plan.marketIndex}`,
+          ...(setupSignature ? [`setupSignature:${setupSignature}`] : []),
+          ...(setupAction ? [`setupAction:${setupAction}`] : []),
+        ],
+      }),
       referencePrice: {
         verdict: "allow",
         reason: null,
@@ -132,24 +475,15 @@ export async function executeDriftPerpOrder(
             ? null
             : String(preview.funding.markPrice),
         executionDivergenceBps: null,
-        snapshot: {
-          marketName: preview.instrument.marketName,
-          marketIndex: preview.instrument.marketIndex,
-          oracle: preview.instrument.oracle,
-          oracleSource: preview.instrument.oracleSource,
-          initialMarginRatio: preview.instrument.initialMarginRatio,
-          maintenanceMarginRatio: preview.instrument.maintenanceMarginRatio,
-          fundingRate1hBps: preview.funding?.fundingRate1hBps ?? null,
-          oraclePrice: preview.funding?.oraclePrice ?? null,
-          markPrice: preview.funding?.markPrice ?? null,
-          reduceOnly: preview.reduceOnly,
-          swiftSupported: preview.swiftSupported,
-        },
+        snapshot: referenceSnapshot(preview),
       },
-      trace: {
-        txBuiltAt: nowIso(),
-        simulatedAt: nowIso(),
-      },
+      trace: orderResult.trace,
+      driftAccount: {
+        before: plan.snapshotBefore,
+        after: snapshotAfter,
+        setupSignature,
+        setupAction,
+      } as Record<string, unknown>,
     },
   };
 }

--- a/apps/worker/src/execution/drift_executor.ts
+++ b/apps/worker/src/execution/drift_executor.ts
@@ -441,14 +441,21 @@ export async function executeDriftPerpOrder(
     plan.orderTransactionBase64,
   );
   const orderResult = await submitSignedTransaction(signedOrder);
-  const snapshotAfter =
-    orderResult.signature === null
-      ? null
-      : await readLiveAccountSnapshot({
-          rpcEndpoint,
-          walletPublicKey: input.intent.wallet,
-          instrumentId: preview.instrument.marketName,
-        });
+  let snapshotAfter: Awaited<ReturnType<ReadDriftLiveAccountSnapshot>> | null =
+    null;
+  let snapshotReadError: string | null = null;
+  if (orderResult.signature !== null) {
+    try {
+      snapshotAfter = await readLiveAccountSnapshot({
+        rpcEndpoint,
+        walletPublicKey: input.intent.wallet,
+        instrumentId: preview.instrument.marketName,
+      });
+    } catch (error) {
+      snapshotReadError =
+        error instanceof Error ? error.message : String(error ?? "unknown");
+    }
+  }
   const afterDirection = snapshotAfter?.positionDirection ?? null;
   const classification =
     orderResult.status === "finalized"
@@ -482,6 +489,9 @@ export async function executeDriftPerpOrder(
           `marketIndex:${plan.marketIndex}`,
           ...(setupSignature ? [`setupSignature:${setupSignature}`] : []),
           ...(setupAction ? [`setupAction:${setupAction}`] : []),
+          ...(snapshotReadError
+            ? [`snapshotReadError:${snapshotReadError}`]
+            : []),
         ],
       }),
       referencePrice: {
@@ -500,6 +510,7 @@ export async function executeDriftPerpOrder(
         after: snapshotAfter,
         setupSignature,
         setupAction,
+        snapshotReadError,
       } as Record<string, unknown>,
     },
   };

--- a/apps/worker/src/execution/drift_executor.ts
+++ b/apps/worker/src/execution/drift_executor.ts
@@ -1,8 +1,4 @@
 import { DriftClient, type DriftOrderOptions } from "../drift";
-import {
-  prepareDriftLivePerpOrder,
-  readDriftLiveAccountSnapshot,
-} from "../drift_live";
 import { signTransactionWithPrivyById } from "../privy";
 import { evaluateSafeLaneTransaction } from "./safe_lane_policy";
 import type {
@@ -15,12 +11,24 @@ type ExecuteDriftPerpOrderInput = ExecuteIntentInput & {
   intent: NonSwapExecutionIntent;
 };
 
+type DriftLiveModule = typeof import("../drift_live");
+type PrepareDriftLivePerpOrder = DriftLiveModule["prepareDriftLivePerpOrder"];
+type ReadDriftLiveAccountSnapshot =
+  DriftLiveModule["readDriftLiveAccountSnapshot"];
+
 type DriftExecutorDeps = {
-  prepareDriftLivePerpOrder?: typeof prepareDriftLivePerpOrder;
-  readDriftLiveAccountSnapshot?: typeof readDriftLiveAccountSnapshot;
+  prepareDriftLivePerpOrder?: PrepareDriftLivePerpOrder;
+  readDriftLiveAccountSnapshot?: ReadDriftLiveAccountSnapshot;
   signTransactionWithPrivyById?: typeof signTransactionWithPrivyById;
   evaluateSafeLaneTransaction?: typeof evaluateSafeLaneTransaction;
 };
+
+let driftLiveModulePromise: Promise<DriftLiveModule> | null = null;
+
+async function loadDriftLiveModule(): Promise<DriftLiveModule> {
+  driftLiveModulePromise ??= import("../drift_live");
+  return await driftLiveModulePromise;
+}
 
 function nowIso(): string {
   return new Date().toISOString();
@@ -242,10 +250,19 @@ export async function executeDriftPerpOrder(
   if (!rpcEndpoint) {
     throw new Error("rpc-endpoint-missing");
   }
+  const driftLiveModule =
+    deps.prepareDriftLivePerpOrder && deps.readDriftLiveAccountSnapshot
+      ? null
+      : await loadDriftLiveModule();
   const prepareLiveOrder =
-    deps.prepareDriftLivePerpOrder ?? prepareDriftLivePerpOrder;
+    deps.prepareDriftLivePerpOrder ??
+    driftLiveModule?.prepareDriftLivePerpOrder;
   const readLiveAccountSnapshot =
-    deps.readDriftLiveAccountSnapshot ?? readDriftLiveAccountSnapshot;
+    deps.readDriftLiveAccountSnapshot ??
+    driftLiveModule?.readDriftLiveAccountSnapshot;
+  if (!prepareLiveOrder || !readLiveAccountSnapshot) {
+    throw new Error("drift-live-module-unavailable");
+  }
   const signWithPrivy =
     deps.signTransactionWithPrivyById ?? signTransactionWithPrivyById;
   const evaluateSafeLane =

--- a/apps/worker/src/execution/router.ts
+++ b/apps/worker/src/execution/router.ts
@@ -277,7 +277,7 @@ function allowsVenueTxSmokeLiveBypass(input: {
   if (input.intentFamily === "clob_order") {
     return input.venueKey === "openbook";
   }
-  return false;
+  return input.intentFamily === "perp_order" && input.venueKey === "drift";
 }
 
 async function resolveExecutionAdapterForIntent(input: {

--- a/apps/worker/src/strategy_lab_readiness_canary.ts
+++ b/apps/worker/src/strategy_lab_readiness_canary.ts
@@ -15,6 +15,14 @@ import {
   TRADING_TOKEN_BY_MINT,
   USDC_MINT,
 } from "./defaults";
+import { DriftClient } from "./drift";
+import {
+  buildDriftSmokeIntent,
+  type DriftLiveAccountSnapshot,
+  prepareDriftLiveCancelOrders,
+  readDriftLiveAccountSnapshot,
+  resolveDriftSmokeUnderlyingMint,
+} from "./drift_live";
 import {
   type CanonicalExecutionErrorCode,
   normalizeExecutionErrorCode,
@@ -34,6 +42,7 @@ import {
 } from "./execution/router";
 import { evaluateSafeLaneTransaction } from "./execution/safe_lane_policy";
 import { quoteSpotSwap } from "./execution/spot_venues";
+import type { ExecuteSwapResult } from "./execution/types";
 import type {
   JupiterQuoteResponse,
   JupiterTriggerOrderRecord,
@@ -103,6 +112,9 @@ type CanaryPairContext = {
   adapterKey: string;
   inputMint: string;
   outputMint: string;
+  marketType: "spot" | "perp";
+  intentFamily: "spot_swap" | "perp_order";
+  instrumentId?: string;
 };
 
 type CanarySubmissionPath = {
@@ -222,6 +234,23 @@ function parseBigIntLike(value: unknown): bigint | null {
   } catch {
     return null;
   }
+}
+
+function parseSignedBigIntLike(value: unknown): bigint | null {
+  if (typeof value === "bigint") return value;
+  const raw = String(value ?? "").trim();
+  if (!raw || !/^-?[0-9]+$/.test(raw)) return null;
+  try {
+    return BigInt(raw);
+  } catch {
+    return null;
+  }
+}
+
+function absoluteAtomic(value: unknown): string | null {
+  const parsed = parseSignedBigIntLike(value);
+  if (parsed === null) return null;
+  return (parsed < 0n ? -parsed : parsed).toString();
 }
 
 function parseUsdAtomic(value: unknown): bigint {
@@ -368,6 +397,9 @@ function allowsVenueTxSmokeLiveBypass(
     return false;
   }
   const smokeIntentFamily = readSmokeIntentFamily(request);
+  if (venueKey === "drift") {
+    return true;
+  }
   if (smokeIntentFamily === "spot_swap") {
     return venueKey === "raydium" || venueKey === "orca";
   }
@@ -461,6 +493,49 @@ function resolveCanaryPairContext(
   const venueKey =
     request.venueKey ??
     (request.subjectKind === "venue" ? request.subjectKey : "jupiter");
+  const capability = requireRuntimeVenueCapability(venueKey);
+  const allowSmokeLiveBypass = allowsVenueTxSmokeLiveBypass(request, venueKey);
+  if (!runtimeVenueSupportsMode(capability, "live") && !allowSmokeLiveBypass) {
+    throw new Error(`strategy-lab-readiness-canary-venue-not-live:${venueKey}`);
+  }
+
+  if (venueKey === "drift") {
+    const instrumentId =
+      request.pairSymbol ??
+      (request.subjectKind === "asset"
+        ? `${request.subjectKey}-PERP`
+        : "SOL-PERP");
+    const outputMint = resolveDriftSmokeUnderlyingMint(instrumentId);
+    const assetKey =
+      request.assetKey ??
+      (request.subjectKind === "asset"
+        ? request.subjectKey
+        : (TRADING_TOKEN_BY_MINT[outputMint]?.symbol ??
+          instrumentId.replace(/-PERP$/i, "")));
+    if (!assetKey || assetKey === "USDC") {
+      throw new Error("strategy-lab-readiness-canary-asset-unresolved");
+    }
+    const adapterKey =
+      request.adapterKey ??
+      capability.adapterKeys.find((candidate) => candidate === "drift");
+    if (!adapterKey) {
+      throw new Error(
+        `strategy-lab-readiness-canary-adapter-unavailable:${venueKey}`,
+      );
+    }
+    return {
+      venueKey,
+      assetKey,
+      pairSymbol: instrumentId,
+      adapterKey,
+      inputMint: USDC_MINT,
+      outputMint,
+      marketType: "perp",
+      intentFamily: "perp_order",
+      instrumentId,
+    };
+  }
+
   const pairSymbol =
     request.pairSymbol ??
     (request.subjectKind === "asset"
@@ -502,15 +577,10 @@ function resolveCanaryPairContext(
     throw new Error("strategy-lab-readiness-canary-asset-unresolved");
   }
 
-  const capability = requireRuntimeVenueCapability(venueKey);
-  const allowSmokeLiveBypass = allowsVenueTxSmokeLiveBypass(request, venueKey);
   if (!runtimeVenueSupportsIntentFamily(capability, smokeIntentFamily)) {
     throw new Error(
       `strategy-lab-readiness-canary-intent-family-unsupported:${venueKey}:${smokeIntentFamily}`,
     );
-  }
-  if (!runtimeVenueSupportsMode(capability, "live") && !allowSmokeLiveBypass) {
-    throw new Error(`strategy-lab-readiness-canary-venue-not-live:${venueKey}`);
   }
 
   const requestedAdapterKey = readOptionalString(request.adapterKey);
@@ -552,6 +622,8 @@ function resolveCanaryPairContext(
     adapterKey,
     inputMint,
     outputMint: effectiveOutputMint,
+    marketType: "spot",
+    intentFamily: "spot_swap",
   };
 }
 
@@ -919,6 +991,34 @@ function mergeMetadata(
   return {
     ...(isRecord(current) ? current : {}),
     ...patch,
+  };
+}
+
+function executionSucceeded(
+  status: ExecuteSwapResult["status"],
+): status is Extract<
+  ExecuteSwapResult["status"],
+  "processed" | "confirmed" | "finalized"
+> {
+  return (
+    status === "processed" || status === "confirmed" || status === "finalized"
+  );
+}
+
+function readDriftExecutionAccountState(result: ExecuteSwapResult): {
+  before: DriftLiveAccountSnapshot | null;
+  after: DriftLiveAccountSnapshot | null;
+  setupSignature: string | null;
+  setupAction: string | null;
+} | null {
+  const executionMeta = asJsonObject(result.executionMeta);
+  const driftAccount = asJsonObject(executionMeta?.driftAccount);
+  if (!driftAccount) return null;
+  return {
+    before: (driftAccount.before ?? null) as DriftLiveAccountSnapshot | null,
+    after: (driftAccount.after ?? null) as DriftLiveAccountSnapshot | null,
+    setupSignature: readOptionalString(driftAccount.setupSignature) ?? null,
+    setupAction: readOptionalString(driftAccount.setupAction) ?? null,
   };
 }
 
@@ -1781,6 +1881,542 @@ function classifyExecutionFailure(
   };
 }
 
+async function runDriftVenueSmoke(input: {
+  env: Env;
+  request: RuntimeResearchReadinessCanaryRequest;
+  runId: string;
+  context: CanaryPairContext;
+  wallet: StrategyLabReadinessCanaryWallet;
+  targetNotionalUsd: string;
+  config: StrategyLabReadinessCanaryConfig;
+  lane: string;
+  submissionPath: {
+    venueKey: string;
+    adapterKey: string;
+    lane: string;
+    adapter: string;
+  };
+  rpc: SolanaRpc;
+  jupiter: JupiterClient;
+  drift: DriftClient;
+}): Promise<RuntimeResearchReadinessCanaryWorkflowResult> {
+  const instrumentId = input.context.instrumentId;
+  if (!instrumentId) {
+    return await finalizeReadinessCanaryRun(input.env, {
+      runId: input.runId,
+      status: "failed",
+      runPatch: {
+        errorCode: "submission-failed",
+        errorMessage: "strategy-lab-readiness-canary-drift-instrument-missing",
+      },
+    });
+  }
+
+  const rpcEndpoint = String(input.env.RPC_ENDPOINT ?? "").trim();
+  if (!rpcEndpoint) {
+    return await finalizeReadinessCanaryRun(input.env, {
+      runId: input.runId,
+      status: "failed",
+      runPatch: {
+        errorCode: "submission-failed",
+        errorMessage: "rpc-endpoint-missing",
+      },
+    });
+  }
+
+  const preflightSnapshot = await readDriftLiveAccountSnapshot({
+    rpcEndpoint,
+    walletPublicKey: input.wallet.walletAddress,
+    instrumentId,
+  }).catch(() => null);
+  if (preflightSnapshot && preflightSnapshot.positionDirection !== "flat") {
+    return await finalizeReadinessCanaryRun(input.env, {
+      runId: input.runId,
+      status: "blocked",
+      runPatch: {
+        errorCode: "policy-denied",
+        errorMessage: "strategy-lab-readiness-canary-drift-position-not-flat",
+        metadata: {
+          submissionPath: input.submissionPath,
+          preflightSnapshot,
+        },
+      },
+    });
+  }
+
+  let preview: Awaited<ReturnType<DriftClient["describePerpIntent"]>>;
+  try {
+    preview = await input.drift.describePerpIntent({
+      instrumentId,
+      side: "long",
+      quantityAtomic: "1",
+      collateralAtomic: "5000000",
+      options: {
+        orderType: "market",
+        timeInForce: "ioc",
+      },
+      executionAdapter: input.context.adapterKey,
+    });
+  } catch (error) {
+    return await finalizeReadinessCanaryRun(input.env, {
+      runId: input.runId,
+      status: "failed",
+      runPatch: {
+        errorCode: "strategy-lab-readiness-canary-quote-failed",
+        errorMessage: executionErrorMessage(error),
+        metadata: {
+          submissionPath: input.submissionPath,
+        },
+      },
+    });
+  }
+
+  const smokeIntent = buildDriftSmokeIntent({
+    instrumentId,
+    side: "long",
+    targetNotionalUsd: input.targetNotionalUsd,
+    referencePrice:
+      preview.funding?.markPrice ?? preview.funding?.oraclePrice ?? null,
+    collateralAtomic: "5000000",
+  });
+  const collateralAtomic = smokeIntent.collateralAtomic ?? "5000000";
+  const policy = normalizePolicy({
+    allowedMints: [input.context.inputMint, input.context.outputMint],
+    slippageBps: input.config.maxSlippageBps,
+    minSolReserveLamports: input.config.minSolReserveLamports,
+    simulateOnly: false,
+    dryRun: false,
+    commitment: "finalized",
+    maxTradeAmountAtomic: smokeIntent.quantityAtomic,
+  });
+
+  const runtimeBalancePolicy = await evaluatePrivyRuntimeBalancePolicy({
+    env: input.env,
+    lane: "safe",
+    walletAddress: input.wallet.walletAddress,
+    inputMint: input.context.inputMint,
+    amountAtomic: collateralAtomic,
+    minSolReserveLamports: input.config.minSolReserveLamports,
+    rpc: input.rpc,
+    runtimeDefaults: null,
+  });
+  if (!runtimeBalancePolicy.ok) {
+    return await finalizeReadinessCanaryRun(input.env, {
+      runId: input.runId,
+      status: "blocked",
+      runPatch: {
+        errorCode: "policy-denied",
+        errorMessage: runtimeBalancePolicy.reason,
+        metadata: {
+          submissionPath: input.submissionPath,
+          runtimePolicy: runtimeBalancePolicy.metadata,
+          driftPreview: asJsonObject(preview),
+          preflightSnapshot,
+        },
+      },
+    });
+  }
+
+  const executeIntent = async (intent: {
+    side: "long" | "short" | "close_long" | "close_short";
+    quantityAtomic: string;
+    collateralAtomic: string | null;
+    reduceOnly?: boolean;
+  }): Promise<ExecuteSwapResult> =>
+    await executeIntentViaRouter({
+      env: input.env,
+      venueKey: input.context.venueKey,
+      runtimeMode: "live",
+      experimentalLiveModeBypass:
+        readProofMode(input.request) === "venue_tx_smoke"
+          ? "venue_tx_smoke"
+          : undefined,
+      requireVenueRouting: true,
+      subjectControlBypassReason: "strategy_lab_readiness_canary",
+      execution: {
+        adapter: input.context.adapterKey,
+        params: {
+          lane: input.lane,
+          requireSimulation: true,
+        },
+      },
+      policy,
+      rpc: input.rpc,
+      jupiter: input.jupiter,
+      drift: input.drift,
+      privyWalletId: input.wallet.walletId,
+      log(level, message, meta) {
+        console[level]("strategy_lab.readiness_canary", {
+          runId: input.runId,
+          message,
+          ...(meta ?? {}),
+        });
+      },
+      intent: {
+        family: "perp_order",
+        wallet: input.wallet.walletAddress,
+        venueKey: input.context.venueKey,
+        marketType: "perp",
+        instrumentId,
+        side: intent.side,
+        quantityAtomic: intent.quantityAtomic,
+        collateralAtomic: intent.collateralAtomic,
+        params: {
+          orderType: "market",
+          timeInForce: "ioc",
+          ...(intent.reduceOnly ? { reduceOnly: true } : {}),
+        },
+      },
+    });
+
+  const openResult = await executeIntent({
+    side: "long",
+    quantityAtomic: smokeIntent.quantityAtomic,
+    collateralAtomic,
+  });
+  if (!executionSucceeded(openResult.status)) {
+    const failure = classifyExecutionFailure(openResult.status, openResult.err);
+    return await finalizeReadinessCanaryRun(input.env, {
+      runId: input.runId,
+      status: failure.status,
+      runPatch: {
+        errorCode: failure.errorCode,
+        errorMessage: failure.errorMessage,
+        metadata: {
+          submissionPath: {
+            ...input.submissionPath,
+            landingStatus: openResult.status,
+          },
+          driftPreview: asJsonObject(preview),
+          executionMeta: asJsonObject(openResult.executionMeta),
+          preflightSnapshot,
+        },
+      },
+    });
+  }
+
+  const openState = readDriftExecutionAccountState(openResult);
+  const openAfter = openState?.after ?? null;
+  const openedQuantityAtomic =
+    absoluteAtomic(openAfter?.baseAssetAmountAtomic) ?? null;
+  const openOrderCount = openAfter?.openOrders ?? 0;
+  if (
+    !openAfter ||
+    openAfter.positionDirection === "flat" ||
+    !openedQuantityAtomic ||
+    openedQuantityAtomic === "0"
+  ) {
+    if (
+      openAfter &&
+      openAfter.positionDirection === "flat" &&
+      openOrderCount > 0
+    ) {
+      let cancelPlan: Awaited<ReturnType<typeof prepareDriftLiveCancelOrders>>;
+      try {
+        cancelPlan = await prepareDriftLiveCancelOrders({
+          rpcEndpoint,
+          walletPublicKey: input.wallet.walletAddress,
+          instrumentId,
+        });
+      } catch (error) {
+        return await finalizeReadinessCanaryRun(input.env, {
+          runId: input.runId,
+          status: "failed",
+          runPatch: {
+            receiptId: `receipt_${input.runId.slice(-16)}`,
+            signature: openResult.signature ?? undefined,
+            errorCode: "strategy-lab-readiness-canary-reconciliation-failed",
+            errorMessage:
+              "strategy-lab-readiness-canary-drift-open-order-cancel-plan-failed",
+            reconciliation: {
+              status: "failed",
+              actualOutputAtomic: "0",
+              minExpectedOutAtomic: "0",
+              notes: [`openStatus=${openResult.status}`],
+            },
+            evidenceRefs: [
+              {
+                kind: "live_canary",
+                ref: `signature:${openResult.signature ?? "missing"}`,
+              },
+            ],
+            metadata: {
+              submissionPath: {
+                ...input.submissionPath,
+                landingStatus: openResult.status,
+              },
+              driftPreview: asJsonObject(preview),
+              openExecutionMeta: asJsonObject(openResult.executionMeta),
+              preflightSnapshot,
+              cancelPlanError: executionErrorMessage(error),
+            },
+          },
+        });
+      }
+
+      const cancelResult = await submitPrivyManagedTransactionPlan({
+        env: input.env,
+        rpc: input.rpc,
+        walletId: input.wallet.walletId,
+        unsignedTransactionBase64: cancelPlan.cancelTransactionBase64,
+        label: "drift-cancel-orders",
+      });
+      if (!cancelResult.ok) {
+        return await finalizeReadinessCanaryRun(input.env, {
+          runId: input.runId,
+          status: "failed",
+          runPatch: {
+            receiptId: `receipt_${input.runId.slice(-16)}`,
+            signature: openResult.signature ?? undefined,
+            errorCode: cancelResult.errorCode,
+            errorMessage: cancelResult.errorMessage,
+            reconciliation: {
+              status: "failed",
+              actualOutputAtomic: "0",
+              minExpectedOutAtomic: "0",
+              notes: [
+                `openStatus=${openResult.status}`,
+                `openOrdersBeforeCancel=${openOrderCount}`,
+              ],
+            },
+            evidenceRefs: [
+              {
+                kind: "live_canary",
+                ref: `signature:${openResult.signature ?? "missing"}`,
+              },
+            ],
+            metadata: {
+              submissionPath: {
+                ...input.submissionPath,
+                landingStatus: openResult.status,
+              },
+              driftPreview: asJsonObject(preview),
+              openExecutionMeta: asJsonObject(openResult.executionMeta),
+              cancelSnapshotBefore: cancelPlan.snapshotBefore,
+              preflightSnapshot,
+            },
+          },
+        });
+      }
+
+      const cancelSnapshotAfter = await readDriftLiveAccountSnapshot({
+        rpcEndpoint,
+        walletPublicKey: input.wallet.walletAddress,
+        instrumentId,
+      }).catch(() => null);
+      const cancelled =
+        cancelSnapshotAfter?.positionDirection === "flat" &&
+        (cancelSnapshotAfter?.openOrders ?? -1) === 0;
+
+      return await finalizeReadinessCanaryRun(input.env, {
+        runId: input.runId,
+        status: cancelled ? "success" : "failed",
+        runPatch: {
+          receiptId: `receipt_${input.runId.slice(-16)}`,
+          signature: openResult.signature ?? undefined,
+          errorCode: cancelled
+            ? undefined
+            : "strategy-lab-readiness-canary-reconciliation-failed",
+          errorMessage: cancelled
+            ? undefined
+            : "strategy-lab-readiness-canary-drift-cancel-not-observed",
+          reconciliation: {
+            status: cancelled ? "passed" : "failed",
+            actualOutputAtomic: "0",
+            minExpectedOutAtomic: "0",
+            notes: [
+              `openStatus=${openResult.status}`,
+              `cancelStatus=${cancelResult.status}`,
+              `openOrdersBeforeCancel=${openOrderCount}`,
+              `openOrdersAfterCancel=${cancelSnapshotAfter?.openOrders ?? "missing"}`,
+            ],
+          },
+          evidenceRefs: [
+            {
+              kind: "live_canary",
+              ref: `signature:${openResult.signature ?? "missing"}`,
+            },
+            {
+              kind: "live_canary_cancel",
+              ref: `signature:${cancelResult.signature}`,
+            },
+          ],
+          metadata: {
+            submissionPath: {
+              ...input.submissionPath,
+              landingStatus: cancelResult.status,
+            },
+            driftPreview: asJsonObject(preview),
+            openExecutionMeta: asJsonObject(openResult.executionMeta),
+            preflightSnapshot,
+            cancelSnapshotBefore: cancelPlan.snapshotBefore,
+            cancelSnapshotAfter,
+            cancelSignature: cancelResult.signature,
+          },
+        },
+      });
+    }
+
+    return await finalizeReadinessCanaryRun(input.env, {
+      runId: input.runId,
+      status: "failed",
+      runPatch: {
+        receiptId: `receipt_${input.runId.slice(-16)}`,
+        signature: openResult.signature ?? undefined,
+        errorCode: "strategy-lab-readiness-canary-reconciliation-failed",
+        errorMessage: "strategy-lab-readiness-canary-drift-open-not-observed",
+        reconciliation: {
+          status: "failed",
+          actualOutputAtomic: "0",
+          minExpectedOutAtomic: smokeIntent.quantityAtomic,
+          notes: [`openStatus=${openResult.status}`],
+        },
+        evidenceRefs: [
+          {
+            kind: "live_canary",
+            ref: `signature:${openResult.signature ?? "missing"}`,
+          },
+        ],
+        metadata: {
+          submissionPath: {
+            ...input.submissionPath,
+            landingStatus: openResult.status,
+          },
+          driftPreview: asJsonObject(preview),
+          openExecutionMeta: asJsonObject(openResult.executionMeta),
+          preflightSnapshot,
+        },
+      },
+    });
+  }
+
+  const closeSide =
+    openAfter.positionDirection === "short" ? "close_short" : "close_long";
+  const closeResult = await executeIntent({
+    side: closeSide,
+    quantityAtomic: openedQuantityAtomic,
+    collateralAtomic: null,
+    reduceOnly: true,
+  });
+  if (!executionSucceeded(closeResult.status)) {
+    const failure = classifyExecutionFailure(
+      closeResult.status,
+      closeResult.err,
+    );
+    return await finalizeReadinessCanaryRun(input.env, {
+      runId: input.runId,
+      status: failure.status,
+      runPatch: {
+        receiptId: `receipt_${input.runId.slice(-16)}`,
+        signature: openResult.signature ?? undefined,
+        errorCode: failure.errorCode,
+        errorMessage: failure.errorMessage,
+        evidenceRefs: [
+          {
+            kind: "live_canary",
+            ref: `signature:${openResult.signature ?? "missing"}`,
+          },
+          ...(closeResult.signature
+            ? [
+                {
+                  kind: "live_canary" as const,
+                  ref: `signature:${closeResult.signature}`,
+                },
+              ]
+            : []),
+        ],
+        metadata: {
+          submissionPath: {
+            ...input.submissionPath,
+            landingStatus: closeResult.status,
+          },
+          driftPreview: asJsonObject(preview),
+          openExecutionMeta: asJsonObject(openResult.executionMeta),
+          closeExecutionMeta: asJsonObject(closeResult.executionMeta),
+          preflightSnapshot,
+        },
+      },
+    });
+  }
+
+  const closeState = readDriftExecutionAccountState(closeResult);
+  const closeAfter = closeState?.after ?? null;
+  const closed =
+    closeAfter?.positionDirection === "flat" &&
+    absoluteAtomic(closeAfter.baseAssetAmountAtomic) === "0";
+  const [openTransaction, closeTransaction] = await Promise.all([
+    openResult.signature
+      ? input.rpc.getTransactionParsed(openResult.signature, {
+          commitment: "confirmed",
+        })
+      : Promise.resolve(null),
+    closeResult.signature
+      ? input.rpc.getTransactionParsed(closeResult.signature, {
+          commitment: "confirmed",
+        })
+      : Promise.resolve(null),
+  ]);
+  const totalFeeLamports = (
+    readReconciliationFeeLamports(openTransaction) +
+    readReconciliationFeeLamports(closeTransaction)
+  ).toString();
+  return await finalizeReadinessCanaryRun(input.env, {
+    runId: input.runId,
+    status: closed ? "success" : "failed",
+    runPatch: {
+      receiptId: `receipt_${input.runId.slice(-16)}`,
+      signature: openResult.signature ?? undefined,
+      errorCode: closed
+        ? undefined
+        : "strategy-lab-readiness-canary-reconciliation-failed",
+      errorMessage: closed
+        ? undefined
+        : "strategy-lab-readiness-canary-drift-close-not-flat",
+      reconciliation: {
+        status: closed ? "passed" : "failed",
+        actualOutputAtomic: openedQuantityAtomic,
+        minExpectedOutAtomic: smokeIntent.quantityAtomic,
+        notes: [
+          `openStatus=${openResult.status}`,
+          `closeStatus=${closeResult.status}`,
+          `closePositionState=${closeAfter?.positionDirection ?? "missing"}`,
+        ],
+      },
+      evidenceRefs: [
+        {
+          kind: "live_canary",
+          ref: `signature:${openResult.signature ?? "missing"}`,
+        },
+        {
+          kind: "live_canary",
+          ref: `signature:${closeResult.signature ?? "missing"}`,
+        },
+        ...(openState?.setupSignature
+          ? [
+              {
+                kind: "live_canary" as const,
+                ref: `signature:${openState.setupSignature}`,
+              },
+            ]
+          : []),
+      ],
+      metadata: {
+        submissionPath: {
+          ...input.submissionPath,
+          landingStatus: closeResult.status,
+        },
+        driftPreview: asJsonObject(preview),
+        preflightSnapshot,
+        openExecutionMeta: asJsonObject(openResult.executionMeta),
+        closeExecutionMeta: asJsonObject(closeResult.executionMeta),
+        setupSignature: openState?.setupSignature ?? null,
+        setupAction: openState?.setupAction ?? null,
+        totalFeeLamports,
+      },
+    },
+  });
+}
+
 async function runOpenBookVenueTxSmoke(input: {
   env: Env;
   request: RuntimeResearchReadinessCanaryRequest;
@@ -2315,6 +2951,8 @@ export async function runRuntimeResearchReadinessCanaryWorkflow(input: {
       "https://lite-api.jup.ag",
     input.env.JUPITER_API_KEY,
   );
+  const drift =
+    context.venueKey === "drift" ? new DriftClient(input.env) : undefined;
   const raydium =
     context.venueKey === "raydium" ? new RaydiumClient() : undefined;
   const orca =
@@ -2323,6 +2961,22 @@ export async function runRuntimeResearchReadinessCanaryWorkflow(input: {
           String(input.env.RPC_ENDPOINT ?? "").trim(),
         )
       : undefined;
+  if (context.marketType === "perp" && context.venueKey === "drift" && drift) {
+    return await runDriftVenueSmoke({
+      env: input.env,
+      request: input.request,
+      runId,
+      context,
+      wallet,
+      targetNotionalUsd,
+      config,
+      lane: laneResolution.lane,
+      submissionPath,
+      rpc,
+      jupiter,
+      drift,
+    });
+  }
   if (smokeIntentFamily === "clob_order") {
     try {
       return await runOpenBookVenueTxSmoke({

--- a/apps/worker/src/strategy_lab_readiness_canary.ts
+++ b/apps/worker/src/strategy_lab_readiness_canary.ts
@@ -12,17 +12,12 @@ import {
 import {
   SOL_MINT,
   SUPPORTED_TRADING_PAIRS,
+  SUPPORTED_TRADING_TOKENS,
   TRADING_TOKEN_BY_MINT,
   USDC_MINT,
 } from "./defaults";
 import { DriftClient } from "./drift";
-import {
-  buildDriftSmokeIntent,
-  type DriftLiveAccountSnapshot,
-  prepareDriftLiveCancelOrders,
-  readDriftLiveAccountSnapshot,
-  resolveDriftSmokeUnderlyingMint,
-} from "./drift_live";
+import type { DriftLiveAccountSnapshot } from "./drift_live";
 import {
   type CanonicalExecutionErrorCode,
   normalizeExecutionErrorCode,
@@ -123,6 +118,15 @@ type CanarySubmissionPath = {
   lane: string;
   adapter: string;
 };
+
+type DriftLiveModule = typeof import("./drift_live");
+
+let driftLiveModulePromise: Promise<DriftLiveModule> | null = null;
+
+async function loadDriftLiveModule(): Promise<DriftLiveModule> {
+  driftLiveModulePromise ??= import("./drift_live");
+  return await driftLiveModulePromise;
+}
 
 export type RuntimeResearchReadinessCanaryWorkflowResult = {
   ok: boolean;
@@ -251,6 +255,26 @@ function absoluteAtomic(value: unknown): string | null {
   const parsed = parseSignedBigIntLike(value);
   if (parsed === null) return null;
   return (parsed < 0n ? -parsed : parsed).toString();
+}
+
+function resolveDriftSmokeUnderlyingMintForCanary(
+  instrumentId: string,
+): string {
+  const symbol = instrumentId
+    .trim()
+    .toUpperCase()
+    .replace(/-PERP$/, "");
+  if (symbol === "SOL") return SOL_MINT;
+  const token =
+    SUPPORTED_TRADING_TOKENS.find(
+      (entry) => entry.symbol.toUpperCase() === symbol,
+    ) ?? null;
+  if (!token) {
+    throw new Error(
+      `strategy-lab-readiness-canary-drift-underlying-mint-unresolved:${instrumentId}`,
+    );
+  }
+  return token.mint;
 }
 
 function parseUsdAtomic(value: unknown): bigint {
@@ -505,7 +529,7 @@ function resolveCanaryPairContext(
       (request.subjectKind === "asset"
         ? `${request.subjectKey}-PERP`
         : "SOL-PERP");
-    const outputMint = resolveDriftSmokeUnderlyingMint(instrumentId);
+    const outputMint = resolveDriftSmokeUnderlyingMintForCanary(instrumentId);
     const assetKey =
       request.assetKey ??
       (request.subjectKind === "asset"
@@ -1924,11 +1948,14 @@ async function runDriftVenueSmoke(input: {
     });
   }
 
-  const preflightSnapshot = await readDriftLiveAccountSnapshot({
-    rpcEndpoint,
-    walletPublicKey: input.wallet.walletAddress,
-    instrumentId,
-  }).catch(() => null);
+  const driftLive = await loadDriftLiveModule();
+  const preflightSnapshot = await driftLive
+    .readDriftLiveAccountSnapshot({
+      rpcEndpoint,
+      walletPublicKey: input.wallet.walletAddress,
+      instrumentId,
+    })
+    .catch(() => null);
   if (preflightSnapshot && preflightSnapshot.positionDirection !== "flat") {
     return await finalizeReadinessCanaryRun(input.env, {
       runId: input.runId,
@@ -1971,7 +1998,7 @@ async function runDriftVenueSmoke(input: {
     });
   }
 
-  const smokeIntent = buildDriftSmokeIntent({
+  const smokeIntent = driftLive.buildDriftSmokeIntent({
     instrumentId,
     side: "long",
     targetNotionalUsd: input.targetNotionalUsd,
@@ -2111,9 +2138,11 @@ async function runDriftVenueSmoke(input: {
       openAfter.positionDirection === "flat" &&
       openOrderCount > 0
     ) {
-      let cancelPlan: Awaited<ReturnType<typeof prepareDriftLiveCancelOrders>>;
+      let cancelPlan: Awaited<
+        ReturnType<DriftLiveModule["prepareDriftLiveCancelOrders"]>
+      >;
       try {
-        cancelPlan = await prepareDriftLiveCancelOrders({
+        cancelPlan = await driftLive.prepareDriftLiveCancelOrders({
           rpcEndpoint,
           walletPublicKey: input.wallet.walletAddress,
           instrumentId,
@@ -2199,11 +2228,13 @@ async function runDriftVenueSmoke(input: {
         });
       }
 
-      const cancelSnapshotAfter = await readDriftLiveAccountSnapshot({
-        rpcEndpoint,
-        walletPublicKey: input.wallet.walletAddress,
-        instrumentId,
-      }).catch(() => null);
+      const cancelSnapshotAfter = await driftLive
+        .readDriftLiveAccountSnapshot({
+          rpcEndpoint,
+          walletPublicKey: input.wallet.walletAddress,
+          instrumentId,
+        })
+        .catch(() => null);
       const cancelled =
         cancelSnapshotAfter?.positionDirection === "flat" &&
         (cancelSnapshotAfter?.openOrders ?? -1) === 0;

--- a/apps/worker/src/strategy_lab_readiness_canary.ts
+++ b/apps/worker/src/strategy_lab_readiness_canary.ts
@@ -1998,14 +1998,50 @@ async function runDriftVenueSmoke(input: {
     });
   }
 
-  const smokeIntent = driftLive.buildDriftSmokeIntent({
-    instrumentId,
-    side: "long",
-    targetNotionalUsd: input.targetNotionalUsd,
-    referencePrice:
-      preview.funding?.markPrice ?? preview.funding?.oraclePrice ?? null,
-    collateralAtomic: "5000000",
-  });
+  const referencePrice =
+    preview.funding?.markPrice ?? preview.funding?.oraclePrice ?? null;
+  if (referencePrice === null) {
+    return await finalizeReadinessCanaryRun(input.env, {
+      runId: input.runId,
+      status: "failed",
+      runPatch: {
+        errorCode: "strategy-lab-readiness-canary-quote-failed",
+        errorMessage:
+          "strategy-lab-readiness-canary-drift-reference-price-unavailable",
+        metadata: {
+          submissionPath: input.submissionPath,
+          driftPreview: asJsonObject(preview),
+          preflightSnapshot,
+        },
+      },
+    });
+  }
+
+  let smokeIntent: ReturnType<typeof driftLive.buildDriftSmokeIntent>;
+  try {
+    smokeIntent = driftLive.buildDriftSmokeIntent({
+      instrumentId,
+      side: "long",
+      targetNotionalUsd: input.targetNotionalUsd,
+      referencePrice,
+      collateralAtomic: "5000000",
+    });
+  } catch (error) {
+    return await finalizeReadinessCanaryRun(input.env, {
+      runId: input.runId,
+      status: "failed",
+      runPatch: {
+        errorCode: "strategy-lab-readiness-canary-quote-failed",
+        errorMessage: executionErrorMessage(error),
+        metadata: {
+          submissionPath: input.submissionPath,
+          driftPreview: asJsonObject(preview),
+          preflightSnapshot,
+        },
+      },
+    });
+  }
+
   const collateralAtomic = smokeIntent.collateralAtomic ?? "5000000";
   const policy = normalizePolicy({
     allowedMints: [input.context.inputMint, input.context.outputMint],

--- a/bun.lock
+++ b/bun.lock
@@ -66,6 +66,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@coral-xyz/anchor": "^0.32.1",
+        "@drift-labs/sdk": "^2.159.0-beta.2",
         "@noble/hashes": "^1.8.0",
         "@openbook-dex/openbook-v2": "^0.2.10",
         "@orca-so/common-sdk": "^0.7.0",
@@ -112,6 +113,8 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.15", "", { "os": "win32", "cpu": "x64" }, "sha512-kDZr/hgg+igo5Emi0LcjlgfkoGZtgIpJKhnvKTRmMBv6FF/3SDyEV4khBwqNebZIyMZTzvpca9sQNSXJ39pI2A=="],
 
+    "@bufbuild/protobuf": ["@bufbuild/protobuf@2.10.2", "", {}, "sha512-uFsRXwIGyu+r6AMdz+XijIIZJYpoWeYzILt5yZ2d3mCjQrWUTVpVD9WL/jZAbvp+Ed04rOhrsk7FiTcEDseB5A=="],
+
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.2", "", {}, "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ=="],
 
     "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.12.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": "^1.20260115.0" }, "optionalPeers": ["workerd"] }, "sha512-tP/Wi+40aBJovonSNJSsS7aFJY0xjuckKplmzDs2Xat06BJ68B6iG7YDUWXJL8gNn0gqW7YC5WhlYhO3QbugQA=="],
@@ -134,11 +137,15 @@
 
     "@coral-xyz/anchor": ["@coral-xyz/anchor@0.32.1", "", { "dependencies": { "@coral-xyz/anchor-errors": "^0.31.1", "@coral-xyz/borsh": "^0.31.1", "@noble/hashes": "^1.3.1", "@solana/web3.js": "^1.69.0", "bn.js": "^5.1.2", "bs58": "^4.0.1", "buffer-layout": "^1.2.2", "camelcase": "^6.3.0", "cross-fetch": "^3.1.5", "eventemitter3": "^4.0.7", "pako": "^2.0.3", "superstruct": "^0.15.4", "toml": "^3.0.0" } }, "sha512-zAyxFtfeje2FbMA1wzgcdVs7Hng/MijPKpRijoySPCicnvcTQs/+dnPZ/cR+LcXM9v9UYSyW81uRNYZtN5G4yg=="],
 
+    "@coral-xyz/anchor-30": ["@coral-xyz/anchor@0.30.1", "", { "dependencies": { "@coral-xyz/anchor-errors": "^0.30.1", "@coral-xyz/borsh": "^0.30.1", "@noble/hashes": "^1.3.1", "@solana/web3.js": "^1.68.0", "bn.js": "^5.1.2", "bs58": "^4.0.1", "buffer-layout": "^1.2.2", "camelcase": "^6.3.0", "cross-fetch": "^3.1.5", "crypto-hash": "^1.3.0", "eventemitter3": "^4.0.7", "pako": "^2.0.3", "snake-case": "^3.0.4", "superstruct": "^0.15.4", "toml": "^3.0.0" } }, "sha512-gDXFoF5oHgpriXAaLpxyWBHdCs8Awgf/gLHIo6crv7Aqm937CNdY+x+6hoj7QR5vaJV7MxWSQ0NGFzL3kPbWEQ=="],
+
     "@coral-xyz/anchor-errors": ["@coral-xyz/anchor-errors@0.31.1", "", {}, "sha512-NhNEku4F3zzUSBtrYz84FzYWm48+9OvmT1Hhnwr6GnPQry2dsEqH/ti/7ASjjpoFTWRnPXrjAIT1qM6Isop+LQ=="],
 
     "@coral-xyz/borsh": ["@coral-xyz/borsh@0.32.1", "", { "dependencies": { "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" }, "peerDependencies": { "@solana/web3.js": "^1.69.0" } }, "sha512-pWsqkkZ+psLlupMkgu5rDok7baDQLWKqyDsb76gUNArbVB783mF3ZOleKMHVXZczl5JuxnVVfO1+XDVvR17C3A=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
+    "@drift-labs/sdk": ["@drift-labs/sdk@2.159.0-beta.2", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/anchor-30": "npm:@coral-xyz/anchor@0.30.1", "@ellipsis-labs/phoenix-sdk": "1.4.5", "@grpc/grpc-js": "1.14.0", "@msgpack/msgpack": "^3.1.2", "@openbook-dex/openbook-v2": "0.2.10", "@project-serum/serum": "0.13.65", "@pythnetwork/client": "2.5.3", "@pythnetwork/price-service-sdk": "1.7.1", "@pythnetwork/pyth-lazer-sdk": "5.2.1", "@solana/spl-token": "0.4.13", "@solana/web3.js": "1.98.0", "@switchboard-xyz/common": "3.0.14", "@switchboard-xyz/on-demand": "2.4.1", "@triton-one/yellowstone-grpc": "5.0.2", "anchor-bankrun": "0.3.0", "gill": "^0.10.2", "nanoid": "3.3.4", "node-cache": "5.1.2", "solana-bankrun": "0.3.1", "strict-event-emitter-types": "2.0.0", "tweetnacl": "1.0.3", "tweetnacl-util": "0.15.1", "uuid": "8.3.2", "yargs": "17.7.2", "zod": "4.0.17", "zstddec": "0.1.0" }, "optionalDependencies": { "helius-laserstream": "0.1.8" } }, "sha512-WkDFgb6aSCeAeVuwN2B+kupc4FyrXN8paWUczfEYk80Bsk0ArPD6teL6Z41NTb6H+saSzUqHUHxxd+3bxgNImQ=="],
 
     "@ecies/ciphers": ["@ecies/ciphers@0.2.5", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A=="],
 
@@ -224,6 +231,10 @@
 
     "@gemini-wallet/core": ["@gemini-wallet/core@0.3.2", "", { "dependencies": { "@metamask/rpc-errors": "7.0.2", "eventemitter3": "5.0.1" }, "peerDependencies": { "viem": ">=2.0.0" } }, "sha512-Z4aHi3ECFf5oWYWM3F1rW83GJfB9OvhBYPTmb5q+VyK3uvzvS48lwo+jwh2eOoCRWEuT/crpb9Vwp2QaS5JqgQ=="],
 
+    "@grpc/grpc-js": ["@grpc/grpc-js@1.14.0", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-N8Jx6PaYzcTRNzirReJCtADVoq4z7+1KQ4E70jTg/koQiMoUSN1kbNjPOqpPbhMFhfU1/l7ixspPl8dNY+FoUg=="],
+
+    "@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
+
     "@hcaptcha/loader": ["@hcaptcha/loader@2.3.0", "", {}, "sha512-i4lnNxKBe+COf3R1nFZEWaZoHIoJjvDgWqvcNrdZq8ehoSNMN6KVZ56dcQ02qKie2h3+BkbkwlJA9DOIuLlK/g=="],
 
     "@hcaptcha/react-hcaptcha": ["@hcaptcha/react-hcaptcha@1.17.4", "", { "dependencies": { "@babel/runtime": "^7.17.9", "@hcaptcha/loader": "^2.3.0" }, "peerDependencies": { "react": ">= 16.3.0", "react-dom": ">= 16.3.0" } }, "sha512-rIvgesG1N7SS9sAYYHFoWm+nXqRrxq7RcA9z2pKkDWV+S1GdfmrTNYA1aPyVWVe3eowphTCwyDJvl97Swwy0mw=="],
@@ -282,6 +293,8 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
+    "@isaacs/ttlcache": ["@isaacs/ttlcache@1.4.1", "", {}, "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -291,6 +304,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
+    "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
     "@lit-labs/ssr-dom-shim": ["@lit-labs/ssr-dom-shim@1.5.1", "", {}, "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA=="],
 
@@ -400,6 +415,38 @@
 
     "@privy-io/urls": ["@privy-io/urls@0.0.3", "", {}, "sha512-cococ82ycPJc+wSCHUG0TrVJXF2PIkmDH8TLV+oGqBr14Q7ziRI63aCFIp6FpSRhdDDo9jmB0VR9NjCak4ptMA=="],
 
+    "@project-serum/anchor": ["@project-serum/anchor@0.11.1", "", { "dependencies": { "@project-serum/borsh": "^0.2.2", "@solana/web3.js": "^1.17.0", "base64-js": "^1.5.1", "bn.js": "^5.1.2", "bs58": "^4.0.1", "buffer-layout": "^1.2.0", "camelcase": "^5.3.1", "crypto-hash": "^1.3.0", "eventemitter3": "^4.0.7", "find": "^0.3.0", "js-sha256": "^0.9.0", "pako": "^2.0.3", "snake-case": "^3.0.4", "toml": "^3.0.0" } }, "sha512-oIdm4vTJkUy6GmE6JgqDAuQPKI7XM4TPJkjtoIzp69RZe0iAD9JP2XHx7lV1jLdYXeYHqDXfBt3zcq7W91K6PA=="],
+
+    "@project-serum/borsh": ["@project-serum/borsh@0.2.5", "", { "dependencies": { "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" }, "peerDependencies": { "@solana/web3.js": "^1.2.0" } }, "sha512-UmeUkUoKdQ7rhx6Leve1SssMR/Ghv8qrEiyywyxSWg7ooV7StdpPBhciiy5eB3T0qU1BXvdRNC8TdrkxK7WC5Q=="],
+
+    "@project-serum/serum": ["@project-serum/serum@0.13.65", "", { "dependencies": { "@project-serum/anchor": "^0.11.1", "@solana/spl-token": "^0.1.6", "@solana/web3.js": "^1.21.0", "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" } }, "sha512-BHRqsTqPSfFB5p+MgI2pjvMBAQtO8ibTK2fYY96boIFkCI3TTwXDt2gUmspeChKO2pqHr5aKevmexzAcXxrSRA=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.4", "", {}, "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
+
+    "@pythnetwork/client": ["@pythnetwork/client@2.5.3", "", { "dependencies": { "@solana/web3.js": "^1.30.2", "assert": "^2.0.0", "buffer": "^6.0.1" } }, "sha512-NBLxPnA6A3tZb/DYUooD4SO63UJ70s9DzzFPGXcQNBR9itcycp7aaV+UA5oUPloD/4UHL9soo2fRuDVur0gmhA=="],
+
+    "@pythnetwork/price-service-sdk": ["@pythnetwork/price-service-sdk@1.7.1", "", { "dependencies": { "bn.js": "^5.2.1" } }, "sha512-xr2boVXTyv1KUt/c6llUTfbv2jpud99pWlMJbFaHGUBoygQsByuy7WbjIJKZ+0Blg1itLZl0Lp/pJGGg8SdJoQ=="],
+
+    "@pythnetwork/pyth-lazer-sdk": ["@pythnetwork/pyth-lazer-sdk@5.2.1", "", { "dependencies": { "@isaacs/ttlcache": "^1.4.1", "buffer": "^6.0.3", "isomorphic-ws": "^5.0.0", "ts-log": "^2.2.7", "ws": "^8.18.0" } }, "sha512-/0rrPi6sZdVH+cWtW+X/hmQzw+nP2fIF6BlrJRTrqwK2IXWZWW+40sHoj839HrbyUXOJyG9zKyco37eFuTE/nA=="],
+
     "@react-aria/focus": ["@react-aria/focus@3.21.4", "", { "dependencies": { "@react-aria/interactions": "^3.27.0", "@react-aria/utils": "^3.33.0", "@react-types/shared": "^3.33.0", "@swc/helpers": "^0.5.0", "clsx": "^2.0.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-6gz+j9ip0/vFRTKJMl3R30MHopn4i19HqqLfSQfElxJD+r9hBnYG1Q6Wd/kl/WRR1+CALn2F+rn06jUnf5sT8Q=="],
 
     "@react-aria/interactions": ["@react-aria/interactions@3.27.0", "", { "dependencies": { "@react-aria/ssr": "^3.9.10", "@react-aria/utils": "^3.33.0", "@react-stately/flags": "^3.1.2", "@react-types/shared": "^3.33.0", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-D27pOy+0jIfHK60BB26AgqjjRFOYdvVSkwC31b2LicIzRCSPOSP06V4gMHuGmkhNTF4+YWDi1HHYjxIvMeiSlA=="],
@@ -478,9 +525,9 @@
 
     "@solana/accounts": ["@solana/accounts@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/rpc-spec": "5.5.1", "@solana/rpc-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ=="],
 
-    "@solana/addresses": ["@solana/addresses@5.5.1", "", { "dependencies": { "@solana/assertions": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA=="],
+    "@solana/addresses": ["@solana/addresses@5.1.0", "", { "dependencies": { "@solana/assertions": "5.1.0", "@solana/codecs-core": "5.1.0", "@solana/codecs-strings": "5.1.0", "@solana/errors": "5.1.0", "@solana/nominal-types": "5.1.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-X84qSZLgve9YeYsyxGI49WnfEre53tdFu4x9/4oULBgoj8d0A+P9VGLYzmRJ0YFYKRcZG7U4u3MQpI5uLZ1AsQ=="],
 
-    "@solana/assertions": ["@solana/assertions@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q=="],
+    "@solana/assertions": ["@solana/assertions@2.3.0", "", { "dependencies": { "@solana/errors": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ=="],
 
     "@solana/buffer-layout": ["@solana/buffer-layout@4.0.1", "", { "dependencies": { "buffer": "~6.0.3" } }, "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA=="],
 
@@ -526,11 +573,11 @@
 
     "@solana/rpc": ["@solana/rpc@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1", "@solana/fast-stable-stringify": "5.5.1", "@solana/functional": "5.5.1", "@solana/rpc-api": "5.5.1", "@solana/rpc-spec": "5.5.1", "@solana/rpc-spec-types": "5.5.1", "@solana/rpc-transformers": "5.5.1", "@solana/rpc-transport-http": "5.5.1", "@solana/rpc-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-ku8zTUMrkCWci66PRIBC+1mXepEnZH/q1f3ck0kJZ95a06bOTl5KU7HeXWtskkyefzARJ5zvCs54AD5nxjQJ+A=="],
 
-    "@solana/rpc-api": ["@solana/rpc-api@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/keys": "5.5.1", "@solana/rpc-parsed-types": "5.5.1", "@solana/rpc-spec": "5.5.1", "@solana/rpc-transformers": "5.5.1", "@solana/rpc-types": "5.5.1", "@solana/transaction-messages": "5.5.1", "@solana/transactions": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-XWOQQPhKl06Vj0xi3RYHAc6oEQd8B82okYJ04K7N0Vvy3J4PN2cxeK7klwkjgavdcN9EVkYCChm2ADAtnztKnA=="],
+    "@solana/rpc-api": ["@solana/rpc-api@5.1.0", "", { "dependencies": { "@solana/addresses": "5.1.0", "@solana/codecs-core": "5.1.0", "@solana/codecs-strings": "5.1.0", "@solana/errors": "5.1.0", "@solana/keys": "5.1.0", "@solana/rpc-parsed-types": "5.1.0", "@solana/rpc-spec": "5.1.0", "@solana/rpc-transformers": "5.1.0", "@solana/rpc-types": "5.1.0", "@solana/transaction-messages": "5.1.0", "@solana/transactions": "5.1.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-eI1tY0i3gmih1C65gFECYbfPRpHEYqFp+9IKjpknZtYpQIe9BqBKSpfYpGiCAbKdN/TMadBNPOzdK15ewhkkvQ=="],
 
     "@solana/rpc-parsed-types": ["@solana/rpc-parsed-types@5.5.1", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-HEi3G2nZqGEsa3vX6U0FrXLaqnUCg4SKIUrOe8CezD+cSFbRTOn3rCLrUmJrhVyXlHoQVaRO9mmeovk31jWxJg=="],
 
-    "@solana/rpc-spec": ["@solana/rpc-spec@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1", "@solana/rpc-spec-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q=="],
+    "@solana/rpc-spec": ["@solana/rpc-spec@5.1.0", "", { "dependencies": { "@solana/errors": "5.1.0", "@solana/rpc-spec-types": "5.1.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-y8B6fUWA1EBKXUsNo6b9EiFcQPsaJREPLlcIDbo4b6TucQNwvl7FHfpf1VHJL64SkI/WE69i2WEkiOJYjmLO0A=="],
 
     "@solana/rpc-spec-types": ["@solana/rpc-spec-types@5.5.1", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw=="],
 
@@ -542,11 +589,11 @@
 
     "@solana/rpc-subscriptions-spec": ["@solana/rpc-subscriptions-spec@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1", "@solana/promises": "5.5.1", "@solana/rpc-spec-types": "5.5.1", "@solana/subscribable": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-iq+rGq5fMKP3/mKHPNB6MC8IbVW41KGZg83Us/+LE3AWOTWV1WT20KT2iH1F1ik9roi42COv/TpoZZvhKj45XQ=="],
 
-    "@solana/rpc-transformers": ["@solana/rpc-transformers@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1", "@solana/functional": "5.5.1", "@solana/nominal-types": "5.5.1", "@solana/rpc-spec-types": "5.5.1", "@solana/rpc-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q=="],
+    "@solana/rpc-transformers": ["@solana/rpc-transformers@5.1.0", "", { "dependencies": { "@solana/errors": "5.1.0", "@solana/functional": "5.1.0", "@solana/nominal-types": "5.1.0", "@solana/rpc-spec-types": "5.1.0", "@solana/rpc-types": "5.1.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-6v93xi/ewGS/xEiSktNQ0bh0Uiv1/q9nR5oiFMn3BiAJRC+FdMRMxCjp6H+/Tua7wdhpClaPKrZYBQHoIp59tw=="],
 
     "@solana/rpc-transport-http": ["@solana/rpc-transport-http@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1", "@solana/rpc-spec": "5.5.1", "@solana/rpc-spec-types": "5.5.1", "undici-types": "^7.19.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-yv8GoVSHqEV0kUJEIhkdOVkR2SvJ6yoWC51cJn2rSV7plr6huLGe0JgujCmB7uZhhaLbcbP3zxXxu9sOjsi7Fg=="],
 
-    "@solana/rpc-types": ["@solana/rpc-types@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA=="],
+    "@solana/rpc-types": ["@solana/rpc-types@5.1.0", "", { "dependencies": { "@solana/addresses": "5.1.0", "@solana/codecs-core": "5.1.0", "@solana/codecs-numbers": "5.1.0", "@solana/codecs-strings": "5.1.0", "@solana/errors": "5.1.0", "@solana/nominal-types": "5.1.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-Rnpt5BuHQvnULPNXUC/yRqB+7iPbon95CSCeyRvPj5tJ4fx2JibvX3s/UEoud5vC+kRjPi/R0BGJ8XFvd3eDWg=="],
 
     "@solana/signers": ["@solana/signers@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1", "@solana/instructions": "5.5.1", "@solana/keys": "5.5.1", "@solana/nominal-types": "5.5.1", "@solana/offchain-messages": "5.5.1", "@solana/transaction-messages": "5.5.1", "@solana/transactions": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ=="],
 
@@ -573,6 +620,10 @@
     "@speed-highlight/core": ["@speed-highlight/core@1.2.14", "", {}, "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
+
+    "@switchboard-xyz/common": ["@switchboard-xyz/common@3.0.14", "", { "dependencies": { "@solana/web3.js": "^1.98.0", "axios": "^1.8.3", "big.js": "^6.2.2", "bn.js": "^5.2.1", "bs58": "^6.0.0", "buffer": "^6.0.3", "decimal.js": "^10.4.3", "js-sha256": "^0.11.0", "protobufjs": "^7.4.0", "yaml": "^2.6.1" } }, "sha512-LpxzEywO0DjPYIgPzQYkf32C7agwW4YRsPN6BcIvYrw0iJdDMtPZ3SQfIGHLSlD1fwvn2KLUYuGaKegeq4aBTw=="],
+
+    "@switchboard-xyz/on-demand": ["@switchboard-xyz/on-demand@2.4.1", "", { "dependencies": { "@coral-xyz/anchor-30": "npm:@coral-xyz/anchor@0.30.1", "@isaacs/ttlcache": "^1.4.1", "@switchboard-xyz/common": ">=3.0.0", "axios": "^1.8.3", "bs58": "^6.0.0", "buffer": "^6.0.3", "js-yaml": "^4.1.0" } }, "sha512-eSlBp+c8lxpcSgh0/2xK8OaLHPziTSZlcs8V96gZGdiCJz1KgWJRNE1qnIJDOwaGdFecZdwcmajfQRtLRLED3w=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.1.18", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "enhanced-resolve": "^5.18.3", "jiti": "^2.6.1", "lightningcss": "1.30.2", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.1.18" } }, "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ=="],
 
@@ -612,6 +663,16 @@
 
     "@tanstack/virtual-core": ["@tanstack/virtual-core@3.13.18", "", {}, "sha512-Mx86Hqu1k39icq2Zusq+Ey2J6dDWTjDvEv43PJtRCoEYTLyfaPnxIQ6iy7YAOK0NV/qOEmZQ/uCufrppZxTgcg=="],
 
+    "@triton-one/yellowstone-grpc": ["@triton-one/yellowstone-grpc@5.0.2", "", { "dependencies": { "@bufbuild/protobuf": "=2.10.2", "@solana/addresses": "=5.1.0", "@solana/rpc-api": "=5.1.0", "@solana/rpc-types": "=5.1.0" }, "optionalDependencies": { "@triton-one/yellowstone-grpc-napi-darwin-arm64": "0.0.6", "@triton-one/yellowstone-grpc-napi-darwin-x64": "0.0.6", "@triton-one/yellowstone-grpc-napi-linux-x64-gnu": "0.0.6", "@triton-one/yellowstone-grpc-napi-linux-x64-musl": "0.0.6" } }, "sha512-RR4X+W6GcvtcSCi+vtUm+6EC1rU9irLmu6bfhNl2MEh8nZakd+y79RLKU815OPZTosXWnbZMu6cQExKy6ixKPQ=="],
+
+    "@triton-one/yellowstone-grpc-napi-darwin-arm64": ["@triton-one/yellowstone-grpc-napi-darwin-arm64@0.0.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-sQ+0wPnDX4vBbqWotgs+T7eJas64CRMhGL3mCYqk35zaU5k+1C9XKTghYao9sp+/8635oo3r1K2of1ZPI0m4tg=="],
+
+    "@triton-one/yellowstone-grpc-napi-darwin-x64": ["@triton-one/yellowstone-grpc-napi-darwin-x64@0.0.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-hWP6TDtX8kG01l7Y3bSmuH95ESgB7ZsNMB9Kr57qTWgRWgcj2tyy7QjxZNZC8f9n0iGxjCgCZB78rsAkIVjrag=="],
+
+    "@triton-one/yellowstone-grpc-napi-linux-x64-gnu": ["@triton-one/yellowstone-grpc-napi-linux-x64-gnu@0.0.6", "", { "os": "linux", "cpu": "x64" }, "sha512-ZMbSNp1I4dvVIdY50zlKO7iiiBNsDdbmGl5cDSOwGG39bxPx+N8Vk1B2ZIQShc5ja7V7pmdYA3maplgkp/Fjjw=="],
+
+    "@triton-one/yellowstone-grpc-napi-linux-x64-musl": ["@triton-one/yellowstone-grpc-napi-linux-x64-musl@0.0.6", "", { "os": "linux", "cpu": "x64" }, "sha512-kORs4rX1aTzReidLLbFhrK8oGj4R3hVP3aDhR8tKFm8modbhaEZPyqY2MPyTS3VNYyFeMQrKTLllOJ5wsUeVkQ=="],
+
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
@@ -621,6 +682,8 @@
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
+
+    "@types/protobufjs": ["@types/protobufjs@6.0.0", "", { "dependencies": { "protobufjs": "*" } }, "sha512-A27RDExpAf3rdDjIrHKiJK6x8kqqJ4CmoChwtipfhVAn1p7+wviQFFP7dppn8FslSbHtQeVPvi8wNKkDjSYjHw=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
@@ -702,6 +765,8 @@
 
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
+    "anchor-bankrun": ["anchor-bankrun@0.3.0", "", { "peerDependencies": { "@coral-xyz/anchor": "^0.28.0", "@solana/web3.js": "^1.78.4", "solana-bankrun": "^0.2.0" } }, "sha512-PYBW5fWX+iGicIS5MIM/omhk1tQPUc0ELAnI/IkLKQJ6d75De/CQRh8MF2bU/TgGyFi6zEel80wUe3uRol9RrQ=="],
+
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -709,6 +774,8 @@
     "ansicolors": ["ansicolors@0.3.2", "", {}, "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "assert": ["assert@2.1.0", "", { "dependencies": { "call-bind": "^1.0.2", "is-nan": "^1.3.2", "object-is": "^1.1.5", "object.assign": "^4.1.4", "util": "^0.12.5" } }, "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw=="],
 
@@ -780,7 +847,9 @@
 
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
-    "cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "clone": ["clone@2.1.2", "", {}, "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
@@ -852,6 +921,8 @@
 
     "dot-case": ["dot-case@3.0.4", "", { "dependencies": { "no-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w=="],
 
+    "dotenv": ["dotenv@10.0.0", "", {}, "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="],
+
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "duplexify": ["duplexify@4.1.3", "", { "dependencies": { "end-of-stream": "^1.4.1", "inherits": "^2.0.3", "readable-stream": "^3.1.1", "stream-shift": "^1.0.2" } }, "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA=="],
@@ -889,6 +960,8 @@
     "es6-promisify": ["es6-promisify@5.0.0", "", { "dependencies": { "es6-promise": "^4.0.3" } }, "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ=="],
 
     "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "eth-block-tracker": ["eth-block-tracker@7.1.0", "", { "dependencies": { "@metamask/eth-json-rpc-provider": "^1.0.0", "@metamask/safe-event-emitter": "^3.0.0", "@metamask/utils": "^5.0.1", "json-rpc-random-id": "^1.0.1", "pify": "^3.0.0" } }, "sha512-8YdplnuE1IK4xfqpf4iU7oBxnOYAc35934o083G8ao+8WM8QQtt/mVlAY6yIAdY1eMeLqg4Z//PZjJGmWGPMRg=="],
 
@@ -936,6 +1009,8 @@
 
     "filter-obj": ["filter-obj@1.1.0", "", {}, "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="],
 
+    "find": ["find@0.3.0", "", { "dependencies": { "traverse-chain": "~0.1.0" } }, "sha512-iSd+O4OEYV/I36Zl8MdYJO0xD82wH528SaCieTVHhclgiYNe9y+yPKSwK+A7/WsmHL1EZ+pYUJBXWTL5qofksw=="],
+
     "find-process": ["find-process@1.4.11", "", { "dependencies": { "chalk": "~4.1.2", "commander": "^12.1.0", "loglevel": "^1.9.2" }, "bin": { "find-process": "bin/find-process.js" } }, "sha512-mAOh9gGk9WZ4ip5UjV0o6Vb4SrfnAmtsFNzkMRH9HQiFXVQnDyQFrSHTK5UoG6E+KV+s+cIznbtwpfN41l2nFA=="],
 
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
@@ -977,6 +1052,20 @@
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "helius-laserstream": ["helius-laserstream@0.1.8", "", { "dependencies": { "@types/protobufjs": "^6.0.0", "protobufjs": "^7.5.3" }, "optionalDependencies": { "helius-laserstream-darwin-arm64": "0.1.8", "helius-laserstream-darwin-x64": "0.1.8", "helius-laserstream-linux-arm64-gnu": "0.1.8", "helius-laserstream-linux-arm64-musl": "0.1.8", "helius-laserstream-linux-x64-gnu": "0.1.8", "helius-laserstream-linux-x64-musl": "0.1.8" }, "os": [ "linux", "darwin", ], "cpu": [ "x64", "arm64", ] }, "sha512-jXQkwQRWiowbVPGQrGacOkI5shKPhrEixCu93OpoMtL5fs9mnhtD7XKMPi8CX0W8gsqsJjwR4NlaR+EflyANbQ=="],
+
+    "helius-laserstream-darwin-arm64": ["helius-laserstream-darwin-arm64@0.1.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-p/K2Mi3wZnMxEYSLCvu858VyMvtJFonhdF8cLaMcszFv04WWdsK+hINNZpVRfakypvDfDPbMudEhL1Q9USD5+w=="],
+
+    "helius-laserstream-darwin-x64": ["helius-laserstream-darwin-x64@0.1.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-Hd5irFyfOqQZLdoj5a+OV7vML2YfySSBuKlOwtisMHkUuIXZ4NpAexslDmK7iP5VWRI+lOv9X/tA7BhxW7RGSQ=="],
+
+    "helius-laserstream-linux-arm64-gnu": ["helius-laserstream-linux-arm64-gnu@0.1.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-PlPm1dvOvTGBL1nuzK98Xe40BJq1JWNREXlBHKDVA/B+KCGQnIMJ1s6e1MevSvFE7SOix5i1BxhYIxGioK2GMg=="],
+
+    "helius-laserstream-linux-arm64-musl": ["helius-laserstream-linux-arm64-musl@0.1.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-LFadfMRuTd1zo6RZqLTgHQapo3gJYioS7wFMWFoBOFulG0BpAqHEDNobkxx0002QArw+zX29MQ/5OaOCf8kKTA=="],
+
+    "helius-laserstream-linux-x64-gnu": ["helius-laserstream-linux-x64-gnu@0.1.8", "", { "os": "linux", "cpu": "x64" }, "sha512-IZWK/OQIe0647QqfYikLb1DFK+nYtXLJiMcpj24qnNVWBOtMXmPc1hL6ebazdEiaKt7fxNd5IiM1RqeaqZAZMw=="],
+
+    "helius-laserstream-linux-x64-musl": ["helius-laserstream-linux-x64-musl@0.1.8", "", { "os": "linux", "cpu": "x64" }, "sha512-riTS6VgxDae1fHOJ2XC/o/v1OZRbEv/3rcoa3NlAOnooDKp5HDgD0zJTcImjQHpYWwGaejx1oX/Ht53lxNoijw=="],
 
     "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
 
@@ -1034,6 +1123,8 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
     "json-rpc-engine": ["json-rpc-engine@6.1.0", "", { "dependencies": { "@metamask/safe-event-emitter": "^2.0.0", "eth-rpc-errors": "^4.0.2" } }, "sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ=="],
 
     "json-rpc-random-id": ["json-rpc-random-id@1.0.1", "", {}, "sha512-RJ9YYNCkhVDBuP4zN5BBtYAzEl03yq/jIIsyif0JY9qyJuQQZNeDK7anAPKKlyEtLSj2s8h6hNh2F8zO5q7ScA=="],
@@ -1084,7 +1175,11 @@
 
     "lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
 
+    "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
+
     "loglevel": ["loglevel@1.9.2", "", {}, "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
@@ -1120,7 +1215,7 @@
 
     "multiformats": ["multiformats@9.9.0", "", {}, "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="],
 
-    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "nanoid": ["nanoid@3.3.4", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="],
 
     "next": ["next@16.1.6", "", { "dependencies": { "@next/env": "16.1.6", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.8.3", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.1.6", "@next/swc-darwin-x64": "16.1.6", "@next/swc-linux-arm64-gnu": "16.1.6", "@next/swc-linux-arm64-musl": "16.1.6", "@next/swc-linux-x64-gnu": "16.1.6", "@next/swc-linux-x64-musl": "16.1.6", "@next/swc-win32-arm64-msvc": "16.1.6", "@next/swc-win32-x64-msvc": "16.1.6", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw=="],
 
@@ -1129,6 +1224,8 @@
     "no-case": ["no-case@3.0.4", "", { "dependencies": { "lower-case": "^2.0.2", "tslib": "^2.0.3" } }, "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg=="],
 
     "node-addon-api": ["node-addon-api@2.0.2", "", {}, "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="],
+
+    "node-cache": ["node-cache@5.1.2", "", { "dependencies": { "clone": "2.x" } }, "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
@@ -1218,6 +1315,8 @@
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
+    "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
+
     "proxy-compare": ["proxy-compare@3.0.1", "", {}, "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q=="],
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
@@ -1304,6 +1403,18 @@
 
     "socket.io-parser": ["socket.io-parser@4.2.5", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1" } }, "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ=="],
 
+    "solana-bankrun": ["solana-bankrun@0.3.1", "", { "dependencies": { "@solana/web3.js": "^1.68.0", "bs58": "^4.0.1" }, "optionalDependencies": { "solana-bankrun-darwin-arm64": "0.3.1", "solana-bankrun-darwin-universal": "0.3.1", "solana-bankrun-darwin-x64": "0.3.1", "solana-bankrun-linux-x64-gnu": "0.3.1", "solana-bankrun-linux-x64-musl": "0.3.1" } }, "sha512-inRwON7fBU5lPC36HdEqPeDg15FXJYcf77+o0iz9amvkUMJepcwnRwEfTNyMVpVYdgjTOBW5vg+596/3fi1kGA=="],
+
+    "solana-bankrun-darwin-arm64": ["solana-bankrun-darwin-arm64@0.3.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9LWtH/3/WR9fs8Ve/srdo41mpSqVHmRqDoo69Dv1Cupi+o1zMU6HiEPUHEvH2Tn/6TDbPEDf18MYNfReLUqE6A=="],
+
+    "solana-bankrun-darwin-universal": ["solana-bankrun-darwin-universal@0.3.1", "", { "os": "darwin" }, "sha512-muGHpVYWT7xCd8ZxEjs/bmsbMp8XBqroYGbE4lQPMDUuLvsJEIrjGqs3MbxEFr71sa58VpyvgywWd5ifI7sGIg=="],
+
+    "solana-bankrun-darwin-x64": ["solana-bankrun-darwin-x64@0.3.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-oCaxfHyt7RC3ZMldrh5AbKfy4EH3YRMl8h6fSlMZpxvjQx7nK7PxlRwMeflMnVdkKKp7U8WIDak1lilIPd3/lg=="],
+
+    "solana-bankrun-linux-x64-gnu": ["solana-bankrun-linux-x64-gnu@0.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-PfRFhr7igGFNt2Ecfdzh3li9eFPB3Xhmk0Eib17EFIB62YgNUg3ItRnQQFaf0spazFjjJLnglY1TRKTuYlgSVA=="],
+
+    "solana-bankrun-linux-x64-musl": ["solana-bankrun-linux-x64-musl@0.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-6r8i0NuXg3CGURql8ISMIUqhE7Hx/O7MlIworK4oN08jYrP0CXdLeB/hywNn7Z8d1NXrox/NpYUgvRm2yIzAsQ=="],
+
     "sonic-boom": ["sonic-boom@3.8.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg=="],
 
     "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
@@ -1321,6 +1432,8 @@
     "stream-json": ["stream-json@1.9.1", "", { "dependencies": { "stream-chain": "^2.2.5" } }, "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw=="],
 
     "stream-shift": ["stream-shift@1.0.3", "", {}, "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="],
+
+    "strict-event-emitter-types": ["strict-event-emitter-types@2.0.0", "", {}, "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA=="],
 
     "strict-uri-encode": ["strict-uri-encode@2.0.0", "", {}, "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="],
 
@@ -1364,6 +1477,10 @@
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
+    "traverse-chain": ["traverse-chain@0.1.0", "", {}, "sha512-up6Yvai4PYKhpNp5PkYtx50m3KbwQrqDwbuZP/ItyL64YEWHAvH6Md83LFLV/GRSk/BoUVwwgUzX6SOQSbsfAg=="],
+
+    "ts-log": ["ts-log@2.2.7", "", {}, "sha512-320x5Ggei84AxzlXp91QkIGSw5wgaLT6GeAH0KsqDmRZdVWW2OiSeVvElVoatk3f7nicwXlElXsoFkARiGE2yg=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "turbo": ["turbo@2.8.7", "", { "optionalDependencies": { "turbo-darwin-64": "2.8.7", "turbo-darwin-arm64": "2.8.7", "turbo-linux-64": "2.8.7", "turbo-linux-arm64": "2.8.7", "turbo-windows-64": "2.8.7", "turbo-windows-arm64": "2.8.7" }, "bin": { "turbo": "bin/turbo" } }, "sha512-RBLh5caMAu1kFdTK1jgH2gH/z+jFsvX5rGbhgJ9nlIAWXSvxlzwId05uDlBA1+pBd3wO/UaKYzaQZQBXDd7kcA=="],
@@ -1381,6 +1498,8 @@
     "turbo-windows-arm64": ["turbo-windows-arm64@2.8.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-WyGiOI2Zp3AhuzVagzQN+T+iq0fWx0oGxDfAWT3ZiLEd4U0cDUkwUZDKVGb3rKqPjDL6lWnuxKKu73ge5xtovQ=="],
 
     "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
+
+    "tweetnacl-util": ["tweetnacl-util@0.15.1", "", {}, "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="],
 
     "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
 
@@ -1432,7 +1551,7 @@
 
     "wrangler": ["wrangler@4.65.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.12.1", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260212.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260212.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260212.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-R+n3o3tlGzLK9I4fGocPReOuvcnjhtOL2aCVKkHMeuEwt9pPbOO4FxJtx/ec5cIUG/otRyJnfQGCAr9DplBVng=="],
 
-    "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
@@ -1444,13 +1563,13 @@
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
-    "y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
-    "yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
-    "yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
 
@@ -1485,6 +1604,24 @@
     "@coral-xyz/anchor/@coral-xyz/borsh": ["@coral-xyz/borsh@0.31.1", "", { "dependencies": { "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" }, "peerDependencies": { "@solana/web3.js": "^1.69.0" } }, "sha512-9N8AU9F0ubriKfNE3g1WF0/4dtlGXoBN/hd1PvbNBamBNwRgHxH4P+o3Zt7rSEloW1HUs6LfZEchlx9fW7POYw=="],
 
     "@coral-xyz/anchor/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
+
+    "@coral-xyz/anchor-30/@coral-xyz/anchor-errors": ["@coral-xyz/anchor-errors@0.30.1", "", {}, "sha512-9Mkradf5yS5xiLWrl9WrpjqOrAV+/W2RQHDlbnAZBivoGpOs1ECjoDCkVk4aRG8ZdiFiB8zQEVlxf+8fKkmSfQ=="],
+
+    "@coral-xyz/anchor-30/@coral-xyz/borsh": ["@coral-xyz/borsh@0.30.1", "", { "dependencies": { "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" }, "peerDependencies": { "@solana/web3.js": "^1.68.0" } }, "sha512-aaxswpPrCFKl8vZTbxLssA2RvwX2zmKLlRCIktJOwW+VpVwYtXRtlWiIP+c2pPRKneiTiWCN2GEMSH9j1zTlWQ=="],
+
+    "@coral-xyz/anchor-30/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
+
+    "@drift-labs/sdk/@coral-xyz/anchor": ["@coral-xyz/anchor@0.29.0", "", { "dependencies": { "@coral-xyz/borsh": "^0.29.0", "@noble/hashes": "^1.3.1", "@solana/web3.js": "^1.68.0", "bn.js": "^5.1.2", "bs58": "^4.0.1", "buffer-layout": "^1.2.2", "camelcase": "^6.3.0", "cross-fetch": "^3.1.5", "crypto-hash": "^1.3.0", "eventemitter3": "^4.0.7", "pako": "^2.0.3", "snake-case": "^3.0.4", "superstruct": "^0.15.4", "toml": "^3.0.0" } }, "sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA=="],
+
+    "@drift-labs/sdk/@ellipsis-labs/phoenix-sdk": ["@ellipsis-labs/phoenix-sdk@1.4.5", "", { "dependencies": { "@metaplex-foundation/beet": "^0.7.1", "@metaplex-foundation/rustbin": "^0.3.1", "@metaplex-foundation/solita": "^0.12.2", "@solana/spl-token": "^0.3.7", "@types/node": "^18.11.13", "bn.js": "^5.2.1", "borsh": "^0.7.0", "bs58": "^5.0.0" } }, "sha512-vEYgMXuV5/mpnpEi+VK4HO8f6SheHtVLdHHlULBiDN1eECYmL67gq+/cRV7Ar6jAQ7rJZL7xBxhbUW5kugMl6A=="],
+
+    "@drift-labs/sdk/@solana/spl-token": ["@solana/spl-token@0.4.13", "", { "dependencies": { "@solana/buffer-layout": "^4.0.0", "@solana/buffer-layout-utils": "^0.2.0", "@solana/spl-token-group": "^0.0.7", "@solana/spl-token-metadata": "^0.1.6", "buffer": "^6.0.3" }, "peerDependencies": { "@solana/web3.js": "^1.95.5" } }, "sha512-cite/pYWQZZVvLbg5lsodSovbetK/eA24gaR0eeUeMuBAMNrT8XFCwaygKy0N2WSg3gSyjjNpIeAGBAKZaY/1w=="],
+
+    "@drift-labs/sdk/@solana/web3.js": ["@solana/web3.js@1.98.0", "", { "dependencies": { "@babel/runtime": "^7.25.0", "@noble/curves": "^1.4.2", "@noble/hashes": "^1.4.0", "@solana/buffer-layout": "^4.0.1", "agentkeepalive": "^4.5.0", "bigint-buffer": "^1.1.5", "bn.js": "^5.2.1", "borsh": "^0.7.0", "bs58": "^4.0.1", "buffer": "6.0.3", "fast-stable-stringify": "^1.0.0", "jayson": "^4.1.1", "node-fetch": "^2.7.0", "rpc-websockets": "^9.0.2", "superstruct": "^2.0.2" } }, "sha512-nz3Q5OeyGFpFCR+erX2f6JPt3sKhzhYcSycBCSPkWjzSVDh/Rr1FqTVMRe58FKO16/ivTUcuJjeS5MyBvpkbzA=="],
+
+    "@drift-labs/sdk/zod": ["zod@4.0.17", "", {}, "sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ=="],
+
+    "@drift-labs/sdk/zstddec": ["zstddec@0.1.0", "", {}, "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg=="],
 
     "@ellipsis-labs/phoenix-sdk/@solana/spl-token": ["@solana/spl-token@0.3.11", "", { "dependencies": { "@solana/buffer-layout": "^4.0.0", "@solana/buffer-layout-utils": "^0.2.0", "@solana/spl-token-metadata": "^0.1.2", "buffer": "^6.0.3" }, "peerDependencies": { "@solana/web3.js": "^1.88.0" } }, "sha512-bvohO3rIMSVL24Pb+I4EYTJ6cL82eFpInEXD/I8K8upOGjpqHsKUoAempR/RnUlI1qSFNyFlWJfu6MNUgfbCQQ=="],
 
@@ -1550,6 +1687,14 @@
 
     "@privy-io/react-auth/lucide-react": ["lucide-react@0.554.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-St+z29uthEJVx0Is7ellNkgTEhaeSoA42I7JjOCBCrc5X6LYMGSv0P/2uS5HDLTExP5tpiqRD2PyUEOS6s9UXA=="],
 
+    "@project-serum/anchor/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
+
+    "@project-serum/anchor/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+
+    "@project-serum/serum/@solana/spl-token": ["@solana/spl-token@0.1.8", "", { "dependencies": { "@babel/runtime": "^7.10.5", "@solana/web3.js": "^1.21.0", "bn.js": "^5.1.0", "buffer": "6.0.3", "buffer-layout": "^1.2.0", "dotenv": "10.0.0" } }, "sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ=="],
+
+    "@pythnetwork/pyth-lazer-sdk/isomorphic-ws": ["isomorphic-ws@5.0.0", "", { "peerDependencies": { "ws": "*" } }, "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw=="],
+
     "@react-aria/focus/@swc/helpers": ["@swc/helpers@0.5.18", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ=="],
 
     "@react-aria/interactions/@swc/helpers": ["@swc/helpers@0.5.18", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ=="],
@@ -1592,15 +1737,25 @@
 
     "@solana-commerce/sdk/@solana/transactions": ["@solana/transactions@2.3.0", "", { "dependencies": { "@solana/addresses": "2.3.0", "@solana/codecs-core": "2.3.0", "@solana/codecs-data-structures": "2.3.0", "@solana/codecs-numbers": "2.3.0", "@solana/codecs-strings": "2.3.0", "@solana/errors": "2.3.0", "@solana/functional": "2.3.0", "@solana/instructions": "2.3.0", "@solana/keys": "2.3.0", "@solana/nominal-types": "2.3.0", "@solana/rpc-types": "2.3.0", "@solana/transaction-messages": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-LnTvdi8QnrQtuEZor5Msje61sDpPstTVwKg4y81tNxDhiyomjuvnSNLAq6QsB9gIxUqbNzPZgOG9IU4I4/Uaug=="],
 
+    "@solana/accounts/@solana/addresses": ["@solana/addresses@5.5.1", "", { "dependencies": { "@solana/assertions": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA=="],
+
     "@solana/accounts/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
 
     "@solana/accounts/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
-    "@solana/addresses/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+    "@solana/accounts/@solana/rpc-spec": ["@solana/rpc-spec@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1", "@solana/rpc-spec-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q=="],
 
-    "@solana/addresses/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+    "@solana/accounts/@solana/rpc-types": ["@solana/rpc-types@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA=="],
 
-    "@solana/assertions/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+    "@solana/addresses/@solana/assertions": ["@solana/assertions@5.1.0", "", { "dependencies": { "@solana/errors": "5.1.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-5But2wyxuvGXMIOnD0jBMQ9yq1QQF2LSK3IbIRSkAkXbD3DS6O2tRvKUHNhogd+BpkPyCGOQHBycezgnxmStlg=="],
+
+    "@solana/addresses/@solana/codecs-core": ["@solana/codecs-core@5.1.0", "", { "dependencies": { "@solana/errors": "5.1.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-vDwi03mxWeWCS5Il6BCdNdifYdOoHVz97YOmbWGIt45b77Ivu5NUYeSD2+ccl6fSw8eYQ6QaqqKXMjbSfsXv4g=="],
+
+    "@solana/addresses/@solana/codecs-strings": ["@solana/codecs-strings@5.1.0", "", { "dependencies": { "@solana/codecs-core": "5.1.0", "@solana/codecs-numbers": "5.1.0", "@solana/errors": "5.1.0" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": ">=5.3.3" }, "optionalPeers": ["fastestsmallesttextencoderdecoder"] }, "sha512-014xwl5T/3VnGW0gceizF47DUs5EURRtgGmbWIR5+Z32yxgQ6hT9Zl0atZbL268RHbUQ03/J8Ush1StQgy7sfQ=="],
+
+    "@solana/addresses/@solana/errors": ["@solana/errors@5.1.0", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": ">=5.3.3" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-JlTyekErWa6Fdcwu1Hrh+jZxjM4YxyorGCFDRVZlmHZFkp5N00DWKcYnSGZrTF8E6ZZEP9pfS2XwM8y7p7HPww=="],
+
+    "@solana/addresses/@solana/nominal-types": ["@solana/nominal-types@5.1.0", "", { "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-+4Cm+SpK+D811i9giqv4Up93ZlmUcZfLDHkSH24F4in61+Y2TKA+XKuRtKhNytQMmqCfbvJZ9MHFaIeZw5g+Bg=="],
 
     "@solana/codecs/@solana/codecs-core": ["@solana/codecs-core@2.0.0-rc.1", "", { "dependencies": { "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ=="],
 
@@ -1630,13 +1785,23 @@
 
     "@solana/instructions/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
+    "@solana/keys/@solana/assertions": ["@solana/assertions@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q=="],
+
     "@solana/keys/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
 
     "@solana/keys/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
+    "@solana/kit/@solana/addresses": ["@solana/addresses@5.5.1", "", { "dependencies": { "@solana/assertions": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA=="],
+
     "@solana/kit/@solana/codecs": ["@solana/codecs@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/options": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g=="],
 
     "@solana/kit/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/kit/@solana/rpc-api": ["@solana/rpc-api@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/keys": "5.5.1", "@solana/rpc-parsed-types": "5.5.1", "@solana/rpc-spec": "5.5.1", "@solana/rpc-transformers": "5.5.1", "@solana/rpc-types": "5.5.1", "@solana/transaction-messages": "5.5.1", "@solana/transactions": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-XWOQQPhKl06Vj0xi3RYHAc6oEQd8B82okYJ04K7N0Vvy3J4PN2cxeK7klwkjgavdcN9EVkYCChm2ADAtnztKnA=="],
+
+    "@solana/kit/@solana/rpc-types": ["@solana/rpc-types@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA=="],
+
+    "@solana/offchain-messages/@solana/addresses": ["@solana/addresses@5.5.1", "", { "dependencies": { "@solana/assertions": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA=="],
 
     "@solana/offchain-messages/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
 
@@ -1654,33 +1819,79 @@
 
     "@solana/options/@solana/errors": ["@solana/errors@2.0.0-rc.1", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^12.1.0" }, "peerDependencies": { "typescript": ">=5" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ=="],
 
+    "@solana/programs/@solana/addresses": ["@solana/addresses@5.5.1", "", { "dependencies": { "@solana/assertions": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA=="],
+
     "@solana/programs/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
     "@solana/rpc/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
-    "@solana/rpc-api/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+    "@solana/rpc/@solana/rpc-api": ["@solana/rpc-api@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/keys": "5.5.1", "@solana/rpc-parsed-types": "5.5.1", "@solana/rpc-spec": "5.5.1", "@solana/rpc-transformers": "5.5.1", "@solana/rpc-types": "5.5.1", "@solana/transaction-messages": "5.5.1", "@solana/transactions": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-XWOQQPhKl06Vj0xi3RYHAc6oEQd8B82okYJ04K7N0Vvy3J4PN2cxeK7klwkjgavdcN9EVkYCChm2ADAtnztKnA=="],
 
-    "@solana/rpc-api/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+    "@solana/rpc/@solana/rpc-spec": ["@solana/rpc-spec@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1", "@solana/rpc-spec-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q=="],
 
-    "@solana/rpc-spec/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+    "@solana/rpc/@solana/rpc-transformers": ["@solana/rpc-transformers@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1", "@solana/functional": "5.5.1", "@solana/nominal-types": "5.5.1", "@solana/rpc-spec-types": "5.5.1", "@solana/rpc-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q=="],
+
+    "@solana/rpc/@solana/rpc-types": ["@solana/rpc-types@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA=="],
+
+    "@solana/rpc-api/@solana/codecs-core": ["@solana/codecs-core@5.1.0", "", { "dependencies": { "@solana/errors": "5.1.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-vDwi03mxWeWCS5Il6BCdNdifYdOoHVz97YOmbWGIt45b77Ivu5NUYeSD2+ccl6fSw8eYQ6QaqqKXMjbSfsXv4g=="],
+
+    "@solana/rpc-api/@solana/codecs-strings": ["@solana/codecs-strings@5.1.0", "", { "dependencies": { "@solana/codecs-core": "5.1.0", "@solana/codecs-numbers": "5.1.0", "@solana/errors": "5.1.0" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": ">=5.3.3" }, "optionalPeers": ["fastestsmallesttextencoderdecoder"] }, "sha512-014xwl5T/3VnGW0gceizF47DUs5EURRtgGmbWIR5+Z32yxgQ6hT9Zl0atZbL268RHbUQ03/J8Ush1StQgy7sfQ=="],
+
+    "@solana/rpc-api/@solana/errors": ["@solana/errors@5.1.0", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": ">=5.3.3" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-JlTyekErWa6Fdcwu1Hrh+jZxjM4YxyorGCFDRVZlmHZFkp5N00DWKcYnSGZrTF8E6ZZEP9pfS2XwM8y7p7HPww=="],
+
+    "@solana/rpc-api/@solana/keys": ["@solana/keys@5.1.0", "", { "dependencies": { "@solana/assertions": "5.1.0", "@solana/codecs-core": "5.1.0", "@solana/codecs-strings": "5.1.0", "@solana/errors": "5.1.0", "@solana/nominal-types": "5.1.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-ma4zTTuSOmtTCvATHMfUGNTw0Vqah/6XPe1VmLc66ohwXMI3yqatX1FQPXgDZozr15SvLAesfs7/bgl2TRoe9w=="],
+
+    "@solana/rpc-api/@solana/rpc-parsed-types": ["@solana/rpc-parsed-types@5.1.0", "", { "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-ZJoXHNItALMNa1zmGrNnIh96RBlc9GpIqoaZkdE14mAQ7gWe7Oc0ejYavUeSCmcL0wZcvIFh50AsfVxrHr4+2Q=="],
+
+    "@solana/rpc-api/@solana/transaction-messages": ["@solana/transaction-messages@5.1.0", "", { "dependencies": { "@solana/addresses": "5.1.0", "@solana/codecs-core": "5.1.0", "@solana/codecs-data-structures": "5.1.0", "@solana/codecs-numbers": "5.1.0", "@solana/errors": "5.1.0", "@solana/functional": "5.1.0", "@solana/instructions": "5.1.0", "@solana/nominal-types": "5.1.0", "@solana/rpc-types": "5.1.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-9rNV2YJhd85WIMvnwa/vUY4xUw3ZTU17jP1KDo/fFZWk55a0ov0ATJJPyC5HAR1i6hT1cmJzGH/UHhnD9m/Q3w=="],
+
+    "@solana/rpc-api/@solana/transactions": ["@solana/transactions@5.1.0", "", { "dependencies": { "@solana/addresses": "5.1.0", "@solana/codecs-core": "5.1.0", "@solana/codecs-data-structures": "5.1.0", "@solana/codecs-numbers": "5.1.0", "@solana/codecs-strings": "5.1.0", "@solana/errors": "5.1.0", "@solana/functional": "5.1.0", "@solana/instructions": "5.1.0", "@solana/keys": "5.1.0", "@solana/nominal-types": "5.1.0", "@solana/rpc-types": "5.1.0", "@solana/transaction-messages": "5.1.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-06JwSPtz+38ozNgpysAXS2eTMPQCufIisXB6K88X8J4GF8ziqs4nkq0BpXAXn+MpZTkuMt+JeW2RxP3HKhXe5g=="],
+
+    "@solana/rpc-spec/@solana/errors": ["@solana/errors@5.1.0", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": ">=5.3.3" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-JlTyekErWa6Fdcwu1Hrh+jZxjM4YxyorGCFDRVZlmHZFkp5N00DWKcYnSGZrTF8E6ZZEP9pfS2XwM8y7p7HPww=="],
+
+    "@solana/rpc-spec/@solana/rpc-spec-types": ["@solana/rpc-spec-types@5.1.0", "", { "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-B8/WyjmHpC34vXtAmTpZyPwRCm7WwoSkmjBcBouaaY1uilJ9+Wp2nptbq2cJyWairOoMSoI7v5kvvnrJuquq4Q=="],
 
     "@solana/rpc-subscriptions/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/rpc-subscriptions/@solana/rpc-transformers": ["@solana/rpc-transformers@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1", "@solana/functional": "5.5.1", "@solana/nominal-types": "5.5.1", "@solana/rpc-spec-types": "5.5.1", "@solana/rpc-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q=="],
+
+    "@solana/rpc-subscriptions/@solana/rpc-types": ["@solana/rpc-types@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA=="],
+
+    "@solana/rpc-subscriptions-api/@solana/addresses": ["@solana/addresses@5.5.1", "", { "dependencies": { "@solana/assertions": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA=="],
+
+    "@solana/rpc-subscriptions-api/@solana/rpc-transformers": ["@solana/rpc-transformers@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1", "@solana/functional": "5.5.1", "@solana/nominal-types": "5.5.1", "@solana/rpc-spec-types": "5.5.1", "@solana/rpc-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q=="],
+
+    "@solana/rpc-subscriptions-api/@solana/rpc-types": ["@solana/rpc-types@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA=="],
 
     "@solana/rpc-subscriptions-channel-websocket/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
     "@solana/rpc-subscriptions-spec/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
-    "@solana/rpc-transformers/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+    "@solana/rpc-transformers/@solana/errors": ["@solana/errors@5.1.0", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": ">=5.3.3" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-JlTyekErWa6Fdcwu1Hrh+jZxjM4YxyorGCFDRVZlmHZFkp5N00DWKcYnSGZrTF8E6ZZEP9pfS2XwM8y7p7HPww=="],
+
+    "@solana/rpc-transformers/@solana/functional": ["@solana/functional@5.1.0", "", { "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-R6jacWU0Gr+j49lTDp+FSECBolqw2Gq7JlC22rI0JkcxJiiAlp3G80v6zAYq0FkHzxZbjyR6//JYUXSwliem5g=="],
+
+    "@solana/rpc-transformers/@solana/nominal-types": ["@solana/nominal-types@5.1.0", "", { "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-+4Cm+SpK+D811i9giqv4Up93ZlmUcZfLDHkSH24F4in61+Y2TKA+XKuRtKhNytQMmqCfbvJZ9MHFaIeZw5g+Bg=="],
+
+    "@solana/rpc-transformers/@solana/rpc-spec-types": ["@solana/rpc-spec-types@5.1.0", "", { "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-B8/WyjmHpC34vXtAmTpZyPwRCm7WwoSkmjBcBouaaY1uilJ9+Wp2nptbq2cJyWairOoMSoI7v5kvvnrJuquq4Q=="],
 
     "@solana/rpc-transport-http/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
+    "@solana/rpc-transport-http/@solana/rpc-spec": ["@solana/rpc-spec@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1", "@solana/rpc-spec-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q=="],
+
     "@solana/rpc-transport-http/undici-types": ["undici-types@7.21.0", "", {}, "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ=="],
 
-    "@solana/rpc-types/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+    "@solana/rpc-types/@solana/codecs-core": ["@solana/codecs-core@5.1.0", "", { "dependencies": { "@solana/errors": "5.1.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-vDwi03mxWeWCS5Il6BCdNdifYdOoHVz97YOmbWGIt45b77Ivu5NUYeSD2+ccl6fSw8eYQ6QaqqKXMjbSfsXv4g=="],
 
-    "@solana/rpc-types/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+    "@solana/rpc-types/@solana/codecs-numbers": ["@solana/codecs-numbers@5.1.0", "", { "dependencies": { "@solana/codecs-core": "5.1.0", "@solana/errors": "5.1.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-Ea5/9yjDNOrDZcI40UGzzi6Aq1JNsmzM4m5pOk6Xb3JRZ0YdKOv/MwuCqb6jRgzZ7SQjHhkfGL43kHLJA++bOw=="],
 
-    "@solana/rpc-types/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+    "@solana/rpc-types/@solana/codecs-strings": ["@solana/codecs-strings@5.1.0", "", { "dependencies": { "@solana/codecs-core": "5.1.0", "@solana/codecs-numbers": "5.1.0", "@solana/errors": "5.1.0" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": ">=5.3.3" }, "optionalPeers": ["fastestsmallesttextencoderdecoder"] }, "sha512-014xwl5T/3VnGW0gceizF47DUs5EURRtgGmbWIR5+Z32yxgQ6hT9Zl0atZbL268RHbUQ03/J8Ush1StQgy7sfQ=="],
+
+    "@solana/rpc-types/@solana/errors": ["@solana/errors@5.1.0", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": ">=5.3.3" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-JlTyekErWa6Fdcwu1Hrh+jZxjM4YxyorGCFDRVZlmHZFkp5N00DWKcYnSGZrTF8E6ZZEP9pfS2XwM8y7p7HPww=="],
+
+    "@solana/rpc-types/@solana/nominal-types": ["@solana/nominal-types@5.1.0", "", { "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-+4Cm+SpK+D811i9giqv4Up93ZlmUcZfLDHkSH24F4in61+Y2TKA+XKuRtKhNytQMmqCfbvJZ9MHFaIeZw5g+Bg=="],
+
+    "@solana/signers/@solana/addresses": ["@solana/addresses@5.5.1", "", { "dependencies": { "@solana/assertions": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA=="],
 
     "@solana/signers/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
 
@@ -1692,7 +1903,15 @@
 
     "@solana/sysvars/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
+    "@solana/sysvars/@solana/rpc-types": ["@solana/rpc-types@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA=="],
+
+    "@solana/transaction-confirmation/@solana/addresses": ["@solana/addresses@5.5.1", "", { "dependencies": { "@solana/assertions": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA=="],
+
     "@solana/transaction-confirmation/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/transaction-confirmation/@solana/rpc-types": ["@solana/rpc-types@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA=="],
+
+    "@solana/transaction-messages/@solana/addresses": ["@solana/addresses@5.5.1", "", { "dependencies": { "@solana/assertions": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA=="],
 
     "@solana/transaction-messages/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
 
@@ -1700,15 +1919,23 @@
 
     "@solana/transaction-messages/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
+    "@solana/transaction-messages/@solana/rpc-types": ["@solana/rpc-types@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA=="],
+
+    "@solana/transactions/@solana/addresses": ["@solana/addresses@5.5.1", "", { "dependencies": { "@solana/assertions": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA=="],
+
     "@solana/transactions/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
 
     "@solana/transactions/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
 
     "@solana/transactions/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
+    "@solana/transactions/@solana/rpc-types": ["@solana/rpc-types@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA=="],
+
     "@solana/web3.js/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "@solana/web3.js/superstruct": ["superstruct@2.0.2", "", {}, "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A=="],
+
+    "@switchboard-xyz/common/js-sha256": ["js-sha256@0.11.1", "", {}, "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
@@ -1798,8 +2025,6 @@
 
     "gill/@solana-program/token-2022": ["@solana-program/token-2022@0.4.2", "", { "peerDependencies": { "@solana/kit": "^2.1.0", "@solana/sysvars": "^2.1.0" } }, "sha512-zIpR5t4s9qEU3hZKupzIBxJ6nUV5/UVyIT400tu9vT1HMs5JHxaTTsb5GUhYjiiTvNwU0MQavbwc4Dl29L0Xvw=="],
 
-    "gill/@solana/assertions": ["@solana/assertions@2.3.0", "", { "dependencies": { "@solana/errors": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ=="],
-
     "gill/@solana/codecs": ["@solana/codecs@2.3.0", "", { "dependencies": { "@solana/codecs-core": "2.3.0", "@solana/codecs-data-structures": "2.3.0", "@solana/codecs-numbers": "2.3.0", "@solana/codecs-strings": "2.3.0", "@solana/options": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-JVqGPkzoeyU262hJGdH64kNLH0M+Oew2CIPOa/9tR3++q2pEd4jU2Rxdfye9sd0Ce3XJrR5AIa8ZfbyQXzjh+g=="],
 
     "gill/@solana/kit": ["@solana/kit@2.3.0", "", { "dependencies": { "@solana/accounts": "2.3.0", "@solana/addresses": "2.3.0", "@solana/codecs": "2.3.0", "@solana/errors": "2.3.0", "@solana/functional": "2.3.0", "@solana/instructions": "2.3.0", "@solana/keys": "2.3.0", "@solana/programs": "2.3.0", "@solana/rpc": "2.3.0", "@solana/rpc-parsed-types": "2.3.0", "@solana/rpc-spec-types": "2.3.0", "@solana/rpc-subscriptions": "2.3.0", "@solana/rpc-types": "2.3.0", "@solana/signers": "2.3.0", "@solana/sysvars": "2.3.0", "@solana/transaction-confirmation": "2.3.0", "@solana/transaction-messages": "2.3.0", "@solana/transactions": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ=="],
@@ -1836,9 +2061,15 @@
 
     "porto/ox": ["ox@0.9.17", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-rKAnhzhRU3Xh3hiko+i1ZxywZ55eWQzeS/Q4HRKLx2PqfHOolisZHErSsJVipGlmQKHW5qwOED/GighEw9dbLg=="],
 
+    "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
+
     "rpc-websockets/@swc/helpers": ["@swc/helpers@0.5.18", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ=="],
 
     "rpc-websockets/eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "solana-bankrun/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "to-buffer/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
@@ -1854,9 +2085,25 @@
 
     "x402/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+    "@coral-xyz/anchor-30/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
     "@coral-xyz/anchor/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
+
+    "@drift-labs/sdk/@coral-xyz/anchor/@coral-xyz/borsh": ["@coral-xyz/borsh@0.29.0", "", { "dependencies": { "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" }, "peerDependencies": { "@solana/web3.js": "^1.68.0" } }, "sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ=="],
+
+    "@drift-labs/sdk/@coral-xyz/anchor/@solana/web3.js": ["@solana/web3.js@1.98.4", "", { "dependencies": { "@babel/runtime": "^7.25.0", "@noble/curves": "^1.4.2", "@noble/hashes": "^1.4.0", "@solana/buffer-layout": "^4.0.1", "@solana/codecs-numbers": "^2.1.0", "agentkeepalive": "^4.5.0", "bn.js": "^5.2.1", "borsh": "^0.7.0", "bs58": "^4.0.1", "buffer": "6.0.3", "fast-stable-stringify": "^1.0.0", "jayson": "^4.1.1", "node-fetch": "^2.7.0", "rpc-websockets": "^9.0.2", "superstruct": "^2.0.2" } }, "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw=="],
+
+    "@drift-labs/sdk/@coral-xyz/anchor/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
+
+    "@drift-labs/sdk/@ellipsis-labs/phoenix-sdk/@solana/spl-token": ["@solana/spl-token@0.3.11", "", { "dependencies": { "@solana/buffer-layout": "^4.0.0", "@solana/buffer-layout-utils": "^0.2.0", "@solana/spl-token-metadata": "^0.1.2", "buffer": "^6.0.3" }, "peerDependencies": { "@solana/web3.js": "^1.88.0" } }, "sha512-bvohO3rIMSVL24Pb+I4EYTJ6cL82eFpInEXD/I8K8upOGjpqHsKUoAempR/RnUlI1qSFNyFlWJfu6MNUgfbCQQ=="],
+
+    "@drift-labs/sdk/@ellipsis-labs/phoenix-sdk/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+
+    "@drift-labs/sdk/@ellipsis-labs/phoenix-sdk/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
+
+    "@drift-labs/sdk/@solana/web3.js/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
+
+    "@drift-labs/sdk/@solana/web3.js/superstruct": ["superstruct@2.0.2", "", {}, "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A=="],
 
     "@ellipsis-labs/phoenix-sdk/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
 
@@ -1886,6 +2133,8 @@
 
     "@openbook-dex/openbook-v2/@coral-xyz/anchor/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
+    "@project-serum/anchor/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
+
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/logger": ["@walletconnect/logger@2.1.2", "", { "dependencies": { "@walletconnect/safe-json": "^1.0.2", "pino": "7.11.0" } }, "sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/sign-client": ["@walletconnect/sign-client@2.21.9", "", { "dependencies": { "@walletconnect/core": "2.21.9", "@walletconnect/events": "1.0.1", "@walletconnect/heartbeat": "1.2.2", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/logger": "2.1.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.21.9", "@walletconnect/utils": "2.21.9", "events": "3.3.0" } }, "sha512-EKLDS97o1rk/0XilD0nQdSR9SNgRsVoIK5M5HpS9sDTvHPv2EF5pIqu6Xr2vLsKcQ0KnCx+D5bnpav8Yh4NVZg=="],
@@ -1893,6 +2142,8 @@
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/types": ["@walletconnect/types@2.21.9", "", { "dependencies": { "@walletconnect/events": "1.0.1", "@walletconnect/heartbeat": "1.2.2", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "2.1.2", "events": "3.3.0" } }, "sha512-+82TRNX3lGRO96WyLISaBs/FkLts7y4hVgmOI4we84I7XdBu1xsjgiJj0JwYXnurz+X94lTqzOkzPps+wadWKw=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils": ["@walletconnect/utils@2.21.9", "", { "dependencies": { "@msgpack/msgpack": "3.1.2", "@noble/ciphers": "1.3.0", "@noble/curves": "1.9.7", "@noble/hashes": "1.8.0", "@scure/base": "1.2.6", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.21.9", "@walletconnect/window-getters": "1.0.1", "@walletconnect/window-metadata": "1.0.1", "blakejs": "1.2.1", "bs58": "6.0.0", "detect-browser": "5.3.0", "uint8arrays": "3.1.1", "viem": "2.36.0" } }, "sha512-FHagysDvp7yQl+74veIeuqwZZnMiTyTW3Lw0NXsbIKnlmlSQu5pma+4EnRD/CnSzbN6PV39k2t1KBaaZ4PjDgg=="],
+
+    "@reown/appkit-ui/qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 
     "@reown/appkit-utils/@walletconnect/logger/pino": ["pino@7.11.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "fast-redact": "^3.0.0", "on-exit-leak-free": "^0.2.0", "pino-abstract-transport": "v0.5.0", "pino-std-serializers": "^4.0.0", "process-warning": "^1.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.1.0", "safe-stable-stringify": "^2.1.0", "sonic-boom": "^2.2.1", "thread-stream": "^0.15.1" }, "bin": { "pino": "bin.js" } }, "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg=="],
 
@@ -1911,8 +2162,6 @@
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/types": ["@walletconnect/types@2.21.9", "", { "dependencies": { "@walletconnect/events": "1.0.1", "@walletconnect/heartbeat": "1.2.2", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "2.1.2", "events": "3.3.0" } }, "sha512-+82TRNX3lGRO96WyLISaBs/FkLts7y4hVgmOI4we84I7XdBu1xsjgiJj0JwYXnurz+X94lTqzOkzPps+wadWKw=="],
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils": ["@walletconnect/utils@2.21.9", "", { "dependencies": { "@msgpack/msgpack": "3.1.2", "@noble/ciphers": "1.3.0", "@noble/curves": "1.9.7", "@noble/hashes": "1.8.0", "@scure/base": "1.2.6", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.21.9", "@walletconnect/window-getters": "1.0.1", "@walletconnect/window-metadata": "1.0.1", "blakejs": "1.2.1", "bs58": "6.0.0", "detect-browser": "5.3.0", "uint8arrays": "3.1.1", "viem": "2.36.0" } }, "sha512-FHagysDvp7yQl+74veIeuqwZZnMiTyTW3Lw0NXsbIKnlmlSQu5pma+4EnRD/CnSzbN6PV39k2t1KBaaZ4PjDgg=="],
-
-    "@solana-commerce/sdk/@solana/keys/@solana/assertions": ["@solana/assertions@2.3.0", "", { "dependencies": { "@solana/errors": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ=="],
 
     "@solana-commerce/sdk/@solana/keys/@solana/codecs-strings": ["@solana/codecs-strings@2.3.0", "", { "dependencies": { "@solana/codecs-core": "2.3.0", "@solana/codecs-numbers": "2.3.0", "@solana/errors": "2.3.0" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": ">=5.3.3" } }, "sha512-y5pSBYwzVziXu521hh+VxqUtp0hYGTl1eWGoc1W+8mdvBdC1kTqm/X7aYQw33J42hw03JjryvYOvmGgk3Qz/Ug=="],
 
@@ -1966,11 +2215,15 @@
 
     "@solana-commerce/sdk/@solana/transactions/@solana/transaction-messages": ["@solana/transaction-messages@2.3.0", "", { "dependencies": { "@solana/addresses": "2.3.0", "@solana/codecs-core": "2.3.0", "@solana/codecs-data-structures": "2.3.0", "@solana/codecs-numbers": "2.3.0", "@solana/errors": "2.3.0", "@solana/functional": "2.3.0", "@solana/instructions": "2.3.0", "@solana/nominal-types": "2.3.0", "@solana/rpc-types": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-bgqvWuy3MqKS5JdNLH649q+ngiyOu5rGS3DizSnWwYUd76RxZl1kN6CoqHSrrMzFMvis6sck/yPGG3wqrMlAww=="],
 
+    "@solana/accounts/@solana/addresses/@solana/assertions": ["@solana/assertions@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q=="],
+
     "@solana/accounts/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
-    "@solana/addresses/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+    "@solana/accounts/@solana/rpc-types/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
 
-    "@solana/assertions/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+    "@solana/addresses/@solana/codecs-strings/@solana/codecs-numbers": ["@solana/codecs-numbers@5.1.0", "", { "dependencies": { "@solana/codecs-core": "5.1.0", "@solana/errors": "5.1.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-Ea5/9yjDNOrDZcI40UGzzi6Aq1JNsmzM4m5pOk6Xb3JRZ0YdKOv/MwuCqb6jRgzZ7SQjHhkfGL43kHLJA++bOw=="],
+
+    "@solana/addresses/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
     "@solana/codecs-data-structures/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
@@ -1990,6 +2243,10 @@
 
     "@solana/keys/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
+    "@solana/kit/@solana/addresses/@solana/assertions": ["@solana/assertions@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q=="],
+
+    "@solana/kit/@solana/addresses/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
     "@solana/kit/@solana/codecs/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
 
     "@solana/kit/@solana/codecs/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
@@ -1998,21 +2255,83 @@
 
     "@solana/kit/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
+    "@solana/kit/@solana/rpc-api/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/kit/@solana/rpc-api/@solana/rpc-spec": ["@solana/rpc-spec@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1", "@solana/rpc-spec-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q=="],
+
+    "@solana/kit/@solana/rpc-api/@solana/rpc-transformers": ["@solana/rpc-transformers@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1", "@solana/functional": "5.5.1", "@solana/nominal-types": "5.5.1", "@solana/rpc-spec-types": "5.5.1", "@solana/rpc-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q=="],
+
+    "@solana/kit/@solana/rpc-types/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/kit/@solana/rpc-types/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
+    "@solana/offchain-messages/@solana/addresses/@solana/assertions": ["@solana/assertions@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q=="],
+
     "@solana/offchain-messages/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
     "@solana/options/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
+    "@solana/programs/@solana/addresses/@solana/assertions": ["@solana/assertions@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q=="],
+
+    "@solana/programs/@solana/addresses/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
     "@solana/programs/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/rpc-api/@solana/codecs-strings/@solana/codecs-numbers": ["@solana/codecs-numbers@5.1.0", "", { "dependencies": { "@solana/codecs-core": "5.1.0", "@solana/errors": "5.1.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-Ea5/9yjDNOrDZcI40UGzzi6Aq1JNsmzM4m5pOk6Xb3JRZ0YdKOv/MwuCqb6jRgzZ7SQjHhkfGL43kHLJA++bOw=="],
 
     "@solana/rpc-api/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
+    "@solana/rpc-api/@solana/keys/@solana/assertions": ["@solana/assertions@5.1.0", "", { "dependencies": { "@solana/errors": "5.1.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-5But2wyxuvGXMIOnD0jBMQ9yq1QQF2LSK3IbIRSkAkXbD3DS6O2tRvKUHNhogd+BpkPyCGOQHBycezgnxmStlg=="],
+
+    "@solana/rpc-api/@solana/keys/@solana/nominal-types": ["@solana/nominal-types@5.1.0", "", { "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-+4Cm+SpK+D811i9giqv4Up93ZlmUcZfLDHkSH24F4in61+Y2TKA+XKuRtKhNytQMmqCfbvJZ9MHFaIeZw5g+Bg=="],
+
+    "@solana/rpc-api/@solana/transaction-messages/@solana/codecs-data-structures": ["@solana/codecs-data-structures@5.1.0", "", { "dependencies": { "@solana/codecs-core": "5.1.0", "@solana/codecs-numbers": "5.1.0", "@solana/errors": "5.1.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-ftAwL/jsurFrk9kFVhkTLdQ8fGZ8I0PcbVH+V1a0dIP2aKDofGePvK0XbwZE/ohizC9gEIZxyBX5IgRKk5PXyg=="],
+
+    "@solana/rpc-api/@solana/transaction-messages/@solana/codecs-numbers": ["@solana/codecs-numbers@5.1.0", "", { "dependencies": { "@solana/codecs-core": "5.1.0", "@solana/errors": "5.1.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-Ea5/9yjDNOrDZcI40UGzzi6Aq1JNsmzM4m5pOk6Xb3JRZ0YdKOv/MwuCqb6jRgzZ7SQjHhkfGL43kHLJA++bOw=="],
+
+    "@solana/rpc-api/@solana/transaction-messages/@solana/functional": ["@solana/functional@5.1.0", "", { "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-R6jacWU0Gr+j49lTDp+FSECBolqw2Gq7JlC22rI0JkcxJiiAlp3G80v6zAYq0FkHzxZbjyR6//JYUXSwliem5g=="],
+
+    "@solana/rpc-api/@solana/transaction-messages/@solana/instructions": ["@solana/instructions@5.1.0", "", { "dependencies": { "@solana/codecs-core": "5.1.0", "@solana/errors": "5.1.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-fkwpUwwqk5K14T/kZDnCrfeR0kww49HBx+BK8xdSeJx+bt4QTwAHa9YeOkGhGrHEFVEJEUf8FKoxxTzZzJZtKQ=="],
+
+    "@solana/rpc-api/@solana/transaction-messages/@solana/nominal-types": ["@solana/nominal-types@5.1.0", "", { "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-+4Cm+SpK+D811i9giqv4Up93ZlmUcZfLDHkSH24F4in61+Y2TKA+XKuRtKhNytQMmqCfbvJZ9MHFaIeZw5g+Bg=="],
+
+    "@solana/rpc-api/@solana/transactions/@solana/codecs-data-structures": ["@solana/codecs-data-structures@5.1.0", "", { "dependencies": { "@solana/codecs-core": "5.1.0", "@solana/codecs-numbers": "5.1.0", "@solana/errors": "5.1.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-ftAwL/jsurFrk9kFVhkTLdQ8fGZ8I0PcbVH+V1a0dIP2aKDofGePvK0XbwZE/ohizC9gEIZxyBX5IgRKk5PXyg=="],
+
+    "@solana/rpc-api/@solana/transactions/@solana/codecs-numbers": ["@solana/codecs-numbers@5.1.0", "", { "dependencies": { "@solana/codecs-core": "5.1.0", "@solana/errors": "5.1.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-Ea5/9yjDNOrDZcI40UGzzi6Aq1JNsmzM4m5pOk6Xb3JRZ0YdKOv/MwuCqb6jRgzZ7SQjHhkfGL43kHLJA++bOw=="],
+
+    "@solana/rpc-api/@solana/transactions/@solana/functional": ["@solana/functional@5.1.0", "", { "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-R6jacWU0Gr+j49lTDp+FSECBolqw2Gq7JlC22rI0JkcxJiiAlp3G80v6zAYq0FkHzxZbjyR6//JYUXSwliem5g=="],
+
+    "@solana/rpc-api/@solana/transactions/@solana/instructions": ["@solana/instructions@5.1.0", "", { "dependencies": { "@solana/codecs-core": "5.1.0", "@solana/errors": "5.1.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-fkwpUwwqk5K14T/kZDnCrfeR0kww49HBx+BK8xdSeJx+bt4QTwAHa9YeOkGhGrHEFVEJEUf8FKoxxTzZzJZtKQ=="],
+
+    "@solana/rpc-api/@solana/transactions/@solana/nominal-types": ["@solana/nominal-types@5.1.0", "", { "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-+4Cm+SpK+D811i9giqv4Up93ZlmUcZfLDHkSH24F4in61+Y2TKA+XKuRtKhNytQMmqCfbvJZ9MHFaIeZw5g+Bg=="],
+
     "@solana/rpc-spec/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/rpc-subscriptions-api/@solana/addresses/@solana/assertions": ["@solana/assertions@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q=="],
+
+    "@solana/rpc-subscriptions-api/@solana/addresses/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/rpc-subscriptions-api/@solana/addresses/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/rpc-subscriptions-api/@solana/rpc-transformers/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/rpc-subscriptions-api/@solana/rpc-types/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/rpc-subscriptions-api/@solana/rpc-types/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
+    "@solana/rpc-subscriptions-api/@solana/rpc-types/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
     "@solana/rpc-subscriptions-channel-websocket/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
     "@solana/rpc-subscriptions-spec/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
     "@solana/rpc-subscriptions/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/rpc-subscriptions/@solana/rpc-types/@solana/addresses": ["@solana/addresses@5.5.1", "", { "dependencies": { "@solana/assertions": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA=="],
+
+    "@solana/rpc-subscriptions/@solana/rpc-types/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/rpc-subscriptions/@solana/rpc-types/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
 
     "@solana/rpc-transformers/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
@@ -2021,6 +2340,18 @@
     "@solana/rpc-types/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
     "@solana/rpc/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/rpc/@solana/rpc-api/@solana/addresses": ["@solana/addresses@5.5.1", "", { "dependencies": { "@solana/assertions": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA=="],
+
+    "@solana/rpc/@solana/rpc-api/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/rpc/@solana/rpc-types/@solana/addresses": ["@solana/addresses@5.5.1", "", { "dependencies": { "@solana/assertions": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA=="],
+
+    "@solana/rpc/@solana/rpc-types/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/rpc/@solana/rpc-types/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
+    "@solana/signers/@solana/addresses/@solana/assertions": ["@solana/assertions@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q=="],
 
     "@solana/signers/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
@@ -2034,9 +2365,27 @@
 
     "@solana/sysvars/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
+    "@solana/sysvars/@solana/rpc-types/@solana/addresses": ["@solana/addresses@5.5.1", "", { "dependencies": { "@solana/assertions": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA=="],
+
+    "@solana/sysvars/@solana/rpc-types/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/sysvars/@solana/rpc-types/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
+    "@solana/transaction-confirmation/@solana/addresses/@solana/assertions": ["@solana/assertions@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q=="],
+
+    "@solana/transaction-confirmation/@solana/addresses/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
     "@solana/transaction-confirmation/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
+    "@solana/transaction-confirmation/@solana/rpc-types/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/transaction-confirmation/@solana/rpc-types/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
+    "@solana/transaction-messages/@solana/addresses/@solana/assertions": ["@solana/assertions@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q=="],
+
     "@solana/transaction-messages/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/transactions/@solana/addresses/@solana/assertions": ["@solana/assertions@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q=="],
 
     "@solana/transactions/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
@@ -2144,6 +2493,8 @@
 
     "jayson/@types/ws/@types/node": ["@types/node@20.19.30", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g=="],
 
+    "next/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
     "obj-multiplex/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "obj-multiplex/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
@@ -2152,7 +2503,25 @@
 
     "porto/ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
+    "qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
+
+    "qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
+
+    "qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
+
+    "solana-bankrun/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
+
     "viem/ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
+    "@drift-labs/sdk/@coral-xyz/anchor/@solana/web3.js/superstruct": ["superstruct@2.0.2", "", {}, "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A=="],
+
+    "@drift-labs/sdk/@coral-xyz/anchor/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
+
+    "@drift-labs/sdk/@ellipsis-labs/phoenix-sdk/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+
+    "@drift-labs/sdk/@ellipsis-labs/phoenix-sdk/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
+
+    "@drift-labs/sdk/@solana/web3.js/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/rpc-errors/@metamask/utils": ["@metamask/utils@9.3.0", "", { "dependencies": { "@ethereumjs/tx": "^4.2.0", "@metamask/superstruct": "^3.1.0", "@noble/hashes": "^1.3.1", "@scure/base": "^1.1.3", "@types/debug": "^4.1.7", "debug": "^4.3.4", "pony-cause": "^2.1.10", "semver": "^7.5.4", "uuid": "^9.0.1" } }, "sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g=="],
 
@@ -2169,6 +2538,12 @@
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/sign-client/@walletconnect/core": ["@walletconnect/core@2.21.9", "", { "dependencies": { "@walletconnect/heartbeat": "1.2.2", "@walletconnect/jsonrpc-provider": "1.0.14", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/jsonrpc-ws-connection": "1.0.16", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "2.1.2", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.21.9", "@walletconnect/utils": "2.21.9", "@walletconnect/window-getters": "1.0.1", "es-toolkit": "1.39.3", "events": "3.3.0", "uint8arrays": "3.1.1" } }, "sha512-SlSknLvbO4i9Y4y8zU0zeCuJv1klQIUX3HRSBs1BaYvQKVVkrdiWPgRj4jcrL2wEOINa9NXw6HXp6x5XCXOolA=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/viem": ["viem@2.36.0", "", { "dependencies": { "@noble/curves": "1.9.6", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.0.8", "isows": "1.0.7", "ox": "0.9.1", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-Xz7AkGtR43K+NY74X2lBevwfRrsXuifGUzt8QiULO47NXIcT7g3jcA4nIvl5m2OTE5v8SlzishwXmg64xOIVmQ=="],
+
+    "@reown/appkit-ui/qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
+
+    "@reown/appkit-ui/qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
+
+    "@reown/appkit-ui/qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
     "@reown/appkit-utils/@walletconnect/logger/pino/on-exit-leak-free": ["on-exit-leak-free@0.2.0", "", {}, "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="],
 
@@ -2211,8 +2586,6 @@
     "@solana-commerce/sdk/@solana/kit/@solana/accounts/@solana/codecs-strings": ["@solana/codecs-strings@2.3.0", "", { "dependencies": { "@solana/codecs-core": "2.3.0", "@solana/codecs-numbers": "2.3.0", "@solana/errors": "2.3.0" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": ">=5.3.3" } }, "sha512-y5pSBYwzVziXu521hh+VxqUtp0hYGTl1eWGoc1W+8mdvBdC1kTqm/X7aYQw33J42hw03JjryvYOvmGgk3Qz/Ug=="],
 
     "@solana-commerce/sdk/@solana/kit/@solana/accounts/@solana/rpc-spec": ["@solana/rpc-spec@2.3.0", "", { "dependencies": { "@solana/errors": "2.3.0", "@solana/rpc-spec-types": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-fA2LMX4BMixCrNB2n6T83AvjZ3oUQTu7qyPLyt8gHQaoEAXs8k6GZmu6iYcr+FboQCjUmRPgMaABbcr9j2J9Sw=="],
-
-    "@solana-commerce/sdk/@solana/kit/@solana/addresses/@solana/assertions": ["@solana/assertions@2.3.0", "", { "dependencies": { "@solana/errors": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ=="],
 
     "@solana-commerce/sdk/@solana/kit/@solana/addresses/@solana/codecs-strings": ["@solana/codecs-strings@2.3.0", "", { "dependencies": { "@solana/codecs-core": "2.3.0", "@solana/codecs-numbers": "2.3.0", "@solana/errors": "2.3.0" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": ">=5.3.3" } }, "sha512-y5pSBYwzVziXu521hh+VxqUtp0hYGTl1eWGoc1W+8mdvBdC1kTqm/X7aYQw33J42hw03JjryvYOvmGgk3Qz/Ug=="],
 
@@ -2258,10 +2631,6 @@
 
     "@solana-commerce/sdk/@solana/kit/@solana/transaction-messages/@solana/nominal-types": ["@solana/nominal-types@2.3.0", "", { "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA=="],
 
-    "@solana-commerce/sdk/@solana/rpc-types/@solana/addresses/@solana/assertions": ["@solana/assertions@2.3.0", "", { "dependencies": { "@solana/errors": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ=="],
-
-    "@solana-commerce/sdk/@solana/transactions/@solana/addresses/@solana/assertions": ["@solana/assertions@2.3.0", "", { "dependencies": { "@solana/errors": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ=="],
-
     "@solana/codecs/@solana/codecs-core/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "@solana/codecs/@solana/codecs-data-structures/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
@@ -2269,6 +2638,20 @@
     "@solana/codecs/@solana/codecs-numbers/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "@solana/codecs/@solana/codecs-strings/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "@solana/rpc-subscriptions-api/@solana/addresses/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/rpc-subscriptions-api/@solana/rpc-transformers/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/rpc-subscriptions-api/@solana/rpc-types/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/rpc-subscriptions/@solana/rpc-types/@solana/addresses/@solana/assertions": ["@solana/assertions@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q=="],
+
+    "@solana/rpc/@solana/rpc-api/@solana/addresses/@solana/assertions": ["@solana/assertions@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q=="],
+
+    "@solana/rpc/@solana/rpc-types/@solana/addresses/@solana/assertions": ["@solana/assertions@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q=="],
+
+    "@solana/sysvars/@solana/rpc-types/@solana/addresses/@solana/assertions": ["@solana/assertions@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q=="],
 
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-common": ["@reown/appkit-common@1.7.8", "", { "dependencies": { "big.js": "6.2.2", "dayjs": "1.11.13", "viem": ">=2.29.0" } }, "sha512-ridIhc/x6JOp7KbDdwGKY4zwf8/iK8EYBl+HtWrruutSLwZyVi5P8WaZa+8iajL6LcDcDF7LoyLwMTym7SRuwQ=="],
 
@@ -2422,6 +2805,10 @@
 
     "jayson/@types/ws/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
+    "qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/rpc-errors/@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/logger/pino/on-exit-leak-free": ["on-exit-leak-free@0.2.0", "", {}, "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="],
@@ -2445,6 +2832,10 @@
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/viem/ox": ["ox@0.9.1", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.8", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-NVI0cajROntJWtFnxZQ1aXDVy+c6DLEXJ3wwON48CgbPhmMJrpRTfVbuppR+47RmXm3lZ/uMaKiFSkLdAO1now=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/viem/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+
+    "@reown/appkit-ui/qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@reown/appkit-ui/qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem/@noble/curves": ["@noble/curves@1.9.6", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-GIKz/j99FRthB8icyJQA51E8Uk5hXmdyThjgQXRKiv9h0zeRlzSCLIzFw6K1LotZ3XuB7yzlf76qk7uBmTdFqA=="],
 
@@ -2574,6 +2965,8 @@
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
+    "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
+
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-utils/@walletconnect/logger/pino": ["pino@7.11.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "fast-redact": "^3.0.0", "on-exit-leak-free": "^0.2.0", "pino-abstract-transport": "v0.5.0", "pino-std-serializers": "^4.0.0", "process-warning": "^1.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.1.0", "safe-stable-stringify": "^2.1.0", "sonic-boom": "^2.2.1", "thread-stream": "^0.15.1" }, "bin": { "pino": "bin.js" } }, "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg=="],
 
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-wallet/@walletconnect/logger/pino": ["pino@7.11.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "fast-redact": "^3.0.0", "on-exit-leak-free": "^0.2.0", "pino-abstract-transport": "v0.5.0", "pino-std-serializers": "^4.0.0", "process-warning": "^1.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.1.0", "safe-stable-stringify": "^2.1.0", "sonic-boom": "^2.2.1", "thread-stream": "^0.15.1" }, "bin": { "pino": "bin.js" } }, "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg=="],
@@ -2654,6 +3047,12 @@
 
     "gill/@solana-program/token-2022/@solana/sysvars/@solana/accounts/@solana/rpc-spec/@solana/rpc-spec-types": ["@solana/rpc-spec-types@2.3.0", "", { "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-xQsb65lahjr8Wc9dMtP7xa0ZmDS8dOE2ncYjlvfyw/h4mpdXTUdrSMi6RtFwX33/rGuztQ7Hwaid5xLNSLvsFQ=="],
 
+    "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
+
+    "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
+
+    "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
+
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-utils/@walletconnect/logger/pino/on-exit-leak-free": ["on-exit-leak-free@0.2.0", "", {}, "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="],
 
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-utils/@walletconnect/logger/pino/pino-abstract-transport": ["pino-abstract-transport@0.5.0", "", { "dependencies": { "duplexify": "^4.1.2", "split2": "^4.0.0" } }, "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ=="],
@@ -2723,6 +3122,10 @@
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/ox": ["ox@0.6.7", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA=="],
 
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+
+    "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/ox/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -82,6 +82,7 @@
     },
   },
   "patchedDependencies": {
+    "@drift-labs/sdk@2.159.0-beta.2": "patches/@drift-labs%2Fsdk@2.159.0-beta.2.patch",
     "@orca-so/common-sdk@0.7.0": "patches/@orca-so%2Fcommon-sdk@0.7.0.patch",
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
   },
   "packageManager": "bun@1.3.0",
   "patchedDependencies": {
-    "@orca-so/common-sdk@0.7.0": "patches/@orca-so%2Fcommon-sdk@0.7.0.patch"
+    "@orca-so/common-sdk@0.7.0": "patches/@orca-so%2Fcommon-sdk@0.7.0.patch",
+    "@drift-labs/sdk@2.159.0-beta.2": "patches/@drift-labs%2Fsdk@2.159.0-beta.2.patch"
   }
 }

--- a/patches/@drift-labs%2Fsdk@2.159.0-beta.2.patch
+++ b/patches/@drift-labs%2Fsdk@2.159.0-beta.2.patch
@@ -7,7 +7,7 @@ index 41a66da1474c34ab67a9deb220993c9df3fb63eb..924b6544e89e04601289615d3ce73b2a
  const oracleId_1 = require("./oracles/oracleId");
  // BN is already imported globally in this file via other imports
 -const sha256_1 = require("@noble/hashes/sha256");
-+const sha256_1 = require("@noble/hashes/sha2");
++const sha256_1 = require("@noble/hashes/sha2.js");
  const utils_3 = require("./oracles/utils");
  const orders_1 = require("./math/orders");
  const builder_1 = require("./math/builder");
@@ -20,7 +20,7 @@ index 4fb011d4758a8f19e611addf38dd0fee44d48fbb..c45c1c7f7ed62363ea95a3320316d1bc
  const tweetnacl_util_1 = require("tweetnacl-util");
  const ws_1 = __importDefault(require("ws"));
 -const sha256_1 = require("@noble/hashes/sha256");
-+const sha256_1 = require("@noble/hashes/sha2");
++const sha256_1 = require("@noble/hashes/sha2.js");
  class SwiftOrderSubscriber {
      constructor(config) {
          this.config = config;
@@ -33,7 +33,7 @@ index 41a66da1474c34ab67a9deb220993c9df3fb63eb..924b6544e89e04601289615d3ce73b2a
  const oracleId_1 = require("./oracles/oracleId");
  // BN is already imported globally in this file via other imports
 -const sha256_1 = require("@noble/hashes/sha256");
-+const sha256_1 = require("@noble/hashes/sha2");
++const sha256_1 = require("@noble/hashes/sha2.js");
  const utils_3 = require("./oracles/utils");
  const orders_1 = require("./math/orders");
  const builder_1 = require("./math/builder");
@@ -46,7 +46,7 @@ index 4fb011d4758a8f19e611addf38dd0fee44d48fbb..c45c1c7f7ed62363ea95a3320316d1bc
  const tweetnacl_util_1 = require("tweetnacl-util");
  const ws_1 = __importDefault(require("ws"));
 -const sha256_1 = require("@noble/hashes/sha256");
-+const sha256_1 = require("@noble/hashes/sha2");
++const sha256_1 = require("@noble/hashes/sha2.js");
  class SwiftOrderSubscriber {
      constructor(config) {
          this.config = config;

--- a/patches/@drift-labs%2Fsdk@2.159.0-beta.2.patch
+++ b/patches/@drift-labs%2Fsdk@2.159.0-beta.2.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/browser/driftClient.js b/lib/browser/driftClient.js
-index 41a66da1474c34ab67a9deb220993c9df3fb63eb..f5facc35cf945e2fe695676ecd671bd628f5a918 100644
+index 41a66da1474c34ab67a9deb220993c9df3fb63eb..924b6544e89e04601289615d3ce73b2a56fe025d 100644
 --- a/lib/browser/driftClient.js
 +++ b/lib/browser/driftClient.js
 @@ -70,7 +70,7 @@ const grpcDriftClientAccountSubscriber_1 = require("./accounts/grpcDriftClientAc
@@ -7,12 +7,12 @@ index 41a66da1474c34ab67a9deb220993c9df3fb63eb..f5facc35cf945e2fe695676ecd671bd6
  const oracleId_1 = require("./oracles/oracleId");
  // BN is already imported globally in this file via other imports
 -const sha256_1 = require("@noble/hashes/sha256");
-+const sha256_1 = require("@noble/hashes/sha2.js");
++const sha256_1 = require("@noble/hashes/sha2");
  const utils_3 = require("./oracles/utils");
  const orders_1 = require("./math/orders");
  const builder_1 = require("./math/builder");
 diff --git a/lib/browser/swift/swiftOrderSubscriber.js b/lib/browser/swift/swiftOrderSubscriber.js
-index 4fb011d4758a8f19e611addf38dd0fee44d48fbb..12ffac7c42cfb6b4aa1de5b1a41d9954cf32832e 100644
+index 4fb011d4758a8f19e611addf38dd0fee44d48fbb..c45c1c7f7ed62363ea95a3320316d1bce4272def 100644
 --- a/lib/browser/swift/swiftOrderSubscriber.js
 +++ b/lib/browser/swift/swiftOrderSubscriber.js
 @@ -11,7 +11,7 @@ const web3_js_1 = require("@solana/web3.js");
@@ -20,12 +20,12 @@ index 4fb011d4758a8f19e611addf38dd0fee44d48fbb..12ffac7c42cfb6b4aa1de5b1a41d9954
  const tweetnacl_util_1 = require("tweetnacl-util");
  const ws_1 = __importDefault(require("ws"));
 -const sha256_1 = require("@noble/hashes/sha256");
-+const sha256_1 = require("@noble/hashes/sha2.js");
++const sha256_1 = require("@noble/hashes/sha2");
  class SwiftOrderSubscriber {
      constructor(config) {
          this.config = config;
 diff --git a/lib/node/driftClient.js b/lib/node/driftClient.js
-index 41a66da1474c34ab67a9deb220993c9df3fb63eb..f5facc35cf945e2fe695676ecd671bd628f5a918 100644
+index 41a66da1474c34ab67a9deb220993c9df3fb63eb..924b6544e89e04601289615d3ce73b2a56fe025d 100644
 --- a/lib/node/driftClient.js
 +++ b/lib/node/driftClient.js
 @@ -70,7 +70,7 @@ const grpcDriftClientAccountSubscriber_1 = require("./accounts/grpcDriftClientAc
@@ -33,12 +33,12 @@ index 41a66da1474c34ab67a9deb220993c9df3fb63eb..f5facc35cf945e2fe695676ecd671bd6
  const oracleId_1 = require("./oracles/oracleId");
  // BN is already imported globally in this file via other imports
 -const sha256_1 = require("@noble/hashes/sha256");
-+const sha256_1 = require("@noble/hashes/sha2.js");
++const sha256_1 = require("@noble/hashes/sha2");
  const utils_3 = require("./oracles/utils");
  const orders_1 = require("./math/orders");
  const builder_1 = require("./math/builder");
 diff --git a/lib/node/swift/swiftOrderSubscriber.js b/lib/node/swift/swiftOrderSubscriber.js
-index 4fb011d4758a8f19e611addf38dd0fee44d48fbb..12ffac7c42cfb6b4aa1de5b1a41d9954cf32832e 100644
+index 4fb011d4758a8f19e611addf38dd0fee44d48fbb..c45c1c7f7ed62363ea95a3320316d1bce4272def 100644
 --- a/lib/node/swift/swiftOrderSubscriber.js
 +++ b/lib/node/swift/swiftOrderSubscriber.js
 @@ -11,7 +11,7 @@ const web3_js_1 = require("@solana/web3.js");
@@ -46,7 +46,7 @@ index 4fb011d4758a8f19e611addf38dd0fee44d48fbb..12ffac7c42cfb6b4aa1de5b1a41d9954
  const tweetnacl_util_1 = require("tweetnacl-util");
  const ws_1 = __importDefault(require("ws"));
 -const sha256_1 = require("@noble/hashes/sha256");
-+const sha256_1 = require("@noble/hashes/sha2.js");
++const sha256_1 = require("@noble/hashes/sha2");
  class SwiftOrderSubscriber {
      constructor(config) {
          this.config = config;

--- a/patches/@drift-labs%2Fsdk@2.159.0-beta.2.patch
+++ b/patches/@drift-labs%2Fsdk@2.159.0-beta.2.patch
@@ -1,0 +1,52 @@
+diff --git a/lib/browser/driftClient.js b/lib/browser/driftClient.js
+index 41a66da1474c34ab67a9deb220993c9df3fb63eb..f5facc35cf945e2fe695676ecd671bd628f5a918 100644
+--- a/lib/browser/driftClient.js
++++ b/lib/browser/driftClient.js
+@@ -70,7 +70,7 @@ const grpcDriftClientAccountSubscriber_1 = require("./accounts/grpcDriftClientAc
+ const tweetnacl_1 = __importDefault(require("tweetnacl"));
+ const oracleId_1 = require("./oracles/oracleId");
+ // BN is already imported globally in this file via other imports
+-const sha256_1 = require("@noble/hashes/sha256");
++const sha256_1 = require("@noble/hashes/sha2.js");
+ const utils_3 = require("./oracles/utils");
+ const orders_1 = require("./math/orders");
+ const builder_1 = require("./math/builder");
+diff --git a/lib/browser/swift/swiftOrderSubscriber.js b/lib/browser/swift/swiftOrderSubscriber.js
+index 4fb011d4758a8f19e611addf38dd0fee44d48fbb..12ffac7c42cfb6b4aa1de5b1a41d9954cf32832e 100644
+--- a/lib/browser/swift/swiftOrderSubscriber.js
++++ b/lib/browser/swift/swiftOrderSubscriber.js
+@@ -11,7 +11,7 @@ const web3_js_1 = require("@solana/web3.js");
+ const tweetnacl_1 = __importDefault(require("tweetnacl"));
+ const tweetnacl_util_1 = require("tweetnacl-util");
+ const ws_1 = __importDefault(require("ws"));
+-const sha256_1 = require("@noble/hashes/sha256");
++const sha256_1 = require("@noble/hashes/sha2.js");
+ class SwiftOrderSubscriber {
+     constructor(config) {
+         this.config = config;
+diff --git a/lib/node/driftClient.js b/lib/node/driftClient.js
+index 41a66da1474c34ab67a9deb220993c9df3fb63eb..f5facc35cf945e2fe695676ecd671bd628f5a918 100644
+--- a/lib/node/driftClient.js
++++ b/lib/node/driftClient.js
+@@ -70,7 +70,7 @@ const grpcDriftClientAccountSubscriber_1 = require("./accounts/grpcDriftClientAc
+ const tweetnacl_1 = __importDefault(require("tweetnacl"));
+ const oracleId_1 = require("./oracles/oracleId");
+ // BN is already imported globally in this file via other imports
+-const sha256_1 = require("@noble/hashes/sha256");
++const sha256_1 = require("@noble/hashes/sha2.js");
+ const utils_3 = require("./oracles/utils");
+ const orders_1 = require("./math/orders");
+ const builder_1 = require("./math/builder");
+diff --git a/lib/node/swift/swiftOrderSubscriber.js b/lib/node/swift/swiftOrderSubscriber.js
+index 4fb011d4758a8f19e611addf38dd0fee44d48fbb..12ffac7c42cfb6b4aa1de5b1a41d9954cf32832e 100644
+--- a/lib/node/swift/swiftOrderSubscriber.js
++++ b/lib/node/swift/swiftOrderSubscriber.js
+@@ -11,7 +11,7 @@ const web3_js_1 = require("@solana/web3.js");
+ const tweetnacl_1 = __importDefault(require("tweetnacl"));
+ const tweetnacl_util_1 = require("tweetnacl-util");
+ const ws_1 = __importDefault(require("ws"));
+-const sha256_1 = require("@noble/hashes/sha256");
++const sha256_1 = require("@noble/hashes/sha2.js");
+ class SwiftOrderSubscriber {
+     constructor(config) {
+         this.config = config;

--- a/patches/@orca-so%2Fcommon-sdk@0.7.0.patch
+++ b/patches/@orca-so%2Fcommon-sdk@0.7.0.patch
@@ -1,5 +1,8 @@
+diff --git a/node_modules/@orca-so/common-sdk/.bun-tag-d1b7d85cd245eea2 b/.bun-tag-d1b7d85cd245eea2
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/web3/token-util.js b/dist/web3/token-util.js
-index a1915973084b9f5c69ddad9922b8b5c8c63b46bf..e7517453fdd4ff3660ddfbe607a789bc61528403 100644
+index a1915973084b9f5c69ddad9922b8b5c8c63b46bf..e634274d137a19cb9028afa139bb36d3228b730e 100644
 --- a/dist/web3/token-util.js
 +++ b/dist/web3/token-util.js
 @@ -6,7 +6,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
@@ -7,7 +10,7 @@ index a1915973084b9f5c69ddad9922b8b5c8c63b46bf..e7517453fdd4ff3660ddfbe607a789bc
  const spl_token_1 = require("@solana/spl-token");
  const web3_js_1 = require("@solana/web3.js");
 -const sha256_1 = require("@noble/hashes/sha256");
-+const sha256_1 = require("@noble/hashes/sha2.js");
++const sha256_1 = require("@noble/hashes/sha2");
  const tiny_invariant_1 = __importDefault(require("tiny-invariant"));
  const math_1 = require("../math");
  const web3_1 = require("../web3");

--- a/patches/@orca-so%2Fcommon-sdk@0.7.0.patch
+++ b/patches/@orca-so%2Fcommon-sdk@0.7.0.patch
@@ -10,7 +10,7 @@ index a1915973084b9f5c69ddad9922b8b5c8c63b46bf..e634274d137a19cb9028afa139bb36d3
  const spl_token_1 = require("@solana/spl-token");
  const web3_js_1 = require("@solana/web3.js");
 -const sha256_1 = require("@noble/hashes/sha256");
-+const sha256_1 = require("@noble/hashes/sha2");
++const sha256_1 = require("@noble/hashes/sha2.js");
  const tiny_invariant_1 = __importDefault(require("tiny-invariant"));
  const math_1 = require("../math");
  const web3_1 = require("../web3");

--- a/tests/unit/worker_drift.test.ts
+++ b/tests/unit/worker_drift.test.ts
@@ -67,4 +67,115 @@ describe("worker Drift client", () => {
     expect(preview.limitPriceAtomic).toBe("155000000");
     expect(preview.swiftSupported).toBe(true);
   });
+
+  test("accepts the current Drift data API payload shape", async () => {
+    const fetchMock = mock(async (input: string | URL) => {
+      const url = String(input);
+      if (url === "https://drift.test/contracts") {
+        return new Response(
+          JSON.stringify([
+            {
+              contract_index: 0,
+              ticker_id: "SOL-PERP",
+              product_type: "PERP",
+              end_timestamp: "1773553587484",
+            },
+          ]),
+        );
+      }
+      if (url === "https://drift.test/fundingRates?marketName=SOL-PERP") {
+        return new Response(
+          JSON.stringify([
+            {
+              marketIndex: 0,
+              fundingRate: "-2633875",
+              oraclePriceTwap: "78551231",
+              markPriceTwap: "78472308",
+              ts: "1770962417",
+            },
+          ]),
+        );
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+
+    const client = new DriftClient(
+      {
+        dataApiBase: "https://drift.test",
+      },
+      { fetch: fetchMock as typeof fetch },
+    );
+    const preview = await client.describePerpIntent({
+      instrumentId: "SOL-PERP",
+      side: "short",
+      quantityAtomic: "1000000",
+      executionAdapter: "drift",
+    });
+
+    expect(preview.instrument.marketName).toBe("SOL-PERP");
+    expect(preview.instrument.marketIndex).toBe(0);
+    expect(preview.instrument.contractType).toBe("PERP");
+    expect(preview.instrument.status).toBe("active");
+    expect(preview.funding?.fundingRate1h).toBeCloseTo(-0.002633875, 12);
+    expect(preview.funding?.oraclePrice).toBeCloseTo(78.551231, 6);
+    expect(preview.funding?.markPrice).toBeCloseTo(78.472308, 6);
+  });
+
+  test("maps close intents to the opposite trading direction", async () => {
+    const fetchMock = mock(async (input: string | URL) => {
+      const url = String(input);
+      if (url === "https://drift.test/contracts") {
+        return new Response(
+          JSON.stringify({
+            contracts: [
+              {
+                marketName: "SOL-PERP",
+                marketIndex: 2,
+                status: "active",
+                contractType: "perp",
+              },
+            ],
+          }),
+        );
+      }
+      if (url === "https://drift.test/fundingRates?marketName=SOL-PERP") {
+        return new Response(
+          JSON.stringify({
+            fundingRates: [
+              {
+                marketName: "SOL-PERP",
+                fundingRate: 0.00012,
+              },
+            ],
+          }),
+        );
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+
+    const client = new DriftClient(
+      {
+        dataApiBase: "https://drift.test",
+      },
+      { fetch: fetchMock as typeof fetch },
+    );
+
+    const closeLong = await client.describePerpIntent({
+      instrumentId: "SOL-PERP",
+      side: "close_long",
+      quantityAtomic: "1000000",
+      executionAdapter: "drift",
+    });
+    const closeShort = await client.describePerpIntent({
+      instrumentId: "SOL-PERP",
+      side: "close_short",
+      quantityAtomic: "1000000",
+      executionAdapter: "drift",
+    });
+
+    expect(closeLong.direction).toBe("short");
+    expect(closeLong.reduceOnly).toBe(true);
+    expect(closeShort.direction).toBe("long");
+    expect(closeShort.reduceOnly).toBe(true);
+  });
 });

--- a/tests/unit/worker_execution_drift.test.ts
+++ b/tests/unit/worker_execution_drift.test.ts
@@ -145,4 +145,197 @@ describe("worker Drift perp execution adapter", () => {
       }),
     ).rejects.toThrow(/drift-live-mode-not-supported/);
   });
+
+  test("allows bounded live smoke through the readiness bypass", async () => {
+    let prepareCallCount = 0;
+    const result = await executeDriftPerpOrder(
+      {
+        env: {
+          RPC_ENDPOINT: "https://rpc.test",
+        } as Env,
+        runtimeMode: "live",
+        experimentalLiveModeBypass: "venue_tx_smoke",
+        subjectControlBypassReason: "strategy_lab_readiness_canary",
+        policy: normalizePolicy({ commitment: "confirmed" }),
+        rpc: {
+          sendTransactionBase64: async (transaction) =>
+            transaction.includes("setup") ? "sig-setup" : "sig-order",
+          confirmSignature: async () => ({
+            ok: true,
+            status: "confirmed" as const,
+          }),
+        } as never,
+        jupiter: {} as never,
+        drift: {
+          swiftConfigured: () => false,
+          describePerpIntent: async () => buildPreview(),
+          buildSyntheticQuote: () => ({
+            inputMint: "SOL-PERP",
+            outputMint: "SOL-PERP",
+            inAmount: "250000",
+            outAmount: "1000000",
+            priceImpactPct: 0,
+            routePlan: [{ poolId: "SOL-PERP", swapInfo: { label: "Drift" } }],
+          }),
+        } as never,
+        privyWalletId: "wallet_strategy_lab",
+        intent: buildIntent(),
+        log: () => {},
+      },
+      {
+        prepareDriftLivePerpOrder: async () => {
+          prepareCallCount += 1;
+          if (prepareCallCount === 1) {
+            return {
+              marketIndex: 2,
+              userAccountAddress: "drift-user-account",
+              spotCollateralMint:
+                "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+              setupAction: "deposit",
+              setupAmountAtomic: "250000",
+              setupTransactionBase64: "setup-tx",
+              orderTransactionBase64: null,
+              lastValidBlockHeight: 88,
+              snapshotBefore: null,
+            };
+          }
+          return {
+            marketIndex: 2,
+            userAccountAddress: "drift-user-account",
+            spotCollateralMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            setupAction: null,
+            setupAmountAtomic: null,
+            setupTransactionBase64: null,
+            orderTransactionBase64: "order-tx",
+            lastValidBlockHeight: 99,
+            snapshotBefore: {
+              userAccountAddress: "drift-user-account",
+              marketIndex: 2,
+              positionDirection: "flat",
+              baseAssetAmountAtomic: "0",
+              quoteAssetAmountAtomic: "0",
+              quoteEntryAmountAtomic: "0",
+              quoteBreakEvenAmountAtomic: "0",
+              settledPnlAtomic: "0",
+              collateralAtomic: "250000",
+              freeCollateralAtomic: "250000",
+              totalCollateralAtomic: "250000",
+              initialMarginRequirementAtomic: "0",
+              maintenanceMarginRequirementAtomic: "0",
+              leverageTenThousand: "0",
+              health: 100,
+              openOrders: 0,
+            },
+          };
+        },
+        readDriftLiveAccountSnapshot: async () => ({
+          userAccountAddress: "drift-user-account",
+          marketIndex: 2,
+          positionDirection: "long",
+          baseAssetAmountAtomic: "1000000",
+          quoteAssetAmountAtomic: "-153300000",
+          quoteEntryAmountAtomic: "-153300000",
+          quoteBreakEvenAmountAtomic: "-153300000",
+          settledPnlAtomic: "0",
+          collateralAtomic: "250000",
+          freeCollateralAtomic: "100000",
+          totalCollateralAtomic: "250000",
+          initialMarginRequirementAtomic: "50000",
+          maintenanceMarginRequirementAtomic: "25000",
+          leverageTenThousand: "500",
+          health: 92,
+          openOrders: 0,
+        }),
+        signTransactionWithPrivyById: async (_env, _walletId, transaction) =>
+          `signed:${transaction}`,
+      },
+    );
+
+    expect(result.status).toBe("confirmed");
+    expect(result.signature).toBe("sig-order");
+    expect(result.executionMeta?.classification).toBe("confirmed");
+    expect(result.executionMeta?.lifecycle?.positionState).toBe("open");
+    expect(
+      (result.executionMeta as Record<string, unknown> | undefined)
+        ?.driftAccount,
+    ).toBeDefined();
+  });
+
+  test("uses confirmed preflight for live smoke even when policy commitment is finalized", async () => {
+    const simulateCommitments: string[] = [];
+    const preflightCommitments: string[] = [];
+
+    const result = await executeDriftPerpOrder(
+      {
+        env: {
+          RPC_ENDPOINT: "https://rpc.test",
+        } as Env,
+        runtimeMode: "live",
+        experimentalLiveModeBypass: "venue_tx_smoke",
+        subjectControlBypassReason: "strategy_lab_readiness_canary",
+        execution: {
+          params: {
+            lane: "safe",
+          },
+        },
+        policy: normalizePolicy({ commitment: "finalized" }),
+        rpc: {
+          simulateTransactionBase64: async (_transaction, options) => {
+            simulateCommitments.push(String(options.commitment ?? ""));
+            return { err: null };
+          },
+          sendTransactionBase64: async (_transaction, options) => {
+            preflightCommitments.push(
+              String(options.preflightCommitment ?? ""),
+            );
+            return "sig-order";
+          },
+          confirmSignature: async () => ({
+            ok: true,
+            status: "finalized" as const,
+          }),
+        } as never,
+        jupiter: {} as never,
+        drift: {
+          swiftConfigured: () => false,
+          describePerpIntent: async () => buildPreview(),
+          buildSyntheticQuote: () => ({
+            inputMint: "SOL-PERP",
+            outputMint: "SOL-PERP",
+            inAmount: "250000",
+            outAmount: "1000000",
+            priceImpactPct: 0,
+            routePlan: [{ poolId: "SOL-PERP", swapInfo: { label: "Drift" } }],
+          }),
+        } as never,
+        privyWalletId: "wallet_strategy_lab",
+        intent: buildIntent(),
+        log: () => {},
+      },
+      {
+        prepareDriftLivePerpOrder: async () => ({
+          marketIndex: 2,
+          userAccountAddress: "drift-user-account",
+          spotCollateralMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          setupAction: null,
+          setupAmountAtomic: null,
+          setupTransactionBase64: null,
+          orderTransactionBase64: "order-tx",
+          lastValidBlockHeight: 99,
+          snapshotBefore: null,
+        }),
+        readDriftLiveAccountSnapshot: async () => null,
+        signTransactionWithPrivyById: async (_env, _walletId, transaction) =>
+          `signed:${transaction}`,
+        evaluateSafeLaneTransaction: () => ({
+          ok: true,
+          profile: "default",
+        }),
+      },
+    );
+
+    expect(result.status).toBe("finalized");
+    expect(simulateCommitments).toEqual(["confirmed"]);
+    expect(preflightCommitments).toEqual(["confirmed"]);
+  });
 });

--- a/tests/unit/worker_execution_drift.test.ts
+++ b/tests/unit/worker_execution_drift.test.ts
@@ -338,4 +338,73 @@ describe("worker Drift perp execution adapter", () => {
     expect(simulateCommitments).toEqual(["confirmed"]);
     expect(preflightCommitments).toEqual(["confirmed"]);
   });
+
+  test("preserves a landed live result when the post-submit snapshot read fails", async () => {
+    const result = await executeDriftPerpOrder(
+      {
+        env: {
+          RPC_ENDPOINT: "https://rpc.test",
+        } as Env,
+        runtimeMode: "live",
+        experimentalLiveModeBypass: "venue_tx_smoke",
+        subjectControlBypassReason: "strategy_lab_readiness_canary",
+        policy: normalizePolicy({ commitment: "confirmed" }),
+        rpc: {
+          sendTransactionBase64: async () => "sig-order",
+          confirmSignature: async () => ({
+            ok: true,
+            status: "confirmed" as const,
+          }),
+        } as never,
+        jupiter: {} as never,
+        drift: {
+          swiftConfigured: () => false,
+          describePerpIntent: async () => buildPreview(),
+          buildSyntheticQuote: () => ({
+            inputMint: "SOL-PERP",
+            outputMint: "SOL-PERP",
+            inAmount: "250000",
+            outAmount: "1000000",
+            priceImpactPct: 0,
+            routePlan: [{ poolId: "SOL-PERP", swapInfo: { label: "Drift" } }],
+          }),
+        } as never,
+        privyWalletId: "wallet_strategy_lab",
+        intent: buildIntent(),
+        log: () => {},
+      },
+      {
+        prepareDriftLivePerpOrder: async () => ({
+          marketIndex: 2,
+          userAccountAddress: "drift-user-account",
+          spotCollateralMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          setupAction: null,
+          setupAmountAtomic: null,
+          setupTransactionBase64: null,
+          orderTransactionBase64: "order-tx",
+          lastValidBlockHeight: 99,
+          snapshotBefore: null,
+        }),
+        readDriftLiveAccountSnapshot: async () => {
+          throw new Error("snapshot-rpc-temporary-failure");
+        },
+        signTransactionWithPrivyById: async (_env, _walletId, transaction) =>
+          `signed:${transaction}`,
+      },
+    );
+
+    expect(result.status).toBe("confirmed");
+    expect(result.signature).toBe("sig-order");
+    expect(result.executionMeta?.classification).toBe("confirmed");
+    expect(result.executionMeta?.lifecycle?.notes).toContain(
+      "snapshotReadError:snapshot-rpc-temporary-failure",
+    );
+    expect(
+      (
+        result.executionMeta as
+          | { driftAccount?: { snapshotReadError?: string | null } }
+          | undefined
+      )?.driftAccount?.snapshotReadError,
+    ).toBe("snapshot-rpc-temporary-failure");
+  });
 });

--- a/tests/unit/worker_execution_router.test.ts
+++ b/tests/unit/worker_execution_router.test.ts
@@ -661,6 +661,134 @@ describe("worker execution router", () => {
     expect(result.executionMeta?.lifecycle?.positionState).toBe("opening");
   });
 
+  test("fails closed when Drift perp orders are requested in live mode", async () => {
+    await expect(
+      executeIntentViaRouter({
+        env: {} as never,
+        venueKey: "drift",
+        runtimeMode: "live",
+        requireVenueRouting: true,
+        execution: { adapter: "drift" },
+        policy: normalizePolicy({ dryRun: true }),
+        rpc: {} as never,
+        jupiter: {} as never,
+        drift: {
+          swiftConfigured: () => false,
+          describePerpIntent: async () => ({
+            instrument: {
+              marketName: "SOL-PERP",
+              marketIndex: 2,
+              oracle: "oracle-sol",
+              oracleSource: "pyth",
+              status: "active",
+              contractType: "perp",
+              initialMarginRatio: 1000,
+              maintenanceMarginRatio: 500,
+            },
+            funding: null,
+            side: "long",
+            direction: "long",
+            reduceOnly: false,
+            orderType: "market",
+            timeInForce: "ioc",
+            quantityAtomic: "1000000",
+            collateralAtomic: "250000",
+            limitPriceAtomic: null,
+            triggerPriceAtomic: null,
+            swiftSupported: false,
+          }),
+          buildSyntheticQuote: () => ({
+            inputMint: "SOL-PERP",
+            outputMint: "SOL-PERP",
+            inAmount: "250000",
+            outAmount: "1000000",
+            priceImpactPct: 0,
+            routePlan: [{ poolId: "SOL-PERP", swapInfo: { label: "Drift" } }],
+          }),
+        } as never,
+        intent: {
+          family: "perp_order",
+          wallet: "11111111111111111111111111111111",
+          venueKey: "drift",
+          marketType: "perp",
+          instrumentId: "SOL-PERP",
+          side: "long",
+          quantityAtomic: "1000000",
+          collateralAtomic: "250000",
+        },
+        log: () => {},
+      }),
+    ).rejects.toThrow(/runtime-venue-mode-not-supported:drift:live/);
+  });
+
+  test("allows Drift live venue smoke only through the bounded readiness bypass", async () => {
+    const { env, sqlite } = await createLiveRouterEnv();
+    try {
+      const result = await executeIntentViaRouter({
+        env,
+        venueKey: "drift",
+        runtimeMode: "live",
+        experimentalLiveModeBypass: "venue_tx_smoke",
+        requireVenueRouting: true,
+        subjectControlBypassReason: "strategy_lab_readiness_canary",
+        execution: { adapter: "drift" },
+        policy: normalizePolicy({ dryRun: true }),
+        rpc: {} as never,
+        jupiter: {} as never,
+        drift: {
+          swiftConfigured: () => false,
+          describePerpIntent: async () => ({
+            instrument: {
+              marketName: "SOL-PERP",
+              marketIndex: 2,
+              oracle: "oracle-sol",
+              oracleSource: "pyth",
+              status: "active",
+              contractType: "perp",
+              initialMarginRatio: 1000,
+              maintenanceMarginRatio: 500,
+            },
+            funding: null,
+            side: "long",
+            direction: "long",
+            reduceOnly: false,
+            orderType: "market",
+            timeInForce: "ioc",
+            quantityAtomic: "1000000",
+            collateralAtomic: "250000",
+            limitPriceAtomic: null,
+            triggerPriceAtomic: null,
+            swiftSupported: false,
+          }),
+          buildSyntheticQuote: () => ({
+            inputMint: "SOL-PERP",
+            outputMint: "SOL-PERP",
+            inAmount: "250000",
+            outAmount: "1000000",
+            priceImpactPct: 0,
+            routePlan: [{ poolId: "SOL-PERP", swapInfo: { label: "Drift" } }],
+          }),
+        } as never,
+        intent: {
+          family: "perp_order",
+          wallet: "11111111111111111111111111111111",
+          venueKey: "drift",
+          marketType: "perp",
+          instrumentId: "SOL-PERP",
+          side: "long",
+          quantityAtomic: "1000000",
+          collateralAtomic: "250000",
+        },
+        log: () => {},
+      });
+
+      expect(result.status).toBe("dry_run");
+      expect(result.executionMeta?.route).toBe("drift");
+    } finally {
+      sqlite.close();
+    }
+  });
+
   test("routes Mango spot margin orders through the Mango executor in paper mode", async () => {
     const result = await executeIntentViaRouter({
       env: {} as never,

--- a/tests/unit/worker_runtime_research_readiness_route.test.ts
+++ b/tests/unit/worker_runtime_research_readiness_route.test.ts
@@ -462,6 +462,57 @@ describe("worker runtime research readiness routes", () => {
     }
   });
 
+  test("allows bounded Drift venue smoke even though the venue is not generally live-enabled", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/research/readiness/smoke",
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              subjectKind: "venue",
+              subjectKey: "drift",
+              requestedBy: "codex",
+              venueKey: "drift",
+              assetKey: "SOL",
+              pairSymbol: "SOL-PERP",
+              proofMode: "venue_tx_smoke",
+              tightenOnFailure: true,
+              failureControlMode: "disable_live",
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(200);
+      const payload = (await response.json()) as {
+        ok: boolean;
+        status: string;
+        run: {
+          venueKey: string;
+          pairSymbol: string;
+          metadata?: Record<string, unknown>;
+          evidenceRefs: Array<{ kind: string }>;
+        };
+      };
+      expect(payload.ok).toBe(true);
+      expect(payload.status).toBe("success");
+      expect(payload.run.venueKey).toBe("drift");
+      expect(payload.run.pairSymbol).toBe("SOL-PERP");
+      expect(payload.run.evidenceRefs[0]?.kind).toBe("live_canary");
+      expect(payload.run.metadata?.proofMode).toBe("venue_tx_smoke");
+    } finally {
+      sqlite.close();
+    }
+  });
+
   test("uses the quote mint for OpenBook buy smoke on USDC/USDT", async () => {
     const { env, sqlite } = createOpsEnv();
     try {


### PR DESCRIPTION
## Summary
- add bounded Drift live smoke support to the readiness canary workflow
- add Drift live account preparation, cancel cleanup, and close reconciliation
- keep Jupiter trigger and OpenBook venue smoke paths intact on top of current main

Closes #417

## Real mainnet evidence
- setup/deposit signature: `4teP4RwiRGn2ZpsDBnvmP4SyVm5rhDTa4CbFvHM2mitWLnJKg1btFAVjNtQMhLKRicUjfwRvXhhCRRR4GDY96KFg`
- open signature: `yUwL8CHQcrZQHuGP8hxiBnb8byFUjACQHWPKaVqQAmuLpjy4DC3B4o4Pgt1VfnemTfseYeaBYvra1T2VMHTNJb6`
- close signature: `2Nj4UNSMFYvsAZtQUwL82NN5cXMdvDF2xCchu7sT15XEtBftWT99otMChk6FAKZyWcBzyq9AzLJC9KSUHxokiFx5`
- cleanup close after direction fix: `4KpLMT5MDXSxAPnfPtKtumYvREm2mueCXWK9wvdnGNUN6aRbV2eM4Wc3u8VzJ95Hm7bMaSXQomr3f2sRVbDxRDcu`
- readiness run id: `readinesscanary_9f87d762c79d499ea02d5a220ed0ffcc`

## Validation
- `bun test tests/unit/worker_drift.test.ts tests/unit/worker_execution_drift.test.ts tests/unit/worker_execution_router.test.ts tests/unit/worker_runtime_research_readiness_route.test.ts`
- `bun run typecheck`
- `bun run lint`
