### PR TITLE
[Phase 6] Add Proof-gated DFlow live smoke path

### DIFF
--- a/apps/portal/app/api/runtime/operator/route.ts
+++ b/apps/portal/app/api/runtime/operator/route.ts
@@ -805,7 +805,8 @@ export async function POST(request: Request) {
           : {}),
         ...(payload.smokeIntentFamily === "spot_swap" ||
         payload.smokeIntentFamily === "conditional_spot_order" ||
-        payload.smokeIntentFamily === "clob_order"
+        payload.smokeIntentFamily === "clob_order" ||
+        payload.smokeIntentFamily === "prediction_order"
           ? { smokeIntentFamily: payload.smokeIntentFamily }
           : {}),
         ...(payload.smokeOrderSide === "buy" ||
@@ -826,6 +827,7 @@ export async function POST(request: Request) {
                 .filter((entry): entry is string => Boolean(entry)),
             }
           : {}),
+        ...(isRecord(payload.metadata) ? { metadata: payload.metadata } : {}),
       },
     });
     return NextResponse.json(result.payload, { status: result.status });

--- a/apps/portal/app/terminal/runtime/types.ts
+++ b/apps/portal/app/terminal/runtime/types.ts
@@ -36,11 +36,16 @@ export type RuntimeOperatorVenueTxSmokeInput = {
   pairSymbol?: string;
   adapterKey?: string;
   targetNotionalUsd?: string;
-  smokeIntentFamily?: "spot_swap" | "conditional_spot_order" | "clob_order";
+  smokeIntentFamily?:
+    | "spot_swap"
+    | "conditional_spot_order"
+    | "clob_order"
+    | "prediction_order";
   smokeOrderSide?: "buy" | "sell";
   tightenOnFailure?: boolean;
   failureControlMode?: "disable_live" | "engage_kill_switch";
   killDrillNotes?: string[];
+  metadata?: Record<string, unknown>;
 };
 
 export type RuntimeOperatorControls = {

--- a/apps/worker/src/dflow.ts
+++ b/apps/worker/src/dflow.ts
@@ -2,6 +2,8 @@ import type { Env } from "./types";
 
 const DEFAULT_DFLOW_METADATA_API_BASE =
   "https://dev-prediction-markets-api.dflow.net/api/v1";
+const DEFAULT_DFLOW_TRADE_API_BASE = "https://dev-quote-api.dflow.net";
+const DEFAULT_DFLOW_PROOF_API_BASE = "https://proof.dflow.net";
 const DEFAULT_DFLOW_NOTIONAL_DECIMALS = 6;
 const DEFAULT_DFLOW_MARKET_NOTIONAL_CAP_USD = 25;
 const DEFAULT_DFLOW_OPEN_INTEREST_SHARE_PCT = 20;
@@ -61,12 +63,32 @@ export type DFlowPredictionIntentPreview = {
   notes: string[];
 };
 
+export type DFlowPredictionVerification = {
+  verified: boolean;
+  raw: Record<string, unknown> | null;
+};
+
+export type DFlowPredictionOrderTransaction = {
+  transactionBase64: string;
+  lastValidBlockHeight: number | null;
+  executionMode: string | null;
+  inputMint: string;
+  outputMint: string;
+  inAmount: string;
+  outAmount: string | null;
+  priceImpactPct: string | null;
+  routePlan: Array<Record<string, unknown>>;
+  raw: Record<string, unknown> | null;
+};
+
 type DFlowClientDeps = {
   fetch?: typeof fetch;
 };
 
 type DFlowClientConfig = {
   metadataApiBase?: string;
+  tradeApiBase?: string;
+  proofApiBase?: string;
   apiKey?: string | null;
 };
 
@@ -93,6 +115,36 @@ function readFiniteNumber(value: unknown): number | null {
   if (typeof value === "number" && Number.isFinite(value)) return value;
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+function readBooleanFlag(value: unknown): boolean | null {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (value === 1) return true;
+    if (value === 0) return false;
+  }
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  if (!normalized) return null;
+  if (
+    normalized === "1" ||
+    normalized === "true" ||
+    normalized === "verified" ||
+    normalized === "ok" ||
+    normalized === "yes"
+  ) {
+    return true;
+  }
+  if (
+    normalized === "0" ||
+    normalized === "false" ||
+    normalized === "unverified" ||
+    normalized === "no"
+  ) {
+    return false;
+  }
+  return null;
 }
 
 function readPositiveAtomic(value: unknown): string | null {
@@ -252,6 +304,75 @@ function atomicToNumber(value: string, decimals: number): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+function ceilDiv(numerator: bigint, denominator: bigint): bigint {
+  if (denominator <= 0n) {
+    throw new Error("dflow-invalid-denominator");
+  }
+  return (numerator + denominator - 1n) / denominator;
+}
+
+function resolvePredictionTradeInputAmountAtomic(
+  preview: DFlowPredictionIntentPreview,
+): string {
+  const quantityAtomic = readPositiveAtomic(preview.quantityAtomic);
+  if (!quantityAtomic) {
+    throw new Error("dflow-quantity-atomic-invalid");
+  }
+  if (preview.side === "sell_yes" || preview.side === "sell_no") {
+    if (preview.quantityMode !== "base") {
+      throw new Error("dflow-live-sell-quantity-mode-unsupported");
+    }
+    return quantityAtomic;
+  }
+  if (preview.quantityMode === "notional" || preview.quantityMode === "quote") {
+    return quantityAtomic;
+  }
+  if (preview.priceQuote === null || preview.priceQuote <= 0) {
+    throw new Error("dflow-live-price-quote-unavailable");
+  }
+  const priceAtomic = BigInt(
+    Math.max(
+      1,
+      Math.ceil(preview.priceQuote * 10 ** DEFAULT_DFLOW_NOTIONAL_DECIMALS),
+    ),
+  );
+  return ceilDiv(
+    BigInt(quantityAtomic) * priceAtomic,
+    10n ** BigInt(DEFAULT_DFLOW_NOTIONAL_DECIMALS),
+  ).toString();
+}
+
+function readVerificationPayload(value: unknown): boolean | null {
+  const direct =
+    readBooleanFlag(value) ??
+    (isRecord(value)
+      ? (readBooleanFlag(value.verified) ??
+        readBooleanFlag(value.isVerified) ??
+        readBooleanFlag(value.is_verified) ??
+        readBooleanFlag(value.allowed) ??
+        readBooleanFlag(value.ok))
+      : null);
+  if (direct !== null) return direct;
+  if (!isRecord(value)) return null;
+  return (
+    readVerificationPayload(value.data) ??
+    readVerificationPayload(value.result) ??
+    readVerificationPayload(value.verification)
+  );
+}
+
+function extractOrderPayload(value: unknown): Record<string, unknown> | null {
+  if (!isRecord(value)) return null;
+  const nested = isRecord(value.data)
+    ? value.data
+    : isRecord(value.order)
+      ? value.order
+      : isRecord(value.result)
+        ? value.result
+        : null;
+  return nested ?? value;
+}
+
 function isTradableStatus(value: string | null): boolean {
   const normalized = String(value ?? "")
     .trim()
@@ -392,6 +513,8 @@ function buildDFlowUrl(path: string, baseUrl: string): URL {
 export class DFlowClient {
   private readonly fetchImpl: typeof fetch;
   private readonly metadataApiBase: string;
+  private readonly tradeApiBase: string;
+  private readonly proofApiBase: string;
   private readonly apiKey: string | null;
 
   constructor(input: Env | DFlowClientConfig, deps?: DFlowClientDeps) {
@@ -401,11 +524,17 @@ export class DFlowClient {
         ? input
         : {
             metadataApiBase: input.DFLOW_METADATA_API_BASE,
+            tradeApiBase: input.DFLOW_TRADE_API_BASE,
+            proofApiBase: input.DFLOW_PROOF_API_BASE,
             apiKey: input.DFLOW_API_KEY,
           };
     this.metadataApiBase =
       readTrimmedString(config.metadataApiBase) ??
       DEFAULT_DFLOW_METADATA_API_BASE;
+    this.tradeApiBase =
+      readTrimmedString(config.tradeApiBase) ?? DEFAULT_DFLOW_TRADE_API_BASE;
+    this.proofApiBase =
+      readTrimmedString(config.proofApiBase) ?? DEFAULT_DFLOW_PROOF_API_BASE;
     this.apiKey = readTrimmedString(config.apiKey);
   }
 
@@ -606,6 +735,101 @@ export class DFlowClient {
           swapInfo: { label: "DFlow Prediction" },
         },
       ],
+    };
+  }
+
+  async verifyPredictionWallet(
+    walletAddress: string,
+  ): Promise<DFlowPredictionVerification> {
+    const normalizedWallet = readTrimmedString(walletAddress);
+    if (!normalizedWallet) {
+      throw new Error("dflow-wallet-address-required");
+    }
+    const url = buildDFlowUrl(
+      `verify/${encodeURIComponent(normalizedWallet)}`,
+      this.proofApiBase,
+    );
+    const response = await this.fetchImpl(url.toString(), {
+      method: "GET",
+      headers: {
+        accept: "application/json",
+        ...(this.apiKey ? { "x-api-key": this.apiKey } : {}),
+      },
+    });
+    const payload = await readJson(response, "DFlow verify address");
+    const verified = readVerificationPayload(payload);
+    if (verified === null) {
+      throw new Error("dflow-verify-invalid-payload");
+    }
+    return {
+      verified,
+      raw: isRecord(payload) ? payload : null,
+    };
+  }
+
+  async buildPredictionOrderTransaction(input: {
+    walletPublicKey: string;
+    preview: DFlowPredictionIntentPreview;
+  }): Promise<DFlowPredictionOrderTransaction> {
+    const walletPublicKey = readTrimmedString(input.walletPublicKey);
+    if (!walletPublicKey) {
+      throw new Error("dflow-wallet-public-key-required");
+    }
+    if (input.preview.orderType !== "market") {
+      throw new Error("dflow-live-order-type-not-supported");
+    }
+    const amountAtomic = resolvePredictionTradeInputAmountAtomic(input.preview);
+    const inputMint =
+      input.preview.side === "buy_yes" || input.preview.side === "buy_no"
+        ? readTrimmedString(input.preview.settlementMint)
+        : input.preview.outcomeMint;
+    const outputMint =
+      input.preview.side === "buy_yes" || input.preview.side === "buy_no"
+        ? input.preview.outcomeMint
+        : readTrimmedString(input.preview.settlementMint);
+    if (!inputMint || !outputMint) {
+      throw new Error("dflow-live-order-mints-unavailable");
+    }
+    const url = buildDFlowUrl("order", this.tradeApiBase);
+    url.searchParams.set("inputMint", inputMint);
+    url.searchParams.set("outputMint", outputMint);
+    url.searchParams.set("amount", amountAtomic);
+    url.searchParams.set("userPublicKey", walletPublicKey);
+    const response = await this.fetchImpl(url.toString(), {
+      method: "GET",
+      headers: {
+        accept: "application/json",
+        ...(this.apiKey ? { "x-api-key": this.apiKey } : {}),
+      },
+    });
+    const payload = await readJson(response, "DFlow order");
+    const order = extractOrderPayload(payload);
+    const transactionBase64 =
+      readTrimmedString(order?.transaction) ??
+      readTrimmedString(order?.serializedTransaction) ??
+      readTrimmedString(order?.tx);
+    if (!transactionBase64) {
+      throw new Error("dflow-order-transaction-missing");
+    }
+    const lastValidBlockHeight = readFiniteNumber(order?.lastValidBlockHeight);
+    return {
+      transactionBase64,
+      lastValidBlockHeight:
+        lastValidBlockHeight === null
+          ? null
+          : Math.max(0, Math.floor(lastValidBlockHeight)),
+      executionMode: readTrimmedString(order?.executionMode),
+      inputMint,
+      outputMint,
+      inAmount: readPositiveAtomic(order?.inAmount) ?? amountAtomic,
+      outAmount: readPositiveAtomic(order?.outAmount),
+      priceImpactPct:
+        readTrimmedString(order?.priceImpactPct) ??
+        readTrimmedString(order?.priceImpactBps),
+      routePlan: Array.isArray(order?.routePlan)
+        ? order.routePlan.filter(isRecord)
+        : [],
+      raw: order,
     };
   }
 }

--- a/apps/worker/src/execution/dflow_executor.ts
+++ b/apps/worker/src/execution/dflow_executor.ts
@@ -1,4 +1,6 @@
 import { DFlowClient } from "../dflow";
+import { signTransactionWithPrivyById } from "../privy";
+import { evaluateSafeLaneTransaction } from "./safe_lane_policy";
 import type {
   ExecuteIntentInput,
   ExecuteSwapResult,
@@ -9,20 +11,77 @@ type ExecuteDFlowPredictionOrderInput = ExecuteIntentInput & {
   intent: NonSwapExecutionIntent;
 };
 
+type DFlowExecutorDeps = {
+  signTransactionWithPrivyById?: typeof signTransactionWithPrivyById;
+  evaluateSafeLaneTransaction?: typeof evaluateSafeLaneTransaction;
+};
+
 function nowIso(): string {
   return new Date().toISOString();
+}
+
+function normalizeConfirmationStatus(
+  status: string | undefined,
+): Extract<
+  ExecuteSwapResult["status"],
+  "processed" | "confirmed" | "finalized" | "error"
+> {
+  if (
+    status === "processed" ||
+    status === "confirmed" ||
+    status === "finalized"
+  ) {
+    return status;
+  }
+  return "error";
+}
+
+function readsTruthyExecutionParam(value: unknown): boolean {
+  if (value === true) return true;
+  if (typeof value !== "string") return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "on";
+}
+
+function isSafeLaneExecution(input: ExecuteDFlowPredictionOrderInput): boolean {
+  const lane = String(input.execution?.params?.lane ?? "")
+    .trim()
+    .toLowerCase();
+  return lane === "safe";
+}
+
+function allowsVenueTxSmokeLiveBypass(
+  input: ExecuteDFlowPredictionOrderInput,
+): boolean {
+  return (
+    input.runtimeMode === "live" &&
+    input.experimentalLiveModeBypass === "venue_tx_smoke" &&
+    input.subjectControlBypassReason === "strategy_lab_readiness_canary"
+  );
 }
 
 function buildLifecycle(input: {
   side: string;
   notes: string[];
+  orderState?: NonNullable<
+    ExecuteSwapResult["executionMeta"]
+  >["lifecycle"]["orderState"];
+  fillState?: NonNullable<
+    ExecuteSwapResult["executionMeta"]
+  >["lifecycle"]["fillState"];
+  positionState?: NonNullable<
+    ExecuteSwapResult["executionMeta"]
+  >["lifecycle"]["positionState"];
+  settlementState?: NonNullable<
+    ExecuteSwapResult["executionMeta"]
+  >["lifecycle"]["settlementState"];
 }): NonNullable<ExecuteSwapResult["executionMeta"]>["lifecycle"] {
   const closing = input.side === "sell_yes" || input.side === "sell_no";
   return {
-    orderState: "open",
-    fillState: "pending",
-    positionState: closing ? "closing" : "opening",
-    settlementState: "pending",
+    orderState: input.orderState ?? "open",
+    fillState: input.fillState ?? "pending",
+    positionState: input.positionState ?? (closing ? "closing" : "opening"),
+    settlementState: input.settlementState ?? "pending",
     notes: input.notes,
   };
 }
@@ -39,6 +98,7 @@ function readDFlowOptions(
 
 export async function executeDFlowPredictionOrder(
   input: ExecuteDFlowPredictionOrderInput,
+  deps: DFlowExecutorDeps = {},
 ): Promise<ExecuteSwapResult> {
   if (input.intent.family !== "prediction_order") {
     throw new Error("invalid-dflow-intent-family");
@@ -49,7 +109,8 @@ export async function executeDFlowPredictionOrder(
   if (input.intent.marketType !== "prediction") {
     throw new Error("invalid-dflow-market-type");
   }
-  if (input.runtimeMode === "live") {
+  const allowLiveSmoke = allowsVenueTxSmokeLiveBypass(input);
+  if (input.runtimeMode === "live" && !allowLiveSmoke) {
     throw new Error("dflow-live-mode-not-supported");
   }
   const side = String(input.intent.side ?? "").trim();
@@ -128,20 +189,260 @@ export async function executeDFlowPredictionOrder(
     };
   }
 
+  if (input.runtimeMode !== "live") {
+    if (input.guardEnabled) await input.guardEnabled();
+    return {
+      status: "simulated",
+      signature: null,
+      usedQuote,
+      refreshed: false,
+      lastValidBlockHeight: null,
+      executionMeta: {
+        route: "dflow",
+        classification: "simulated",
+        intentId: preview.market.marketId,
+        venueSessionId: `prediction:${preview.market.marketId}:${preview.outcomeSide}`,
+        lifecycle,
+        referencePrice: {
+          verdict: "allow",
+          reason: null,
+          executionPrice:
+            preview.priceQuote === null ? null : String(preview.priceQuote),
+          executionDivergenceBps: null,
+          snapshot: referenceSnapshot,
+        },
+        trace: {
+          txBuiltAt: nowIso(),
+          simulatedAt: nowIso(),
+        },
+      },
+    };
+  }
+
+  if (!input.privyWalletId) {
+    throw new Error("missing-privy-wallet-id");
+  }
+
+  const route = "dflow";
+  const safeLane = isSafeLaneExecution(input);
+  const txBuiltAt = nowIso();
+  const verification =
+    side === "buy_yes" || side === "buy_no"
+      ? await dflow.verifyPredictionWallet(input.intent.wallet)
+      : { verified: true, raw: null };
+  if (!verification.verified) {
+    throw new Error("dflow-wallet-not-verified");
+  }
+  const plan = await dflow.buildPredictionOrderTransaction({
+    walletPublicKey: input.intent.wallet,
+    preview,
+  });
+  const orderQuote = {
+    ...usedQuote,
+    inputMint: plan.inputMint,
+    outputMint: plan.outputMint,
+    inAmount: plan.inAmount,
+    outAmount: plan.outAmount ?? usedQuote.outAmount,
+    ...(plan.routePlan.length > 0 ? { routePlan: plan.routePlan } : {}),
+  };
+
   if (input.guardEnabled) await input.guardEnabled();
 
+  const signWithPrivy =
+    deps.signTransactionWithPrivyById ?? signTransactionWithPrivyById;
+  const signedBase64 = await signWithPrivy(
+    input.env,
+    input.privyWalletId,
+    plan.transactionBase64,
+  );
+
+  const evaluateSafeLane =
+    deps.evaluateSafeLaneTransaction ?? evaluateSafeLaneTransaction;
+  if (safeLane) {
+    const evaluation = evaluateSafeLane({
+      env: input.env,
+      signedTransactionBase64: signedBase64,
+    });
+    if (!evaluation.ok) {
+      const failedAt = nowIso();
+      return {
+        status: "simulate_error",
+        signature: null,
+        usedQuote: orderQuote,
+        refreshed: false,
+        lastValidBlockHeight: plan.lastValidBlockHeight,
+        err: {
+          code: "policy-denied",
+          reason: evaluation.reason,
+          profile: evaluation.profile,
+          limits: evaluation.limits,
+        },
+        executionMeta: {
+          route,
+          classification: "error",
+          intentId: preview.market.marketId,
+          venueSessionId: `prediction:${preview.market.marketId}:${preview.outcomeSide}`,
+          lifecycle: buildLifecycle({
+            side,
+            notes: [evaluation.reason],
+            orderState: "rejected",
+            fillState: "failed",
+            settlementState: "failed",
+          }),
+          referencePrice: {
+            verdict: "allow",
+            reason: null,
+            executionPrice:
+              preview.priceQuote === null ? null : String(preview.priceQuote),
+            executionDivergenceBps: null,
+            snapshot: referenceSnapshot,
+          },
+          trace: {
+            txBuiltAt,
+            failedAt,
+          },
+        },
+      };
+    }
+  }
+
+  const preflightCommitment =
+    input.policy.commitment === "finalized"
+      ? "confirmed"
+      : input.policy.commitment;
+  const requiresSimulation =
+    safeLane ||
+    input.policy.simulateOnly ||
+    readsTruthyExecutionParam(input.execution?.params?.requireSimulation);
+  let simulatedAt: string | undefined;
+  if (requiresSimulation) {
+    const simulation = await input.rpc.simulateTransactionBase64(signedBase64, {
+      commitment: preflightCommitment,
+      sigVerify: true,
+    });
+    simulatedAt = nowIso();
+    if (simulation.err) {
+      return {
+        status: "simulate_error",
+        signature: null,
+        usedQuote: orderQuote,
+        refreshed: false,
+        lastValidBlockHeight: plan.lastValidBlockHeight,
+        err: simulation.err,
+        executionMeta: {
+          route,
+          classification: "error",
+          intentId: preview.market.marketId,
+          venueSessionId: `prediction:${preview.market.marketId}:${preview.outcomeSide}`,
+          lifecycle: buildLifecycle({
+            side,
+            notes: ["simulation-failed"],
+            fillState: "failed",
+            settlementState: "failed",
+          }),
+          referencePrice: {
+            verdict: "allow",
+            reason: null,
+            executionPrice:
+              preview.priceQuote === null ? null : String(preview.priceQuote),
+            executionDivergenceBps: null,
+            snapshot: referenceSnapshot,
+          },
+          trace: {
+            txBuiltAt,
+            simulatedAt,
+            failedAt: simulatedAt,
+          },
+        },
+      };
+    }
+  }
+
+  if (input.policy.simulateOnly) {
+    return {
+      status: "simulated",
+      signature: null,
+      usedQuote: orderQuote,
+      refreshed: false,
+      lastValidBlockHeight: plan.lastValidBlockHeight,
+      executionMeta: {
+        route,
+        classification: "simulated",
+        intentId: preview.market.marketId,
+        venueSessionId: `prediction:${preview.market.marketId}:${preview.outcomeSide}`,
+        lifecycle,
+        referencePrice: {
+          verdict: "allow",
+          reason: null,
+          executionPrice:
+            preview.priceQuote === null ? null : String(preview.priceQuote),
+          executionDivergenceBps: null,
+          snapshot: referenceSnapshot,
+        },
+        trace: {
+          txBuiltAt,
+          ...(simulatedAt ? { simulatedAt } : {}),
+        },
+      },
+    };
+  }
+
+  const sentAt = nowIso();
+  const signature = await input.rpc.sendTransactionBase64(signedBase64, {
+    skipPreflight: false,
+    preflightCommitment,
+  });
+  const confirmation = await input.rpc.confirmSignature(signature, {
+    commitment: input.policy.commitment,
+  });
+  const terminalAt = nowIso();
+  const status = confirmation.ok
+    ? normalizeConfirmationStatus(confirmation.status)
+    : "error";
+  const classification =
+    status === "finalized"
+      ? "finalized"
+      : status === "confirmed"
+        ? "confirmed"
+        : status === "processed"
+          ? "landed"
+          : "error";
+
   return {
-    status: "simulated",
-    signature: null,
-    usedQuote,
+    status,
+    signature,
+    usedQuote: orderQuote,
     refreshed: false,
-    lastValidBlockHeight: null,
+    lastValidBlockHeight: plan.lastValidBlockHeight,
+    ...(confirmation.ok ? {} : { err: confirmation.err ?? null }),
     executionMeta: {
-      route: "dflow",
-      classification: "simulated",
+      route,
+      classification,
       intentId: preview.market.marketId,
       venueSessionId: `prediction:${preview.market.marketId}:${preview.outcomeSide}`,
-      lifecycle,
+      lifecycle: buildLifecycle({
+        side,
+        notes: [
+          `executionMode:${plan.executionMode ?? "unknown"}`,
+          `inputMint:${plan.inputMint}`,
+          `outputMint:${plan.outputMint}`,
+        ],
+        orderState: confirmation.ok ? "filled" : "rejected",
+        fillState: confirmation.ok ? "filled" : "failed",
+        positionState:
+          confirmation.ok && (side === "buy_yes" || side === "buy_no")
+            ? "open"
+            : confirmation.ok
+              ? "closing"
+              : side === "sell_yes" || side === "sell_no"
+                ? "closing"
+                : "opening",
+        settlementState: confirmation.ok
+          ? status === "finalized"
+            ? "finalized"
+            : "confirmed"
+          : "failed",
+      }),
       referencePrice: {
         verdict: "allow",
         reason: null,
@@ -151,9 +452,29 @@ export async function executeDFlowPredictionOrder(
         snapshot: referenceSnapshot,
       },
       trace: {
-        txBuiltAt: nowIso(),
-        simulatedAt: nowIso(),
+        txBuiltAt,
+        ...(simulatedAt ? { simulatedAt } : {}),
+        sentAt,
+        ...(confirmation.ok
+          ? {
+              landedAt: terminalAt,
+              ...(status === "confirmed" || status === "finalized"
+                ? { confirmedAt: terminalAt }
+                : {}),
+              ...(status === "finalized" ? { finalizedAt: terminalAt } : {}),
+            }
+          : { failedAt: terminalAt }),
       },
+      dflowOrder: {
+        verification,
+        executionMode: plan.executionMode,
+        inputMint: plan.inputMint,
+        outputMint: plan.outputMint,
+        inAmount: plan.inAmount,
+        outAmount: plan.outAmount,
+        priceImpactPct: plan.priceImpactPct,
+        routePlan: plan.routePlan,
+      } as Record<string, unknown>,
     },
   };
 }

--- a/apps/worker/src/execution/router.ts
+++ b/apps/worker/src/execution/router.ts
@@ -277,6 +277,9 @@ function allowsVenueTxSmokeLiveBypass(input: {
   if (input.intentFamily === "clob_order") {
     return input.venueKey === "openbook";
   }
+  if (input.intentFamily === "prediction_order") {
+    return input.venueKey === "dflow";
+  }
   return input.intentFamily === "perp_order" && input.venueKey === "drift";
 }
 

--- a/apps/worker/src/execution/types.ts
+++ b/apps/worker/src/execution/types.ts
@@ -211,6 +211,8 @@ export type ExecuteSwapResult = {
       flashEstimatedFeeByMint?: Record<string, string>;
       settlementMint?: string | null;
     };
+    driftAccount?: Record<string, unknown>;
+    dflowOrder?: Record<string, unknown>;
     trace?: {
       txBuiltAt?: string;
       simulatedAt?: string;

--- a/apps/worker/src/strategy_lab_readiness_canary.ts
+++ b/apps/worker/src/strategy_lab_readiness_canary.ts
@@ -16,6 +16,7 @@ import {
   TRADING_TOKEN_BY_MINT,
   USDC_MINT,
 } from "./defaults";
+import { DFlowClient } from "./dflow";
 import { DriftClient } from "./drift";
 import type { DriftLiveAccountSnapshot } from "./drift_live";
 import {
@@ -107,9 +108,11 @@ type CanaryPairContext = {
   adapterKey: string;
   inputMint: string;
   outputMint: string;
-  marketType: "spot" | "perp";
-  intentFamily: "spot_swap" | "perp_order";
+  marketType: "spot" | "perp" | "prediction";
+  intentFamily: "spot_swap" | "perp_order" | "prediction_order";
   instrumentId?: string;
+  predictionOutcomeId?: string;
+  predictionOutcomeSide?: "yes" | "no";
 };
 
 type CanarySubmissionPath = {
@@ -181,6 +184,42 @@ function readStringArray(value: unknown): string[] {
     .filter((entry): entry is string => Boolean(entry));
 }
 
+function readDFlowSmokeMetadata(input: {
+  request: RuntimeResearchReadinessCanaryRequest;
+}): {
+  instrumentId: string;
+  outcomeId: string;
+  outcomeSide: "yes" | "no";
+  settlementMint: string;
+} {
+  const metadata = isRecord(input.request.metadata)
+    ? input.request.metadata
+    : {};
+  const instrumentId =
+    readOptionalString(metadata.instrumentId) ??
+    readOptionalString(input.request.pairSymbol);
+  const outcomeId = readOptionalString(metadata.outcomeId);
+  const outcomeSideRaw =
+    readOptionalString(metadata.outcomeSide)?.toLowerCase() ?? "yes";
+  const outcomeSide = outcomeSideRaw === "no" ? "no" : "yes";
+  const settlementMint =
+    readOptionalString(metadata.settlementMint) ?? USDC_MINT;
+  if (!instrumentId) {
+    throw new Error(
+      "strategy-lab-readiness-canary-dflow-instrument-id-required",
+    );
+  }
+  if (!outcomeId) {
+    throw new Error("strategy-lab-readiness-canary-dflow-outcome-id-required");
+  }
+  return {
+    instrumentId,
+    outcomeId,
+    outcomeSide,
+    settlementMint,
+  };
+}
+
 function readSmokeIntentFamily(
   request: RuntimeResearchReadinessCanaryRequest | Record<string, unknown>,
 ): RuntimeResearchVenueTxSmokeIntentFamily {
@@ -188,6 +227,7 @@ function readSmokeIntentFamily(
     "smokeIntentFamily" in request
       ? readOptionalString(request.smokeIntentFamily)
       : undefined;
+  if (raw === "prediction_order") return "prediction_order";
   if (raw === "conditional_spot_order") return "conditional_spot_order";
   if (raw === "clob_order") return "clob_order";
   return "spot_swap";
@@ -430,6 +470,9 @@ function allowsVenueTxSmokeLiveBypass(
   if (smokeIntentFamily === "clob_order") {
     return venueKey === "openbook";
   }
+  if (smokeIntentFamily === "prediction_order") {
+    return venueKey === "dflow";
+  }
   return false;
 }
 
@@ -521,6 +564,64 @@ function resolveCanaryPairContext(
   const allowSmokeLiveBypass = allowsVenueTxSmokeLiveBypass(request, venueKey);
   if (!runtimeVenueSupportsMode(capability, "live") && !allowSmokeLiveBypass) {
     throw new Error(`strategy-lab-readiness-canary-venue-not-live:${venueKey}`);
+  }
+
+  if (venueKey === "dflow") {
+    if (smokeIntentFamily !== "prediction_order") {
+      throw new Error(
+        `strategy-lab-readiness-canary-intent-family-unsupported:${venueKey}:${smokeIntentFamily}`,
+      );
+    }
+    const prediction = readDFlowSmokeMetadata({ request });
+    const assetKey =
+      request.assetKey ??
+      (request.subjectKind === "asset"
+        ? request.subjectKey
+        : prediction.instrumentId);
+    const requestedAdapterKey = readOptionalString(request.adapterKey);
+    const adapterKey =
+      requestedAdapterKey ??
+      capability.adapterKeys.find((candidate) => {
+        const registration = resolveExecutionAdapterRegistration(candidate);
+        return (
+          registration !== null &&
+          registration.venueKey === venueKey &&
+          registration.supportedIntentFamilies.includes(smokeIntentFamily) &&
+          (registration.supportedModes.includes("live") || allowSmokeLiveBypass)
+        );
+      });
+    if (!adapterKey) {
+      throw new Error(
+        `strategy-lab-readiness-canary-adapter-unavailable:${venueKey}`,
+      );
+    }
+    if (requestedAdapterKey) {
+      const registration =
+        resolveExecutionAdapterRegistration(requestedAdapterKey);
+      if (
+        !registration ||
+        registration.venueKey !== venueKey ||
+        !registration.supportedIntentFamilies.includes(smokeIntentFamily) ||
+        (!registration.supportedModes.includes("live") && !allowSmokeLiveBypass)
+      ) {
+        throw new Error(
+          `strategy-lab-readiness-canary-adapter-unavailable:${venueKey}:${requestedAdapterKey}:${smokeIntentFamily}`,
+        );
+      }
+    }
+    return {
+      venueKey,
+      assetKey,
+      pairSymbol: prediction.instrumentId,
+      adapterKey,
+      inputMint: prediction.settlementMint,
+      outputMint: prediction.outcomeId,
+      marketType: "prediction",
+      intentFamily: "prediction_order",
+      instrumentId: prediction.instrumentId,
+      predictionOutcomeId: prediction.outcomeId,
+      predictionOutcomeSide: prediction.outcomeSide,
+    };
   }
 
   if (venueKey === "drift") {
@@ -1175,6 +1276,309 @@ async function finalizeReadinessCanaryRun(
               : undefined,
         }),
   };
+}
+
+async function runDFlowVenueSmoke(input: {
+  env: Env;
+  request: RuntimeResearchReadinessCanaryRequest;
+  runId: string;
+  context: CanaryPairContext;
+  wallet: StrategyLabReadinessCanaryWallet;
+  targetNotionalUsd: string;
+  config: StrategyLabReadinessCanaryConfig;
+  lane: string;
+  submissionPath: CanarySubmissionPath;
+  rpc: SolanaRpc;
+  jupiter: JupiterClient;
+  dflow: DFlowClient;
+}): Promise<RuntimeResearchReadinessCanaryWorkflowResult> {
+  const instrumentId = input.context.instrumentId;
+  const outcomeId =
+    input.context.predictionOutcomeId ?? input.context.outputMint;
+  const outcomeSide = input.context.predictionOutcomeSide ?? "yes";
+  if (!instrumentId || !outcomeId) {
+    return await finalizeReadinessCanaryRun(input.env, {
+      runId: input.runId,
+      status: "failed",
+      runPatch: {
+        errorCode: "submission-failed",
+        errorMessage:
+          "strategy-lab-readiness-canary-dflow-market-context-missing",
+      },
+    });
+  }
+
+  const smokeOrderSide = readSmokeOrderSide(input.request);
+  const metadata = isRecord(input.request.metadata)
+    ? input.request.metadata
+    : {};
+  const side =
+    smokeOrderSide === "sell"
+      ? (`sell_${outcomeSide}` as const)
+      : (`buy_${outcomeSide}` as const);
+  const orderInputMint =
+    smokeOrderSide === "sell"
+      ? input.context.outputMint
+      : input.context.inputMint;
+  const orderOutputMint =
+    smokeOrderSide === "sell"
+      ? input.context.inputMint
+      : input.context.outputMint;
+  const quantityAtomic =
+    smokeOrderSide === "sell"
+      ? readOptionalString(metadata.quantityAtomic)
+      : parseUsdAtomic(input.targetNotionalUsd).toString();
+  if (!quantityAtomic) {
+    return await finalizeReadinessCanaryRun(input.env, {
+      runId: input.runId,
+      status: "blocked",
+      runPatch: {
+        errorCode: "invalid-request",
+        errorMessage:
+          "strategy-lab-readiness-canary-dflow-sell-quantity-required",
+      },
+    });
+  }
+  const quantityMode = smokeOrderSide === "sell" ? "base" : "notional";
+
+  const preview = await input.dflow.describePredictionIntent({
+    instrumentId,
+    outcomeId,
+    side,
+    quantityAtomic,
+    options: {
+      orderType: "market",
+      quantityMode,
+      marketNotionalCapUsd: Number(input.targetNotionalUsd),
+    },
+  });
+  const referencePriceMetadata = {
+    verdict: "allow" as const,
+    reason: null,
+    executionPrice:
+      preview.priceQuote === null ? null : String(preview.priceQuote),
+    executionDivergenceBps: null,
+    snapshot: {
+      marketId: preview.market.marketId,
+      title: preview.market.title,
+      eventTitle: preview.market.eventTitle,
+      marketStatus: preview.market.status,
+      result: preview.market.result,
+      endTime: preview.market.endTime,
+      settleTime: preview.market.settleTime,
+      outcomeSide: preview.outcomeSide,
+      outcomeMint: preview.outcomeMint,
+      settlementMint: preview.settlementMint,
+      priceQuote: preview.priceQuote,
+      estimatedNotionalUsd: preview.estimatedNotionalUsd,
+      openInterest: preview.marketAccount.openInterest,
+      volume: preview.marketAccount.volume,
+      redemptionStatus: preview.marketAccount.redemptionStatus,
+    },
+  };
+
+  const policy = normalizePolicy({
+    allowedMints: [orderInputMint, orderOutputMint],
+    minSolReserveLamports: input.config.minSolReserveLamports,
+    simulateOnly: false,
+    dryRun: false,
+    commitment: "finalized",
+    maxTradeAmountAtomic: quantityAtomic,
+  });
+
+  const runtimeBalancePolicy = await evaluatePrivyRuntimeBalancePolicy({
+    env: input.env,
+    lane: "safe",
+    walletAddress: input.wallet.walletAddress,
+    inputMint: orderInputMint,
+    amountAtomic: quantityAtomic,
+    minSolReserveLamports: input.config.minSolReserveLamports,
+    rpc: input.rpc,
+    runtimeDefaults: null,
+  });
+  if (!runtimeBalancePolicy.ok) {
+    return await finalizeReadinessCanaryRun(input.env, {
+      runId: input.runId,
+      status: "blocked",
+      runPatch: {
+        errorCode: "policy-denied",
+        errorMessage: runtimeBalancePolicy.reason,
+        metadata: {
+          submissionPath: input.submissionPath,
+          runtimePolicy: runtimeBalancePolicy.metadata,
+        },
+      },
+    });
+  }
+
+  const beforeBalances = await readBalances({
+    rpc: input.rpc,
+    walletAddress: input.wallet.walletAddress,
+    inputMint: orderInputMint,
+    outputMint: orderOutputMint,
+  });
+
+  try {
+    const result = await executeIntentViaRouter({
+      env: input.env,
+      venueKey: input.context.venueKey,
+      runtimeMode: "live",
+      experimentalLiveModeBypass:
+        readProofMode(input.request) === "venue_tx_smoke"
+          ? "venue_tx_smoke"
+          : undefined,
+      requireVenueRouting: true,
+      subjectControlBypassReason: "strategy_lab_readiness_canary",
+      execution: {
+        adapter: input.context.adapterKey,
+        params: {
+          lane: input.lane,
+          requireSimulation: true,
+        },
+      },
+      policy,
+      rpc: input.rpc,
+      jupiter: input.jupiter,
+      dflow: input.dflow,
+      privyWalletId: input.wallet.walletId,
+      intent: {
+        family: "prediction_order",
+        wallet: input.wallet.walletAddress,
+        venueKey: "dflow",
+        marketType: "prediction",
+        instrumentId,
+        outcomeId,
+        side,
+        quantityAtomic,
+        params: {
+          orderType: "market",
+          quantityMode,
+          marketNotionalCapUsd: Number(input.targetNotionalUsd),
+        },
+      },
+      log(level, message, meta) {
+        console[level]("strategy_lab.readiness_canary", {
+          runId: input.runId,
+          message,
+          ...(meta ?? {}),
+        });
+      },
+    });
+
+    if (
+      result.status !== "processed" &&
+      result.status !== "confirmed" &&
+      result.status !== "finalized"
+    ) {
+      const failure = classifyExecutionFailure(result.status, result.err);
+      return await finalizeReadinessCanaryRun(input.env, {
+        runId: input.runId,
+        status: failure.status,
+        runPatch: {
+          errorCode: failure.errorCode,
+          errorMessage: failure.errorMessage,
+          metadata: {
+            submissionPath: {
+              ...input.submissionPath,
+              landingStatus: result.status,
+            },
+            executionMeta: asJsonObject(result.executionMeta),
+            referencePrice: referencePriceMetadata,
+          },
+        },
+      });
+    }
+
+    const transaction =
+      result.signature !== null
+        ? await input.rpc.getTransactionParsed(result.signature, {
+            commitment: "confirmed",
+          })
+        : null;
+    const feeLamports = readReconciliationFeeLamports(transaction);
+    const afterBalances = await readBalances({
+      rpc: input.rpc,
+      walletAddress: input.wallet.walletAddress,
+      inputMint: orderInputMint,
+      outputMint: orderOutputMint,
+    });
+    const actualInputDelta =
+      beforeBalances.inputAtomic - afterBalances.inputAtomic;
+    const actualOutputDelta =
+      orderOutputMint === SOL_MINT
+        ? afterBalances.outputAtomic - beforeBalances.outputAtomic + feeLamports
+        : afterBalances.outputAtomic - beforeBalances.outputAtomic;
+    const reconciliationPassed =
+      readTransactionError(transaction) === null &&
+      actualInputDelta > 0n &&
+      actualOutputDelta > 0n;
+
+    return await finalizeReadinessCanaryRun(input.env, {
+      runId: input.runId,
+      status: reconciliationPassed ? "success" : "failed",
+      runPatch: {
+        receiptId: `receipt_${input.runId.slice(-16)}`,
+        signature: result.signature ?? undefined,
+        errorCode: reconciliationPassed
+          ? undefined
+          : "strategy-lab-readiness-canary-reconciliation-failed",
+        errorMessage: reconciliationPassed
+          ? undefined
+          : "strategy-lab-readiness-canary-reconciliation-failed",
+        reconciliation: {
+          status: reconciliationPassed ? "passed" : "failed",
+          actualOutputAtomic: actualOutputDelta.toString(),
+          minExpectedOutAtomic: "1",
+          notes: [
+            `status=${result.status}`,
+            `actualInputAtomic=${actualInputDelta.toString()}`,
+            `smokeOrderSide=${smokeOrderSide}`,
+          ],
+        },
+        evidenceRefs: [
+          {
+            kind: "live_canary",
+            ref: `signature:${result.signature ?? "missing"}`,
+          },
+        ],
+        metadata: {
+          submissionPath: {
+            ...input.submissionPath,
+            landingStatus: result.status,
+          },
+          executionMeta: asJsonObject(result.executionMeta),
+          referencePrice: referencePriceMetadata,
+          feeLamports: feeLamports.toString(),
+          beforeBalances: {
+            inputAtomic: beforeBalances.inputAtomic.toString(),
+            outputAtomic: beforeBalances.outputAtomic.toString(),
+            solLamports: beforeBalances.solLamports.toString(),
+          },
+          afterBalances: {
+            inputAtomic: afterBalances.inputAtomic.toString(),
+            outputAtomic: afterBalances.outputAtomic.toString(),
+            solLamports: afterBalances.solLamports.toString(),
+          },
+        },
+      },
+    });
+  } catch (error) {
+    return await finalizeReadinessCanaryRun(input.env, {
+      runId: input.runId,
+      status: "failed",
+      runPatch: {
+        errorCode: normalizeExecutionErrorCode({
+          error,
+          fallback: "submission-failed",
+        }),
+        errorMessage: executionErrorMessage(error),
+        metadata: {
+          submissionPath: input.submissionPath,
+          referencePrice: referencePriceMetadata,
+        },
+      },
+    });
+  }
 }
 
 async function runJupiterConditionalSpotSmoke(input: {
@@ -3018,6 +3422,8 @@ export async function runRuntimeResearchReadinessCanaryWorkflow(input: {
       "https://lite-api.jup.ag",
     input.env.JUPITER_API_KEY,
   );
+  const dflow =
+    context.venueKey === "dflow" ? new DFlowClient(input.env) : undefined;
   const drift =
     context.venueKey === "drift" ? new DriftClient(input.env) : undefined;
   const raydium =
@@ -3042,6 +3448,26 @@ export async function runRuntimeResearchReadinessCanaryWorkflow(input: {
       rpc,
       jupiter,
       drift,
+    });
+  }
+  if (
+    context.marketType === "prediction" &&
+    context.venueKey === "dflow" &&
+    dflow
+  ) {
+    return await runDFlowVenueSmoke({
+      env: input.env,
+      request: input.request,
+      runId,
+      context,
+      wallet,
+      targetNotionalUsd,
+      config,
+      lane: laneResolution.lane,
+      submissionPath,
+      rpc,
+      jupiter,
+      dflow,
     });
   }
   if (smokeIntentFamily === "clob_order") {

--- a/apps/worker/src/types.ts
+++ b/apps/worker/src/types.ts
@@ -73,6 +73,8 @@ export type Env = {
   DRIFT_DATA_API_BASE?: string;
   DRIFT_SWIFT_API_BASE?: string;
   DFLOW_METADATA_API_BASE?: string;
+  DFLOW_TRADE_API_BASE?: string;
+  DFLOW_PROOF_API_BASE?: string;
   DFLOW_API_KEY?: string;
   ORCA_API_BASE_URL?: string;
   RAYDIUM_API_BASE_URL?: string;

--- a/patches/@drift-labs%2Fsdk@2.159.0-beta.2.patch
+++ b/patches/@drift-labs%2Fsdk@2.159.0-beta.2.patch
@@ -7,7 +7,7 @@ index 41a66da1474c34ab67a9deb220993c9df3fb63eb..924b6544e89e04601289615d3ce73b2a
  const oracleId_1 = require("./oracles/oracleId");
  // BN is already imported globally in this file via other imports
 -const sha256_1 = require("@noble/hashes/sha256");
-+const sha256_1 = require("@noble/hashes/sha2.js");
++const sha256_1 = require("@noble/hashes/sha2");
  const utils_3 = require("./oracles/utils");
  const orders_1 = require("./math/orders");
  const builder_1 = require("./math/builder");
@@ -20,7 +20,7 @@ index 4fb011d4758a8f19e611addf38dd0fee44d48fbb..c45c1c7f7ed62363ea95a3320316d1bc
  const tweetnacl_util_1 = require("tweetnacl-util");
  const ws_1 = __importDefault(require("ws"));
 -const sha256_1 = require("@noble/hashes/sha256");
-+const sha256_1 = require("@noble/hashes/sha2.js");
++const sha256_1 = require("@noble/hashes/sha2");
  class SwiftOrderSubscriber {
      constructor(config) {
          this.config = config;
@@ -33,7 +33,7 @@ index 41a66da1474c34ab67a9deb220993c9df3fb63eb..924b6544e89e04601289615d3ce73b2a
  const oracleId_1 = require("./oracles/oracleId");
  // BN is already imported globally in this file via other imports
 -const sha256_1 = require("@noble/hashes/sha256");
-+const sha256_1 = require("@noble/hashes/sha2.js");
++const sha256_1 = require("@noble/hashes/sha2");
  const utils_3 = require("./oracles/utils");
  const orders_1 = require("./math/orders");
  const builder_1 = require("./math/builder");
@@ -46,7 +46,7 @@ index 4fb011d4758a8f19e611addf38dd0fee44d48fbb..c45c1c7f7ed62363ea95a3320316d1bc
  const tweetnacl_util_1 = require("tweetnacl-util");
  const ws_1 = __importDefault(require("ws"));
 -const sha256_1 = require("@noble/hashes/sha256");
-+const sha256_1 = require("@noble/hashes/sha2.js");
++const sha256_1 = require("@noble/hashes/sha2");
  class SwiftOrderSubscriber {
      constructor(config) {
          this.config = config;

--- a/patches/@orca-so%2Fcommon-sdk@0.7.0.patch
+++ b/patches/@orca-so%2Fcommon-sdk@0.7.0.patch
@@ -10,7 +10,7 @@ index a1915973084b9f5c69ddad9922b8b5c8c63b46bf..e634274d137a19cb9028afa139bb36d3
  const spl_token_1 = require("@solana/spl-token");
  const web3_js_1 = require("@solana/web3.js");
 -const sha256_1 = require("@noble/hashes/sha256");
-+const sha256_1 = require("@noble/hashes/sha2.js");
++const sha256_1 = require("@noble/hashes/sha2");
  const tiny_invariant_1 = __importDefault(require("tiny-invariant"));
  const math_1 = require("../math");
  const web3_1 = require("../web3");

--- a/src/runtime/research/readiness.ts
+++ b/src/runtime/research/readiness.ts
@@ -83,7 +83,8 @@ export type RuntimeResearchReadinessCanaryRequest = {
 export type RuntimeResearchVenueTxSmokeIntentFamily =
   | "spot_swap"
   | "conditional_spot_order"
-  | "clob_order";
+  | "clob_order"
+  | "prediction_order";
 
 type ReadinessContext = {
   subjectKind: "venue" | "asset";
@@ -371,7 +372,8 @@ export function parseRuntimeResearchReadinessCanaryRequest(
     smokeIntentFamilyValue &&
     smokeIntentFamilyValue !== "spot_swap" &&
     smokeIntentFamilyValue !== "conditional_spot_order" &&
-    smokeIntentFamilyValue !== "clob_order"
+    smokeIntentFamilyValue !== "clob_order" &&
+    smokeIntentFamilyValue !== "prediction_order"
   ) {
     throw new Error(
       "invalid-runtime-research-readiness-canary-smoke-intent-family",
@@ -404,7 +406,8 @@ export function parseRuntimeResearchReadinessCanaryRequest(
   const smokeIntentFamily =
     smokeIntentFamilyValue === "spot_swap" ||
     smokeIntentFamilyValue === "conditional_spot_order" ||
-    smokeIntentFamilyValue === "clob_order"
+    smokeIntentFamilyValue === "clob_order" ||
+    smokeIntentFamilyValue === "prediction_order"
       ? smokeIntentFamilyValue
       : undefined;
   const smokeOrderSide =

--- a/tests/unit/portal_runtime_operator_route.test.ts
+++ b/tests/unit/portal_runtime_operator_route.test.ts
@@ -840,6 +840,91 @@ describe("portal runtime operator route", () => {
     });
   });
 
+  test("forwards prediction venue smoke metadata", async () => {
+    process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
+    process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";
+    process.env.RUNTIME_OPERATOR_USER_ALLOWLIST = "u_1";
+
+    let capturedBody = "";
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url = String(input);
+      if (url.endsWith("/api/me")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            user: { id: "u_1", email: "operator@example.com" },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (url.endsWith("/api/admin/ops/runtime/research/readiness/smoke")) {
+        capturedBody = String(init?.body ?? "");
+        return new Response(
+          JSON.stringify({ ok: true, run: { runId: "smoke_dflow" } }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const response = await POST(
+      new Request("https://www.trader-ralph.com/api/runtime/operator", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer user-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          action: "run_venue_tx_smoke",
+          subjectKind: "venue",
+          subjectKey: "dflow",
+          venueKey: "dflow",
+          pairSymbol: "PRES-2028",
+          smokeIntentFamily: "prediction_order",
+          smokeOrderSide: "buy",
+          metadata: {
+            instrumentId: "PRES-2028",
+            outcomeId: "YesMint1111111111111111111111111111111",
+            outcomeSide: "yes",
+          },
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(JSON.parse(capturedBody)).toMatchObject({
+      subjectKind: "venue",
+      subjectKey: "dflow",
+      venueKey: "dflow",
+      pairSymbol: "PRES-2028",
+      requestedBy: "operator@example.com",
+      triggerSource: "manual",
+      proofMode: "venue_tx_smoke",
+      smokeIntentFamily: "prediction_order",
+      smokeOrderSide: "buy",
+      metadata: {
+        instrumentId: "PRES-2028",
+        outcomeId: "YesMint1111111111111111111111111111111",
+        outcomeSide: "yes",
+      },
+    });
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      run: {
+        runId: "smoke_dflow",
+      },
+    });
+  });
+
   test("forwards deployment evaluation actions", async () => {
     process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
     process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";

--- a/tests/unit/worker_dflow_client.test.ts
+++ b/tests/unit/worker_dflow_client.test.ts
@@ -56,3 +56,109 @@ test("DFlow client preserves versioned API base for market metadata routes", asy
     "https://dev-prediction-markets-api.dflow.net/api/v1/markets/by-mint/YesMint1111111111111111111111111111111",
   ]);
 });
+
+test("DFlow client uses trade and proof API bases for live prediction routes", async () => {
+  const requests: Array<{ url: string; apiKey: string | null }> = [];
+  const client = new DFlowClient(
+    {
+      metadataApiBase: "https://dev-prediction-markets-api.dflow.net/api/v1",
+      tradeApiBase: "https://dev-quote-api.dflow.net",
+      proofApiBase: "https://proof.dflow.net",
+      apiKey: "test-key",
+    },
+    {
+      fetch: (async (input, init) => {
+        const url = String(input);
+        requests.push({
+          url,
+          apiKey:
+            init?.headers && typeof init.headers === "object"
+              ? String(
+                  "x-api-key" in init.headers
+                    ? init.headers["x-api-key" as keyof typeof init.headers]
+                    : "",
+                ) || null
+              : null,
+        });
+        if (url.includes("/verify/")) {
+          return new Response(JSON.stringify({ verified: true }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return new Response(
+          JSON.stringify({
+            transaction: "base64tx",
+            executionMode: "sync",
+            inAmount: "1000000",
+            outAmount: "1900000",
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }) as typeof fetch,
+    },
+  );
+
+  const verification = await client.verifyPredictionWallet(
+    "Wallet11111111111111111111111111111111111",
+  );
+  const order = await client.buildPredictionOrderTransaction({
+    walletPublicKey: "Wallet11111111111111111111111111111111111",
+    preview: {
+      market: {
+        marketId: "PRES-2028",
+        title: "Will candidate X win in 2028?",
+        eventTitle: "Election",
+        status: "active",
+        result: null,
+        endTime: null,
+        settleTime: null,
+        accounts: [],
+      },
+      marketAccount: {
+        accountId: "acct_1",
+        yesMint: "YesMint1111111111111111111111111111111",
+        noMint: "NoMint11111111111111111111111111111111",
+        ledgerMint: "Ledger1111111111111111111111111111111",
+        settlementMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        scalarOutcomePct: null,
+        yesBid: 0.49,
+        yesAsk: 0.52,
+        noBid: 0.47,
+        noAsk: 0.51,
+        volume: 2450,
+        openInterest: 5000,
+        redemptionStatus: "open",
+        status: "active",
+      },
+      outcomeMint: "YesMint1111111111111111111111111111111",
+      outcomeSide: "yes",
+      side: "buy_yes",
+      orderType: "market",
+      timeInForce: "gtc",
+      quantityMode: "notional",
+      quantityAtomic: "1000000",
+      settlementMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      priceQuote: 0.52,
+      estimatedNotionalUsd: 1,
+      liveReady: false,
+      notes: [],
+    },
+  });
+
+  expect(verification.verified).toBe(true);
+  expect(order.transactionBase64).toBe("base64tx");
+  expect(requests).toEqual([
+    {
+      url: "https://proof.dflow.net/verify/Wallet11111111111111111111111111111111111",
+      apiKey: "test-key",
+    },
+    {
+      url: "https://dev-quote-api.dflow.net/order?inputMint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&outputMint=YesMint1111111111111111111111111111111&amount=1000000&userPublicKey=Wallet11111111111111111111111111111111111",
+      apiKey: "test-key",
+    },
+  ]);
+});

--- a/tests/unit/worker_execution_dflow.test.ts
+++ b/tests/unit/worker_execution_dflow.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { normalizePolicy } from "../../apps/worker/src/policy";
 import type { Env } from "../../apps/worker/src/types";
 
@@ -62,6 +62,14 @@ function buildPreview() {
     estimatedNotionalUsd: 1,
     liveReady: false,
     notes: ["prediction-market-live-requires-proof"],
+  };
+}
+
+function buildMarketPreview() {
+  return {
+    ...buildPreview(),
+    orderType: "market" as const,
+    notes: [],
   };
 }
 
@@ -139,5 +147,141 @@ describe("worker DFlow prediction execution adapter", () => {
         log: () => {},
       }),
     ).rejects.toThrow(/dflow-live-mode-not-supported/);
+  });
+
+  test("submits DFlow venue smoke in live mode through the bounded bypass", async () => {
+    const simulateTransactionBase64 = mock(async () => ({ err: null }));
+    const sendTransactionBase64 = mock(async () => "sig-dflow");
+    const confirmSignature = mock(async () => ({
+      ok: true,
+      status: "finalized",
+    }));
+
+    const result = await executeDFlowPredictionOrder(
+      {
+        env: {} as Env,
+        runtimeMode: "live",
+        experimentalLiveModeBypass: "venue_tx_smoke",
+        subjectControlBypassReason: "strategy_lab_readiness_canary",
+        execution: {
+          params: { lane: "safe", requireSimulation: true },
+        },
+        policy: normalizePolicy({ commitment: "finalized" }),
+        rpc: {
+          simulateTransactionBase64,
+          sendTransactionBase64,
+          confirmSignature,
+        } as never,
+        jupiter: {} as never,
+        dflow: {
+          describePredictionIntent: async () => buildMarketPreview(),
+          buildSyntheticQuote: () => ({
+            inputMint: "USDC",
+            outputMint: "YES",
+            inAmount: "1000000",
+            outAmount: "1900000",
+            priceImpactPct: 0,
+            routePlan: [
+              { poolId: "PRES-2028", swapInfo: { label: "DFlow Prediction" } },
+            ],
+          }),
+          verifyPredictionWallet: async () => ({
+            verified: true,
+            raw: { verified: true },
+          }),
+          buildPredictionOrderTransaction: async () => ({
+            transactionBase64: "unsigned-dflow",
+            lastValidBlockHeight: 77,
+            executionMode: "sync",
+            inputMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            outputMint: "YesMint1111111111111111111111111111111",
+            inAmount: "1000000",
+            outAmount: "1900000",
+            priceImpactPct: "0",
+            routePlan: [
+              { poolId: "PRES-2028", swapInfo: { label: "DFlow Prediction" } },
+            ],
+            raw: { executionMode: "sync" },
+          }),
+        } as never,
+        intent: {
+          ...buildIntent(),
+          params: { orderType: "market", quantityMode: "notional" },
+        },
+        privyWalletId: "wallet_strategy_lab",
+        log: () => {},
+      },
+      {
+        signTransactionWithPrivyById: mock(async () => "signed-dflow"),
+        evaluateSafeLaneTransaction: mock(() => ({
+          ok: true,
+          profile: {
+            txSizeBytes: 512,
+            instructionCount: 4,
+            accountKeyCount: 12,
+            addressTableLookupCount: 0,
+            signatureCount: 1,
+            computeUnitLimit: null,
+            computeUnitPriceMicroLamports: null,
+            estimatedFeeLamports: "10000",
+          },
+          limits: {
+            maxTxBytes: 1232,
+            maxInstructionCount: 24,
+            maxAccountKeys: 96,
+            maxComputeUnitLimit: 1_400_000,
+            maxEstimatedFeeLamports: "2000000",
+          },
+        })),
+      },
+    );
+
+    expect(result.status).toBe("finalized");
+    expect(result.executionMeta?.classification).toBe("finalized");
+    expect(result.executionMeta?.route).toBe("dflow");
+    expect(result.executionMeta?.lifecycle?.positionState).toBe("open");
+    expect(simulateTransactionBase64).toHaveBeenCalledWith("signed-dflow", {
+      commitment: "confirmed",
+      sigVerify: true,
+    });
+    expect(sendTransactionBase64).toHaveBeenCalledWith("signed-dflow", {
+      skipPreflight: false,
+      preflightCommitment: "confirmed",
+    });
+  });
+
+  test("blocks live buy orders when the receiving wallet is not Proof verified", async () => {
+    await expect(
+      executeDFlowPredictionOrder({
+        env: {} as Env,
+        runtimeMode: "live",
+        experimentalLiveModeBypass: "venue_tx_smoke",
+        subjectControlBypassReason: "strategy_lab_readiness_canary",
+        policy: normalizePolicy({}),
+        rpc: {} as never,
+        jupiter: {} as never,
+        dflow: {
+          describePredictionIntent: async () => buildMarketPreview(),
+          buildSyntheticQuote: () => ({
+            inputMint: "USDC",
+            outputMint: "YES",
+            inAmount: "1000000",
+            outAmount: "1900000",
+            priceImpactPct: 0,
+            routePlan: [],
+          }),
+          verifyPredictionWallet: async () => ({
+            verified: false,
+            raw: { verified: false },
+          }),
+        } as never,
+        intent: {
+          ...buildIntent(),
+          params: { orderType: "market", quantityMode: "notional" },
+        },
+        privyWalletId: "wallet_strategy_lab",
+        log: () => {},
+      }),
+    ).rejects.toThrow(/dflow-wallet-not-verified/);
   });
 });

--- a/tests/unit/worker_runtime_research_readiness_route.test.ts
+++ b/tests/unit/worker_runtime_research_readiness_route.test.ts
@@ -513,6 +513,70 @@ describe("worker runtime research readiness routes", () => {
     }
   });
 
+  test("accepts bounded DFlow venue smoke requests with prediction metadata", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/research/readiness/smoke",
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              subjectKind: "venue",
+              subjectKey: "dflow",
+              requestedBy: "codex",
+              venueKey: "dflow",
+              pairSymbol: "PRES-2028",
+              proofMode: "venue_tx_smoke",
+              smokeIntentFamily: "prediction_order",
+              smokeOrderSide: "buy",
+              metadata: {
+                instrumentId: "PRES-2028",
+                outcomeId: "YesMint1111111111111111111111111111111",
+                outcomeSide: "yes",
+              },
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(200);
+      const payload = (await response.json()) as {
+        ok: boolean;
+        status: string;
+        run: {
+          venueKey: string;
+          pairSymbol: string;
+          inputMint: string;
+          outputMint: string;
+          metadata?: Record<string, unknown>;
+          evidenceRefs: Array<{ kind: string }>;
+        };
+      };
+      expect(payload.ok).toBe(true);
+      expect(payload.status).toBe("success");
+      expect(payload.run.venueKey).toBe("dflow");
+      expect(payload.run.pairSymbol).toBe("PRES-2028");
+      expect(payload.run.inputMint).toBe(
+        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      );
+      expect(payload.run.outputMint).toBe(
+        "YesMint1111111111111111111111111111111",
+      );
+      expect(payload.run.metadata?.proofMode).toBe("venue_tx_smoke");
+      expect(payload.run.metadata?.smokeIntentFamily).toBe("prediction_order");
+      expect(payload.run.evidenceRefs[0]?.kind).toBe("live_canary");
+    } finally {
+      sqlite.close();
+    }
+  });
+
   test("uses the quote mint for OpenBook buy smoke on USDC/USDT", async () => {
     const { env, sqlite } = createOpsEnv();
     try {


### PR DESCRIPTION
Refs #420

## Summary
- add DFlow trade and Proof API client support for live prediction-market orders
- enable a bounded live `prediction_order` smoke path behind the existing `venue_tx_smoke` bypass
- extend readiness and operator request plumbing so DFlow smoke runs can carry market/outcome metadata

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun test tests/unit/worker_dflow_client.test.ts tests/unit/worker_execution_dflow.test.ts tests/unit/worker_runtime_research_readiness_route.test.ts tests/unit/portal_runtime_operator_route.test.ts`
- `bun test tests/unit/worker_execution_router.test.ts`

## Remaining blocker
- actual DFlow live proof is still blocked on a Proof-verified canary wallet; known canary wallets currently return `{"verified":false}` from `https://proof.dflow.net/verify/{address}`