### PR TITLE
[Phase 6] Add bounded flash-liquidity live smoke path

### DIFF
--- a/apps/portal/app/api/runtime/operator/route.ts
+++ b/apps/portal/app/api/runtime/operator/route.ts
@@ -806,7 +806,8 @@ export async function POST(request: Request) {
         ...(payload.smokeIntentFamily === "spot_swap" ||
         payload.smokeIntentFamily === "conditional_spot_order" ||
         payload.smokeIntentFamily === "clob_order" ||
-        payload.smokeIntentFamily === "prediction_order"
+        payload.smokeIntentFamily === "prediction_order" ||
+        payload.smokeIntentFamily === "flash_atomic"
           ? { smokeIntentFamily: payload.smokeIntentFamily }
           : {}),
         ...(payload.smokeOrderSide === "buy" ||

--- a/apps/portal/app/terminal/runtime/types.ts
+++ b/apps/portal/app/terminal/runtime/types.ts
@@ -40,7 +40,8 @@ export type RuntimeOperatorVenueTxSmokeInput = {
     | "spot_swap"
     | "conditional_spot_order"
     | "clob_order"
-    | "prediction_order";
+    | "prediction_order"
+    | "flash_atomic";
   smokeOrderSide?: "buy" | "sell";
   tightenOnFailure?: boolean;
   failureControlMode?: "disable_live" | "engage_kill_switch";

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@coral-xyz/anchor": "^0.32.1",
     "@drift-labs/sdk": "^2.159.0-beta.2",
+    "@mrgnlabs/marginfi-client-v2": "^6.4.1",
     "@noble/hashes": "^1.8.0",
     "@openbook-dex/openbook-v2": "^0.2.10",
     "@orca-so/common-sdk": "^0.7.0",

--- a/apps/worker/src/execution/flash_atomic_executor.ts
+++ b/apps/worker/src/execution/flash_atomic_executor.ts
@@ -1,4 +1,6 @@
 import { buildFlashAtomicPlan } from "../flash_liquidity";
+import { signTransactionWithPrivyById } from "../privy";
+import { evaluateSafeLaneTransaction } from "./safe_lane_policy";
 import type {
   ExecuteIntentInput,
   ExecuteSwapResult,
@@ -9,12 +11,249 @@ type ExecuteFlashAtomicIntentInput = ExecuteIntentInput & {
   intent: NonSwapExecutionIntent;
 };
 
+type FlashLiquidityLiveModule = typeof import("../flash_liquidity_live");
+type ResolveFlashLiquidityLiveAccount =
+  FlashLiquidityLiveModule["resolveFlashLiquidityLiveAccount"];
+type BuildFlashLiquidityLiveTransactionPlan =
+  FlashLiquidityLiveModule["buildFlashLiquidityLiveTransactionPlan"];
+type ReadFlashLiquidityLiveAccountState =
+  FlashLiquidityLiveModule["readFlashLiquidityLiveAccountState"];
+
+type FlashAtomicExecutorDeps = {
+  resolveFlashLiquidityLiveAccount?: ResolveFlashLiquidityLiveAccount;
+  buildFlashLiquidityLiveTransactionPlan?: BuildFlashLiquidityLiveTransactionPlan;
+  readFlashLiquidityLiveAccountState?: ReadFlashLiquidityLiveAccountState;
+  signTransactionWithPrivyById?: typeof signTransactionWithPrivyById;
+  evaluateSafeLaneTransaction?: typeof evaluateSafeLaneTransaction;
+};
+
+let flashLiquidityLiveModulePromise: Promise<FlashLiquidityLiveModule> | null =
+  null;
+
+async function loadFlashLiquidityLiveModule(): Promise<FlashLiquidityLiveModule> {
+  flashLiquidityLiveModulePromise ??= import("../flash_liquidity_live");
+  return await flashLiquidityLiveModulePromise;
+}
+
 function nowIso(): string {
   return new Date().toISOString();
 }
 
+function isSafeLaneExecution(input: ExecuteFlashAtomicIntentInput): boolean {
+  const lane = String(input.execution?.params?.lane ?? "")
+    .trim()
+    .toLowerCase();
+  return lane === "safe";
+}
+
+function allowsVenueTxSmokeLiveBypass(
+  input: ExecuteFlashAtomicIntentInput,
+): boolean {
+  return (
+    input.runtimeMode === "live" &&
+    input.experimentalLiveModeBypass === "venue_tx_smoke" &&
+    input.subjectControlBypassReason === "strategy_lab_readiness_canary"
+  );
+}
+
+function normalizeConfirmationStatus(
+  status: string | undefined,
+): Extract<
+  ExecuteSwapResult["status"],
+  "processed" | "confirmed" | "finalized" | "error"
+> {
+  if (
+    status === "processed" ||
+    status === "confirmed" ||
+    status === "finalized"
+  ) {
+    return status;
+  }
+  return "error";
+}
+
+function sanitizePlanNotes(notes: string[]): string[] {
+  return notes.filter(
+    (note) =>
+      note !== "flash-liquidity-live-blocked" &&
+      note !== "paper-only-flash-liquidity-preview",
+  );
+}
+
+async function submitPrivyManagedTransactionPlan(input: {
+  env: ExecuteFlashAtomicIntentInput["env"];
+  rpc: ExecuteFlashAtomicIntentInput["rpc"];
+  walletId: string;
+  unsignedTransactionBase64: string;
+  txBuiltAt: string;
+  lastValidBlockHeight: number | null;
+  route: string;
+  intentId: string;
+  venueSessionId: string;
+  lifecycle: NonNullable<ExecuteSwapResult["executionMeta"]>["lifecycle"];
+  signTransactionWithPrivyById: typeof signTransactionWithPrivyById;
+  evaluateSafeLaneTransaction: typeof evaluateSafeLaneTransaction;
+  requireSafeLaneEvaluation: boolean;
+}): Promise<
+  | {
+      ok: true;
+      status: Extract<
+        ExecuteSwapResult["status"],
+        "processed" | "confirmed" | "finalized"
+      >;
+      signature: string;
+      simulationUnitsConsumed: number | null;
+    }
+  | {
+      ok: false;
+      result: ExecuteSwapResult;
+    }
+> {
+  const signedBase64 = await input.signTransactionWithPrivyById(
+    input.env,
+    input.walletId,
+    input.unsignedTransactionBase64,
+  );
+  if (input.requireSafeLaneEvaluation) {
+    const safeEvaluation = input.evaluateSafeLaneTransaction({
+      env: input.env,
+      signedTransactionBase64: signedBase64,
+    });
+    if (!safeEvaluation.ok) {
+      return {
+        ok: false,
+        result: {
+          status: "simulate_error",
+          signature: null,
+          usedQuote: {
+            inputMint: "11111111111111111111111111111111",
+            outputMint: "11111111111111111111111111111111",
+            inAmount: "0",
+            outAmount: "0",
+            priceImpactPct: 0,
+            routePlan: [],
+          },
+          refreshed: false,
+          lastValidBlockHeight: input.lastValidBlockHeight,
+          err: {
+            code: "policy-denied",
+            reason: safeEvaluation.reason,
+            profile: safeEvaluation.profile,
+            limits: safeEvaluation.limits,
+          },
+          executionMeta: {
+            route: input.route,
+            classification: "error",
+            intentId: input.intentId,
+            venueSessionId: input.venueSessionId,
+            lifecycle: {
+              orderState: "rejected",
+              fillState: "failed",
+              settlementState: "failed",
+              notes: [safeEvaluation.reason],
+            },
+            trace: {
+              txBuiltAt: input.txBuiltAt,
+              failedAt: nowIso(),
+            },
+          },
+        },
+      };
+    }
+  }
+
+  const simulation = await input.rpc.simulateTransactionBase64(signedBase64, {
+    commitment: "confirmed",
+    sigVerify: true,
+  });
+  if (simulation.err) {
+    return {
+      ok: false,
+      result: {
+        status: "simulate_error",
+        signature: null,
+        usedQuote: {
+          inputMint: "11111111111111111111111111111111",
+          outputMint: "11111111111111111111111111111111",
+          inAmount: "0",
+          outAmount: "0",
+          priceImpactPct: 0,
+          routePlan: [],
+        },
+        refreshed: false,
+        lastValidBlockHeight: input.lastValidBlockHeight,
+        err: simulation.err,
+        executionMeta: {
+          route: input.route,
+          classification: "error",
+          intentId: input.intentId,
+          venueSessionId: input.venueSessionId,
+          lifecycle: input.lifecycle,
+          trace: {
+            txBuiltAt: input.txBuiltAt,
+            simulatedAt: nowIso(),
+            failedAt: nowIso(),
+          },
+        },
+      },
+    };
+  }
+
+  const signature = await input.rpc.sendTransactionBase64(signedBase64, {
+    skipPreflight: false,
+    preflightCommitment: "confirmed",
+  });
+  const confirmation = await input.rpc.confirmSignature(signature, {
+    commitment: "finalized",
+  });
+  if (!confirmation.ok) {
+    return {
+      ok: false,
+      result: {
+        status: "error",
+        signature,
+        usedQuote: {
+          inputMint: "11111111111111111111111111111111",
+          outputMint: "11111111111111111111111111111111",
+          inAmount: "0",
+          outAmount: "0",
+          priceImpactPct: 0,
+          routePlan: [],
+        },
+        refreshed: false,
+        lastValidBlockHeight: input.lastValidBlockHeight,
+        err: confirmation.err,
+        executionMeta: {
+          route: input.route,
+          classification: "error",
+          intentId: input.intentId,
+          venueSessionId: input.venueSessionId,
+          lifecycle: {
+            ...input.lifecycle,
+            settlementState: "failed",
+          },
+          trace: {
+            txBuiltAt: input.txBuiltAt,
+            simulatedAt: nowIso(),
+            sentAt: nowIso(),
+            failedAt: nowIso(),
+          },
+        },
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    status: normalizeConfirmationStatus(confirmation.status),
+    signature,
+    simulationUnitsConsumed: simulation.unitsConsumed ?? null,
+  };
+}
+
 export async function executeFlashAtomicIntent(
   input: ExecuteFlashAtomicIntentInput,
+  deps: FlashAtomicExecutorDeps = {},
 ): Promise<ExecuteSwapResult> {
   if (input.intent.family !== "flash_atomic") {
     throw new Error("invalid-flash-atomic-intent-family");
@@ -25,7 +264,8 @@ export async function executeFlashAtomicIntent(
   if (input.intent.marketType !== "spot") {
     throw new Error("invalid-flash-liquidity-market-type");
   }
-  if (input.runtimeMode === "live") {
+  const allowLiveSmoke = allowsVenueTxSmokeLiveBypass(input);
+  if (input.runtimeMode === "live" && !allowLiveSmoke) {
     throw new Error("flash-liquidity-live-mode-not-supported");
   }
 
@@ -55,6 +295,10 @@ export async function executeFlashAtomicIntent(
     })),
     feeByMint: plan.flashEstimatedFeeByMint,
   };
+  const baseLifecycleNotes = sanitizePlanNotes(plan.notes);
+  const route = "flash_liquidity";
+  const intentId = plan.referenceId;
+  const venueSessionId = `flash:${plan.referenceId}`;
 
   if (input.policy.dryRun) {
     return {
@@ -64,10 +308,10 @@ export async function executeFlashAtomicIntent(
       refreshed: false,
       lastValidBlockHeight: null,
       executionMeta: {
-        route: "flash_liquidity",
+        route,
         classification: "dry_run",
-        intentId: plan.referenceId,
-        venueSessionId: `flash:${plan.referenceId}`,
+        intentId,
+        venueSessionId,
         lifecycle,
         referencePrice: {
           verdict: "allow",
@@ -92,33 +336,217 @@ export async function executeFlashAtomicIntent(
     await input.guardEnabled();
   }
 
+  if (input.runtimeMode !== "live") {
+    return {
+      status: "simulated",
+      signature: null,
+      usedQuote: plan.syntheticQuote,
+      refreshed: false,
+      lastValidBlockHeight: null,
+      executionMeta: {
+        route,
+        classification: "simulated",
+        intentId,
+        venueSessionId,
+        lifecycle,
+        referencePrice: {
+          verdict: "allow",
+          reason: null,
+          executionPrice: null,
+          executionDivergenceBps: null,
+          snapshot: referenceSnapshot,
+        },
+        composedPlan: {
+          mode: "flash_atomic",
+          ...plan.instructionSummary,
+          simulationUnitsConsumed: null,
+        },
+        trace: {
+          txBuiltAt,
+          simulatedAt: nowIso(),
+        },
+      },
+    };
+  }
+
+  if (!input.privyWalletId) {
+    throw new Error("missing-privy-wallet-id");
+  }
+
+  const flashLiquidityLiveModule =
+    deps.resolveFlashLiquidityLiveAccount &&
+    deps.buildFlashLiquidityLiveTransactionPlan &&
+    deps.readFlashLiquidityLiveAccountState
+      ? null
+      : await loadFlashLiquidityLiveModule();
+  const resolveLiveAccount =
+    deps.resolveFlashLiquidityLiveAccount ??
+    flashLiquidityLiveModule?.resolveFlashLiquidityLiveAccount;
+  const buildLivePlan =
+    deps.buildFlashLiquidityLiveTransactionPlan ??
+    flashLiquidityLiveModule?.buildFlashLiquidityLiveTransactionPlan;
+  const readLiveAccountState =
+    deps.readFlashLiquidityLiveAccountState ??
+    flashLiquidityLiveModule?.readFlashLiquidityLiveAccountState;
+  if (!resolveLiveAccount || !buildLivePlan || !readLiveAccountState) {
+    throw new Error("flash-liquidity-live-module-unavailable");
+  }
+
+  const signWithPrivy =
+    deps.signTransactionWithPrivyById ?? signTransactionWithPrivyById;
+  const evaluateSafeLane =
+    deps.evaluateSafeLaneTransaction ?? evaluateSafeLaneTransaction;
+
+  const accountResolution = await resolveLiveAccount({
+    env: input.env,
+    walletPublicKey: input.intent.wallet,
+    intent: input.intent,
+  });
+  const marginfiAccountAddress = accountResolution.marginfiAccountAddress;
+  let setupSignature: string | null = null;
+  if (accountResolution.setup) {
+    const setupSubmit = await submitPrivyManagedTransactionPlan({
+      env: input.env,
+      rpc: input.rpc,
+      walletId: input.privyWalletId,
+      unsignedTransactionBase64:
+        accountResolution.setup.unsignedTransactionBase64,
+      txBuiltAt,
+      lastValidBlockHeight: accountResolution.setup.lastValidBlockHeight,
+      route,
+      intentId: `${intentId}:marginfi_setup`,
+      venueSessionId: marginfiAccountAddress,
+      lifecycle: {
+        orderState: "accepted",
+        fillState: "pending",
+        settlementState: "pending",
+        notes: ["flash-liquidity-live-marginfi-account-setup"],
+      },
+      signTransactionWithPrivyById: signWithPrivy,
+      evaluateSafeLaneTransaction: evaluateSafeLane,
+      requireSafeLaneEvaluation: isSafeLaneExecution(input),
+    });
+    if (!setupSubmit.ok) {
+      return {
+        ...setupSubmit.result,
+        usedQuote: plan.syntheticQuote,
+      };
+    }
+    setupSignature = setupSubmit.signature;
+  }
+
+  const livePlan = await buildLivePlan({
+    env: input.env,
+    walletPublicKey: input.intent.wallet,
+    marginfiAccountAddress,
+    intent: input.intent,
+  });
+  const liveSubmit = await submitPrivyManagedTransactionPlan({
+    env: input.env,
+    rpc: input.rpc,
+    walletId: input.privyWalletId,
+    unsignedTransactionBase64: livePlan.unsignedTransactionBase64,
+    txBuiltAt,
+    lastValidBlockHeight: livePlan.lastValidBlockHeight,
+    route,
+    intentId,
+    venueSessionId: marginfiAccountAddress,
+    lifecycle: {
+      orderState: "accepted",
+      fillState: "filled",
+      settlementState: "confirmed",
+      notes: [
+        ...baseLifecycleNotes,
+        "flash-liquidity-live-marginfi-smoke",
+        `marginfi-account:${marginfiAccountAddress}`,
+        `bank:${livePlan.bankAddress}`,
+      ],
+    },
+    signTransactionWithPrivyById: signWithPrivy,
+    evaluateSafeLaneTransaction: evaluateSafeLane,
+    requireSafeLaneEvaluation: isSafeLaneExecution(input),
+  });
+  if (!liveSubmit.ok) {
+    return {
+      ...liveSubmit.result,
+      usedQuote: plan.syntheticQuote,
+    };
+  }
+
+  const accountState = await readLiveAccountState({
+    env: input.env,
+    walletPublicKey: input.intent.wallet,
+    marginfiAccountAddress,
+  });
+  const finalStatus =
+    liveSubmit.status === "finalized"
+      ? "finalized"
+      : liveSubmit.status === "confirmed"
+        ? "confirmed"
+        : "processed";
+  const classification =
+    finalStatus === "finalized"
+      ? "finalized"
+      : finalStatus === "confirmed"
+        ? "confirmed"
+        : "submitted";
+
   return {
-    status: "simulated",
-    signature: null,
+    status: finalStatus,
+    signature: liveSubmit.signature,
     usedQuote: plan.syntheticQuote,
     refreshed: false,
-    lastValidBlockHeight: null,
+    lastValidBlockHeight: livePlan.lastValidBlockHeight,
     executionMeta: {
-      route: "flash_liquidity",
-      classification: "simulated",
-      intentId: plan.referenceId,
-      venueSessionId: `flash:${plan.referenceId}`,
-      lifecycle,
+      route,
+      classification,
+      intentId,
+      venueSessionId: marginfiAccountAddress,
+      lifecycle: {
+        orderState: accountState.activeBalanceCount < 1 ? "filled" : "open",
+        fillState: "filled",
+        settlementState:
+          finalStatus === "finalized" ? "finalized" : "confirmed",
+        notes: [
+          ...baseLifecycleNotes,
+          "flash-liquidity-live-marginfi-smoke",
+          `marginfi-account:${marginfiAccountAddress}`,
+          `bank:${livePlan.bankAddress}`,
+          ...(setupSignature
+            ? [`setup-signature:${setupSignature}`]
+            : ["setup-signature:none"]),
+          `active-balances:${accountState.activeBalanceCount}`,
+        ],
+      },
       referencePrice: {
         verdict: "allow",
         reason: null,
         executionPrice: null,
         executionDivergenceBps: null,
-        snapshot: referenceSnapshot,
+        snapshot: {
+          ...referenceSnapshot,
+          liveProvider: livePlan.provider,
+          liveBankAddress: livePlan.bankAddress,
+          liveBankMint: livePlan.bankMint,
+          liveTokenSymbol: livePlan.tokenSymbol,
+          marginfiAccountAddress,
+          activeBalanceCount: accountState.activeBalanceCount,
+          activeBankAddresses: accountState.activeBankAddresses,
+        },
       },
       composedPlan: {
         mode: "flash_atomic",
         ...plan.instructionSummary,
-        simulationUnitsConsumed: null,
+        simulationUnitsConsumed: liveSubmit.simulationUnitsConsumed,
+        addressLookupTableCount: livePlan.addressLookupTableAddresses.length,
+        addressLookupTableAddresses: livePlan.addressLookupTableAddresses,
       },
       trace: {
         txBuiltAt,
-        simulatedAt: nowIso(),
+        ...(setupSignature ? { simulatedAt: nowIso() } : {}),
+        sentAt: nowIso(),
+        ...(finalStatus === "processed" ? {} : { confirmedAt: nowIso() }),
+        ...(finalStatus === "finalized" ? { finalizedAt: nowIso() } : {}),
       },
     },
   };

--- a/apps/worker/src/execution/flash_atomic_executor.ts
+++ b/apps/worker/src/execution/flash_atomic_executor.ts
@@ -475,6 +475,7 @@ export async function executeFlashAtomicIntent(
 
   const accountState = await readLiveAccountState({
     env: input.env,
+    bankMint: livePlan.bankMint,
     walletPublicKey: input.intent.wallet,
     marginfiAccountAddress,
   });

--- a/apps/worker/src/execution/router.ts
+++ b/apps/worker/src/execution/router.ts
@@ -280,6 +280,9 @@ function allowsVenueTxSmokeLiveBypass(input: {
   if (input.intentFamily === "prediction_order") {
     return input.venueKey === "dflow";
   }
+  if (input.intentFamily === "flash_atomic") {
+    return input.venueKey === "flash_liquidity";
+  }
   return input.intentFamily === "perp_order" && input.venueKey === "drift";
 }
 

--- a/apps/worker/src/flash_liquidity_live.ts
+++ b/apps/worker/src/flash_liquidity_live.ts
@@ -1,5 +1,8 @@
 import type { Address } from "@coral-xyz/anchor";
+import type { BankRaw, MarginfiGroupRaw } from "@mrgnlabs/marginfi-client-v2";
+import type { BankMetadataMap } from "@mrgnlabs/mrgn-common";
 import {
+  type AccountInfo,
   type AddressLookupTableAccount,
   Connection,
   Keypair,
@@ -65,9 +68,29 @@ export type FlashLiquidityLiveAccountState = {
   marginfiAccountAddress: string;
   activeBalanceCount: number;
   activeBankAddresses: string[];
+  activeBalances: Array<{
+    assetQuantityUi: string;
+    assetShares: string;
+    bankAddress: string;
+    liabilityQuantityUi: string;
+    liabilityShares: string;
+  }>;
 };
 
 let marginfiClientModulePromise: Promise<MarginfiClientModule> | null = null;
+
+const MARGINFI_BANK_MINT_OFFSET = 8;
+const MARGINFI_BANK_GROUP_OFFSET = MARGINFI_BANK_MINT_OFFSET + 32 + 1;
+
+const KNOWN_FLASH_BANK_METADATA_BY_MINT: Record<
+  string,
+  { tokenName: string; tokenSymbol: string }
+> = {
+  EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v: {
+    tokenName: "USD Coin",
+    tokenSymbol: "USDC",
+  },
+};
 
 function loadMarginfiClientModule(): Promise<MarginfiClientModule> {
   marginfiClientModulePromise ??= import("@mrgnlabs/marginfi-client-v2");
@@ -209,6 +232,7 @@ function readFlashMarginfiBorrowLeg(intent: NonSwapExecutionIntent): {
 async function buildMarginfiClient(input: {
   env: Pick<Env, "RPC_ENDPOINT">;
   walletPublicKey: PublicKey;
+  mint: string;
 }): Promise<{
   connection: Connection;
   client: MarginfiClient;
@@ -219,7 +243,34 @@ async function buildMarginfiClient(input: {
   const module = await loadMarginfiClientModule();
   const wallet = makeReadOnlyWallet(input.walletPublicKey);
   const config = module.getConfig("production");
-  const client = await module.MarginfiClient.fetch(config, wallet, connection);
+  const bankMint = new PublicKey(input.mint);
+  const bankAddresses = await findMarginfiBankAddressesByMint({
+    connection,
+    groupAddress: config.groupPk,
+    mint: bankMint,
+    programId: config.programId,
+  });
+  const client = await module.MarginfiClient.fetch(config, wallet, connection, {
+    bankMetadataMap: buildMinimalMarginfiBankMetadata({
+      bankAddresses,
+      mint: bankMint,
+    }),
+    fetchGroupDataOverride: (
+      program,
+      groupAddress,
+      _commitment,
+      preloaded,
+      bankMetadataMap,
+    ) =>
+      fetchMarginfiGroupDataWithoutBatch({
+        bankAddresses: preloaded,
+        bankMetadataMap,
+        groupAddress,
+        module,
+        program,
+      }),
+    preloadedBankAddresses: bankAddresses,
+  });
   return { connection, client, module };
 }
 
@@ -230,6 +281,240 @@ function selectReusableMarginfiAccount(
     accounts.find(
       (account) => !account.isDisabled && account.activeBalances.length < 1,
     ) ?? null
+  );
+}
+
+function buildMinimalMarginfiBankMetadata(input: {
+  bankAddresses: PublicKey[];
+  mint: PublicKey;
+}): BankMetadataMap {
+  const mint = input.mint.toBase58();
+  const knownMetadata = KNOWN_FLASH_BANK_METADATA_BY_MINT[mint];
+  return Object.fromEntries(
+    input.bankAddresses.map((bankAddress) => [
+      bankAddress.toBase58(),
+      {
+        tokenAddress: mint,
+        tokenName: knownMetadata?.tokenName ?? mint,
+        tokenSymbol: knownMetadata?.tokenSymbol ?? mint.slice(0, 6),
+      },
+    ]),
+  );
+}
+
+async function findMarginfiBankAddressesByMint(input: {
+  connection: Connection;
+  groupAddress: PublicKey;
+  mint: PublicKey;
+  programId: PublicKey;
+}): Promise<PublicKey[]> {
+  const accounts = await input.connection.getProgramAccounts(input.programId, {
+    commitment: "confirmed",
+    dataSlice: { offset: 0, length: 0 },
+    filters: [
+      {
+        memcmp: {
+          offset: MARGINFI_BANK_MINT_OFFSET,
+          bytes: input.mint.toBase58(),
+        },
+      },
+      {
+        memcmp: {
+          offset: MARGINFI_BANK_GROUP_OFFSET,
+          bytes: input.groupAddress.toBase58(),
+        },
+      },
+    ],
+  });
+  if (accounts.length < 1) {
+    throw new Error(
+      `flash-liquidity-live-bank-lookup-failed:${input.mint.toBase58()}:${accounts.length}`,
+    );
+  }
+  return accounts.map((account) => account.pubkey);
+}
+
+async function readAccountInfosWithoutBatch(
+  connection: Connection,
+  publicKeys: PublicKey[],
+): Promise<AccountInfo<Buffer>[]> {
+  const accountInfos = await Promise.all(
+    publicKeys.map((publicKey) =>
+      connection.getAccountInfo(publicKey, "confirmed"),
+    ),
+  );
+  if (accountInfos.some((accountInfo) => accountInfo === null)) {
+    throw new Error("flash-liquidity-live-account-info-missing");
+  }
+  return accountInfos as AccountInfo<Buffer>[];
+}
+
+async function fetchMarginfiGroupDataWithoutBatch(input: {
+  bankAddresses?: PublicKey[];
+  bankMetadataMap?: BankMetadataMap;
+  groupAddress: PublicKey;
+  module: MarginfiClientModule;
+  program: {
+    account: {
+      bank: {
+        fetchMultiple(addresses: PublicKey[]): Promise<Array<BankRaw | null>>;
+      };
+      marginfiGroup: {
+        fetch(address: PublicKey): Promise<MarginfiGroupRaw>;
+      };
+    };
+    provider: {
+      connection: Connection;
+    };
+  };
+}): Promise<{
+  marginfiGroup: unknown;
+  banks: Map<string, Bank>;
+  priceInfos: Map<string, unknown>;
+  tokenDatas: Map<
+    string,
+    {
+      mint: PublicKey;
+      tokenProgram: PublicKey;
+      feeBps: number;
+      emissionTokenProgram: PublicKey | null;
+    }
+  >;
+  feedIdMap: Map<never, never>;
+}> {
+  const bankAddresses = Array.isArray(input.bankAddresses)
+    ? input.bankAddresses
+    : [];
+  if (bankAddresses.length < 1) {
+    throw new Error("flash-liquidity-live-preloaded-bank-required");
+  }
+  const fetchedBankAccounts =
+    await input.program.account.bank.fetchMultiple(bankAddresses);
+  const bankDatasKeyed = bankAddresses.flatMap((address, index) => {
+    const data = fetchedBankAccounts[index];
+    return data === null ? [] : [{ address, data }];
+  });
+  const mintKeys = bankDatasKeyed.map((bank) => bank.data.mint);
+  const emissionMintKeys = bankDatasKeyed
+    .map((bank) => bank.data.emissionsMint)
+    .filter((mint) => !mint.equals(PublicKey.default));
+  const oracleKeys = bankDatasKeyed.map(
+    (bank) =>
+      input.module.findOracleKey(
+        input.module.BankConfig.fromAccountParsed(bank.data.config),
+      ).oracleKey,
+  );
+  const [marginfiGroupRaw, accountInfos] = await Promise.all([
+    input.program.account.marginfiGroup.fetch(input.groupAddress),
+    readAccountInfosWithoutBatch(input.program.provider.connection, [
+      ...oracleKeys,
+      ...mintKeys,
+      ...emissionMintKeys,
+    ]),
+  ]);
+  const oracleAis = accountInfos.splice(0, oracleKeys.length);
+  const mintAis = accountInfos.splice(0, mintKeys.length);
+  const emissionMintAis = accountInfos.splice(0);
+  const banks = new Map(
+    bankDatasKeyed.map(({ address, data }) => {
+      const bankMetadata = input.bankMetadataMap?.[address.toBase58()];
+      const bank = input.module.Bank.fromAccountParsed(
+        address,
+        data,
+        undefined,
+        bankMetadata,
+      );
+      return [address.toBase58(), bank];
+    }),
+  );
+  const tokenDatas = new Map(
+    bankDatasKeyed.map(({ address: bankAddress, data: bankData }, index) => {
+      const mintAddress = mintKeys[index];
+      const mintDataRaw = mintAis[index];
+      if (!mintDataRaw) {
+        throw new Error(
+          `flash-liquidity-live-mint-account-missing:${bankAddress.toBase58()}`,
+        );
+      }
+      let emissionTokenProgram: PublicKey | null = null;
+      if (!bankData.emissionsMint.equals(PublicKey.default)) {
+        const emissionMintIndex = emissionMintKeys.findIndex((mint) =>
+          mint.equals(bankData.emissionsMint),
+        );
+        emissionTokenProgram =
+          emissionMintIndex >= 0
+            ? emissionMintAis[emissionMintIndex].owner
+            : null;
+      }
+      return [
+        bankAddress.toBase58(),
+        {
+          mint: mintAddress,
+          tokenProgram: mintDataRaw.owner,
+          feeBps: 0,
+          emissionTokenProgram,
+        },
+      ];
+    }),
+  );
+  const priceInfos = new Map(
+    bankDatasKeyed.map(({ address: bankAddress, data: bankData }, index) => {
+      const priceDataRaw = oracleAis[index];
+      if (!priceDataRaw) {
+        throw new Error(
+          `flash-liquidity-live-oracle-account-missing:${bankAddress.toBase58()}`,
+        );
+      }
+      const parsedBankConfig = input.module.BankConfig.fromAccountParsed(
+        bankData.config,
+      );
+      const oracleSetup = input.module.parseOracleSetup(
+        bankData.config.oracleSetup,
+      );
+      const fixedPrice = parsedBankConfig.fixedPrice;
+      return [
+        bankAddress.toBase58(),
+        input.module.parsePriceInfo(oracleSetup, priceDataRaw.data, fixedPrice),
+      ];
+    }),
+  );
+  return {
+    marginfiGroup: input.module.MarginfiGroup.fromAccountParsed(
+      input.groupAddress,
+      marginfiGroupRaw,
+    ),
+    banks,
+    priceInfos,
+    tokenDatas,
+    feedIdMap: new Map(),
+  };
+}
+
+async function listMarginfiAccountsForAuthority(input: {
+  authority: PublicKey;
+  client: MarginfiClient;
+  module: MarginfiClientModule;
+}): Promise<MarginfiAccountWrapper[]> {
+  const accounts = await input.client.program.account.marginfiAccount.all([
+    {
+      memcmp: {
+        bytes: input.client.groupAddress.toBase58(),
+        offset: 8,
+      },
+    },
+    {
+      memcmp: {
+        bytes: input.authority.toBase58(),
+        offset: 8 + 32,
+      },
+    },
+  ]);
+  return accounts.map((account) =>
+    input.module.MarginfiAccountWrapper.fromAccountParsed(
+      account.publicKey,
+      input.client,
+      account.account,
+    ),
   );
 }
 
@@ -251,8 +536,9 @@ export async function resolveFlashLiquidityLiveAccount(input: {
 }): Promise<FlashLiquidityLiveAccountResolution> {
   const walletPublicKey = new PublicKey(input.walletPublicKey);
   const borrowLeg = readFlashMarginfiBorrowLeg(input.intent);
-  const { client, connection } = await buildMarginfiClient({
+  const { client, connection, module } = await buildMarginfiClient({
     env: input.env,
+    mint: borrowLeg.mint,
     walletPublicKey,
   });
   const bank = await resolveMarginfiBank({
@@ -263,8 +549,11 @@ export async function resolveFlashLiquidityLiveAccount(input: {
     borrowLeg.amountAtomic,
     bank.mintDecimals,
   );
-  const accounts =
-    await client.getMarginfiAccountsForAuthority(walletPublicKey);
+  const accounts = await listMarginfiAccountsForAuthority({
+    authority: walletPublicKey,
+    client,
+    module,
+  });
   const reusableAccount = selectReusableMarginfiAccount(accounts);
   if (reusableAccount) {
     return {
@@ -317,6 +606,7 @@ export async function buildFlashLiquidityLiveTransactionPlan(input: {
   const borrowLeg = readFlashMarginfiBorrowLeg(input.intent);
   const { client, connection, module } = await buildMarginfiClient({
     env: input.env,
+    mint: borrowLeg.mint,
     walletPublicKey,
   });
   const bank = await resolveMarginfiBank({
@@ -378,12 +668,14 @@ export async function buildFlashLiquidityLiveTransactionPlan(input: {
 
 export async function readFlashLiquidityLiveAccountState(input: {
   env: Pick<Env, "RPC_ENDPOINT">;
+  bankMint: string;
   walletPublicKey: string;
   marginfiAccountAddress: string;
 }): Promise<FlashLiquidityLiveAccountState> {
   const walletPublicKey = new PublicKey(input.walletPublicKey);
   const { client, module } = await buildMarginfiClient({
     env: input.env,
+    mint: input.bankMint,
     walletPublicKey,
   });
   const marginfiAccount = await module.MarginfiAccountWrapper.fetch(
@@ -397,5 +689,22 @@ export async function readFlashLiquidityLiveAccountState(input: {
     activeBankAddresses: marginfiAccount.activeBalances.map((balance) =>
       balance.bankPk.toBase58(),
     ),
+    activeBalances: marginfiAccount.activeBalances.map((balance) => {
+      const bank = client.getBankByPk(balance.bankPk);
+      const quantities = bank
+        ? balance.computeQuantityUi(bank)
+        : { assets: null, liabilities: null };
+      return {
+        bankAddress: balance.bankPk.toBase58(),
+        assetShares: balance.assetShares.toFixed(),
+        liabilityShares: balance.liabilityShares.toFixed(),
+        assetQuantityUi:
+          quantities.assets === null ? "unknown" : quantities.assets.toFixed(),
+        liabilityQuantityUi:
+          quantities.liabilities === null
+            ? "unknown"
+            : quantities.liabilities.toFixed(),
+      };
+    }),
   };
 }

--- a/apps/worker/src/flash_liquidity_live.ts
+++ b/apps/worker/src/flash_liquidity_live.ts
@@ -1,0 +1,401 @@
+import type { Address } from "@coral-xyz/anchor";
+import {
+  type AddressLookupTableAccount,
+  Connection,
+  Keypair,
+  PublicKey,
+  type Transaction,
+  type VersionedTransaction,
+} from "@solana/web3.js";
+import type { NonSwapExecutionIntent } from "./execution/types";
+import type { Env } from "./types";
+
+type FlashLiquidityLiveProvider = "marginfi";
+
+type MarginfiClientModule = typeof import("@mrgnlabs/marginfi-client-v2");
+type MarginfiClient = InstanceType<MarginfiClientModule["MarginfiClient"]>;
+type MarginfiAccountWrapper = Awaited<
+  ReturnType<MarginfiClient["getMarginfiAccountsForAuthority"]>
+>[number];
+type Bank =
+  ReturnType<MarginfiClient["getBankByMint"]> extends infer T
+    ? Exclude<T, null>
+    : never;
+
+type ReadOnlyWallet = {
+  publicKey: PublicKey;
+  signTransaction<T extends Transaction | VersionedTransaction>(
+    tx: T,
+  ): Promise<T>;
+  signAllTransactions<T extends Transaction | VersionedTransaction>(
+    txs: T[],
+  ): Promise<T[]>;
+};
+
+export type FlashLiquidityLiveAccountResolution = {
+  provider: FlashLiquidityLiveProvider;
+  bankAddress: string;
+  bankMint: string;
+  tokenSymbol: string | null;
+  borrowAmountAtomic: string;
+  borrowAmountUi: number;
+  marginfiAccountAddress: string;
+  setup: {
+    unsignedTransactionBase64: string;
+    lastValidBlockHeight: number | null;
+  } | null;
+};
+
+export type FlashLiquidityLiveTransactionPlan = {
+  provider: FlashLiquidityLiveProvider;
+  bankAddress: string;
+  bankMint: string;
+  tokenSymbol: string | null;
+  borrowAmountAtomic: string;
+  borrowAmountUi: number;
+  referenceId: string;
+  marginfiAccountAddress: string;
+  unsignedTransactionBase64: string;
+  lastValidBlockHeight: number | null;
+  addressLookupTableAddresses: string[];
+};
+
+export type FlashLiquidityLiveAccountState = {
+  provider: FlashLiquidityLiveProvider;
+  marginfiAccountAddress: string;
+  activeBalanceCount: number;
+  activeBankAddresses: string[];
+};
+
+let marginfiClientModulePromise: Promise<MarginfiClientModule> | null = null;
+
+function loadMarginfiClientModule(): Promise<MarginfiClientModule> {
+  marginfiClientModulePromise ??= import("@mrgnlabs/marginfi-client-v2");
+  return marginfiClientModulePromise;
+}
+
+function readRpcEndpoint(env: Pick<Env, "RPC_ENDPOINT">): string {
+  const rpcEndpoint = String(env.RPC_ENDPOINT ?? "").trim();
+  if (!rpcEndpoint) {
+    throw new Error("rpc-endpoint-missing");
+  }
+  return rpcEndpoint;
+}
+
+function readPositiveAtomic(value: string | null | undefined): string {
+  const normalized = String(value ?? "").trim();
+  if (!/^[1-9][0-9]*$/.test(normalized)) {
+    throw new Error("flash-liquidity-live-amount-invalid");
+  }
+  return normalized;
+}
+
+function atomicToUiAmount(value: string, decimals: number): number {
+  const atomic = BigInt(readPositiveAtomic(value));
+  const base = 10n ** BigInt(Math.max(0, decimals));
+  const intPart = atomic / base;
+  const fracPart = atomic % base;
+  const normalized =
+    fracPart === 0n
+      ? intPart.toString()
+      : `${intPart.toString()}.${fracPart
+          .toString()
+          .padStart(decimals, "0")
+          .replace(/0+$/, "")}`;
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error("flash-liquidity-live-ui-amount-invalid");
+  }
+  return parsed;
+}
+
+function makeReadOnlyWallet(publicKey: PublicKey): ReadOnlyWallet {
+  return {
+    publicKey,
+    async signTransaction<T extends Transaction | VersionedTransaction>(
+      tx: T,
+    ): Promise<T> {
+      return tx;
+    },
+    async signAllTransactions<T extends Transaction | VersionedTransaction>(
+      txs: T[],
+    ): Promise<T[]> {
+      return txs;
+    },
+  };
+}
+
+type LegacyTransactionLike = {
+  feePayer?: PublicKey;
+  recentBlockhash?: string;
+  partialSign?: (...signers: Keypair[]) => void;
+  serialize: (options?: {
+    requireAllSignatures?: boolean;
+    verifySignatures?: boolean;
+  }) => Uint8Array;
+};
+
+type VersionedTransactionWithLookupTables = VersionedTransaction & {
+  addressLookupTables?: AddressLookupTableAccount[];
+};
+
+function serializeUnsignedTransactionBase64(
+  transaction: Transaction | VersionedTransaction,
+  walletPublicKey: PublicKey,
+): string {
+  if (
+    "instructions" in transaction &&
+    Array.isArray(transaction.instructions)
+  ) {
+    transaction.feePayer = walletPublicKey;
+    return Buffer.from(
+      (transaction as Transaction | LegacyTransactionLike).serialize({
+        requireAllSignatures: false,
+        verifySignatures: false,
+      }),
+    ).toString("base64");
+  }
+  return Buffer.from(transaction.serialize()).toString("base64");
+}
+
+async function refreshLegacyTransactionMetadata(input: {
+  connection: Connection;
+  transaction: Transaction;
+  walletPublicKey: PublicKey;
+}): Promise<number | null> {
+  const latest = await input.connection.getLatestBlockhash("confirmed");
+  input.transaction.feePayer = input.walletPublicKey;
+  input.transaction.recentBlockhash = latest.blockhash;
+  return latest.lastValidBlockHeight;
+}
+
+function readFlashMarginfiBorrowLeg(intent: NonSwapExecutionIntent): {
+  provider: FlashLiquidityLiveProvider;
+  mint: string;
+  amountAtomic: string;
+} {
+  const borrowLegs = Array.isArray(intent.borrowLegs) ? intent.borrowLegs : [];
+  if (borrowLegs.length !== 1) {
+    throw new Error("flash-liquidity-live-single-borrow-leg-required");
+  }
+  const [leg] = borrowLegs;
+  if (
+    String(leg.provider ?? "")
+      .trim()
+      .toLowerCase() !== "marginfi"
+  ) {
+    throw new Error(
+      `flash-liquidity-live-provider-not-supported:${String(
+        leg.provider ?? "",
+      ).trim()}`,
+    );
+  }
+  const mint = String(leg.mint ?? "").trim();
+  if (!mint) {
+    throw new Error("flash-liquidity-live-mint-required");
+  }
+  const amountAtomic = readPositiveAtomic(leg.amountAtomic);
+  const settlementMint = String(intent.settlementMint ?? "").trim();
+  if (!settlementMint || settlementMint !== mint) {
+    throw new Error("flash-liquidity-live-settlement-mint-mismatch");
+  }
+  return {
+    provider: "marginfi",
+    mint,
+    amountAtomic,
+  };
+}
+
+async function buildMarginfiClient(input: {
+  env: Pick<Env, "RPC_ENDPOINT">;
+  walletPublicKey: PublicKey;
+}): Promise<{
+  connection: Connection;
+  client: MarginfiClient;
+  module: MarginfiClientModule;
+}> {
+  const rpcEndpoint = readRpcEndpoint(input.env);
+  const connection = new Connection(rpcEndpoint, "confirmed");
+  const module = await loadMarginfiClientModule();
+  const wallet = makeReadOnlyWallet(input.walletPublicKey);
+  const config = module.getConfig("production");
+  const client = await module.MarginfiClient.fetch(config, wallet, connection);
+  return { connection, client, module };
+}
+
+function selectReusableMarginfiAccount(
+  accounts: MarginfiAccountWrapper[],
+): MarginfiAccountWrapper | null {
+  return (
+    accounts.find(
+      (account) => !account.isDisabled && account.activeBalances.length < 1,
+    ) ?? null
+  );
+}
+
+async function resolveMarginfiBank(input: {
+  client: MarginfiClient;
+  mint: string;
+}): Promise<Bank> {
+  const bank = input.client.getBankByMint(new PublicKey(input.mint));
+  if (!bank) {
+    throw new Error(`flash-liquidity-live-bank-not-found:${input.mint}`);
+  }
+  return bank;
+}
+
+export async function resolveFlashLiquidityLiveAccount(input: {
+  env: Pick<Env, "RPC_ENDPOINT">;
+  walletPublicKey: string;
+  intent: NonSwapExecutionIntent;
+}): Promise<FlashLiquidityLiveAccountResolution> {
+  const walletPublicKey = new PublicKey(input.walletPublicKey);
+  const borrowLeg = readFlashMarginfiBorrowLeg(input.intent);
+  const { client, connection } = await buildMarginfiClient({
+    env: input.env,
+    walletPublicKey,
+  });
+  const bank = await resolveMarginfiBank({
+    client,
+    mint: borrowLeg.mint,
+  });
+  const borrowAmountUi = atomicToUiAmount(
+    borrowLeg.amountAtomic,
+    bank.mintDecimals,
+  );
+  const accounts =
+    await client.getMarginfiAccountsForAuthority(walletPublicKey);
+  const reusableAccount = selectReusableMarginfiAccount(accounts);
+  if (reusableAccount) {
+    return {
+      provider: "marginfi",
+      bankAddress: bank.address.toBase58(),
+      bankMint: bank.mint.toBase58(),
+      tokenSymbol: bank.tokenSymbol ?? null,
+      borrowAmountAtomic: borrowLeg.amountAtomic,
+      borrowAmountUi,
+      marginfiAccountAddress: reusableAccount.address.toBase58(),
+      setup: null,
+    };
+  }
+
+  const accountKeypair = Keypair.generate();
+  const setupTransaction = await client.createMarginfiAccountTx({
+    accountKeypair,
+  });
+  const lastValidBlockHeight = await refreshLegacyTransactionMetadata({
+    connection,
+    transaction: setupTransaction,
+    walletPublicKey,
+  });
+  setupTransaction.partialSign(accountKeypair);
+  return {
+    provider: "marginfi",
+    bankAddress: bank.address.toBase58(),
+    bankMint: bank.mint.toBase58(),
+    tokenSymbol: bank.tokenSymbol ?? null,
+    borrowAmountAtomic: borrowLeg.amountAtomic,
+    borrowAmountUi,
+    marginfiAccountAddress: accountKeypair.publicKey.toBase58(),
+    setup: {
+      unsignedTransactionBase64: serializeUnsignedTransactionBase64(
+        setupTransaction,
+        walletPublicKey,
+      ),
+      lastValidBlockHeight,
+    },
+  };
+}
+
+export async function buildFlashLiquidityLiveTransactionPlan(input: {
+  env: Pick<Env, "RPC_ENDPOINT">;
+  walletPublicKey: string;
+  marginfiAccountAddress: string;
+  intent: NonSwapExecutionIntent;
+}): Promise<FlashLiquidityLiveTransactionPlan> {
+  const walletPublicKey = new PublicKey(input.walletPublicKey);
+  const borrowLeg = readFlashMarginfiBorrowLeg(input.intent);
+  const { client, connection, module } = await buildMarginfiClient({
+    env: input.env,
+    walletPublicKey,
+  });
+  const bank = await resolveMarginfiBank({
+    client,
+    mint: borrowLeg.mint,
+  });
+  const marginfiAccount = await module.MarginfiAccountWrapper.fetch(
+    input.marginfiAccountAddress as Address,
+    client,
+  );
+  const borrowAmountUi = atomicToUiAmount(
+    borrowLeg.amountAtomic,
+    bank.mintDecimals,
+  );
+  const borrowIx = await marginfiAccount.makeBorrowIx(
+    borrowAmountUi,
+    bank.address,
+    {
+      createAtas: true,
+      observationBanksOverride: [bank.address],
+      wrapAndUnwrapSol: false,
+    },
+  );
+  const repayIx = await marginfiAccount.makeRepayIx(
+    borrowAmountUi,
+    bank.address,
+    false,
+    {
+      wrapAndUnwrapSol: false,
+    },
+  );
+  const latest = await connection.getLatestBlockhash("confirmed");
+  const transaction = await marginfiAccount.buildFlashLoanTx({
+    blockhash: latest.blockhash,
+    ixs: [...borrowIx.instructions, ...repayIx.instructions],
+    signers: [...borrowIx.keys, ...repayIx.keys],
+  });
+  return {
+    provider: "marginfi",
+    bankAddress: bank.address.toBase58(),
+    bankMint: bank.mint.toBase58(),
+    tokenSymbol: bank.tokenSymbol ?? null,
+    borrowAmountAtomic: borrowLeg.amountAtomic,
+    borrowAmountUi,
+    referenceId: String(input.intent.referenceId ?? "").trim(),
+    marginfiAccountAddress: marginfiAccount.address.toBase58(),
+    unsignedTransactionBase64: serializeUnsignedTransactionBase64(
+      transaction,
+      walletPublicKey,
+    ),
+    lastValidBlockHeight: latest.lastValidBlockHeight,
+    addressLookupTableAddresses:
+      (
+        transaction as VersionedTransactionWithLookupTables
+      ).addressLookupTables?.map((lookupTable) => lookupTable.key.toBase58()) ??
+      [],
+  };
+}
+
+export async function readFlashLiquidityLiveAccountState(input: {
+  env: Pick<Env, "RPC_ENDPOINT">;
+  walletPublicKey: string;
+  marginfiAccountAddress: string;
+}): Promise<FlashLiquidityLiveAccountState> {
+  const walletPublicKey = new PublicKey(input.walletPublicKey);
+  const { client, module } = await buildMarginfiClient({
+    env: input.env,
+    walletPublicKey,
+  });
+  const marginfiAccount = await module.MarginfiAccountWrapper.fetch(
+    input.marginfiAccountAddress as Address,
+    client,
+  );
+  return {
+    provider: "marginfi",
+    marginfiAccountAddress: marginfiAccount.address.toBase58(),
+    activeBalanceCount: marginfiAccount.activeBalances.length,
+    activeBankAddresses: marginfiAccount.activeBalances.map((balance) =>
+      balance.bankPk.toBase58(),
+    ),
+  };
+}

--- a/apps/worker/src/strategy_lab_readiness_canary.ts
+++ b/apps/worker/src/strategy_lab_readiness_canary.ts
@@ -109,7 +109,11 @@ type CanaryPairContext = {
   inputMint: string;
   outputMint: string;
   marketType: "spot" | "perp" | "prediction";
-  intentFamily: "spot_swap" | "perp_order" | "prediction_order";
+  intentFamily:
+    | "spot_swap"
+    | "perp_order"
+    | "prediction_order"
+    | "flash_atomic";
   instrumentId?: string;
   predictionOutcomeId?: string;
   predictionOutcomeSide?: "yes" | "no";
@@ -230,6 +234,7 @@ function readSmokeIntentFamily(
   if (raw === "prediction_order") return "prediction_order";
   if (raw === "conditional_spot_order") return "conditional_spot_order";
   if (raw === "clob_order") return "clob_order";
+  if (raw === "flash_atomic") return "flash_atomic";
   return "spot_swap";
 }
 
@@ -473,6 +478,9 @@ function allowsVenueTxSmokeLiveBypass(
   if (smokeIntentFamily === "prediction_order") {
     return venueKey === "dflow";
   }
+  if (smokeIntentFamily === "flash_atomic") {
+    return venueKey === "flash_liquidity";
+  }
   return false;
 }
 
@@ -658,6 +666,57 @@ function resolveCanaryPairContext(
       marketType: "perp",
       intentFamily: "perp_order",
       instrumentId,
+    };
+  }
+
+  if (smokeIntentFamily === "flash_atomic") {
+    if (!runtimeVenueSupportsIntentFamily(capability, smokeIntentFamily)) {
+      throw new Error(
+        `strategy-lab-readiness-canary-intent-family-unsupported:${venueKey}:${smokeIntentFamily}`,
+      );
+    }
+    const requestedAdapterKey = readOptionalString(request.adapterKey);
+    const adapterKey =
+      requestedAdapterKey ??
+      capability.adapterKeys.find((candidate) => {
+        const registration = resolveExecutionAdapterRegistration(candidate);
+        return (
+          registration !== null &&
+          registration.venueKey === venueKey &&
+          registration.supportedIntentFamilies.includes(smokeIntentFamily) &&
+          (registration.supportedModes.includes("live") || allowSmokeLiveBypass)
+        );
+      });
+    if (!adapterKey) {
+      throw new Error(
+        `strategy-lab-readiness-canary-adapter-unavailable:${venueKey}`,
+      );
+    }
+    if (requestedAdapterKey) {
+      const registration =
+        resolveExecutionAdapterRegistration(requestedAdapterKey);
+      if (
+        !registration ||
+        registration.venueKey !== venueKey ||
+        !registration.supportedIntentFamilies.includes(smokeIntentFamily) ||
+        (!registration.supportedModes.includes("live") && !allowSmokeLiveBypass)
+      ) {
+        throw new Error(
+          `strategy-lab-readiness-canary-adapter-unavailable:${venueKey}:${requestedAdapterKey}:${smokeIntentFamily}`,
+        );
+      }
+    }
+
+    return {
+      venueKey,
+      assetKey: request.assetKey ?? "USDC",
+      pairSymbol: request.pairSymbol ?? "USDC/USDC",
+      adapterKey,
+      inputMint: USDC_MINT,
+      outputMint: USDC_MINT,
+      marketType: "spot",
+      intentFamily: "flash_atomic",
+      instrumentId: request.pairSymbol ?? "USDC/USDC",
     };
   }
 
@@ -2279,6 +2338,76 @@ function buildStubCanaryMetadata(input: {
   };
 }
 
+function readFlashSmokeProvider(
+  request: RuntimeResearchReadinessCanaryRequest,
+): "marginfi" {
+  const metadata = isRecord(request.metadata) ? request.metadata : {};
+  const provider =
+    readOptionalString(metadata.provider) ??
+    readOptionalString(metadata.flashProvider) ??
+    "marginfi";
+  if (provider !== "marginfi") {
+    throw new Error(
+      `strategy-lab-readiness-canary-flash-provider-unsupported:${provider}`,
+    );
+  }
+  return "marginfi";
+}
+
+function readFlashSmokeSettlementMint(
+  request: RuntimeResearchReadinessCanaryRequest,
+): string {
+  const metadata = isRecord(request.metadata) ? request.metadata : {};
+  const settlementMint =
+    readOptionalString(metadata.settlementMint) ?? USDC_MINT;
+  if (settlementMint !== USDC_MINT) {
+    throw new Error(
+      `strategy-lab-readiness-canary-flash-settlement-mint-unsupported:${settlementMint}`,
+    );
+  }
+  return settlementMint;
+}
+
+function readFlashExecutionAccountState(result: ExecuteSwapResult): {
+  marginfiAccountAddress: string | null;
+  activeBalanceCount: number | null;
+  activeBankAddresses: string[];
+  setupSignature: string | null;
+  liveProvider: string | null;
+  liveBankAddress: string | null;
+  liveBankMint: string | null;
+} {
+  const snapshot = isRecord(result.executionMeta?.referencePrice?.snapshot)
+    ? result.executionMeta?.referencePrice?.snapshot
+    : null;
+  const lifecycleNotes = Array.isArray(result.executionMeta?.lifecycle?.notes)
+    ? result.executionMeta?.lifecycle?.notes
+        .map((entry) => readOptionalString(entry))
+        .filter((entry): entry is string => Boolean(entry))
+    : [];
+  const setupSignatureNote = lifecycleNotes.find((note) =>
+    note.startsWith("setup-signature:"),
+  );
+  const setupSignature =
+    setupSignatureNote && setupSignatureNote !== "setup-signature:none"
+      ? setupSignatureNote.slice("setup-signature:".length)
+      : null;
+  return {
+    marginfiAccountAddress:
+      readOptionalString(snapshot?.marginfiAccountAddress) ?? null,
+    activeBalanceCount:
+      typeof snapshot?.activeBalanceCount === "number" &&
+      Number.isInteger(snapshot.activeBalanceCount)
+        ? snapshot.activeBalanceCount
+        : null,
+    activeBankAddresses: readStringArray(snapshot?.activeBankAddresses),
+    setupSignature,
+    liveProvider: readOptionalString(snapshot?.liveProvider) ?? null,
+    liveBankAddress: readOptionalString(snapshot?.liveBankAddress) ?? null,
+    liveBankMint: readOptionalString(snapshot?.liveBankMint) ?? null,
+  };
+}
+
 function classifyExecutionFailure(
   status: string,
   error: unknown,
@@ -2888,6 +3017,221 @@ async function runDriftVenueSmoke(input: {
   });
 }
 
+async function runFlashLiquidityVenueSmoke(input: {
+  env: Env;
+  request: RuntimeResearchReadinessCanaryRequest;
+  context: CanaryPairContext;
+  config: StrategyLabReadinessCanaryConfig;
+  wallet: StrategyLabReadinessCanaryWallet;
+  runId: string;
+  targetNotionalUsd: string;
+  submissionPath: {
+    venueKey: string;
+    adapterKey: string;
+    lane: string;
+    adapter: string;
+  };
+  laneResolution: { lane: string };
+  rpc: SolanaRpc;
+  jupiter: JupiterClient;
+}): Promise<RuntimeResearchReadinessCanaryWorkflowResult> {
+  const flashProvider = readFlashSmokeProvider(input.request);
+  const settlementMint = readFlashSmokeSettlementMint(input.request);
+  const amountAtomic = parseUsdAtomic(input.targetNotionalUsd).toString();
+  const minimumSolReserve =
+    parseBigIntLike(input.config.minSolReserveLamports) ?? 0n;
+  const beforeSolLamports = await input.rpc.getBalanceLamports(
+    input.wallet.walletAddress,
+  );
+  if (beforeSolLamports < minimumSolReserve) {
+    return await finalizeReadinessCanaryRun(input.env, {
+      runId: input.runId,
+      status: "blocked",
+      runPatch: {
+        errorCode: "policy-denied",
+        errorMessage: "strategy-lab-readiness-canary-sol-reserve-too-low",
+        metadata: {
+          submissionPath: input.submissionPath,
+          smokeIntentFamily: "flash_atomic",
+          flashProvider,
+          walletSolLamports: beforeSolLamports.toString(),
+          minSolReserveLamports: input.config.minSolReserveLamports,
+        },
+      },
+    });
+  }
+
+  const beforeTokenAtomic = await input.rpc.getTokenBalanceAtomic(
+    input.wallet.walletAddress,
+    settlementMint,
+  );
+  const intent = {
+    family: "flash_atomic" as const,
+    wallet: input.wallet.walletAddress,
+    venueKey: "flash_liquidity" as const,
+    marketType: "spot" as const,
+    instrumentId: input.context.instrumentId ?? input.context.pairSymbol,
+    referenceId: `flash-smoke:${flashProvider}:${input.runId}`,
+    settlementMint,
+    borrowLegs: [
+      {
+        provider: flashProvider,
+        mint: settlementMint,
+        amountAtomic,
+      },
+    ],
+    params: {
+      orderType: "market",
+    },
+  };
+  const policy = normalizePolicy({
+    allowedMints: [settlementMint],
+    slippageBps: input.config.maxSlippageBps,
+    minSolReserveLamports: input.config.minSolReserveLamports,
+    simulateOnly: false,
+    dryRun: false,
+    commitment: "finalized",
+    maxTradeAmountAtomic: amountAtomic,
+  });
+
+  const result = await executeIntentViaRouter({
+    env: input.env,
+    venueKey: input.context.venueKey,
+    runtimeMode: "live",
+    experimentalLiveModeBypass: "venue_tx_smoke",
+    requireVenueRouting: true,
+    subjectControlBypassReason: "strategy_lab_readiness_canary",
+    execution: {
+      adapter: input.context.adapterKey,
+      params: {
+        lane: input.laneResolution.lane,
+        requireSimulation: true,
+      },
+    },
+    policy,
+    rpc: input.rpc,
+    jupiter: input.jupiter,
+    intent,
+    privyWalletId: input.wallet.walletId,
+    log(level, message, meta) {
+      console[level]("strategy_lab.readiness_canary", {
+        runId: input.runId,
+        message,
+        ...(meta ?? {}),
+      });
+    },
+  });
+  if (!executionSucceeded(result.status)) {
+    const failure = classifyExecutionFailure(result.status, result.err);
+    return await finalizeReadinessCanaryRun(input.env, {
+      runId: input.runId,
+      status: failure.status,
+      runPatch: {
+        errorCode: failure.errorCode,
+        errorMessage: failure.errorMessage,
+        metadata: {
+          submissionPath: {
+            ...input.submissionPath,
+            landingStatus: result.status,
+          },
+          smokeIntentFamily: "flash_atomic",
+          flashProvider,
+          executionMeta: asJsonObject(result.executionMeta),
+        },
+      },
+    });
+  }
+
+  const executionState = readFlashExecutionAccountState(result);
+  const transaction =
+    result.signature !== null
+      ? await input.rpc.getTransactionParsed(result.signature, {
+          commitment: "confirmed",
+        })
+      : null;
+  const feeLamports = readReconciliationFeeLamports(transaction);
+  const afterTokenAtomic = await input.rpc.getTokenBalanceAtomic(
+    input.wallet.walletAddress,
+    settlementMint,
+  );
+  const afterSolLamports = await input.rpc.getBalanceLamports(
+    input.wallet.walletAddress,
+  );
+  const tokenDeltaAtomic = afterTokenAtomic - beforeTokenAtomic;
+  const reconciliationPassed =
+    readTransactionError(transaction) === null &&
+    tokenDeltaAtomic === 0n &&
+    executionState.activeBalanceCount === 0;
+
+  return await finalizeReadinessCanaryRun(input.env, {
+    runId: input.runId,
+    status: reconciliationPassed ? "success" : "failed",
+    runPatch: {
+      receiptId: `receipt_${input.runId.slice(-16)}`,
+      signature: result.signature ?? undefined,
+      ...(reconciliationPassed
+        ? {}
+        : {
+            errorCode: "strategy-lab-readiness-canary-reconciliation-failed",
+            errorMessage:
+              "strategy-lab-readiness-canary-flash-reconciliation-failed",
+          }),
+      reconciliation: {
+        status: reconciliationPassed ? "passed" : "failed",
+        actualOutputAtomic: absoluteAtomic(tokenDeltaAtomic) ?? "0",
+        minExpectedOutAtomic: "0",
+        notes: [
+          `status=${result.status}`,
+          `flashProvider=${flashProvider}`,
+          `activeBalanceCount=${executionState.activeBalanceCount ?? -1}`,
+          `netTokenDeltaAtomic=${tokenDeltaAtomic.toString()}`,
+        ],
+      },
+      evidenceRefs: [
+        {
+          kind: "live_canary",
+          ref: `signature:${result.signature ?? "missing"}`,
+        },
+        ...(executionState.setupSignature
+          ? [
+              {
+                kind: "live_canary" as const,
+                ref: `signature:${executionState.setupSignature}`,
+              },
+            ]
+          : []),
+      ],
+      metadata: {
+        submissionPath: {
+          ...input.submissionPath,
+          landingStatus: result.status,
+        },
+        smokeIntentFamily: "flash_atomic",
+        flashProvider,
+        referenceId: intent.referenceId,
+        marginfiAccountAddress: executionState.marginfiAccountAddress,
+        activeBalanceCount: executionState.activeBalanceCount,
+        activeBankAddresses: executionState.activeBankAddresses,
+        setupSignature: executionState.setupSignature,
+        liveBankAddress: executionState.liveBankAddress,
+        liveBankMint: executionState.liveBankMint,
+        liveProvider: executionState.liveProvider,
+        executionMeta: asJsonObject(result.executionMeta),
+        feeLamports: feeLamports.toString(),
+        beforeBalances: {
+          tokenAtomic: beforeTokenAtomic.toString(),
+          solLamports: beforeSolLamports.toString(),
+        },
+        afterBalances: {
+          tokenAtomic: afterTokenAtomic.toString(),
+          solLamports: afterSolLamports.toString(),
+        },
+        netTokenDeltaAtomic: tokenDeltaAtomic.toString(),
+      },
+    },
+  });
+}
+
 async function runOpenBookVenueTxSmoke(input: {
   env: Env;
   request: RuntimeResearchReadinessCanaryRequest;
@@ -3469,6 +3813,39 @@ export async function runRuntimeResearchReadinessCanaryWorkflow(input: {
       jupiter,
       dflow,
     });
+  }
+  if (smokeIntentFamily === "flash_atomic") {
+    try {
+      return await runFlashLiquidityVenueSmoke({
+        env: input.env,
+        request: input.request,
+        context,
+        config,
+        wallet,
+        runId,
+        targetNotionalUsd,
+        submissionPath,
+        laneResolution: { lane: laneResolution.lane },
+        rpc,
+        jupiter,
+      });
+    } catch (error) {
+      return await finalizeReadinessCanaryRun(input.env, {
+        runId,
+        status: "failed",
+        runPatch: {
+          errorCode: normalizeExecutionErrorCode({
+            error,
+            fallback: "submission-failed",
+          }),
+          errorMessage: executionErrorMessage(error),
+          metadata: {
+            submissionPath,
+            smokeIntentFamily,
+          },
+        },
+      });
+    }
   }
   if (smokeIntentFamily === "clob_order") {
     try {

--- a/apps/worker/src/strategy_lab_readiness_canary.ts
+++ b/apps/worker/src/strategy_lab_readiness_canary.ts
@@ -2372,6 +2372,13 @@ function readFlashExecutionAccountState(result: ExecuteSwapResult): {
   marginfiAccountAddress: string | null;
   activeBalanceCount: number | null;
   activeBankAddresses: string[];
+  activeBalances: Array<{
+    assetQuantityUi: string;
+    assetShares: string;
+    bankAddress: string;
+    liabilityQuantityUi: string;
+    liabilityShares: string;
+  }>;
   setupSignature: string | null;
   liveProvider: string | null;
   liveBankAddress: string | null;
@@ -2401,11 +2408,45 @@ function readFlashExecutionAccountState(result: ExecuteSwapResult): {
         ? snapshot.activeBalanceCount
         : null,
     activeBankAddresses: readStringArray(snapshot?.activeBankAddresses),
+    activeBalances: Array.isArray(snapshot?.activeBalances)
+      ? snapshot.activeBalances.flatMap((entry) => {
+          if (!isRecord(entry)) {
+            return [];
+          }
+          return [
+            {
+              bankAddress: readOptionalString(entry.bankAddress) ?? "unknown",
+              assetShares: readOptionalString(entry.assetShares) ?? "unknown",
+              liabilityShares:
+                readOptionalString(entry.liabilityShares) ?? "unknown",
+              assetQuantityUi:
+                readOptionalString(entry.assetQuantityUi) ?? "unknown",
+              liabilityQuantityUi:
+                readOptionalString(entry.liabilityQuantityUi) ?? "unknown",
+            },
+          ];
+        })
+      : [],
     setupSignature,
     liveProvider: readOptionalString(snapshot?.liveProvider) ?? null,
     liveBankAddress: readOptionalString(snapshot?.liveBankAddress) ?? null,
     liveBankMint: readOptionalString(snapshot?.liveBankMint) ?? null,
   };
+}
+
+function flashAccountHasResidualExposure(
+  executionState: ReturnType<typeof readFlashExecutionAccountState>,
+): boolean {
+  const isZeroQuantity = (value: string): boolean =>
+    /^(?:0|0\.0+)$/.test(value.trim());
+  if (executionState.activeBalances.length < 1) {
+    return false;
+  }
+  return executionState.activeBalances.some(
+    (balance) =>
+      !isZeroQuantity(balance.assetQuantityUi) ||
+      !isZeroQuantity(balance.liabilityQuantityUi),
+  );
 }
 
 function classifyExecutionFailure(
@@ -3161,7 +3202,7 @@ async function runFlashLiquidityVenueSmoke(input: {
   const reconciliationPassed =
     readTransactionError(transaction) === null &&
     tokenDeltaAtomic === 0n &&
-    executionState.activeBalanceCount === 0;
+    !flashAccountHasResidualExposure(executionState);
 
   return await finalizeReadinessCanaryRun(input.env, {
     runId: input.runId,
@@ -3184,6 +3225,7 @@ async function runFlashLiquidityVenueSmoke(input: {
           `status=${result.status}`,
           `flashProvider=${flashProvider}`,
           `activeBalanceCount=${executionState.activeBalanceCount ?? -1}`,
+          `activeBalances=${JSON.stringify(executionState.activeBalances)}`,
           `netTokenDeltaAtomic=${tokenDeltaAtomic.toString()}`,
         ],
       },
@@ -3212,6 +3254,7 @@ async function runFlashLiquidityVenueSmoke(input: {
         marginfiAccountAddress: executionState.marginfiAccountAddress,
         activeBalanceCount: executionState.activeBalanceCount,
         activeBankAddresses: executionState.activeBankAddresses,
+        activeBalances: executionState.activeBalances,
         setupSignature: executionState.setupSignature,
         liveBankAddress: executionState.liveBankAddress,
         liveBankMint: executionState.liveBankMint,

--- a/bun.lock
+++ b/bun.lock
@@ -67,6 +67,7 @@
       "dependencies": {
         "@coral-xyz/anchor": "^0.32.1",
         "@drift-labs/sdk": "^2.159.0-beta.2",
+        "@mrgnlabs/marginfi-client-v2": "^6.4.1",
         "@noble/hashes": "^1.8.0",
         "@openbook-dex/openbook-v2": "^0.2.10",
         "@orca-so/common-sdk": "^0.7.0",
@@ -139,6 +140,8 @@
     "@coral-xyz/anchor": ["@coral-xyz/anchor@0.32.1", "", { "dependencies": { "@coral-xyz/anchor-errors": "^0.31.1", "@coral-xyz/borsh": "^0.31.1", "@noble/hashes": "^1.3.1", "@solana/web3.js": "^1.69.0", "bn.js": "^5.1.2", "bs58": "^4.0.1", "buffer-layout": "^1.2.2", "camelcase": "^6.3.0", "cross-fetch": "^3.1.5", "eventemitter3": "^4.0.7", "pako": "^2.0.3", "superstruct": "^0.15.4", "toml": "^3.0.0" } }, "sha512-zAyxFtfeje2FbMA1wzgcdVs7Hng/MijPKpRijoySPCicnvcTQs/+dnPZ/cR+LcXM9v9UYSyW81uRNYZtN5G4yg=="],
 
     "@coral-xyz/anchor-30": ["@coral-xyz/anchor@0.30.1", "", { "dependencies": { "@coral-xyz/anchor-errors": "^0.30.1", "@coral-xyz/borsh": "^0.30.1", "@noble/hashes": "^1.3.1", "@solana/web3.js": "^1.68.0", "bn.js": "^5.1.2", "bs58": "^4.0.1", "buffer-layout": "^1.2.2", "camelcase": "^6.3.0", "cross-fetch": "^3.1.5", "crypto-hash": "^1.3.0", "eventemitter3": "^4.0.7", "pako": "^2.0.3", "snake-case": "^3.0.4", "superstruct": "^0.15.4", "toml": "^3.0.0" } }, "sha512-gDXFoF5oHgpriXAaLpxyWBHdCs8Awgf/gLHIo6crv7Aqm937CNdY+x+6hoj7QR5vaJV7MxWSQ0NGFzL3kPbWEQ=="],
+
+    "@coral-xyz/anchor-31": ["@coral-xyz/anchor@0.31.1", "", { "dependencies": { "@coral-xyz/anchor-errors": "^0.31.1", "@coral-xyz/borsh": "^0.31.1", "@noble/hashes": "^1.3.1", "@solana/web3.js": "^1.69.0", "bn.js": "^5.1.2", "bs58": "^4.0.1", "buffer-layout": "^1.2.2", "camelcase": "^6.3.0", "cross-fetch": "^3.1.5", "eventemitter3": "^4.0.7", "pako": "^2.0.3", "superstruct": "^0.15.4", "toml": "^3.0.0" } }, "sha512-QUqpoEK+gi2S6nlYc2atgT2r41TT3caWr/cPUEL8n8Md9437trZ68STknq897b82p5mW0XrTBNOzRbmIRJtfsA=="],
 
     "@coral-xyz/anchor-errors": ["@coral-xyz/anchor-errors@0.31.1", "", {}, "sha512-NhNEku4F3zzUSBtrYz84FzYWm48+9OvmT1Hhnwr6GnPQry2dsEqH/ti/7ASjjpoFTWRnPXrjAIT1qM6Isop+LQ=="],
 
@@ -352,6 +355,10 @@
 
     "@metaplex-foundation/solita": ["@metaplex-foundation/solita@0.12.2", "", { "dependencies": { "@metaplex-foundation/beet": "^0.4.0", "@metaplex-foundation/beet-solana": "^0.3.0", "@metaplex-foundation/rustbin": "^0.3.0", "@solana/web3.js": "^1.36.0", "camelcase": "^6.2.1", "debug": "^4.3.3", "js-sha256": "^0.9.0", "prettier": "^2.5.1", "snake-case": "^3.0.4", "spok": "^1.4.3" }, "bin": { "solita": "dist/src/cli/solita.js" } }, "sha512-oczMfE43NNHWweSqhXPTkQBUbap/aAiwjDQw8zLKNnd/J8sXr/0+rKcN5yJIEgcHeKRkp90eTqkmt2WepQc8yw=="],
 
+    "@mrgnlabs/marginfi-client-v2": ["@mrgnlabs/marginfi-client-v2@6.4.1", "", { "dependencies": { "@coral-xyz/anchor": "^0.30.1", "@coral-xyz/borsh": "^0.30.1", "@mrgnlabs/mrgn-common": "2.0.7", "@pythnetwork/pyth-solana-receiver": "^0.8.0", "@solana/spl-token": "^0.1.8", "@solana/wallet-adapter-base": "^0.9.23", "@solana/web3.js": "^1.93.2", "@switchboard-xyz/common": "^4.1.0", "@switchboard-xyz/on-demand": "2.14.4", "bignumber.js": "^9.1.2", "bn.js": "^5.2.1", "borsh": "^2.0.0", "bs58": "^6.0.0", "crypto-hash": "^3.1.0", "decimal.js": "^10.4.3", "superstruct": "^1.0.4" } }, "sha512-tLsdgntluUK4qUlwWNPMw35x23VUSmdMH9zT/i2/bs9+f8ai3JM3zUA1GiMoDW5EhkOi92IKBi9oDlL36k7Pwg=="],
+
+    "@mrgnlabs/mrgn-common": ["@mrgnlabs/mrgn-common@2.0.7", "", { "dependencies": { "@coral-xyz/anchor": "^0.30.1", "@solana/buffer-layout": "4.0.1", "@solana/buffer-layout-utils": "^0.2.0", "@solana/wallet-adapter-base": "^0.9.23", "@solana/web3.js": "1.98.0", "bignumber.js": "^9.1.2", "bs58": "^6.0.0", "decimal.js": "^10.4.3", "numeral": "^2.0.6", "superstruct": "^1.0.4" } }, "sha512-sSB9jGgRJISBKG5Fh2SL7Ltn85FCnp74Hxoo8TrMq2FYsrh+mZQfEQW82CVVy939EDL8EHNpxqoDb/nlD0VGRQ=="],
+
     "@msgpack/msgpack": ["@msgpack/msgpack@3.1.2", "", {}, "sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ=="],
 
     "@next/env": ["@next/env@16.1.6", "", {}, "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ=="],
@@ -375,6 +382,8 @@
     "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
     "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
+
+    "@noble/ed25519": ["@noble/ed25519@1.7.5", "", {}, "sha512-xuS0nwRMQBvSxDa7UxMb61xTiH3MxTgUfhyPUALVIe0FlOAz4sjELwyDRyUvqeEYfRSG9qNjFIycqLZppg4RSA=="],
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -447,6 +456,10 @@
     "@pythnetwork/price-service-sdk": ["@pythnetwork/price-service-sdk@1.7.1", "", { "dependencies": { "bn.js": "^5.2.1" } }, "sha512-xr2boVXTyv1KUt/c6llUTfbv2jpud99pWlMJbFaHGUBoygQsByuy7WbjIJKZ+0Blg1itLZl0Lp/pJGGg8SdJoQ=="],
 
     "@pythnetwork/pyth-lazer-sdk": ["@pythnetwork/pyth-lazer-sdk@5.2.1", "", { "dependencies": { "@isaacs/ttlcache": "^1.4.1", "buffer": "^6.0.3", "isomorphic-ws": "^5.0.0", "ts-log": "^2.2.7", "ws": "^8.18.0" } }, "sha512-/0rrPi6sZdVH+cWtW+X/hmQzw+nP2fIF6BlrJRTrqwK2IXWZWW+40sHoj839HrbyUXOJyG9zKyco37eFuTE/nA=="],
+
+    "@pythnetwork/pyth-solana-receiver": ["@pythnetwork/pyth-solana-receiver@0.8.2", "", { "dependencies": { "@coral-xyz/anchor": "^0.29.0", "@noble/hashes": "^1.4.0", "@pythnetwork/price-service-sdk": ">=1.6.0", "@pythnetwork/solana-utils": "0.4.2", "@solana/web3.js": "^1.90.0" } }, "sha512-WrrdwwhSYvvB5vJEL+SfPnfuxgkRKMeKdZvGFFwe6ENrMhrQCM05oDkvNNYfXATLcpQGRAyBu9l1xIxUxixpqw=="],
+
+    "@pythnetwork/solana-utils": ["@pythnetwork/solana-utils@0.4.2", "", { "dependencies": { "@coral-xyz/anchor": "^0.29.0", "@solana/web3.js": "^1.90.0", "bs58": "^5.0.0", "jito-ts": "^3.0.1" } }, "sha512-hKo7Bcs/kDWA5Fnqhg9zJSB94NMoUDIDjHjSi/uvZOzwizISUQI6oY3LWd2CXzNh4f8djjY2BS5iNHaM4cm8Bw=="],
 
     "@react-aria/focus": ["@react-aria/focus@3.21.4", "", { "dependencies": { "@react-aria/interactions": "^3.27.0", "@react-aria/utils": "^3.33.0", "@react-types/shared": "^3.33.0", "@swc/helpers": "^0.5.0", "clsx": "^2.0.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-6gz+j9ip0/vFRTKJMl3R30MHopn4i19HqqLfSQfElxJD+r9hBnYG1Q6Wd/kl/WRR1+CALn2F+rn06jUnf5sT8Q=="],
 
@@ -614,6 +627,8 @@
 
     "@solana/transactions": ["@solana/transactions@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/functional": "5.5.1", "@solana/instructions": "5.5.1", "@solana/keys": "5.5.1", "@solana/nominal-types": "5.5.1", "@solana/rpc-types": "5.5.1", "@solana/transaction-messages": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-8hHtDxtqalZ157pnx6p8k10D7J/KY/biLzfgh9R09VNLLY3Fqi7kJvJCr7M2ik3oRll56pxhraAGCC9yIT6eOA=="],
 
+    "@solana/wallet-adapter-base": ["@solana/wallet-adapter-base@0.9.27", "", { "dependencies": { "@solana/wallet-standard-features": "^1.3.0", "@wallet-standard/base": "^1.1.0", "@wallet-standard/features": "^1.1.0", "eventemitter3": "^5.0.1" }, "peerDependencies": { "@solana/web3.js": "^1.98.0" } }, "sha512-kXjeNfNFVs/NE9GPmysBRKQ/nf+foSaq3kfVSeMcO/iVgigyRmB551OjU3WyAolLG/1jeEfKLqF9fKwMCRkUqg=="],
+
     "@solana/wallet-standard-features": ["@solana/wallet-standard-features@1.3.0", "", { "dependencies": { "@wallet-standard/base": "^1.1.0", "@wallet-standard/features": "^1.1.0" } }, "sha512-ZhpZtD+4VArf6RPitsVExvgkF+nGghd1rzPjd97GmBximpnt1rsUxMOEyoIEuH3XBxPyNB6Us7ha7RHWQR+abg=="],
 
     "@solana/web3.js": ["@solana/web3.js@1.98.4", "", { "dependencies": { "@babel/runtime": "^7.25.0", "@noble/curves": "^1.4.2", "@noble/hashes": "^1.4.0", "@solana/buffer-layout": "^4.0.1", "@solana/codecs-numbers": "^2.1.0", "agentkeepalive": "^4.5.0", "bn.js": "^5.2.1", "borsh": "^0.7.0", "bs58": "^4.0.1", "buffer": "6.0.3", "fast-stable-stringify": "^1.0.0", "jayson": "^4.1.1", "node-fetch": "^2.7.0", "rpc-websockets": "^9.0.2", "superstruct": "^2.0.2" } }, "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw=="],
@@ -758,6 +773,8 @@
 
     "@walletconnect/window-metadata": ["@walletconnect/window-metadata@1.0.1", "", { "dependencies": { "@walletconnect/window-getters": "^1.0.1", "tslib": "1.14.1" } }, "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA=="],
 
+    "@zod/core": ["@zod/core@0.11.6", "", {}, "sha512-03Bv82fFSfjDAvMfdHHdGSS6SOJs0iCcJlWJv1kJHRtoTT02hZpyip/2Lk6oo4l4FtjuwTrsEQTwg/LD8I7dJA=="],
+
     "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
@@ -878,7 +895,7 @@
 
     "crypt": ["crypt@0.0.2", "", {}, "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="],
 
-    "crypto-hash": ["crypto-hash@1.3.0", "", {}, "sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg=="],
+    "crypto-hash": ["crypto-hash@3.1.0", "", {}, "sha512-HR8JlZ+Dn54Lc5gGWZJxJitWbOCUzWb9/AlyONGecBnYZ+n/ONvt0gQnEzDNpJMYeRrYO7KogQ4qwyTPKnWKEw=="],
 
     "css-color-keywords": ["css-color-keywords@1.0.0", "", {}, "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="],
 
@@ -1114,6 +1131,8 @@
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
+    "jito-ts": ["jito-ts@3.0.1", "", { "dependencies": { "@grpc/grpc-js": "^1.8.13", "@noble/ed25519": "^1.7.1", "@solana/web3.js": "~1.77.3", "agentkeepalive": "^4.3.0", "dotenv": "^16.0.3", "jayson": "^4.0.0", "node-fetch": "^2.6.7", "superstruct": "^1.0.3" } }, "sha512-TSofF7KqcwyaWGjPaSYC8RDoNBY1TPRNBHdrw24bdIi7mQ5bFEDdYK3D//llw/ml8YDvcZlgd644WxhjLTS9yg=="],
+
     "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
 
     "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
@@ -1237,6 +1256,8 @@
     "node-mock-http": ["node-mock-http@1.0.4", "", {}, "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
+
+    "numeral": ["numeral@2.0.6", "", {}, "sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA=="],
 
     "obj-multiplex": ["obj-multiplex@1.0.0", "", { "dependencies": { "end-of-stream": "^1.4.0", "once": "^1.4.0", "readable-stream": "^2.3.3" } }, "sha512-0GNJAOsHoBHeNTvl5Vt6IWnpUEcc3uSRxzBri7EDyIcMgYvnY2JL2qdeV5zTMjWQX5OHcD5amcW2HFfDh0gjIA=="],
 
@@ -1612,6 +1633,12 @@
 
     "@coral-xyz/anchor-30/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
+    "@coral-xyz/anchor-30/crypto-hash": ["crypto-hash@1.3.0", "", {}, "sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg=="],
+
+    "@coral-xyz/anchor-31/@coral-xyz/borsh": ["@coral-xyz/borsh@0.31.1", "", { "dependencies": { "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" }, "peerDependencies": { "@solana/web3.js": "^1.69.0" } }, "sha512-9N8AU9F0ubriKfNE3g1WF0/4dtlGXoBN/hd1PvbNBamBNwRgHxH4P+o3Zt7rSEloW1HUs6LfZEchlx9fW7POYw=="],
+
+    "@coral-xyz/anchor-31/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
+
     "@drift-labs/sdk/@coral-xyz/anchor": ["@coral-xyz/anchor@0.29.0", "", { "dependencies": { "@coral-xyz/borsh": "^0.29.0", "@noble/hashes": "^1.3.1", "@solana/web3.js": "^1.68.0", "bn.js": "^5.1.2", "bs58": "^4.0.1", "buffer-layout": "^1.2.2", "camelcase": "^6.3.0", "cross-fetch": "^3.1.5", "crypto-hash": "^1.3.0", "eventemitter3": "^4.0.7", "pako": "^2.0.3", "snake-case": "^3.0.4", "superstruct": "^0.15.4", "toml": "^3.0.0" } }, "sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA=="],
 
     "@drift-labs/sdk/@ellipsis-labs/phoenix-sdk": ["@ellipsis-labs/phoenix-sdk@1.4.5", "", { "dependencies": { "@metaplex-foundation/beet": "^0.7.1", "@metaplex-foundation/rustbin": "^0.3.1", "@metaplex-foundation/solita": "^0.12.2", "@solana/spl-token": "^0.3.7", "@types/node": "^18.11.13", "bn.js": "^5.2.1", "borsh": "^0.7.0", "bs58": "^5.0.0" } }, "sha512-vEYgMXuV5/mpnpEi+VK4HO8f6SheHtVLdHHlULBiDN1eECYmL67gq+/cRV7Ar6jAQ7rJZL7xBxhbUW5kugMl6A=="],
@@ -1674,6 +1701,26 @@
 
     "@metaplex-foundation/solita/@metaplex-foundation/beet": ["@metaplex-foundation/beet@0.4.0", "", { "dependencies": { "ansicolors": "^0.3.2", "bn.js": "^5.2.0", "debug": "^4.3.3" } }, "sha512-2OAKJnLatCc3mBXNL0QmWVQKAWK2C7XDfepgL0p/9+8oSx4bmRAFHFqptl1A/C0U5O3dxGwKfmKluW161OVGcA=="],
 
+    "@mrgnlabs/marginfi-client-v2/@coral-xyz/anchor": ["@coral-xyz/anchor@0.30.1", "", { "dependencies": { "@coral-xyz/anchor-errors": "^0.30.1", "@coral-xyz/borsh": "^0.30.1", "@noble/hashes": "^1.3.1", "@solana/web3.js": "^1.68.0", "bn.js": "^5.1.2", "bs58": "^4.0.1", "buffer-layout": "^1.2.2", "camelcase": "^6.3.0", "cross-fetch": "^3.1.5", "crypto-hash": "^1.3.0", "eventemitter3": "^4.0.7", "pako": "^2.0.3", "snake-case": "^3.0.4", "superstruct": "^0.15.4", "toml": "^3.0.0" } }, "sha512-gDXFoF5oHgpriXAaLpxyWBHdCs8Awgf/gLHIo6crv7Aqm937CNdY+x+6hoj7QR5vaJV7MxWSQ0NGFzL3kPbWEQ=="],
+
+    "@mrgnlabs/marginfi-client-v2/@coral-xyz/borsh": ["@coral-xyz/borsh@0.30.1", "", { "dependencies": { "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" }, "peerDependencies": { "@solana/web3.js": "^1.68.0" } }, "sha512-aaxswpPrCFKl8vZTbxLssA2RvwX2zmKLlRCIktJOwW+VpVwYtXRtlWiIP+c2pPRKneiTiWCN2GEMSH9j1zTlWQ=="],
+
+    "@mrgnlabs/marginfi-client-v2/@solana/spl-token": ["@solana/spl-token@0.1.8", "", { "dependencies": { "@babel/runtime": "^7.10.5", "@solana/web3.js": "^1.21.0", "bn.js": "^5.1.0", "buffer": "6.0.3", "buffer-layout": "^1.2.0", "dotenv": "10.0.0" } }, "sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ=="],
+
+    "@mrgnlabs/marginfi-client-v2/@switchboard-xyz/common": ["@switchboard-xyz/common@4.1.11", "", { "dependencies": { "@solana/web3.js": "^1.98.2", "axios": "^1.9.0", "big.js": "^6.2.2", "bn.js": "^5.2.1", "bs58": "^6.0.0", "buffer": "^6.0.3", "decimal.js": "^10.4.3", "js-sha256": "^0.11.0", "protobufjs": "^7.4.0", "yaml": "^2.6.1", "zod": "4.0.0-beta.20250505T195954" } }, "sha512-zNclN+7Be28qL5dFlScL4qGCPAe/kLUQ7umNsT9+V9WC3jB3uUdYVlzsQzJc3WVYAGn0xc6gKJ0S/XW7NAxhzQ=="],
+
+    "@mrgnlabs/marginfi-client-v2/@switchboard-xyz/on-demand": ["@switchboard-xyz/on-demand@2.14.4", "", { "dependencies": { "@coral-xyz/anchor-31": "npm:@coral-xyz/anchor@0.31.1", "@isaacs/ttlcache": "^1.4.1", "@switchboard-xyz/common": "^4.0.0", "axios": "^1.9", "bs58": "^6.0.0", "buffer": "^6.0.3", "isomorphic-ws": "^5.0.0", "js-yaml": "^4.1.0", "ws": "^8.18.1" } }, "sha512-+YL0+BUlJXEtX4MHS+1+0CpzS2z5z7moM58FqXixBu8Zm6L/KVZ4K29LHhRUW8sLZ4Lmet/JOLNMVCYDI+F8HQ=="],
+
+    "@mrgnlabs/marginfi-client-v2/borsh": ["borsh@2.0.0", "", {}, "sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg=="],
+
+    "@mrgnlabs/marginfi-client-v2/superstruct": ["superstruct@1.0.4", "", {}, "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ=="],
+
+    "@mrgnlabs/mrgn-common/@coral-xyz/anchor": ["@coral-xyz/anchor@0.30.1", "", { "dependencies": { "@coral-xyz/anchor-errors": "^0.30.1", "@coral-xyz/borsh": "^0.30.1", "@noble/hashes": "^1.3.1", "@solana/web3.js": "^1.68.0", "bn.js": "^5.1.2", "bs58": "^4.0.1", "buffer-layout": "^1.2.2", "camelcase": "^6.3.0", "cross-fetch": "^3.1.5", "crypto-hash": "^1.3.0", "eventemitter3": "^4.0.7", "pako": "^2.0.3", "snake-case": "^3.0.4", "superstruct": "^0.15.4", "toml": "^3.0.0" } }, "sha512-gDXFoF5oHgpriXAaLpxyWBHdCs8Awgf/gLHIo6crv7Aqm937CNdY+x+6hoj7QR5vaJV7MxWSQ0NGFzL3kPbWEQ=="],
+
+    "@mrgnlabs/mrgn-common/@solana/web3.js": ["@solana/web3.js@1.98.0", "", { "dependencies": { "@babel/runtime": "^7.25.0", "@noble/curves": "^1.4.2", "@noble/hashes": "^1.4.0", "@solana/buffer-layout": "^4.0.1", "agentkeepalive": "^4.5.0", "bigint-buffer": "^1.1.5", "bn.js": "^5.2.1", "borsh": "^0.7.0", "bs58": "^4.0.1", "buffer": "6.0.3", "fast-stable-stringify": "^1.0.0", "jayson": "^4.1.1", "node-fetch": "^2.7.0", "rpc-websockets": "^9.0.2", "superstruct": "^2.0.2" } }, "sha512-nz3Q5OeyGFpFCR+erX2f6JPt3sKhzhYcSycBCSPkWjzSVDh/Rr1FqTVMRe58FKO16/ivTUcuJjeS5MyBvpkbzA=="],
+
+    "@mrgnlabs/mrgn-common/superstruct": ["superstruct@1.0.4", "", {}, "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ=="],
+
     "@openbook-dex/openbook-v2/@coral-xyz/anchor": ["@coral-xyz/anchor@0.29.0", "", { "dependencies": { "@coral-xyz/borsh": "^0.29.0", "@noble/hashes": "^1.3.1", "@solana/web3.js": "^1.68.0", "bn.js": "^5.1.2", "bs58": "^4.0.1", "buffer-layout": "^1.2.2", "camelcase": "^6.3.0", "cross-fetch": "^3.1.5", "crypto-hash": "^1.3.0", "eventemitter3": "^4.0.7", "pako": "^2.0.3", "snake-case": "^3.0.4", "superstruct": "^0.15.4", "toml": "^3.0.0" } }, "sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA=="],
 
     "@privy-io/api-base/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -1692,9 +1739,17 @@
 
     "@project-serum/anchor/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
+    "@project-serum/anchor/crypto-hash": ["crypto-hash@1.3.0", "", {}, "sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg=="],
+
     "@project-serum/serum/@solana/spl-token": ["@solana/spl-token@0.1.8", "", { "dependencies": { "@babel/runtime": "^7.10.5", "@solana/web3.js": "^1.21.0", "bn.js": "^5.1.0", "buffer": "6.0.3", "buffer-layout": "^1.2.0", "dotenv": "10.0.0" } }, "sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ=="],
 
     "@pythnetwork/pyth-lazer-sdk/isomorphic-ws": ["isomorphic-ws@5.0.0", "", { "peerDependencies": { "ws": "*" } }, "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw=="],
+
+    "@pythnetwork/pyth-solana-receiver/@coral-xyz/anchor": ["@coral-xyz/anchor@0.29.0", "", { "dependencies": { "@coral-xyz/borsh": "^0.29.0", "@noble/hashes": "^1.3.1", "@solana/web3.js": "^1.68.0", "bn.js": "^5.1.2", "bs58": "^4.0.1", "buffer-layout": "^1.2.2", "camelcase": "^6.3.0", "cross-fetch": "^3.1.5", "crypto-hash": "^1.3.0", "eventemitter3": "^4.0.7", "pako": "^2.0.3", "snake-case": "^3.0.4", "superstruct": "^0.15.4", "toml": "^3.0.0" } }, "sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA=="],
+
+    "@pythnetwork/solana-utils/@coral-xyz/anchor": ["@coral-xyz/anchor@0.29.0", "", { "dependencies": { "@coral-xyz/borsh": "^0.29.0", "@noble/hashes": "^1.3.1", "@solana/web3.js": "^1.68.0", "bn.js": "^5.1.2", "bs58": "^4.0.1", "buffer-layout": "^1.2.2", "camelcase": "^6.3.0", "cross-fetch": "^3.1.5", "crypto-hash": "^1.3.0", "eventemitter3": "^4.0.7", "pako": "^2.0.3", "snake-case": "^3.0.4", "superstruct": "^0.15.4", "toml": "^3.0.0" } }, "sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA=="],
+
+    "@pythnetwork/solana-utils/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
 
     "@react-aria/focus/@swc/helpers": ["@swc/helpers@0.5.18", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ=="],
 
@@ -1932,6 +1987,8 @@
 
     "@solana/transactions/@solana/rpc-types": ["@solana/rpc-types@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA=="],
 
+    "@solana/wallet-adapter-base/eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
     "@solana/web3.js/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "@solana/web3.js/superstruct": ["superstruct@2.0.2", "", {}, "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A=="],
@@ -2040,6 +2097,12 @@
 
     "jayson/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
+    "jito-ts/@solana/web3.js": ["@solana/web3.js@1.77.4", "", { "dependencies": { "@babel/runtime": "^7.12.5", "@noble/curves": "^1.0.0", "@noble/hashes": "^1.3.0", "@solana/buffer-layout": "^4.0.0", "agentkeepalive": "^4.2.1", "bigint-buffer": "^1.1.5", "bn.js": "^5.0.0", "borsh": "^0.7.0", "bs58": "^4.0.1", "buffer": "6.0.3", "fast-stable-stringify": "^1.0.0", "jayson": "^4.1.0", "node-fetch": "^2.6.7", "rpc-websockets": "^7.5.1", "superstruct": "^0.14.2" } }, "sha512-XdN0Lh4jdY7J8FYMyucxCwzn6Ga2Sr1DHDWRbqVzk7ZPmmpSPOVWHzO67X1cVT+jNi1D6gZi2tgjHgDPuj6e9Q=="],
+
+    "jito-ts/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
+
+    "jito-ts/superstruct": ["superstruct@1.0.4", "", {}, "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ=="],
+
     "json-rpc-engine/@metamask/safe-event-emitter": ["@metamask/safe-event-emitter@2.0.0", "", {}, "sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q=="],
 
     "keccak/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
@@ -2088,6 +2151,8 @@
 
     "@coral-xyz/anchor-30/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
+    "@coral-xyz/anchor-31/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
+
     "@coral-xyz/anchor/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
     "@drift-labs/sdk/@coral-xyz/anchor/@coral-xyz/borsh": ["@coral-xyz/borsh@0.29.0", "", { "dependencies": { "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" }, "peerDependencies": { "@solana/web3.js": "^1.68.0" } }, "sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ=="],
@@ -2095,6 +2160,8 @@
     "@drift-labs/sdk/@coral-xyz/anchor/@solana/web3.js": ["@solana/web3.js@1.98.4", "", { "dependencies": { "@babel/runtime": "^7.25.0", "@noble/curves": "^1.4.2", "@noble/hashes": "^1.4.0", "@solana/buffer-layout": "^4.0.1", "@solana/codecs-numbers": "^2.1.0", "agentkeepalive": "^4.5.0", "bn.js": "^5.2.1", "borsh": "^0.7.0", "bs58": "^4.0.1", "buffer": "6.0.3", "fast-stable-stringify": "^1.0.0", "jayson": "^4.1.1", "node-fetch": "^2.7.0", "rpc-websockets": "^9.0.2", "superstruct": "^2.0.2" } }, "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw=="],
 
     "@drift-labs/sdk/@coral-xyz/anchor/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
+
+    "@drift-labs/sdk/@coral-xyz/anchor/crypto-hash": ["crypto-hash@1.3.0", "", {}, "sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg=="],
 
     "@drift-labs/sdk/@ellipsis-labs/phoenix-sdk/@solana/spl-token": ["@solana/spl-token@0.3.11", "", { "dependencies": { "@solana/buffer-layout": "^4.0.0", "@solana/buffer-layout-utils": "^0.2.0", "@solana/spl-token-metadata": "^0.1.2", "buffer": "^6.0.3" }, "peerDependencies": { "@solana/web3.js": "^1.88.0" } }, "sha512-bvohO3rIMSVL24Pb+I4EYTJ6cL82eFpInEXD/I8K8upOGjpqHsKUoAempR/RnUlI1qSFNyFlWJfu6MNUgfbCQQ=="],
 
@@ -2130,11 +2197,57 @@
 
     "@metaplex-foundation/beet-solana/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
 
+    "@mrgnlabs/marginfi-client-v2/@coral-xyz/anchor/@coral-xyz/anchor-errors": ["@coral-xyz/anchor-errors@0.30.1", "", {}, "sha512-9Mkradf5yS5xiLWrl9WrpjqOrAV+/W2RQHDlbnAZBivoGpOs1ECjoDCkVk4aRG8ZdiFiB8zQEVlxf+8fKkmSfQ=="],
+
+    "@mrgnlabs/marginfi-client-v2/@coral-xyz/anchor/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
+
+    "@mrgnlabs/marginfi-client-v2/@coral-xyz/anchor/crypto-hash": ["crypto-hash@1.3.0", "", {}, "sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg=="],
+
+    "@mrgnlabs/marginfi-client-v2/@coral-xyz/anchor/superstruct": ["superstruct@0.15.5", "", {}, "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ=="],
+
+    "@mrgnlabs/marginfi-client-v2/@switchboard-xyz/common/js-sha256": ["js-sha256@0.11.1", "", {}, "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg=="],
+
+    "@mrgnlabs/marginfi-client-v2/@switchboard-xyz/common/zod": ["zod@4.0.0-beta.20250505T195954", "", { "dependencies": { "@zod/core": "0.11.6" } }, "sha512-iB8WvxkobVIXMARvQu20fKvbS7mUTiYRpcD8OQV1xjRhxO0EEpYIRJBk6yfBzHAHEdOSDh3SxDITr5Eajr2vtg=="],
+
+    "@mrgnlabs/marginfi-client-v2/@switchboard-xyz/on-demand/isomorphic-ws": ["isomorphic-ws@5.0.0", "", { "peerDependencies": { "ws": "*" } }, "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw=="],
+
+    "@mrgnlabs/mrgn-common/@coral-xyz/anchor/@coral-xyz/anchor-errors": ["@coral-xyz/anchor-errors@0.30.1", "", {}, "sha512-9Mkradf5yS5xiLWrl9WrpjqOrAV+/W2RQHDlbnAZBivoGpOs1ECjoDCkVk4aRG8ZdiFiB8zQEVlxf+8fKkmSfQ=="],
+
+    "@mrgnlabs/mrgn-common/@coral-xyz/anchor/@coral-xyz/borsh": ["@coral-xyz/borsh@0.30.1", "", { "dependencies": { "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" }, "peerDependencies": { "@solana/web3.js": "^1.68.0" } }, "sha512-aaxswpPrCFKl8vZTbxLssA2RvwX2zmKLlRCIktJOwW+VpVwYtXRtlWiIP+c2pPRKneiTiWCN2GEMSH9j1zTlWQ=="],
+
+    "@mrgnlabs/mrgn-common/@coral-xyz/anchor/@solana/web3.js": ["@solana/web3.js@1.98.4", "", { "dependencies": { "@babel/runtime": "^7.25.0", "@noble/curves": "^1.4.2", "@noble/hashes": "^1.4.0", "@solana/buffer-layout": "^4.0.1", "@solana/codecs-numbers": "^2.1.0", "agentkeepalive": "^4.5.0", "bn.js": "^5.2.1", "borsh": "^0.7.0", "bs58": "^4.0.1", "buffer": "6.0.3", "fast-stable-stringify": "^1.0.0", "jayson": "^4.1.1", "node-fetch": "^2.7.0", "rpc-websockets": "^9.0.2", "superstruct": "^2.0.2" } }, "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw=="],
+
+    "@mrgnlabs/mrgn-common/@coral-xyz/anchor/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
+
+    "@mrgnlabs/mrgn-common/@coral-xyz/anchor/crypto-hash": ["crypto-hash@1.3.0", "", {}, "sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg=="],
+
+    "@mrgnlabs/mrgn-common/@coral-xyz/anchor/superstruct": ["superstruct@0.15.5", "", {}, "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ=="],
+
+    "@mrgnlabs/mrgn-common/@solana/web3.js/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
+
+    "@mrgnlabs/mrgn-common/@solana/web3.js/superstruct": ["superstruct@2.0.2", "", {}, "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A=="],
+
     "@openbook-dex/openbook-v2/@coral-xyz/anchor/@coral-xyz/borsh": ["@coral-xyz/borsh@0.29.0", "", { "dependencies": { "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" }, "peerDependencies": { "@solana/web3.js": "^1.68.0" } }, "sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ=="],
 
     "@openbook-dex/openbook-v2/@coral-xyz/anchor/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
+    "@openbook-dex/openbook-v2/@coral-xyz/anchor/crypto-hash": ["crypto-hash@1.3.0", "", {}, "sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg=="],
+
     "@project-serum/anchor/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
+
+    "@pythnetwork/pyth-solana-receiver/@coral-xyz/anchor/@coral-xyz/borsh": ["@coral-xyz/borsh@0.29.0", "", { "dependencies": { "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" }, "peerDependencies": { "@solana/web3.js": "^1.68.0" } }, "sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ=="],
+
+    "@pythnetwork/pyth-solana-receiver/@coral-xyz/anchor/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
+
+    "@pythnetwork/pyth-solana-receiver/@coral-xyz/anchor/crypto-hash": ["crypto-hash@1.3.0", "", {}, "sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg=="],
+
+    "@pythnetwork/solana-utils/@coral-xyz/anchor/@coral-xyz/borsh": ["@coral-xyz/borsh@0.29.0", "", { "dependencies": { "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" }, "peerDependencies": { "@solana/web3.js": "^1.68.0" } }, "sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ=="],
+
+    "@pythnetwork/solana-utils/@coral-xyz/anchor/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
+
+    "@pythnetwork/solana-utils/@coral-xyz/anchor/crypto-hash": ["crypto-hash@1.3.0", "", {}, "sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg=="],
+
+    "@pythnetwork/solana-utils/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/logger": ["@walletconnect/logger@2.1.2", "", { "dependencies": { "@walletconnect/safe-json": "^1.0.2", "pino": "7.11.0" } }, "sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw=="],
 
@@ -2494,6 +2607,12 @@
 
     "jayson/@types/ws/@types/node": ["@types/node@20.19.30", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g=="],
 
+    "jito-ts/@solana/web3.js/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
+
+    "jito-ts/@solana/web3.js/rpc-websockets": ["rpc-websockets@7.11.2", "", { "dependencies": { "eventemitter3": "^4.0.7", "uuid": "^8.3.2", "ws": "^8.5.0" }, "optionalDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" } }, "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ=="],
+
+    "jito-ts/@solana/web3.js/superstruct": ["superstruct@0.14.2", "", {}, "sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ=="],
+
     "next/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "obj-multiplex/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
@@ -2532,7 +2651,19 @@
 
     "@metamask/providers/@metamask/rpc-errors/@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
+    "@mrgnlabs/marginfi-client-v2/@coral-xyz/anchor/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
+
+    "@mrgnlabs/mrgn-common/@coral-xyz/anchor/@solana/web3.js/superstruct": ["superstruct@2.0.2", "", {}, "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A=="],
+
+    "@mrgnlabs/mrgn-common/@coral-xyz/anchor/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
+
+    "@mrgnlabs/mrgn-common/@solana/web3.js/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
+
     "@openbook-dex/openbook-v2/@coral-xyz/anchor/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
+
+    "@pythnetwork/pyth-solana-receiver/@coral-xyz/anchor/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
+
+    "@pythnetwork/solana-utils/@coral-xyz/anchor/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/logger/pino": ["pino@7.11.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "fast-redact": "^3.0.0", "on-exit-leak-free": "^0.2.0", "pino-abstract-transport": "v0.5.0", "pino-std-serializers": "^4.0.0", "process-warning": "^1.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.1.0", "safe-stable-stringify": "^2.1.0", "sonic-boom": "^2.2.1", "thread-stream": "^0.15.1" }, "bin": { "pino": "bin.js" } }, "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg=="],
 
@@ -2805,6 +2936,8 @@
     "gill/@solana/transaction-confirmation/@solana/transactions/@solana/nominal-types": ["@solana/nominal-types@2.3.0", "", { "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA=="],
 
     "jayson/@types/ws/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "jito-ts/@solana/web3.js/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
     "qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 

--- a/patches/@orca-so%2Fcommon-sdk@0.7.0.patch
+++ b/patches/@orca-so%2Fcommon-sdk@0.7.0.patch
@@ -10,7 +10,7 @@ index a1915973084b9f5c69ddad9922b8b5c8c63b46bf..e634274d137a19cb9028afa139bb36d3
  const spl_token_1 = require("@solana/spl-token");
  const web3_js_1 = require("@solana/web3.js");
 -const sha256_1 = require("@noble/hashes/sha256");
-+const sha256_1 = require("@noble/hashes/sha2");
++const sha256_1 = require("@noble/hashes/sha2.js");
  const tiny_invariant_1 = __importDefault(require("tiny-invariant"));
  const math_1 = require("../math");
  const web3_1 = require("../web3");

--- a/src/runtime/research/readiness.ts
+++ b/src/runtime/research/readiness.ts
@@ -84,7 +84,8 @@ export type RuntimeResearchVenueTxSmokeIntentFamily =
   | "spot_swap"
   | "conditional_spot_order"
   | "clob_order"
-  | "prediction_order";
+  | "prediction_order"
+  | "flash_atomic";
 
 type ReadinessContext = {
   subjectKind: "venue" | "asset";
@@ -373,7 +374,8 @@ export function parseRuntimeResearchReadinessCanaryRequest(
     smokeIntentFamilyValue !== "spot_swap" &&
     smokeIntentFamilyValue !== "conditional_spot_order" &&
     smokeIntentFamilyValue !== "clob_order" &&
-    smokeIntentFamilyValue !== "prediction_order"
+    smokeIntentFamilyValue !== "prediction_order" &&
+    smokeIntentFamilyValue !== "flash_atomic"
   ) {
     throw new Error(
       "invalid-runtime-research-readiness-canary-smoke-intent-family",
@@ -407,7 +409,8 @@ export function parseRuntimeResearchReadinessCanaryRequest(
     smokeIntentFamilyValue === "spot_swap" ||
     smokeIntentFamilyValue === "conditional_spot_order" ||
     smokeIntentFamilyValue === "clob_order" ||
-    smokeIntentFamilyValue === "prediction_order"
+    smokeIntentFamilyValue === "prediction_order" ||
+    smokeIntentFamilyValue === "flash_atomic"
       ? smokeIntentFamilyValue
       : undefined;
   const smokeOrderSide =

--- a/tests/unit/portal_runtime_operator_route.test.ts
+++ b/tests/unit/portal_runtime_operator_route.test.ts
@@ -840,6 +840,87 @@ describe("portal runtime operator route", () => {
     });
   });
 
+  test("forwards flash venue tx smoke actions", async () => {
+    process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
+    process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";
+    process.env.RUNTIME_OPERATOR_USER_ALLOWLIST = "u_1";
+
+    let capturedBody = "";
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url = String(input);
+      if (url.endsWith("/api/me")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            user: { id: "u_1", email: "operator@example.com" },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (url.endsWith("/api/admin/ops/runtime/research/readiness/smoke")) {
+        capturedBody = String(init?.body ?? "");
+        return new Response(
+          JSON.stringify({ ok: true, run: { runId: "smoke_flash" } }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const response = await POST(
+      new Request("https://www.trader-ralph.com/api/runtime/operator", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer user-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          action: "run_venue_tx_smoke",
+          subjectKind: "venue",
+          subjectKey: "flash_liquidity",
+          venueKey: "flash_liquidity",
+          assetKey: "USDC",
+          pairSymbol: "USDC/USDC",
+          targetNotionalUsd: "1.00",
+          smokeIntentFamily: "flash_atomic",
+          tightenOnFailure: true,
+          failureControlMode: "disable_live",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(JSON.parse(capturedBody)).toMatchObject({
+      subjectKind: "venue",
+      subjectKey: "flash_liquidity",
+      venueKey: "flash_liquidity",
+      assetKey: "USDC",
+      pairSymbol: "USDC/USDC",
+      targetNotionalUsd: "1.00",
+      requestedBy: "operator@example.com",
+      triggerSource: "manual",
+      proofMode: "venue_tx_smoke",
+      smokeIntentFamily: "flash_atomic",
+      tightenOnFailure: true,
+      failureControlMode: "disable_live",
+    });
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      run: {
+        runId: "smoke_flash",
+      },
+    });
+  });
+
   test("forwards prediction venue smoke metadata", async () => {
     process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
     process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";

--- a/tests/unit/worker_execution_flash_atomic.test.ts
+++ b/tests/unit/worker_execution_flash_atomic.test.ts
@@ -30,6 +30,19 @@ function buildIntent() {
   };
 }
 
+function buildLiveIntent() {
+  return {
+    ...buildIntent(),
+    borrowLegs: [
+      {
+        provider: "marginfi",
+        mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        amountAtomic: "1000000",
+      },
+    ],
+  };
+}
+
 describe("worker flash atomic execution adapter", () => {
   test("returns dry_run for bounded flash-atomic plans", async () => {
     const result = await executeFlashAtomicIntent({
@@ -97,5 +110,105 @@ describe("worker flash atomic execution adapter", () => {
         log: () => {},
       }),
     ).rejects.toThrow(/flash-liquidity-live-mode-not-supported/);
+  });
+
+  test("allows bounded live smoke through the readiness bypass", async () => {
+    let sendCount = 0;
+    const result = await executeFlashAtomicIntent(
+      {
+        env: {} as Env,
+        runtimeMode: "live",
+        experimentalLiveModeBypass: "venue_tx_smoke",
+        subjectControlBypassReason: "strategy_lab_readiness_canary",
+        policy: normalizePolicy({}),
+        rpc: {
+          simulateTransactionBase64: async () => ({
+            err: null,
+            unitsConsumed: 321_000,
+          }),
+          sendTransactionBase64: async () =>
+            ++sendCount === 1 ? "sig-setup" : "sig-live",
+          confirmSignature: async () => ({
+            ok: true,
+            status: "confirmed",
+          }),
+        } as never,
+        jupiter: {} as never,
+        intent: buildLiveIntent(),
+        privyWalletId: "privy-wallet-1",
+        execution: {
+          params: {
+            lane: "safe",
+          },
+        },
+        log: () => {},
+      },
+      {
+        resolveFlashLiquidityLiveAccount: async () => ({
+          provider: "marginfi",
+          bankAddress: "bank-1",
+          bankMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          tokenSymbol: "USDC",
+          borrowAmountAtomic: "1000000",
+          borrowAmountUi: 1,
+          marginfiAccountAddress: "marginfi-account-1",
+          setup: {
+            unsignedTransactionBase64: "setup-base64",
+            lastValidBlockHeight: 100,
+          },
+        }),
+        buildFlashLiquidityLiveTransactionPlan: async () => ({
+          provider: "marginfi",
+          bankAddress: "bank-1",
+          bankMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          tokenSymbol: "USDC",
+          borrowAmountAtomic: "1000000",
+          borrowAmountUi: 1,
+          referenceId: "arb:sol-usdc-jupiter-raydium",
+          marginfiAccountAddress: "marginfi-account-1",
+          unsignedTransactionBase64: "flash-base64",
+          lastValidBlockHeight: 101,
+          addressLookupTableAddresses: ["lut-1"],
+        }),
+        readFlashLiquidityLiveAccountState: async () => ({
+          provider: "marginfi",
+          marginfiAccountAddress: "marginfi-account-1",
+          activeBalanceCount: 0,
+          activeBankAddresses: [],
+        }),
+        signTransactionWithPrivyById: async (_env, _walletId, unsignedTx) =>
+          `signed:${unsignedTx}`,
+        evaluateSafeLaneTransaction: () => ({
+          ok: true as const,
+          profile: "safe" as const,
+          limits: {
+            maxTxBytes: 1400,
+            maxInstructionCount: 24,
+            maxAccountKeyCount: 64,
+            maxComputeUnitLimit: 1_400_000,
+            maxEstimatedFeeLamports: 5_000_000,
+          },
+        }),
+      },
+    );
+
+    expect(result.status).toBe("confirmed");
+    expect(result.signature).toBe("sig-live");
+    expect(result.executionMeta?.route).toBe("flash_liquidity");
+    expect(result.executionMeta?.classification).toBe("confirmed");
+    expect(result.executionMeta?.lifecycle?.notes).toContain(
+      "setup-signature:sig-setup",
+    );
+    expect(result.executionMeta?.referencePrice?.snapshot).toMatchObject({
+      liveProvider: "marginfi",
+      marginfiAccountAddress: "marginfi-account-1",
+      activeBalanceCount: 0,
+    });
+    expect(result.executionMeta?.composedPlan).toMatchObject({
+      mode: "flash_atomic",
+      addressLookupTableCount: 1,
+      addressLookupTableAddresses: ["lut-1"],
+      simulationUnitsConsumed: 321_000,
+    });
   });
 });

--- a/tests/unit/worker_execution_router.test.ts
+++ b/tests/unit/worker_execution_router.test.ts
@@ -246,6 +246,46 @@ describe("worker execution router", () => {
     expect(result.executionMeta?.route).toBe("flash_liquidity");
   });
 
+  test("allows flash-liquidity live venue smoke only through the bounded readiness bypass", async () => {
+    const { env, sqlite } = await createLiveRouterEnv();
+    try {
+      const result = await executeIntentViaRouter({
+        env,
+        venueKey: "flash_liquidity",
+        runtimeMode: "live",
+        experimentalLiveModeBypass: "venue_tx_smoke",
+        requireVenueRouting: true,
+        subjectControlBypassReason: "strategy_lab_readiness_canary",
+        execution: { adapter: "flash_liquidity" },
+        policy: normalizePolicy({ dryRun: true }),
+        rpc: {} as never,
+        jupiter: {} as never,
+        intent: {
+          family: "flash_atomic",
+          wallet: "11111111111111111111111111111111",
+          venueKey: "flash_liquidity",
+          marketType: "spot",
+          instrumentId: "USDC/USDC",
+          referenceId: "flash-smoke",
+          settlementMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          borrowLegs: [
+            {
+              provider: "marginfi",
+              mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+              amountAtomic: "1000000",
+            },
+          ],
+        },
+        log: () => {},
+      });
+
+      expect(result.status).toBe("dry_run");
+      expect(result.executionMeta?.route).toBe("flash_liquidity");
+    } finally {
+      sqlite.close();
+    }
+  });
+
   test("custom execution adapters can be registered for new intent families", async () => {
     registerExecutionAdapter(
       "phoenix_orderbook",

--- a/tests/unit/worker_runtime_research_readiness_route.test.ts
+++ b/tests/unit/worker_runtime_research_readiness_route.test.ts
@@ -681,6 +681,55 @@ describe("worker runtime research readiness routes", () => {
     }
   });
 
+  test("runs a flash-liquidity venue tx smoke and records the flash intent", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/research/readiness/smoke",
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              subjectKind: "venue",
+              subjectKey: "flash_liquidity",
+              requestedBy: "codex",
+              venueKey: "flash_liquidity",
+              assetKey: "USDC",
+              pairSymbol: "USDC/USDC",
+              smokeIntentFamily: "flash_atomic",
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(200);
+      const payload = (await response.json()) as {
+        ok: boolean;
+        status: string;
+        markdown: string;
+        run: {
+          assetKey: string;
+          metadata?: Record<string, unknown>;
+          evidenceRefs: Array<{ kind: string }>;
+        };
+      };
+      expect(payload.ok).toBe(true);
+      expect(payload.status).toBe("success");
+      expect(payload.run.assetKey).toBe("USDC");
+      expect(payload.markdown).toContain("Smoke intent: flash_atomic");
+      expect(payload.run.metadata?.smokeIntentFamily).toBe("flash_atomic");
+      expect(payload.run.evidenceRefs[0]?.kind).toBe("live_canary");
+    } finally {
+      sqlite.close();
+    }
+  });
+
   test("blocks conditional venue smoke on a live adapter that does not support trigger intents", async () => {
     const { env, sqlite } = createOpsEnv();
     try {


### PR DESCRIPTION
## Summary\n- add a marginfi-backed live flash transaction module for bounded flash-liquidity smoke runs\n- extend readiness smoke routing, operator forwarding, and router bypasses to support the flash_atomic intent family\n- add focused tests covering flash live smoke routing and operator/request contract flow\n\n## Validation\n- bun run typecheck\n- bun run lint\n- bun test tests/unit/worker_execution_flash_atomic.test.ts tests/unit/worker_execution_router.test.ts tests/unit/worker_runtime_research_readiness_route.test.ts tests/unit/portal_runtime_operator_route.test.ts\n\n## Remaining blocker\n- Real mainnet flash proof is still blocked on credentialed access to a worker with production secrets and readiness-smoke auth. Code is ready; the bounded real transaction has not been executed yet.\n\nRefs #421