### PR TITLE
[Phase SD2] Build composite strategy desk shadow/paper runner

### DIFF
--- a/apps/worker/migrations/0032_strategy_desk_leg_intent.sql
+++ b/apps/worker/migrations/0032_strategy_desk_leg_intent.sql
@@ -1,0 +1,2 @@
+ALTER TABLE strategy_desk_scenario_legs
+ADD COLUMN intent_json TEXT;

--- a/apps/worker/src/dflow.ts
+++ b/apps/worker/src/dflow.ts
@@ -518,7 +518,7 @@ export class DFlowClient {
   private readonly apiKey: string | null;
 
   constructor(input: Env | DFlowClientConfig, deps?: DFlowClientDeps) {
-    this.fetchImpl = deps?.fetch ?? fetch;
+    this.fetchImpl = deps?.fetch ?? ((resource, init) => fetch(resource, init));
     const config: DFlowClientConfig =
       "metadataApiBase" in input
         ? input

--- a/apps/worker/src/drift.ts
+++ b/apps/worker/src/drift.ts
@@ -260,7 +260,7 @@ export class DriftClient {
         },
     deps?: DriftClientDeps,
   ) {
-    this.fetchImpl = deps?.fetch ?? fetch;
+    this.fetchImpl = deps?.fetch ?? ((resource, init) => fetch(resource, init));
     this.dataApiBase =
       readTrimmedString(
         "DRIFT_DATA_API_BASE" in input

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -621,9 +621,7 @@ function parseAdminEntityActionPath(
   }
 }
 
-function parseRuntimeStrategyDeskExecuteRequest(
-  payload: unknown,
-): {
+function parseRuntimeStrategyDeskExecuteRequest(payload: unknown): {
   runKind: "shadow" | "paper";
   requestedBy: string;
   walletAddress: string;
@@ -651,7 +649,9 @@ function parseRuntimeStrategyDeskExecuteRequest(
   const reportId = String(record.reportId ?? "").trim();
   const maxRetriesPerLeg = Number(record.maxRetriesPerLeg);
   const trigger =
-    record.trigger && typeof record.trigger === "object" && !Array.isArray(record.trigger)
+    record.trigger &&
+    typeof record.trigger === "object" &&
+    !Array.isArray(record.trigger)
       ? (record.trigger as Record<string, unknown>)
       : null;
   if (!runKind || !requestedBy || !walletAddress) {

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -231,6 +231,7 @@ import {
   upsertRuntimeStrategyDeskScenarioRunWorkflow,
   upsertRuntimeStrategyDeskScenarioWorkflow,
 } from "./runtime_strategy_desk";
+import { executeRuntimeStrategyDeskScenarioWorkflow } from "./runtime_strategy_desk_runner";
 import { SolanaRpc } from "./solana_rpc";
 import type { Env, ExecutionConfig } from "./types";
 import type { UserRow } from "./users_db";
@@ -601,6 +602,85 @@ function parseAdminEntityDetailPath(
   } catch {
     return null;
   }
+}
+
+function parseAdminEntityActionPath(
+  pathname: string,
+  prefix: string,
+  suffix: string,
+): string | null {
+  if (!pathname.startsWith(prefix) || !pathname.endsWith(suffix)) {
+    return null;
+  }
+  const entityId = pathname.slice(prefix.length, -suffix.length);
+  if (!entityId || entityId.includes("/")) return null;
+  try {
+    return decodeURIComponent(entityId);
+  } catch {
+    return null;
+  }
+}
+
+function parseRuntimeStrategyDeskExecuteRequest(
+  payload: unknown,
+): {
+  runKind: "shadow" | "paper";
+  requestedBy: string;
+  walletAddress: string;
+  privyWalletId?: string;
+  scenarioRunId?: string;
+  reportId?: string;
+  maxRetriesPerLeg?: number;
+  trigger?: {
+    reason?: string;
+    featureSnapshotId?: string;
+  };
+} {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("runtime-strategy-desk-execute-invalid-body");
+  }
+  const record = payload as Record<string, unknown>;
+  const runKind =
+    record.runKind === "shadow" || record.runKind === "paper"
+      ? record.runKind
+      : null;
+  const requestedBy = String(record.requestedBy ?? "").trim();
+  const walletAddress = String(record.walletAddress ?? "").trim();
+  const privyWalletId = String(record.privyWalletId ?? "").trim();
+  const scenarioRunId = String(record.scenarioRunId ?? "").trim();
+  const reportId = String(record.reportId ?? "").trim();
+  const maxRetriesPerLeg = Number(record.maxRetriesPerLeg);
+  const trigger =
+    record.trigger && typeof record.trigger === "object" && !Array.isArray(record.trigger)
+      ? (record.trigger as Record<string, unknown>)
+      : null;
+  if (!runKind || !requestedBy || !walletAddress) {
+    throw new Error("runtime-strategy-desk-execute-invalid-body");
+  }
+  return {
+    runKind,
+    requestedBy,
+    walletAddress,
+    ...(privyWalletId ? { privyWalletId } : {}),
+    ...(scenarioRunId ? { scenarioRunId } : {}),
+    ...(reportId ? { reportId } : {}),
+    ...(Number.isFinite(maxRetriesPerLeg)
+      ? { maxRetriesPerLeg: Math.max(0, Math.trunc(maxRetriesPerLeg)) }
+      : {}),
+    ...(trigger
+      ? {
+          trigger: {
+            ...(typeof trigger.reason === "string" && trigger.reason.trim()
+              ? { reason: trigger.reason.trim() }
+              : {}),
+            ...(typeof trigger.featureSnapshotId === "string" &&
+            trigger.featureSnapshotId.trim()
+              ? { featureSnapshotId: trigger.featureSnapshotId.trim() }
+              : {}),
+          },
+        }
+      : {}),
+  };
 }
 
 function newExecutionAttemptId(): string {
@@ -3807,6 +3887,57 @@ const worker = {
                   error instanceof Error
                     ? error.message
                     : "runtime-strategy-desk-scenario-read-failed",
+              },
+              { status: 400 },
+            ),
+            env,
+          );
+        }
+      }
+
+      const strategyDeskExecuteScenarioId =
+        request.method === "POST"
+          ? parseAdminEntityActionPath(
+              url.pathname,
+              "/api/admin/ops/runtime/strategy-desk/scenarios/",
+              "/execute",
+            )
+          : null;
+      if (request.method === "POST" && strategyDeskExecuteScenarioId) {
+        const auth = authorizeAdminRoute(request, env);
+        if (!auth.ok) {
+          return withCors(
+            json({ ok: false, error: auth.error }, { status: auth.status }),
+            env,
+          );
+        }
+        try {
+          const parsed = parseRuntimeStrategyDeskExecuteRequest(
+            await request.json(),
+          );
+          const result = await executeRuntimeStrategyDeskScenarioWorkflow({
+            env,
+            scenarioId: strategyDeskExecuteScenarioId,
+            ...parsed,
+          });
+          return withCors(
+            json({
+              ok: true,
+              scenario: result.scenario,
+              run: result.run,
+              report: result.report,
+            }),
+            env,
+          );
+        } catch (error) {
+          return withCors(
+            json(
+              {
+                ok: false,
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "runtime-strategy-desk-scenario-execute-failed",
               },
               { status: 400 },
             ),

--- a/apps/worker/src/runtime_strategy_desk_runner.ts
+++ b/apps/worker/src/runtime_strategy_desk_runner.ts
@@ -1,0 +1,1224 @@
+import {
+  requireRuntimeVenueCapability,
+  runtimeVenueSupportsAdapter,
+  runtimeVenueSupportsIntentFamily,
+  runtimeVenueSupportsMode,
+} from "../../../src/runtime/venues/catalog.js";
+import type {
+  RuntimeMode,
+  RuntimeStrategyDeskRunKind,
+  RuntimeStrategyDeskScenarioLeg,
+  RuntimeStrategyDeskScenarioManifest,
+  RuntimeStrategyDeskScenarioReport,
+  RuntimeStrategyDeskScenarioRun,
+} from "./runtime_contracts";
+import { DFlowClient } from "./dflow";
+import { DriftClient } from "./drift";
+import {
+  SUPPORTED_TRADING_MINTS,
+  TRADING_TOKEN_BY_MINT,
+  USDC_MINT,
+} from "./defaults";
+import {
+  executeIntentViaRouter,
+  type ExecutionAdapterRegistration,
+  resolveExecutionAdapterRegistration,
+} from "./execution/router";
+import { quoteSpotSwap, resolveSpotVenueExecutionAdapter } from "./execution/spot_venues";
+import type {
+  ExecuteSwapResult,
+  ExecutionRouterIntent,
+  NonSwapExecutionIntent,
+  SpotSwapExecutionIntent,
+} from "./execution/types";
+import { JupiterClient } from "./jupiter";
+import { MangoClient } from "./mango";
+import { OpenBookClient } from "./openbook";
+import { OrcaClient } from "./orca";
+import { normalizePolicy, enforcePolicy } from "./policy";
+import { RaydiumClient } from "./raydium";
+import { SolanaRpc } from "./solana_rpc";
+import {
+  getRuntimeStrategyDeskScenarioWorkflow,
+  upsertRuntimeStrategyDeskScenarioReportWorkflow,
+  upsertRuntimeStrategyDeskScenarioRunWorkflow,
+} from "./runtime_strategy_desk";
+import type { Env } from "./types";
+
+type StrategyDeskExecuteRunKind = Extract<RuntimeStrategyDeskRunKind, "shadow" | "paper">;
+
+export type RuntimeStrategyDeskExecuteWorkflowInput = {
+  env: Env;
+  scenarioId: string;
+  runKind: StrategyDeskExecuteRunKind;
+  requestedBy: string;
+  walletAddress: string;
+  privyWalletId?: string;
+  scenarioRunId?: string;
+  reportId?: string;
+  trigger?: Partial<RuntimeStrategyDeskScenarioRun["trigger"]>;
+  maxRetriesPerLeg?: number;
+};
+
+type StrategyDeskExecutionDeps = {
+  now?: () => string;
+  createId?: (prefix: string) => string;
+  createRpc?: (env: Env) => SolanaRpc;
+  createJupiterClient?: (env: Env) => JupiterClient;
+  createDFlowClient?: (env: Env) => DFlowClient;
+  createDriftClient?: (env: Env) => DriftClient;
+  createRaydiumClient?: () => RaydiumClient;
+  createOrcaClient?: (env: Env) => OrcaClient;
+  createMangoClient?: () => MangoClient;
+  createOpenBookClient?: (env: Env) => OpenBookClient;
+  quoteSpotSwap?: typeof quoteSpotSwap;
+  executeIntentViaRouter?: typeof executeIntentViaRouter;
+};
+
+export type RuntimeStrategyDeskExecuteWorkflowResult = {
+  scenario: RuntimeStrategyDeskScenarioManifest;
+  run: RuntimeStrategyDeskScenarioRun;
+  report: RuntimeStrategyDeskScenarioReport;
+};
+
+type StrategyDeskRunnerContext = {
+  rpc: SolanaRpc;
+  jupiter: JupiterClient;
+  dflow: DFlowClient;
+  drift: DriftClient;
+  raydium: RaydiumClient;
+  orca: OrcaClient;
+  mango: MangoClient;
+  openbook: OpenBookClient;
+};
+
+type ResolvedStrategyDeskLeg = {
+  leg: RuntimeStrategyDeskScenarioLeg;
+  capability: ReturnType<typeof requireRuntimeVenueCapability>;
+  adapter: ExecutionAdapterRegistration;
+  policy: ReturnType<typeof normalizePolicy>;
+  intent: ExecutionRouterIntent;
+  quoteResponse?: Parameters<typeof enforcePolicy>[1];
+};
+
+type StrategyDeskRunArtifact = {
+  legId: string;
+  attemptCount: number;
+  adapterKey: string;
+  venueKey: string;
+  requestRef: string;
+  status: ExecuteSwapResult["status"] | "blocked" | "skipped";
+  signature: string | null;
+  quote?: {
+    inputMint: string;
+    outputMint: string;
+    inAmount: string;
+    outAmount: string;
+  };
+  executionMeta?: Record<string, unknown> | null;
+  error?: string;
+  errorCode?: string;
+};
+
+const STABLE_MINTS = new Set(
+  ["USDC", "USDT", "PYUSD", "USD1", "USDG"]
+    .map((symbol) => Object.values(TRADING_TOKEN_BY_MINT).find((token) => token.symbol === symbol)?.mint)
+    .filter((value): value is string => Boolean(value)),
+);
+
+function nowIso(deps?: StrategyDeskExecutionDeps): string {
+  return deps?.now ? deps.now() : new Date().toISOString();
+}
+
+function createDeskId(prefix: string, deps?: StrategyDeskExecutionDeps): string {
+  if (deps?.createId) return deps.createId(prefix);
+  return `${prefix}_${crypto.randomUUID().replace(/-/g, "")}`;
+}
+
+function decimalToAtomic(value: string, decimals: number): string {
+  const raw = String(value ?? "").trim();
+  const match = raw.match(/^([0-9]+)(?:\.([0-9]+))?$/);
+  if (!match) {
+    throw new Error(`runtime-strategy-desk-invalid-decimal:${value}`);
+  }
+  const whole = match[1] ?? "0";
+  const fraction = (match[2] ?? "").padEnd(decimals, "0").slice(0, decimals);
+  return `${BigInt(whole) * 10n ** BigInt(decimals) + BigInt(fraction || "0")}`;
+}
+
+function stableMintDecimals(mint: string): number | null {
+  if (!STABLE_MINTS.has(mint)) return null;
+  return TRADING_TOKEN_BY_MINT[mint]?.decimals ?? 6;
+}
+
+function usdToStableAtomic(usd: string, mint: string): string {
+  const decimals = stableMintDecimals(mint);
+  if (decimals === null) {
+    throw new Error(
+      `runtime-strategy-desk-stable-mint-required:${mint}`,
+    );
+  }
+  return decimalToAtomic(usd, decimals);
+}
+
+function readPositiveInt(value: unknown, fallback: number): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(0, Math.min(2, Math.floor(parsed)));
+}
+
+function stageForRunKind(
+  runKind: StrategyDeskExecuteRunKind,
+): RuntimeStrategyDeskScenarioReport["stage"] {
+  return runKind;
+}
+
+function scenarioStateAllowsRun(
+  scenario: RuntimeStrategyDeskScenarioManifest,
+  runKind: StrategyDeskExecuteRunKind,
+): boolean {
+  if (runKind === "shadow") {
+    return (
+      scenario.state === "shadow_ready" ||
+      scenario.state === "paper_ready" ||
+      scenario.state === "operator_review" ||
+      scenario.state === "execution_ready" ||
+      scenario.state === "execution_bound"
+    );
+  }
+  return (
+    scenario.state === "paper_ready" ||
+    scenario.state === "operator_review" ||
+    scenario.state === "execution_ready" ||
+    scenario.state === "execution_bound"
+  );
+}
+
+function isExecutionSuccessStatus(
+  status: ExecuteSwapResult["status"],
+): boolean {
+  return (
+    status === "dry_run" ||
+    status === "simulated" ||
+    status === "processed" ||
+    status === "confirmed" ||
+    status === "finalized"
+  );
+}
+
+function readExecutionErrorCode(err: unknown): string | null {
+  if (!err || typeof err !== "object" || Array.isArray(err)) return null;
+  const code = String((err as Record<string, unknown>).code ?? "").trim();
+  return code || null;
+}
+
+function readExecutionError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (!err || typeof err !== "object") return String(err ?? "execution-failed");
+  const code = String((err as Record<string, unknown>).code ?? "").trim();
+  const reason = String((err as Record<string, unknown>).reason ?? "").trim();
+  if (code && reason) return `${code}:${reason}`;
+  if (reason) return reason;
+  if (code) return code;
+  return JSON.stringify(err);
+}
+
+function summarizeExecutionMeta(
+  value: ExecuteSwapResult["executionMeta"],
+): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+}
+
+function topologicalScenarioLegs(
+  scenario: RuntimeStrategyDeskScenarioManifest,
+): RuntimeStrategyDeskScenarioLeg[] {
+  const byId = new Map(scenario.legs.map((leg) => [leg.legId, leg]));
+  const incoming = new Map<string, number>();
+  const dependents = new Map<string, string[]>();
+  const originalOrder = new Map(scenario.legs.map((leg, index) => [leg.legId, index]));
+
+  for (const leg of scenario.legs) {
+    incoming.set(leg.legId, 0);
+    dependents.set(leg.legId, []);
+  }
+
+  for (const leg of scenario.legs) {
+    for (const dependency of leg.dependencies ?? []) {
+      if (!byId.has(dependency)) {
+        throw new Error(
+          `runtime-strategy-desk-leg-dependency-unknown:${scenario.scenarioId}:${leg.legId}:${dependency}`,
+        );
+      }
+      incoming.set(leg.legId, (incoming.get(leg.legId) ?? 0) + 1);
+      dependents.get(dependency)?.push(leg.legId);
+    }
+  }
+
+  const ready = scenario.legs
+    .filter((leg) => (incoming.get(leg.legId) ?? 0) === 0)
+    .sort((left, right) => (originalOrder.get(left.legId) ?? 0) - (originalOrder.get(right.legId) ?? 0));
+
+  const ordered: RuntimeStrategyDeskScenarioLeg[] = [];
+  while (ready.length > 0) {
+    const next = ready.shift();
+    if (!next) break;
+    ordered.push(next);
+    for (const dependentId of dependents.get(next.legId) ?? []) {
+      const count = (incoming.get(dependentId) ?? 1) - 1;
+      incoming.set(dependentId, count);
+      if (count === 0) {
+        const dependent = byId.get(dependentId);
+        if (dependent) {
+          ready.push(dependent);
+          ready.sort(
+            (left, right) =>
+              (originalOrder.get(left.legId) ?? 0) -
+              (originalOrder.get(right.legId) ?? 0),
+          );
+        }
+      }
+    }
+  }
+
+  if (ordered.length !== scenario.legs.length) {
+    throw new Error(
+      `runtime-strategy-desk-leg-dependency-cycle:${scenario.scenarioId}`,
+    );
+  }
+  return ordered;
+}
+
+function defaultTrigger(
+  now: string,
+  override?: Partial<RuntimeStrategyDeskScenarioRun["trigger"]>,
+): RuntimeStrategyDeskScenarioRun["trigger"] {
+  return {
+    kind: "operator",
+    source: "strategy_desk_runner",
+    observedAt: now,
+    ...(override?.reason ? { reason: override.reason } : {}),
+    ...(override?.featureSnapshotId
+      ? { featureSnapshotId: override.featureSnapshotId }
+      : {}),
+  };
+}
+
+function defaultLegRuns(
+  scenario: RuntimeStrategyDeskScenarioManifest,
+  stage: RuntimeStrategyDeskScenarioReport["stage"],
+): RuntimeStrategyDeskScenarioRun["legRuns"] {
+  return scenario.legs.map((leg) => ({
+    legId: leg.legId,
+    stage,
+    state: "pending" as const,
+  }));
+}
+
+function buildRunnerContext(
+  env: Env,
+  deps?: StrategyDeskExecutionDeps,
+): StrategyDeskRunnerContext {
+  const rpcEndpoint =
+    String(env.RPC_ENDPOINT ?? "").trim() ||
+    "https://api.mainnet-beta.solana.com";
+  const rpc =
+    deps?.createRpc?.(env) ??
+    new SolanaRpc(rpcEndpoint);
+  const jupiter =
+    deps?.createJupiterClient?.(env) ??
+    new JupiterClient(
+      String(env.JUPITER_BASE_URL ?? "").trim() || "https://lite-api.jup.ag",
+      env.JUPITER_API_KEY,
+    );
+  const dflow = deps?.createDFlowClient?.(env) ?? new DFlowClient(env);
+  const drift = deps?.createDriftClient?.(env) ?? new DriftClient(env);
+  const raydium = deps?.createRaydiumClient?.() ?? new RaydiumClient();
+  const orca =
+    deps?.createOrcaClient?.(env) ??
+    new OrcaClient(
+      rpcEndpoint,
+      String(env.ORCA_API_BASE_URL ?? "").trim() || "https://api.orca.so",
+    );
+  const mango = deps?.createMangoClient?.() ?? new MangoClient();
+  const openbook =
+    deps?.createOpenBookClient?.(env) ??
+    new OpenBookClient(rpcEndpoint);
+  return {
+    rpc,
+    jupiter,
+    dflow,
+    drift,
+    raydium,
+    orca,
+    mango,
+    openbook,
+  };
+}
+
+function defaultAdapterKey(
+  leg: RuntimeStrategyDeskScenarioLeg,
+): string {
+  if (leg.intentFamily === "spot_swap") {
+    return resolveSpotVenueExecutionAdapter({
+      venueKey: leg.venueKey,
+      runtimeMode: "paper",
+      defaultAdapter: "jupiter",
+    });
+  }
+  if (leg.intentFamily === "perp_order" && leg.venueKey === "drift") {
+    return "drift";
+  }
+  if (leg.intentFamily === "prediction_order" && leg.venueKey === "dflow") {
+    return "dflow";
+  }
+  if (leg.intentFamily === "flash_atomic") {
+    return "flash_liquidity";
+  }
+  if (leg.intentFamily === "clob_order" && leg.venueKey === "openbook") {
+    return "openbook_v2";
+  }
+  return leg.venueKey;
+}
+
+function resolveLegAdapter(
+  leg: RuntimeStrategyDeskScenarioLeg,
+): ExecutionAdapterRegistration {
+  const adapterKey = leg.intent?.adapterKey ?? defaultAdapterKey(leg);
+  const registration = resolveExecutionAdapterRegistration(adapterKey);
+  if (!registration) {
+    throw new Error(
+      `runtime-strategy-desk-adapter-not-registered:${leg.legId}:${adapterKey}`,
+    );
+  }
+  return registration;
+}
+
+function buildLegPolicy(
+  leg: RuntimeStrategyDeskScenarioLeg,
+  maxTradeAmountAtomic: string,
+): ReturnType<typeof normalizePolicy> {
+  return normalizePolicy({
+    allowedMints: SUPPORTED_TRADING_MINTS,
+    slippageBps: leg.sizing.maxSlippageBps ?? 50,
+    maxPriceImpactPct: 0.05,
+    maxTradeAmountAtomic,
+    minSolReserveLamports: "50000000",
+    simulateOnly: true,
+    dryRun: false,
+    commitment: "confirmed",
+  });
+}
+
+async function buildSpotLeg(
+  input: {
+    env: Env;
+    leg: RuntimeStrategyDeskScenarioLeg;
+    runKind: StrategyDeskExecuteRunKind;
+    walletAddress: string;
+    context: StrategyDeskRunnerContext;
+    deps?: StrategyDeskExecutionDeps;
+  },
+): Promise<ResolvedStrategyDeskLeg> {
+  const { leg, context } = input;
+  if (!leg.pair) {
+    throw new Error(`runtime-strategy-desk-pair-required:${leg.legId}`);
+  }
+  const side = String(leg.intent?.side ?? "buy").trim().toLowerCase();
+  if (side !== "buy" && side !== "sell") {
+    throw new Error(`runtime-strategy-desk-spot-side-invalid:${leg.legId}`);
+  }
+
+  const inputMint = side === "sell" ? leg.pair.baseMint : leg.pair.quoteMint;
+  const outputMint = side === "sell" ? leg.pair.quoteMint : leg.pair.baseMint;
+  const amountAtomic =
+    leg.intent?.quantityAtomic ??
+    (side === "buy"
+      ? usdToStableAtomic(leg.sizing.targetNotionalUsd, leg.pair.quoteMint)
+      : null);
+  if (!amountAtomic) {
+    throw new Error(
+      `runtime-strategy-desk-spot-quantity-required:${leg.legId}`,
+    );
+  }
+
+  const policy = buildLegPolicy(leg, amountAtomic);
+  const quote = await (input.deps?.quoteSpotSwap ?? quoteSpotSwap)({
+    venueKey: leg.venueKey,
+    inputMint,
+    outputMint,
+    amountAtomic,
+    slippageBps: policy.slippageBps,
+    jupiter: context.jupiter,
+    orca: context.orca,
+    raydium: context.raydium,
+  });
+  enforcePolicy(policy, quote.quoteResponse);
+
+  return {
+    leg,
+    capability: requireRuntimeVenueCapability(leg.venueKey),
+    adapter: resolveLegAdapter(leg),
+    policy,
+    intent: {
+      family: "spot_swap",
+      wallet: input.walletAddress,
+      venueKey: leg.venueKey,
+      marketType: "spot",
+      inputMint,
+      outputMint,
+      amountAtomic,
+      slippageBps: policy.slippageBps,
+    } satisfies SpotSwapExecutionIntent,
+    quoteResponse: quote.quoteResponse,
+  };
+}
+
+function buildNonSpotIntent(
+  leg: RuntimeStrategyDeskScenarioLeg,
+): NonSwapExecutionIntent {
+  const side = String(leg.intent?.side ?? "").trim();
+
+  if (leg.intentFamily === "prediction_order") {
+    const instrumentId = String(leg.instrumentId ?? "").trim();
+    if (!instrumentId) {
+      throw new Error(
+        `runtime-strategy-desk-instrument-required:${leg.legId}`,
+      );
+    }
+    const outcomeId = String(leg.intent?.outcomeId ?? "").trim();
+    if (!outcomeId) {
+      throw new Error(
+        `runtime-strategy-desk-prediction-outcome-required:${leg.legId}`,
+      );
+    }
+    if (
+      side !== "buy_yes" &&
+      side !== "buy_no" &&
+      side !== "sell_yes" &&
+      side !== "sell_no"
+    ) {
+      throw new Error(
+        `runtime-strategy-desk-prediction-side-invalid:${leg.legId}`,
+      );
+    }
+    return {
+      family: "prediction_order",
+      wallet: "",
+      venueKey: leg.venueKey,
+      marketType: "prediction",
+      instrumentId,
+      outcomeId,
+      side,
+      quantityAtomic:
+        leg.intent?.quantityAtomic ??
+        usdToStableAtomic(leg.sizing.targetNotionalUsd, leg.intent?.settlementMint ?? USDC_MINT),
+      settlementMint: leg.intent?.settlementMint ?? USDC_MINT,
+      params: {
+        quantityMode: "quote",
+        marketNotionalCapUsd: Number(leg.sizing.maxNotionalUsd ?? leg.sizing.targetNotionalUsd),
+        ...(leg.intent?.params ?? {}),
+      },
+    };
+  }
+
+  if (leg.intentFamily === "flash_atomic") {
+    const instrumentId =
+      String(leg.instrumentId ?? "").trim() ||
+      String(leg.pair?.symbol ?? "").trim() ||
+      String(leg.intent?.referenceId ?? "").trim();
+    const referenceId = String(leg.intent?.referenceId ?? "").trim();
+    const settlementMint =
+      leg.intent?.settlementMint ?? leg.pair?.quoteMint ?? USDC_MINT;
+    const borrowLegs =
+      leg.intent?.borrowLegs?.map((borrowLeg) => ({
+        provider: borrowLeg.provider,
+        mint: borrowLeg.mint,
+        amountAtomic:
+          borrowLeg.amountAtomic ??
+          usdToStableAtomic(leg.sizing.targetNotionalUsd, borrowLeg.mint),
+      })) ?? [];
+    if (!referenceId || borrowLegs.length < 1) {
+      throw new Error(
+        `runtime-strategy-desk-flash-borrow-legs-required:${leg.legId}`,
+      );
+    }
+    return {
+      family: "flash_atomic",
+      wallet: "",
+      venueKey: leg.venueKey,
+      marketType: "spot",
+      instrumentId,
+      referenceId,
+      settlementMint,
+      borrowLegs,
+      params: leg.intent?.params ?? null,
+    };
+  }
+
+  if (leg.intentFamily === "perp_order") {
+    const instrumentId = String(leg.instrumentId ?? "").trim();
+    if (!instrumentId) {
+      throw new Error(
+        `runtime-strategy-desk-instrument-required:${leg.legId}`,
+      );
+    }
+    if (
+      side !== "long" &&
+      side !== "short" &&
+      side !== "close_long" &&
+      side !== "close_short"
+    ) {
+      throw new Error(`runtime-strategy-desk-perp-side-invalid:${leg.legId}`);
+    }
+    if (!leg.intent?.quantityAtomic) {
+      throw new Error(
+        `runtime-strategy-desk-perp-quantity-required:${leg.legId}`,
+      );
+    }
+    return {
+      family: "perp_order",
+      wallet: "",
+      venueKey: leg.venueKey,
+      marketType: "perp",
+      instrumentId,
+      side,
+      quantityAtomic: leg.intent.quantityAtomic,
+      collateralAtomic:
+        leg.intent.collateralAtomic ??
+        (leg.sizing.reserveUsd
+          ? usdToStableAtomic(leg.sizing.reserveUsd, USDC_MINT)
+          : undefined),
+      params: leg.intent.params ?? null,
+    };
+  }
+
+  if (leg.intentFamily === "clob_order") {
+    const instrumentId = String(leg.instrumentId ?? "").trim();
+    if (!instrumentId) {
+      throw new Error(
+        `runtime-strategy-desk-instrument-required:${leg.legId}`,
+      );
+    }
+    if (side !== "buy" && side !== "sell") {
+      throw new Error(`runtime-strategy-desk-clob-side-invalid:${leg.legId}`);
+    }
+    if (!leg.intent?.quantityAtomic) {
+      throw new Error(
+        `runtime-strategy-desk-clob-quantity-required:${leg.legId}`,
+      );
+    }
+    return {
+      family: "clob_order",
+      wallet: "",
+      venueKey: leg.venueKey,
+      marketType: leg.marketType === "perp" ? "perp" : "spot",
+      instrumentId,
+      side,
+      quantityAtomic: leg.intent.quantityAtomic,
+      params: leg.intent.params ?? null,
+    };
+  }
+
+  throw new Error(
+    `runtime-strategy-desk-intent-family-unsupported:${leg.legId}:${leg.intentFamily}`,
+  );
+}
+
+function buildNonSpotLeg(
+  input: {
+    leg: RuntimeStrategyDeskScenarioLeg;
+    walletAddress: string;
+  },
+): ResolvedStrategyDeskLeg {
+  const intent = buildNonSpotIntent(input.leg);
+  intent.wallet = input.walletAddress;
+  const maxTradeAmountAtomic =
+    intent.collateralAtomic ??
+    intent.quantityAtomic ??
+    input.leg.intent?.quantityAtomic ??
+    "0";
+  return {
+    leg: input.leg,
+    capability: requireRuntimeVenueCapability(input.leg.venueKey),
+    adapter: resolveLegAdapter(input.leg),
+    policy: buildLegPolicy(input.leg, maxTradeAmountAtomic),
+    intent,
+  };
+}
+
+async function resolveStrategyDeskLeg(
+  input: {
+    env: Env;
+    leg: RuntimeStrategyDeskScenarioLeg;
+    runKind: StrategyDeskExecuteRunKind;
+    walletAddress: string;
+    context: StrategyDeskRunnerContext;
+    deps?: StrategyDeskExecutionDeps;
+  },
+): Promise<ResolvedStrategyDeskLeg> {
+  const mode = input.runKind as RuntimeMode;
+  const capability = requireRuntimeVenueCapability(input.leg.venueKey);
+  if (!runtimeVenueSupportsMode(capability, mode)) {
+    throw new Error(
+      `runtime-strategy-desk-mode-not-supported:${input.leg.legId}:${input.runKind}`,
+    );
+  }
+  if (!runtimeVenueSupportsIntentFamily(capability, input.leg.intentFamily)) {
+    throw new Error(
+      `runtime-strategy-desk-intent-family-not-supported:${input.leg.legId}:${input.leg.intentFamily}`,
+    );
+  }
+  if (!capability.marketTypes.includes(input.leg.marketType)) {
+    throw new Error(
+      `runtime-strategy-desk-market-type-not-supported:${input.leg.legId}:${input.leg.marketType}`,
+    );
+  }
+  if (!input.leg.enabledModes.includes(mode)) {
+    throw new Error(
+      `runtime-strategy-desk-leg-mode-disabled:${input.leg.legId}:${input.runKind}`,
+    );
+  }
+  const adapter = resolveLegAdapter(input.leg);
+  if (!runtimeVenueSupportsAdapter(capability, adapter.adapterKey)) {
+    throw new Error(
+      `runtime-strategy-desk-adapter-not-supported:${input.leg.legId}:${adapter.adapterKey}`,
+    );
+  }
+  if (input.leg.intentFamily === "spot_swap") {
+    const resolved = await buildSpotLeg(input);
+    return { ...resolved, adapter };
+  }
+  const resolved = buildNonSpotLeg({
+    leg: input.leg,
+    walletAddress: input.walletAddress,
+  });
+  return { ...resolved, adapter };
+}
+
+async function executeResolvedLeg(
+  input: {
+    env: Env;
+    resolved: ResolvedStrategyDeskLeg;
+    runKind: StrategyDeskExecuteRunKind;
+    walletAddress: string;
+    privyWalletId?: string;
+    requestRef: string;
+    context: StrategyDeskRunnerContext;
+    deps?: StrategyDeskExecutionDeps;
+  },
+): Promise<ExecuteSwapResult> {
+  const execute = input.deps?.executeIntentViaRouter ?? executeIntentViaRouter;
+  return await execute({
+    env: input.env,
+    venueKey: input.resolved.leg.venueKey,
+    runtimeMode: input.runKind,
+    requireVenueRouting: true,
+    execution: {
+      adapter: input.resolved.adapter.adapterKey,
+      params: {
+        lane: "safe",
+        requireSimulation: true,
+        ...(input.resolved.intent.family === "spot_swap" &&
+        input.resolved.adapter.adapterKey === "jupiter"
+          ? {
+              composePlan: true,
+            }
+          : {}),
+      },
+    },
+    policy: input.resolved.policy,
+    rpc: input.context.rpc,
+    jupiter: input.context.jupiter,
+    dflow: input.context.dflow,
+    drift: input.context.drift,
+    mango: input.context.mango,
+    openbook: input.context.openbook,
+    orca: input.context.orca,
+    raydium: input.context.raydium,
+    ...(input.resolved.intent.family === "spot_swap"
+      ? {
+          quoteResponse: input.resolved.quoteResponse!,
+          userPublicKey: input.walletAddress,
+        }
+      : {}),
+    privyWalletId: input.privyWalletId,
+    intent: input.resolved.intent,
+    log(level, message, meta) {
+      console[level]("runtime.strategy_desk_runner", {
+        scenarioRunId: input.requestRef.split(":")[0],
+        legId: input.resolved.leg.legId,
+        message,
+        ...(meta ?? {}),
+      });
+    },
+  } as Parameters<typeof executeIntentViaRouter>[0]);
+}
+
+function buildLegRun(
+  input: {
+    run: RuntimeStrategyDeskScenarioRun;
+    legId: string;
+    stage: RuntimeStrategyDeskScenarioReport["stage"];
+    state: RuntimeStrategyDeskScenarioRun["legRuns"][number]["state"];
+    requestRef?: string;
+    notes?: string;
+  },
+): RuntimeStrategyDeskScenarioRun["legRuns"][number] {
+  const existing = input.run.legRuns.find((legRun) => legRun.legId === input.legId);
+  return {
+    legId: input.legId,
+    stage: input.stage,
+    state: input.state,
+    ...(input.requestRef ? { requestRef: input.requestRef } : {}),
+    ...(input.notes ?? existing?.notes ? { notes: input.notes ?? existing?.notes } : {}),
+  };
+}
+
+function replaceLegRun(
+  run: RuntimeStrategyDeskScenarioRun,
+  replacement: RuntimeStrategyDeskScenarioRun["legRuns"][number],
+): RuntimeStrategyDeskScenarioRun {
+  return {
+    ...run,
+    legRuns: run.legRuns.map((legRun) =>
+      legRun.legId === replacement.legId ? replacement : legRun,
+    ),
+  };
+}
+
+function buildReport(
+  input: {
+    scenario: RuntimeStrategyDeskScenarioManifest;
+    run: RuntimeStrategyDeskScenarioRun;
+    runKind: StrategyDeskExecuteRunKind;
+    generatedAt: string;
+    reportId: string;
+    artifacts: Record<string, StrategyDeskRunArtifact>;
+  },
+): RuntimeStrategyDeskScenarioReport {
+  const legOutcomes = input.scenario.legs.map((leg) => {
+    const artifact = input.artifacts[leg.legId];
+    if (!artifact || artifact.status === "skipped") {
+      return {
+        legId: leg.legId,
+        status: "not_applicable" as const,
+        evidenceRefs: [
+          {
+            kind: "strategy_desk_leg_receipt",
+            ref: `${input.run.scenarioRunId}:${leg.legId}`,
+            notes: "leg-skipped",
+          },
+        ],
+        notes: ["leg skipped after upstream failure"],
+      };
+    }
+
+    const passed =
+      artifact.status !== "blocked" &&
+      artifact.status !== "skipped" &&
+      artifact.status !== "simulate_error" &&
+      artifact.status !== "error";
+
+    return {
+      legId: leg.legId,
+      status: passed ? ("pass" as const) : ("blocked" as const),
+      evidenceRefs: [
+        {
+          kind: "strategy_desk_leg_receipt",
+          ref: artifact.requestRef,
+          notes: `${artifact.venueKey}:${artifact.status}`,
+        },
+      ],
+      notes: [
+        `adapter:${artifact.adapterKey}`,
+        `status:${artifact.status}`,
+        ...(artifact.error ? [artifact.error] : []),
+      ],
+    };
+  });
+
+  const passedCount = legOutcomes.filter((outcome) => outcome.status === "pass").length;
+  const blockedCount = legOutcomes.filter((outcome) => outcome.status === "blocked").length;
+  const skippedCount = legOutcomes.filter((outcome) => outcome.status === "not_applicable").length;
+  const overallStatus =
+    blockedCount > 0 || input.run.state === "failed" || input.run.state === "rejected"
+      ? ("blocked" as const)
+      : ("pass" as const);
+  const stage = stageForRunKind(input.runKind);
+  return {
+    schemaVersion: "v1",
+    reportId: input.reportId,
+    scenarioId: input.scenario.scenarioId,
+    scenarioRunId: input.run.scenarioRunId,
+    stage,
+    status: overallStatus,
+    summary:
+      overallStatus === "pass"
+        ? `Composite ${input.runKind} scenario completed with ${passedCount}/${input.scenario.legs.length} successful legs.`
+        : `Composite ${input.runKind} scenario failed closed after ${blockedCount} blocked leg(s).`,
+    generatedAt: input.generatedAt,
+    legOutcomes,
+    portfolioSummary: {
+      tradeCount: passedCount,
+      notes: [
+        `passed_legs:${passedCount}`,
+        `blocked_legs:${blockedCount}`,
+        `skipped_legs:${skippedCount}`,
+      ],
+    },
+    evidence: [
+      {
+        stage,
+        summary: `Composite ${input.runKind} run evidence for ${input.scenario.title}.`,
+        evidenceRefs: [
+          {
+            kind: "strategy_desk_run",
+            ref: input.run.scenarioRunId,
+          },
+          ...Object.values(input.artifacts).map((artifact) => ({
+            kind: "strategy_desk_leg_receipt",
+            ref: artifact.requestRef,
+            notes: `${artifact.venueKey}:${artifact.status}`,
+          })),
+        ],
+        latestReportId: input.reportId,
+      },
+    ],
+    checks: [
+      {
+        checkId: "scenario-ready-state",
+        status: "pass",
+        observedValue: input.scenario.state,
+        thresholdValue: input.runKind === "shadow" ? "shadow_ready+" : "paper_ready+",
+        message: "Scenario state allowed composite execution.",
+      },
+      {
+        checkId: "legs-completed",
+        status: overallStatus,
+        observedValue: `${passedCount}/${input.scenario.legs.length}`,
+        thresholdValue: `${input.scenario.legs.length}/${input.scenario.legs.length}`,
+        message:
+          overallStatus === "pass"
+            ? "All legs completed through the Worker router."
+            : "At least one leg failed or was unsupported, so the scenario failed closed.",
+      },
+      {
+        checkId: "router-gates-enforced",
+        status: "pass",
+        message: "Each leg ran through the existing Worker router with venue capability checks enabled.",
+      },
+    ],
+    approvals: [],
+    metadata: {
+      runKind: input.runKind,
+      artifacts: input.artifacts,
+    },
+  };
+}
+
+export async function executeRuntimeStrategyDeskScenarioWorkflow(
+  input: RuntimeStrategyDeskExecuteWorkflowInput,
+  deps?: StrategyDeskExecutionDeps,
+): Promise<RuntimeStrategyDeskExecuteWorkflowResult> {
+  const { scenario } = await getRuntimeStrategyDeskScenarioWorkflow({
+    env: input.env,
+    scenarioId: input.scenarioId,
+  });
+  if (!scenarioStateAllowsRun(scenario, input.runKind)) {
+    throw new Error(
+      `runtime-strategy-desk-scenario-state-not-ready:${scenario.scenarioId}:${scenario.state}:${input.runKind}`,
+    );
+  }
+
+  const stage = stageForRunKind(input.runKind);
+  const createdAt = nowIso(deps);
+  let run: RuntimeStrategyDeskScenarioRun = {
+    schemaVersion: "v1",
+    scenarioRunId:
+      input.scenarioRunId ??
+      createDeskId(`desk_run_${scenario.scenarioId}_${input.runKind}`, deps),
+    scenarioId: scenario.scenarioId,
+    scenarioState: scenario.state,
+    runKind: input.runKind,
+    state: "pending",
+    requestedBy: input.requestedBy,
+    trigger: defaultTrigger(createdAt, input.trigger),
+    createdAt,
+    updatedAt: createdAt,
+    legRuns: defaultLegRuns(scenario, stage),
+    metadata: {
+      walletAddress: input.walletAddress,
+      maxRetriesPerLeg: readPositiveInt(input.maxRetriesPerLeg, 0),
+    },
+  };
+  run = (
+    await upsertRuntimeStrategyDeskScenarioRunWorkflow({
+      env: input.env,
+      run,
+    })
+  ).run;
+
+  const context = buildRunnerContext(input.env, deps);
+  const orderedLegs = topologicalScenarioLegs(scenario);
+  const artifacts: Record<string, StrategyDeskRunArtifact> = {};
+  const maxRetriesPerLeg = readPositiveInt(input.maxRetriesPerLeg, 0);
+
+  run = (
+    await upsertRuntimeStrategyDeskScenarioRunWorkflow({
+      env: input.env,
+      run: {
+        ...run,
+        state: "legs_requested",
+        startedAt: createdAt,
+        updatedAt: nowIso(deps),
+        metadata: {
+          ...(run.metadata ?? {}),
+          orderedLegIds: orderedLegs.map((leg) => leg.legId),
+        },
+      },
+    })
+  ).run;
+
+  let terminalState: RuntimeStrategyDeskScenarioRun["state"] = "completed";
+  let failureCode: string | undefined;
+  let failureMessage: string | undefined;
+
+  for (const leg of orderedLegs) {
+    const requestRef = `${run.scenarioRunId}:${leg.legId}`;
+    run = (
+      await upsertRuntimeStrategyDeskScenarioRunWorkflow({
+        env: input.env,
+        run: replaceLegRun(
+          {
+            ...run,
+            state: "legs_running",
+            updatedAt: nowIso(deps),
+          },
+          buildLegRun({
+            run,
+            legId: leg.legId,
+            stage,
+            state: "submitted",
+            requestRef,
+            notes: `queued:${leg.venueKey}:${leg.intentFamily}`,
+          }),
+        ),
+      })
+    ).run;
+
+    let result: ExecuteSwapResult | null = null;
+    let attemptCount = 0;
+    try {
+      const resolved = await resolveStrategyDeskLeg({
+        env: input.env,
+        leg,
+        runKind: input.runKind,
+        walletAddress: input.walletAddress,
+        context,
+        deps,
+      });
+
+      while (attemptCount <= maxRetriesPerLeg) {
+        attemptCount += 1;
+        result = await executeResolvedLeg({
+          env: input.env,
+          resolved,
+          runKind: input.runKind,
+          walletAddress: input.walletAddress,
+          privyWalletId: input.privyWalletId,
+          requestRef,
+          context,
+          deps,
+        });
+        if (isExecutionSuccessStatus(result.status)) {
+          break;
+        }
+      }
+
+      const artifact: StrategyDeskRunArtifact = {
+        legId: leg.legId,
+        attemptCount,
+        adapterKey: resolved.adapter.adapterKey,
+        venueKey: leg.venueKey,
+        requestRef,
+        status: result?.status ?? "blocked",
+        signature: result?.signature ?? null,
+        ...(result?.usedQuote
+          ? {
+              quote: {
+                inputMint: String(result.usedQuote.inputMint ?? ""),
+                outputMint: String(result.usedQuote.outputMint ?? ""),
+                inAmount: String(result.usedQuote.inAmount ?? ""),
+                outAmount: String(result.usedQuote.outAmount ?? ""),
+              },
+            }
+          : {}),
+        executionMeta: summarizeExecutionMeta(result?.executionMeta),
+        ...(result && !isExecutionSuccessStatus(result.status)
+          ? {
+              error: readExecutionError(result.err),
+              errorCode: readExecutionErrorCode(result.err) ?? result.status,
+            }
+          : {}),
+      };
+      artifacts[leg.legId] = artifact;
+
+      if (!result || !isExecutionSuccessStatus(result.status)) {
+        terminalState = "failed";
+        failureCode = artifact.errorCode ?? "strategy-desk-leg-execution-failed";
+        failureMessage =
+          artifact.error ??
+          `strategy-desk-leg-execution-failed:${leg.legId}:${artifact.status}`;
+        run = replaceLegRun(
+          run,
+          buildLegRun({
+            run,
+            legId: leg.legId,
+            stage,
+            state: "failed",
+            requestRef,
+            notes: failureMessage,
+          }),
+        );
+        break;
+      }
+
+      run = replaceLegRun(
+        run,
+        buildLegRun({
+          run,
+          legId: leg.legId,
+          stage,
+          state: "completed",
+          requestRef,
+          notes: `completed:${result.status}`,
+        }),
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      artifacts[leg.legId] = {
+        legId: leg.legId,
+        attemptCount: Math.max(1, attemptCount),
+        adapterKey: leg.intent?.adapterKey ?? defaultAdapterKey(leg),
+        venueKey: leg.venueKey,
+        requestRef,
+        status: "blocked",
+        signature: null,
+        error: message,
+        errorCode: message.split(":")[0] || "strategy-desk-leg-blocked",
+      };
+      terminalState = message.includes("not-supported") || message.includes("disabled")
+        ? "rejected"
+        : "failed";
+      failureCode = message.split(":")[0] || "strategy-desk-leg-blocked";
+      failureMessage = message;
+      run = replaceLegRun(
+        run,
+        buildLegRun({
+          run,
+          legId: leg.legId,
+          stage,
+          state: "failed",
+          requestRef,
+          notes: message,
+        }),
+      );
+      break;
+    }
+  }
+
+  if (terminalState !== "completed") {
+    run = {
+      ...run,
+      legRuns: run.legRuns.map((legRun) =>
+        legRun.state === "pending"
+          ? {
+              ...legRun,
+              state: "skipped",
+              notes: "skipped after prior leg failure",
+            }
+          : legRun,
+      ),
+    };
+    for (const legRun of run.legRuns) {
+      if (legRun.state === "skipped") {
+        const scenarioLeg =
+          scenario.legs.find((leg) => leg.legId === legRun.legId) ?? null;
+        artifacts[legRun.legId] = {
+          legId: legRun.legId,
+          attemptCount: 0,
+          adapterKey: scenarioLeg
+            ? scenarioLeg.intent?.adapterKey ?? defaultAdapterKey(scenarioLeg)
+            : "unknown",
+          venueKey: scenarioLeg?.venueKey ?? "unknown",
+          requestRef: `${run.scenarioRunId}:${legRun.legId}`,
+          status: "skipped",
+          signature: null,
+        };
+      }
+    }
+  }
+
+  const collectingAt = nowIso(deps);
+  run = (
+    await upsertRuntimeStrategyDeskScenarioRunWorkflow({
+      env: input.env,
+      run: {
+        ...run,
+        state: "collecting_evidence",
+        updatedAt: collectingAt,
+        ...(failureCode ? { failureCode } : {}),
+        ...(failureMessage ? { failureMessage } : {}),
+        metadata: {
+          ...(run.metadata ?? {}),
+          artifacts,
+        },
+      },
+    })
+  ).run;
+
+  const completedAt = nowIso(deps);
+  const report = (
+    await upsertRuntimeStrategyDeskScenarioReportWorkflow({
+      env: input.env,
+      report: buildReport({
+        scenario,
+        run,
+        runKind: input.runKind,
+        generatedAt: completedAt,
+        reportId:
+          input.reportId ??
+          createDeskId(`desk_report_${scenario.scenarioId}_${input.runKind}`, deps),
+        artifacts,
+      }),
+    })
+  ).report;
+
+  run = (
+    await upsertRuntimeStrategyDeskScenarioRunWorkflow({
+      env: input.env,
+      run: {
+        ...run,
+        state: terminalState,
+        updatedAt: completedAt,
+        completedAt,
+        ...(failureCode ? { failureCode } : {}),
+        ...(failureMessage ? { failureMessage } : {}),
+        metadata: {
+          ...(run.metadata ?? {}),
+          latestReportId: report.reportId,
+          artifacts,
+        },
+      },
+    })
+  ).run;
+
+  return {
+    scenario,
+    run,
+    report,
+  };
+}

--- a/apps/worker/src/runtime_strategy_desk_runner.ts
+++ b/apps/worker/src/runtime_strategy_desk_runner.ts
@@ -4,27 +4,22 @@ import {
   runtimeVenueSupportsIntentFamily,
   runtimeVenueSupportsMode,
 } from "../../../src/runtime/venues/catalog.js";
-import type {
-  RuntimeMode,
-  RuntimeStrategyDeskRunKind,
-  RuntimeStrategyDeskScenarioLeg,
-  RuntimeStrategyDeskScenarioManifest,
-  RuntimeStrategyDeskScenarioReport,
-  RuntimeStrategyDeskScenarioRun,
-} from "./runtime_contracts";
-import { DFlowClient } from "./dflow";
-import { DriftClient } from "./drift";
 import {
   SUPPORTED_TRADING_MINTS,
   TRADING_TOKEN_BY_MINT,
   USDC_MINT,
 } from "./defaults";
+import { DFlowClient } from "./dflow";
+import { DriftClient } from "./drift";
 import {
-  executeIntentViaRouter,
   type ExecutionAdapterRegistration,
+  executeIntentViaRouter,
   resolveExecutionAdapterRegistration,
 } from "./execution/router";
-import { quoteSpotSwap, resolveSpotVenueExecutionAdapter } from "./execution/spot_venues";
+import {
+  quoteSpotSwap,
+  resolveSpotVenueExecutionAdapter,
+} from "./execution/spot_venues";
 import type {
   ExecuteSwapResult,
   ExecutionRouterIntent,
@@ -35,17 +30,28 @@ import { JupiterClient } from "./jupiter";
 import { MangoClient } from "./mango";
 import { OpenBookClient } from "./openbook";
 import { OrcaClient } from "./orca";
-import { normalizePolicy, enforcePolicy } from "./policy";
+import { enforcePolicy, normalizePolicy } from "./policy";
 import { RaydiumClient } from "./raydium";
-import { SolanaRpc } from "./solana_rpc";
+import type {
+  RuntimeMode,
+  RuntimeStrategyDeskRunKind,
+  RuntimeStrategyDeskScenarioLeg,
+  RuntimeStrategyDeskScenarioManifest,
+  RuntimeStrategyDeskScenarioReport,
+  RuntimeStrategyDeskScenarioRun,
+} from "./runtime_contracts";
 import {
   getRuntimeStrategyDeskScenarioWorkflow,
   upsertRuntimeStrategyDeskScenarioReportWorkflow,
   upsertRuntimeStrategyDeskScenarioRunWorkflow,
 } from "./runtime_strategy_desk";
+import { SolanaRpc } from "./solana_rpc";
 import type { Env } from "./types";
 
-type StrategyDeskExecuteRunKind = Extract<RuntimeStrategyDeskRunKind, "shadow" | "paper">;
+type StrategyDeskExecuteRunKind = Extract<
+  RuntimeStrategyDeskRunKind,
+  "shadow" | "paper"
+>;
 
 export type RuntimeStrategyDeskExecuteWorkflowInput = {
   env: Env;
@@ -122,7 +128,12 @@ type StrategyDeskRunArtifact = {
 
 const STABLE_MINTS = new Set(
   ["USDC", "USDT", "PYUSD", "USD1", "USDG"]
-    .map((symbol) => Object.values(TRADING_TOKEN_BY_MINT).find((token) => token.symbol === symbol)?.mint)
+    .map(
+      (symbol) =>
+        Object.values(TRADING_TOKEN_BY_MINT).find(
+          (token) => token.symbol === symbol,
+        )?.mint,
+    )
     .filter((value): value is string => Boolean(value)),
 );
 
@@ -130,7 +141,10 @@ function nowIso(deps?: StrategyDeskExecutionDeps): string {
   return deps?.now ? deps.now() : new Date().toISOString();
 }
 
-function createDeskId(prefix: string, deps?: StrategyDeskExecutionDeps): string {
+function createDeskId(
+  prefix: string,
+  deps?: StrategyDeskExecutionDeps,
+): string {
   if (deps?.createId) return deps.createId(prefix);
   return `${prefix}_${crypto.randomUUID().replace(/-/g, "")}`;
 }
@@ -154,9 +168,7 @@ function stableMintDecimals(mint: string): number | null {
 function usdToStableAtomic(usd: string, mint: string): string {
   const decimals = stableMintDecimals(mint);
   if (decimals === null) {
-    throw new Error(
-      `runtime-strategy-desk-stable-mint-required:${mint}`,
-    );
+    throw new Error(`runtime-strategy-desk-stable-mint-required:${mint}`);
   }
   return decimalToAtomic(usd, decimals);
 }
@@ -238,7 +250,9 @@ function topologicalScenarioLegs(
   const byId = new Map(scenario.legs.map((leg) => [leg.legId, leg]));
   const incoming = new Map<string, number>();
   const dependents = new Map<string, string[]>();
-  const originalOrder = new Map(scenario.legs.map((leg, index) => [leg.legId, index]));
+  const originalOrder = new Map(
+    scenario.legs.map((leg, index) => [leg.legId, index]),
+  );
 
   for (const leg of scenario.legs) {
     incoming.set(leg.legId, 0);
@@ -259,7 +273,11 @@ function topologicalScenarioLegs(
 
   const ready = scenario.legs
     .filter((leg) => (incoming.get(leg.legId) ?? 0) === 0)
-    .sort((left, right) => (originalOrder.get(left.legId) ?? 0) - (originalOrder.get(right.legId) ?? 0));
+    .sort(
+      (left, right) =>
+        (originalOrder.get(left.legId) ?? 0) -
+        (originalOrder.get(right.legId) ?? 0),
+    );
 
   const ordered: RuntimeStrategyDeskScenarioLeg[] = [];
   while (ready.length > 0) {
@@ -324,9 +342,7 @@ function buildRunnerContext(
   const rpcEndpoint =
     String(env.RPC_ENDPOINT ?? "").trim() ||
     "https://api.mainnet-beta.solana.com";
-  const rpc =
-    deps?.createRpc?.(env) ??
-    new SolanaRpc(rpcEndpoint);
+  const rpc = deps?.createRpc?.(env) ?? new SolanaRpc(rpcEndpoint);
   const jupiter =
     deps?.createJupiterClient?.(env) ??
     new JupiterClient(
@@ -344,8 +360,7 @@ function buildRunnerContext(
     );
   const mango = deps?.createMangoClient?.() ?? new MangoClient();
   const openbook =
-    deps?.createOpenBookClient?.(env) ??
-    new OpenBookClient(rpcEndpoint);
+    deps?.createOpenBookClient?.(env) ?? new OpenBookClient(rpcEndpoint);
   return {
     rpc,
     jupiter,
@@ -358,9 +373,7 @@ function buildRunnerContext(
   };
 }
 
-function defaultAdapterKey(
-  leg: RuntimeStrategyDeskScenarioLeg,
-): string {
+function defaultAdapterKey(leg: RuntimeStrategyDeskScenarioLeg): string {
   if (leg.intentFamily === "spot_swap") {
     return resolveSpotVenueExecutionAdapter({
       venueKey: leg.venueKey,
@@ -412,21 +425,21 @@ function buildLegPolicy(
   });
 }
 
-async function buildSpotLeg(
-  input: {
-    env: Env;
-    leg: RuntimeStrategyDeskScenarioLeg;
-    runKind: StrategyDeskExecuteRunKind;
-    walletAddress: string;
-    context: StrategyDeskRunnerContext;
-    deps?: StrategyDeskExecutionDeps;
-  },
-): Promise<ResolvedStrategyDeskLeg> {
+async function buildSpotLeg(input: {
+  env: Env;
+  leg: RuntimeStrategyDeskScenarioLeg;
+  runKind: StrategyDeskExecuteRunKind;
+  walletAddress: string;
+  context: StrategyDeskRunnerContext;
+  deps?: StrategyDeskExecutionDeps;
+}): Promise<ResolvedStrategyDeskLeg> {
   const { leg, context } = input;
   if (!leg.pair) {
     throw new Error(`runtime-strategy-desk-pair-required:${leg.legId}`);
   }
-  const side = String(leg.intent?.side ?? "buy").trim().toLowerCase();
+  const side = String(leg.intent?.side ?? "buy")
+    .trim()
+    .toLowerCase();
   if (side !== "buy" && side !== "sell") {
     throw new Error(`runtime-strategy-desk-spot-side-invalid:${leg.legId}`);
   }
@@ -484,9 +497,7 @@ function buildNonSpotIntent(
   if (leg.intentFamily === "prediction_order") {
     const instrumentId = String(leg.instrumentId ?? "").trim();
     if (!instrumentId) {
-      throw new Error(
-        `runtime-strategy-desk-instrument-required:${leg.legId}`,
-      );
+      throw new Error(`runtime-strategy-desk-instrument-required:${leg.legId}`);
     }
     const outcomeId = String(leg.intent?.outcomeId ?? "").trim();
     if (!outcomeId) {
@@ -514,11 +525,16 @@ function buildNonSpotIntent(
       side,
       quantityAtomic:
         leg.intent?.quantityAtomic ??
-        usdToStableAtomic(leg.sizing.targetNotionalUsd, leg.intent?.settlementMint ?? USDC_MINT),
+        usdToStableAtomic(
+          leg.sizing.targetNotionalUsd,
+          leg.intent?.settlementMint ?? USDC_MINT,
+        ),
       settlementMint: leg.intent?.settlementMint ?? USDC_MINT,
       params: {
         quantityMode: "quote",
-        marketNotionalCapUsd: Number(leg.sizing.maxNotionalUsd ?? leg.sizing.targetNotionalUsd),
+        marketNotionalCapUsd: Number(
+          leg.sizing.maxNotionalUsd ?? leg.sizing.targetNotionalUsd,
+        ),
         ...(leg.intent?.params ?? {}),
       },
     };
@@ -561,9 +577,7 @@ function buildNonSpotIntent(
   if (leg.intentFamily === "perp_order") {
     const instrumentId = String(leg.instrumentId ?? "").trim();
     if (!instrumentId) {
-      throw new Error(
-        `runtime-strategy-desk-instrument-required:${leg.legId}`,
-      );
+      throw new Error(`runtime-strategy-desk-instrument-required:${leg.legId}`);
     }
     if (
       side !== "long" &&
@@ -598,9 +612,7 @@ function buildNonSpotIntent(
   if (leg.intentFamily === "clob_order") {
     const instrumentId = String(leg.instrumentId ?? "").trim();
     if (!instrumentId) {
-      throw new Error(
-        `runtime-strategy-desk-instrument-required:${leg.legId}`,
-      );
+      throw new Error(`runtime-strategy-desk-instrument-required:${leg.legId}`);
     }
     if (side !== "buy" && side !== "sell") {
       throw new Error(`runtime-strategy-desk-clob-side-invalid:${leg.legId}`);
@@ -627,12 +639,10 @@ function buildNonSpotIntent(
   );
 }
 
-function buildNonSpotLeg(
-  input: {
-    leg: RuntimeStrategyDeskScenarioLeg;
-    walletAddress: string;
-  },
-): ResolvedStrategyDeskLeg {
+function buildNonSpotLeg(input: {
+  leg: RuntimeStrategyDeskScenarioLeg;
+  walletAddress: string;
+}): ResolvedStrategyDeskLeg {
   const intent = buildNonSpotIntent(input.leg);
   intent.wallet = input.walletAddress;
   const maxTradeAmountAtomic =
@@ -649,16 +659,14 @@ function buildNonSpotLeg(
   };
 }
 
-async function resolveStrategyDeskLeg(
-  input: {
-    env: Env;
-    leg: RuntimeStrategyDeskScenarioLeg;
-    runKind: StrategyDeskExecuteRunKind;
-    walletAddress: string;
-    context: StrategyDeskRunnerContext;
-    deps?: StrategyDeskExecutionDeps;
-  },
-): Promise<ResolvedStrategyDeskLeg> {
+async function resolveStrategyDeskLeg(input: {
+  env: Env;
+  leg: RuntimeStrategyDeskScenarioLeg;
+  runKind: StrategyDeskExecuteRunKind;
+  walletAddress: string;
+  context: StrategyDeskRunnerContext;
+  deps?: StrategyDeskExecutionDeps;
+}): Promise<ResolvedStrategyDeskLeg> {
   const mode = input.runKind as RuntimeMode;
   const capability = requireRuntimeVenueCapability(input.leg.venueKey);
   if (!runtimeVenueSupportsMode(capability, mode)) {
@@ -698,19 +706,31 @@ async function resolveStrategyDeskLeg(
   return { ...resolved, adapter };
 }
 
-async function executeResolvedLeg(
-  input: {
-    env: Env;
-    resolved: ResolvedStrategyDeskLeg;
-    runKind: StrategyDeskExecuteRunKind;
-    walletAddress: string;
-    privyWalletId?: string;
-    requestRef: string;
-    context: StrategyDeskRunnerContext;
-    deps?: StrategyDeskExecutionDeps;
-  },
-): Promise<ExecuteSwapResult> {
+async function executeResolvedLeg(input: {
+  env: Env;
+  resolved: ResolvedStrategyDeskLeg;
+  runKind: StrategyDeskExecuteRunKind;
+  walletAddress: string;
+  privyWalletId?: string;
+  requestRef: string;
+  context: StrategyDeskRunnerContext;
+  deps?: StrategyDeskExecutionDeps;
+}): Promise<ExecuteSwapResult> {
   const execute = input.deps?.executeIntentViaRouter ?? executeIntentViaRouter;
+  const spotExecutionInput =
+    input.resolved.intent.family === "spot_swap"
+      ? (() => {
+          if (!input.resolved.quoteResponse) {
+            throw new Error(
+              `runtime-strategy-desk-spot-quote-missing:${input.resolved.leg.legId}`,
+            );
+          }
+          return {
+            quoteResponse: input.resolved.quoteResponse,
+            userPublicKey: input.walletAddress,
+          };
+        })()
+      : null;
   return await execute({
     env: input.env,
     venueKey: input.resolved.leg.venueKey,
@@ -738,12 +758,7 @@ async function executeResolvedLeg(
     openbook: input.context.openbook,
     orca: input.context.orca,
     raydium: input.context.raydium,
-    ...(input.resolved.intent.family === "spot_swap"
-      ? {
-          quoteResponse: input.resolved.quoteResponse!,
-          userPublicKey: input.walletAddress,
-        }
-      : {}),
+    ...(spotExecutionInput ?? {}),
     privyWalletId: input.privyWalletId,
     intent: input.resolved.intent,
     log(level, message, meta) {
@@ -757,23 +772,25 @@ async function executeResolvedLeg(
   } as Parameters<typeof executeIntentViaRouter>[0]);
 }
 
-function buildLegRun(
-  input: {
-    run: RuntimeStrategyDeskScenarioRun;
-    legId: string;
-    stage: RuntimeStrategyDeskScenarioReport["stage"];
-    state: RuntimeStrategyDeskScenarioRun["legRuns"][number]["state"];
-    requestRef?: string;
-    notes?: string;
-  },
-): RuntimeStrategyDeskScenarioRun["legRuns"][number] {
-  const existing = input.run.legRuns.find((legRun) => legRun.legId === input.legId);
+function buildLegRun(input: {
+  run: RuntimeStrategyDeskScenarioRun;
+  legId: string;
+  stage: RuntimeStrategyDeskScenarioReport["stage"];
+  state: RuntimeStrategyDeskScenarioRun["legRuns"][number]["state"];
+  requestRef?: string;
+  notes?: string;
+}): RuntimeStrategyDeskScenarioRun["legRuns"][number] {
+  const existing = input.run.legRuns.find(
+    (legRun) => legRun.legId === input.legId,
+  );
   return {
     legId: input.legId,
     stage: input.stage,
     state: input.state,
     ...(input.requestRef ? { requestRef: input.requestRef } : {}),
-    ...(input.notes ?? existing?.notes ? { notes: input.notes ?? existing?.notes } : {}),
+    ...((input.notes ?? existing?.notes)
+      ? { notes: input.notes ?? existing?.notes }
+      : {}),
   };
 }
 
@@ -789,16 +806,14 @@ function replaceLegRun(
   };
 }
 
-function buildReport(
-  input: {
-    scenario: RuntimeStrategyDeskScenarioManifest;
-    run: RuntimeStrategyDeskScenarioRun;
-    runKind: StrategyDeskExecuteRunKind;
-    generatedAt: string;
-    reportId: string;
-    artifacts: Record<string, StrategyDeskRunArtifact>;
-  },
-): RuntimeStrategyDeskScenarioReport {
+function buildReport(input: {
+  scenario: RuntimeStrategyDeskScenarioManifest;
+  run: RuntimeStrategyDeskScenarioRun;
+  runKind: StrategyDeskExecuteRunKind;
+  generatedAt: string;
+  reportId: string;
+  artifacts: Record<string, StrategyDeskRunArtifact>;
+}): RuntimeStrategyDeskScenarioReport {
   const legOutcomes = input.scenario.legs.map((leg) => {
     const artifact = input.artifacts[leg.legId];
     if (!artifact || artifact.status === "skipped") {
@@ -840,11 +855,19 @@ function buildReport(
     };
   });
 
-  const passedCount = legOutcomes.filter((outcome) => outcome.status === "pass").length;
-  const blockedCount = legOutcomes.filter((outcome) => outcome.status === "blocked").length;
-  const skippedCount = legOutcomes.filter((outcome) => outcome.status === "not_applicable").length;
+  const passedCount = legOutcomes.filter(
+    (outcome) => outcome.status === "pass",
+  ).length;
+  const blockedCount = legOutcomes.filter(
+    (outcome) => outcome.status === "blocked",
+  ).length;
+  const skippedCount = legOutcomes.filter(
+    (outcome) => outcome.status === "not_applicable",
+  ).length;
   const overallStatus =
-    blockedCount > 0 || input.run.state === "failed" || input.run.state === "rejected"
+    blockedCount > 0 ||
+    input.run.state === "failed" ||
+    input.run.state === "rejected"
       ? ("blocked" as const)
       : ("pass" as const);
   const stage = stageForRunKind(input.runKind);
@@ -892,7 +915,8 @@ function buildReport(
         checkId: "scenario-ready-state",
         status: "pass",
         observedValue: input.scenario.state,
-        thresholdValue: input.runKind === "shadow" ? "shadow_ready+" : "paper_ready+",
+        thresholdValue:
+          input.runKind === "shadow" ? "shadow_ready+" : "paper_ready+",
         message: "Scenario state allowed composite execution.",
       },
       {
@@ -908,7 +932,8 @@ function buildReport(
       {
         checkId: "router-gates-enforced",
         status: "pass",
-        message: "Each leg ran through the existing Worker router with venue capability checks enabled.",
+        message:
+          "Each leg ran through the existing Worker router with venue capability checks enabled.",
       },
     ],
     approvals: [],
@@ -1068,7 +1093,8 @@ export async function executeRuntimeStrategyDeskScenarioWorkflow(
 
       if (!result || !isExecutionSuccessStatus(result.status)) {
         terminalState = "failed";
-        failureCode = artifact.errorCode ?? "strategy-desk-leg-execution-failed";
+        failureCode =
+          artifact.errorCode ?? "strategy-desk-leg-execution-failed";
         failureMessage =
           artifact.error ??
           `strategy-desk-leg-execution-failed:${leg.legId}:${artifact.status}`;
@@ -1110,9 +1136,10 @@ export async function executeRuntimeStrategyDeskScenarioWorkflow(
         error: message,
         errorCode: message.split(":")[0] || "strategy-desk-leg-blocked",
       };
-      terminalState = message.includes("not-supported") || message.includes("disabled")
-        ? "rejected"
-        : "failed";
+      terminalState =
+        message.includes("not-supported") || message.includes("disabled")
+          ? "rejected"
+          : "failed";
       failureCode = message.split(":")[0] || "strategy-desk-leg-blocked";
       failureMessage = message;
       run = replaceLegRun(
@@ -1151,7 +1178,7 @@ export async function executeRuntimeStrategyDeskScenarioWorkflow(
           legId: legRun.legId,
           attemptCount: 0,
           adapterKey: scenarioLeg
-            ? scenarioLeg.intent?.adapterKey ?? defaultAdapterKey(scenarioLeg)
+            ? (scenarioLeg.intent?.adapterKey ?? defaultAdapterKey(scenarioLeg))
             : "unknown",
           venueKey: scenarioLeg?.venueKey ?? "unknown",
           requestRef: `${run.scenarioRunId}:${legRun.legId}`,
@@ -1191,7 +1218,10 @@ export async function executeRuntimeStrategyDeskScenarioWorkflow(
         generatedAt: completedAt,
         reportId:
           input.reportId ??
-          createDeskId(`desk_report_${scenario.scenarioId}_${input.runKind}`, deps),
+          createDeskId(
+            `desk_report_${scenario.scenarioId}_${input.runKind}`,
+            deps,
+          ),
         artifacts,
       }),
     })

--- a/apps/worker/src/runtime_strategy_desk_runner.ts
+++ b/apps/worker/src/runtime_strategy_desk_runner.ts
@@ -375,10 +375,11 @@ function buildRunnerContext(
 
 function defaultAdapterKey(leg: RuntimeStrategyDeskScenarioLeg): string {
   if (leg.intentFamily === "spot_swap") {
+    const capability = requireRuntimeVenueCapability(leg.venueKey);
     return resolveSpotVenueExecutionAdapter({
       venueKey: leg.venueKey,
       runtimeMode: "paper",
-      defaultAdapter: "jupiter",
+      defaultAdapter: capability.adapterKeys[0] ?? leg.venueKey,
     });
   }
   if (leg.intentFamily === "perp_order" && leg.venueKey === "drift") {
@@ -960,6 +961,7 @@ export async function executeRuntimeStrategyDeskScenarioWorkflow(
 
   const stage = stageForRunKind(input.runKind);
   const createdAt = nowIso(deps);
+  const orderedLegs = topologicalScenarioLegs(scenario);
   let run: RuntimeStrategyDeskScenarioRun = {
     schemaVersion: "v1",
     scenarioRunId:
@@ -987,7 +989,6 @@ export async function executeRuntimeStrategyDeskScenarioWorkflow(
   ).run;
 
   const context = buildRunnerContext(input.env, deps);
-  const orderedLegs = topologicalScenarioLegs(scenario);
   const artifacts: Record<string, StrategyDeskRunArtifact> = {};
   const maxRetriesPerLeg = readPositiveInt(input.maxRetriesPerLeg, 0);
 

--- a/apps/worker/src/strategy_desk_repository.ts
+++ b/apps/worker/src/strategy_desk_repository.ts
@@ -50,6 +50,7 @@ function mapScenarioLegRow(
   const assetKeys = parseJsonValue(row.assetKeys);
   const enabledModes = parseJsonValue(row.enabledModes);
   const sizing = parseJsonValue(row.sizing);
+  const intent = parseJsonValue(row.intent);
   const dependencies = parseJsonValue(row.dependencies);
   const tags = parseJsonValue(row.tags);
 
@@ -73,6 +74,7 @@ function mapScenarioLegRow(
     assetKeys: Array.isArray(assetKeys) ? assetKeys : [],
     enabledModes: Array.isArray(enabledModes) ? enabledModes : [],
     sizing: isRecord(sizing) ? sizing : {},
+    ...(isRecord(intent) ? { intent } : {}),
     ...(stringOrNull(row.thesis) ? { thesis: stringValue(row.thesis) } : {}),
     ...(Array.isArray(dependencies) && dependencies.length > 0
       ? { dependencies }
@@ -213,6 +215,7 @@ async function listScenarioLegsForIds(
         asset_keys_json AS assetKeys,
         enabled_modes_json AS enabledModes,
         sizing_json AS sizing,
+        intent_json AS intent,
         thesis,
         dependencies_json AS dependencies,
         tags_json AS tags
@@ -332,11 +335,12 @@ export async function writeStrategyDeskScenarioManifest(
           asset_keys_json,
           enabled_modes_json,
           sizing_json,
+          intent_json,
           thesis,
           dependencies_json,
           tags_json
         ) VALUES (
-          ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16
+          ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17
         )
         `,
       )
@@ -354,6 +358,7 @@ export async function writeStrategyDeskScenarioManifest(
         stringifyJson(leg.assetKeys) ?? "[]",
         stringifyJson(leg.enabledModes) ?? "[]",
         stringifyJson(leg.sizing) ?? "{}",
+        stringifyJson(leg.intent),
         leg.thesis ?? null,
         stringifyJson(leg.dependencies),
         stringifyJson(leg.tags),

--- a/docs/runtime-contracts/fixtures/runtime.strategy_desk_scenario.valid.v1.json
+++ b/docs/runtime-contracts/fixtures/runtime.strategy_desk_scenario.valid.v1.json
@@ -34,6 +34,9 @@
         "reserveUsd": "1000",
         "maxSlippageBps": 50
       },
+      "intent": {
+        "side": "buy"
+      },
       "thesis": "Primary directional spot leg.",
       "tags": ["alpha", "spot"]
     },
@@ -59,6 +62,10 @@
         "reserveUsd": "250",
         "maxSlippageBps": 30
       },
+      "intent": {
+        "side": "short",
+        "quantityAtomic": "3521126760"
+      },
       "thesis": "Hedge spot beta when momentum weakens.",
       "dependencies": ["leg_spot_alpha"],
       "tags": ["hedge", "perp"]
@@ -69,7 +76,7 @@
       "role": "prediction",
       "venueKey": "dflow",
       "intentFamily": "prediction_order",
-      "marketType": "spot",
+      "marketType": "prediction",
       "instrumentId": "macro-fed-cut-jun-2026",
       "assetKeys": ["SOL", "USDC"],
       "enabledModes": ["shadow", "paper"],
@@ -78,6 +85,10 @@
         "maxNotionalUsd": "250",
         "reserveUsd": "100",
         "maxSlippageBps": 100
+      },
+      "intent": {
+        "side": "buy_yes",
+        "outcomeId": "yes"
       },
       "thesis": "Event hedge for macro-sensitive weeks.",
       "tags": ["overlay", "prediction"]
@@ -102,6 +113,17 @@
         "maxNotionalUsd": "500",
         "reserveUsd": "125",
         "maxSlippageBps": 35
+      },
+      "intent": {
+        "referenceId": "flash_rebalance_sol_usdc",
+        "settlementMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        "borrowLegs": [
+          {
+            "provider": "marginfi",
+            "mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amountAtomic": "250000000"
+          }
+        ]
       },
       "thesis": "Atomic rebalance path for bounded inventory clean-up.",
       "dependencies": ["leg_spot_alpha", "leg_perp_hedge"],

--- a/docs/runtime-contracts/schemas/runtime.strategy_desk_leg.v1.schema.json
+++ b/docs/runtime-contracts/schemas/runtime.strategy_desk_leg.v1.schema.json
@@ -114,6 +114,72 @@
       "required": ["targetNotionalUsd"],
       "additionalProperties": false
     },
+    "intent": {
+      "type": "object",
+      "properties": {
+        "adapterKey": {
+          "type": "string",
+          "minLength": 1
+        },
+        "side": {
+          "type": "string",
+          "minLength": 1
+        },
+        "quantityAtomic": {
+          "type": "string",
+          "pattern": "^\\d+(?:\\.\\d+)?$"
+        },
+        "collateralAtomic": {
+          "type": "string",
+          "pattern": "^\\d+(?:\\.\\d+)?$"
+        },
+        "outcomeId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "settlementMint": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        },
+        "referenceId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "borrowLegs": {
+          "maxItems": 8,
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "provider": {
+                "type": "string",
+                "minLength": 1
+              },
+              "mint": {
+                "type": "string",
+                "minLength": 32,
+                "maxLength": 64
+              },
+              "amountAtomic": {
+                "type": "string",
+                "pattern": "^\\d+(?:\\.\\d+)?$"
+              }
+            },
+            "required": ["provider", "mint"],
+            "additionalProperties": false
+          }
+        },
+        "params": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        }
+      },
+      "additionalProperties": false
+    },
     "thesis": {
       "type": "string",
       "minLength": 1

--- a/docs/runtime-contracts/schemas/runtime.strategy_desk_scenario.v1.schema.json
+++ b/docs/runtime-contracts/schemas/runtime.strategy_desk_scenario.v1.schema.json
@@ -190,6 +190,72 @@
             "required": ["targetNotionalUsd"],
             "additionalProperties": false
           },
+          "intent": {
+            "type": "object",
+            "properties": {
+              "adapterKey": {
+                "type": "string",
+                "minLength": 1
+              },
+              "side": {
+                "type": "string",
+                "minLength": 1
+              },
+              "quantityAtomic": {
+                "type": "string",
+                "pattern": "^\\d+(?:\\.\\d+)?$"
+              },
+              "collateralAtomic": {
+                "type": "string",
+                "pattern": "^\\d+(?:\\.\\d+)?$"
+              },
+              "outcomeId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "settlementMint": {
+                "type": "string",
+                "minLength": 32,
+                "maxLength": 64
+              },
+              "referenceId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "borrowLegs": {
+                "maxItems": 8,
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "provider": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "mint": {
+                      "type": "string",
+                      "minLength": 32,
+                      "maxLength": 64
+                    },
+                    "amountAtomic": {
+                      "type": "string",
+                      "pattern": "^\\d+(?:\\.\\d+)?$"
+                    }
+                  },
+                  "required": ["provider", "mint"],
+                  "additionalProperties": false
+                }
+              },
+              "params": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {}
+              }
+            },
+            "additionalProperties": false
+          },
           "thesis": {
             "type": "string",
             "minLength": 1

--- a/src/bin/strategy_desk_registry.ts
+++ b/src/bin/strategy_desk_registry.ts
@@ -7,7 +7,7 @@ import {
 } from "../runtime/contracts/autonomous_runtime.js";
 
 type Resource = "scenario" | "run" | "report";
-type Action = "upsert" | "list";
+type Action = "upsert" | "list" | "execute";
 
 function readArg(flag: string): string | null {
   const index = process.argv.indexOf(flag);
@@ -29,13 +29,37 @@ function resolveResource(): Resource {
 
 function resolveAction(): Action {
   const raw = readArg("--action") ?? "upsert";
-  if (raw === "upsert" || raw === "list") {
+  if (raw === "upsert" || raw === "list" || raw === "execute") {
     return raw;
   }
   throw new Error("invalid-arg:--action");
 }
 
-function endpointFor(resource: Resource): string {
+function endpointFor(input: {
+  resource: Resource;
+  action: Action;
+  requestPayload: unknown;
+}): string {
+  if (input.action === "execute") {
+    if (input.resource !== "scenario") {
+      throw new Error("strategy-desk-execute-scenario-resource-required");
+    }
+    const scenarioId =
+      typeof input.requestPayload === "object" &&
+      input.requestPayload &&
+      !Array.isArray(input.requestPayload)
+        ? String(
+            (input.requestPayload as Record<string, unknown>).scenarioId ?? "",
+          ).trim()
+        : "";
+    if (!scenarioId) {
+      throw new Error("strategy-desk-execute-scenario-id-required");
+    }
+    return `/api/admin/ops/runtime/strategy-desk/scenarios/${encodeURIComponent(
+      scenarioId,
+    )}/execute`;
+  }
+  const resource = input.resource;
   switch (resource) {
     case "scenario":
       return "/api/admin/ops/runtime/strategy-desk/scenarios";
@@ -55,6 +79,17 @@ function buildUpsertBody(resource: Resource, payload: unknown): unknown {
     case "report":
       return parseRuntimeStrategyDeskScenarioReport(payload);
   }
+}
+
+function buildExecuteBody(payload: unknown): unknown {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("strategy-desk-execute-invalid-body");
+  }
+  const {
+    scenarioId: _scenarioId,
+    ...rest
+  } = payload as Record<string, unknown>;
+  return rest;
 }
 
 function buildQueryString(payload: unknown): string {
@@ -92,20 +127,24 @@ async function main(): Promise<void> {
   const requestPayload = requestFile
     ? readJsonFile(resolve(requestFile))
     : null;
-  if (action === "upsert" && !requestPayload) {
+  if ((action === "upsert" || action === "execute") && !requestPayload) {
     throw new Error("missing-arg:--request-file");
   }
 
-  const endpoint = endpointFor(resource);
+  const endpoint = endpointFor({
+    resource,
+    action,
+    requestPayload,
+  });
   const queryString =
     action === "list" ? buildQueryString(requestPayload ?? undefined) : "";
   const response = await fetch(
     `${baseUrl.replace(/\/$/, "")}${endpoint}${queryString ? `?${queryString}` : ""}`,
     {
-      method: action === "upsert" ? "POST" : "GET",
+      method: action === "list" ? "GET" : "POST",
       headers: {
         authorization: `Bearer ${adminToken}`,
-        ...(action === "upsert" ? { "content-type": "application/json" } : {}),
+        ...(action !== "list" ? { "content-type": "application/json" } : {}),
       },
       ...(action === "upsert"
         ? {
@@ -113,7 +152,11 @@ async function main(): Promise<void> {
               buildUpsertBody(resource, requestPayload as unknown),
             ),
           }
-        : {}),
+        : action === "execute"
+          ? {
+              body: JSON.stringify(buildExecuteBody(requestPayload as unknown)),
+            }
+          : {}),
     },
   );
 

--- a/src/bin/strategy_desk_registry.ts
+++ b/src/bin/strategy_desk_registry.ts
@@ -85,10 +85,10 @@ function buildExecuteBody(payload: unknown): unknown {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
     throw new Error("strategy-desk-execute-invalid-body");
   }
-  const {
-    scenarioId: _scenarioId,
-    ...rest
-  } = payload as Record<string, unknown>;
+  const { scenarioId: _scenarioId, ...rest } = payload as Record<
+    string,
+    unknown
+  >;
   return rest;
 }
 

--- a/src/harness/manager.ts
+++ b/src/harness/manager.ts
@@ -469,6 +469,8 @@ export async function startHarness(root = resolveRepoRoot()): Promise<void> {
     process.env.RUNTIME_INTERNAL_SERVICE_NAME ??
     DEFAULT_RUNTIME_INTERNAL_SERVICE_NAME;
   const runtimeInternalStubMode = process.env.RUNTIME_INTERNAL_STUB_MODE ?? "1";
+  const adminToken = String(process.env.ADMIN_TOKEN ?? "").trim();
+  const rpcEndpoint = String(process.env.RPC_ENDPOINT ?? "").trim();
 
   ensureWorkspaceDependencies(root);
   runWorkerMigration(workerDir, paths.workerStateDir);
@@ -497,6 +499,8 @@ export async function startHarness(root = resolveRepoRoot()): Promise<void> {
         `RUNTIME_INTERNAL_SERVICE_NAME:${runtimeInternalServiceName}`,
         "--var",
         `RUNTIME_INTERNAL_STUB_MODE:${runtimeInternalStubMode}`,
+        ...(adminToken ? ["--var", `ADMIN_TOKEN:${adminToken}`] : []),
+        ...(rpcEndpoint ? ["--var", `RPC_ENDPOINT:${rpcEndpoint}`] : []),
       ],
       logFile: paths.workerLog,
     });

--- a/src/runtime/contracts/autonomous_runtime.ts
+++ b/src/runtime/contracts/autonomous_runtime.ts
@@ -1524,6 +1524,31 @@ const RuntimeStrategyDeskScenarioLegSizingSchema = z
   })
   .strict();
 
+const RuntimeStrategyDeskScenarioBorrowLegSchema = z
+  .object({
+    provider: NON_EMPTY_STRING_SCHEMA,
+    mint: PUBKEY_SCHEMA,
+    amountAtomic: DECIMAL_STRING_SCHEMA.optional(),
+  })
+  .strict();
+
+const RuntimeStrategyDeskScenarioLegIntentSchema = z
+  .object({
+    adapterKey: NON_EMPTY_STRING_SCHEMA.optional(),
+    side: NON_EMPTY_STRING_SCHEMA.optional(),
+    quantityAtomic: DECIMAL_STRING_SCHEMA.optional(),
+    collateralAtomic: DECIMAL_STRING_SCHEMA.optional(),
+    outcomeId: NON_EMPTY_STRING_SCHEMA.optional(),
+    settlementMint: PUBKEY_SCHEMA.optional(),
+    referenceId: NON_EMPTY_STRING_SCHEMA.optional(),
+    borrowLegs: z
+      .array(RuntimeStrategyDeskScenarioBorrowLegSchema)
+      .max(8)
+      .optional(),
+    params: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict();
+
 const RuntimeStrategyDeskEvidenceBucketSchema = z
   .object({
     stage: RuntimeStrategyDeskEvidenceStageSchema,
@@ -1546,6 +1571,7 @@ export const RuntimeStrategyDeskScenarioLegSchema = z
     assetKeys: z.array(NON_EMPTY_STRING_SCHEMA).min(1).max(8),
     enabledModes: z.array(RuntimeModeSchema).min(1).max(3),
     sizing: RuntimeStrategyDeskScenarioLegSizingSchema,
+    intent: RuntimeStrategyDeskScenarioLegIntentSchema.optional(),
     thesis: NON_EMPTY_STRING_SCHEMA.optional(),
     dependencies: z.array(NON_EMPTY_STRING_SCHEMA).max(16).optional(),
     tags: z.array(NON_EMPTY_STRING_SCHEMA).max(16).optional(),
@@ -2109,7 +2135,7 @@ export const RUNTIME_STRATEGY_DESK_RUN_STATE_TRANSITIONS = {
   pending: ["legs_requested", "rejected", "cancelled"],
   legs_requested: ["legs_running", "failed", "cancelled"],
   legs_running: ["collecting_evidence", "failed", "cancelled"],
-  collecting_evidence: ["completed", "needs_review", "failed"],
+  collecting_evidence: ["completed", "needs_review", "failed", "rejected"],
   needs_review: ["completed", "failed", "cancelled"],
   completed: [],
   rejected: [],

--- a/tests/unit/runtime_strategy_desk_runner.test.ts
+++ b/tests/unit/runtime_strategy_desk_runner.test.ts
@@ -3,9 +3,10 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import {
-  executeRuntimeStrategyDeskScenarioWorkflow,
-} from "../../apps/worker/src/runtime_strategy_desk_runner";
-import { getRuntimeStrategyDeskScenarioWorkflow, upsertRuntimeStrategyDeskScenarioWorkflow } from "../../apps/worker/src/runtime_strategy_desk";
+  getRuntimeStrategyDeskScenarioWorkflow,
+  upsertRuntimeStrategyDeskScenarioWorkflow,
+} from "../../apps/worker/src/runtime_strategy_desk";
+import { executeRuntimeStrategyDeskScenarioWorkflow } from "../../apps/worker/src/runtime_strategy_desk_runner";
 import type { Env } from "../../apps/worker/src/types";
 import { createWorkerLiveEnv } from "../integration/_worker_live_test_utils";
 
@@ -97,60 +98,64 @@ function readFixture(fileName: string): Record<string, unknown> {
   ) as Record<string, unknown>;
 }
 
-const quoteSpotSwapMock = mock(async (input: {
-  venueKey?: string;
-  inputMint: string;
-  outputMint: string;
-  amountAtomic: string;
-}) => ({
-  venueKey: input.venueKey ?? "jupiter",
-  quoteProvider: "mock-quote",
-  quoteResponse: {
-    inputMint: input.inputMint,
-    outputMint: input.outputMint,
-    inAmount: input.amountAtomic,
-    outAmount: "7000000000",
-    priceImpactPct: 0.001,
-    routePlan: [{ poolId: "pool_1", swapInfo: { label: "MockRoute" } }],
-  },
-  routeQuality: {
+const quoteSpotSwapMock = mock(
+  async (input: {
+    venueKey?: string;
+    inputMint: string;
+    outputMint: string;
+    amountAtomic: string;
+  }) => ({
     venueKey: input.venueKey ?? "jupiter",
     quoteProvider: "mock-quote",
-    routeHopCount: 1,
-    routeLabels: ["MockRoute"],
-    poolIds: ["pool_1"],
-    quotedOutAmountAtomic: "7000000000",
-    minExpectedOutAmountAtomic: "6900000000",
-    priceImpactPct: 0.001,
-  },
-}));
-
-const executeIntentViaRouterMock = mock(async (input: {
-  intent: { family: string; venueKey?: string };
-  execution?: { adapter?: string };
-}) => ({
-  status: "simulated" as const,
-  signature: null,
-  usedQuote: {
-    inputMint: "mint_in",
-    outputMint: "mint_out",
-    inAmount: "100",
-    outAmount: "101",
-    priceImpactPct: 0,
-    routePlan: [],
-  },
-  refreshed: false,
-  lastValidBlockHeight: null,
-  executionMeta: {
-    route: input.execution?.adapter ?? input.intent.venueKey ?? "mock",
-    classification: "simulated" as const,
-    lifecycle: {
-      fillState: "pending" as const,
-      settlementState: "pending" as const,
-      notes: [`family:${input.intent.family}`],
+    quoteResponse: {
+      inputMint: input.inputMint,
+      outputMint: input.outputMint,
+      inAmount: input.amountAtomic,
+      outAmount: "7000000000",
+      priceImpactPct: 0.001,
+      routePlan: [{ poolId: "pool_1", swapInfo: { label: "MockRoute" } }],
     },
-  },
-}));
+    routeQuality: {
+      venueKey: input.venueKey ?? "jupiter",
+      quoteProvider: "mock-quote",
+      routeHopCount: 1,
+      routeLabels: ["MockRoute"],
+      poolIds: ["pool_1"],
+      quotedOutAmountAtomic: "7000000000",
+      minExpectedOutAmountAtomic: "6900000000",
+      priceImpactPct: 0.001,
+    },
+  }),
+);
+
+const executeIntentViaRouterMock = mock(
+  async (input: {
+    intent: { family: string; venueKey?: string };
+    execution?: { adapter?: string };
+  }) => ({
+    status: "simulated" as const,
+    signature: null,
+    usedQuote: {
+      inputMint: "mint_in",
+      outputMint: "mint_out",
+      inAmount: "100",
+      outAmount: "101",
+      priceImpactPct: 0,
+      routePlan: [],
+    },
+    refreshed: false,
+    lastValidBlockHeight: null,
+    executionMeta: {
+      route: input.execution?.adapter ?? input.intent.venueKey ?? "mock",
+      classification: "simulated" as const,
+      lifecycle: {
+        fillState: "pending" as const,
+        settlementState: "pending" as const,
+        notes: [`family:${input.intent.family}`],
+      },
+    },
+  }),
+);
 
 describe("runtime strategy desk runner", () => {
   beforeEach(() => {
@@ -251,8 +256,12 @@ describe("runtime strategy desk runner", () => {
       ]);
       expect(result.run.state).toBe("completed");
       expect(result.report.status).toBe("pass");
-      expect(result.run.legRuns.every((legRun) => legRun.state === "completed")).toBe(true);
-      expect(result.report.legOutcomes.every((outcome) => outcome.status === "pass")).toBe(true);
+      expect(
+        result.run.legRuns.every((legRun) => legRun.state === "completed"),
+      ).toBe(true);
+      expect(
+        result.report.legOutcomes.every((outcome) => outcome.status === "pass"),
+      ).toBe(true);
 
       const storedScenario = await getRuntimeStrategyDeskScenarioWorkflow({
         env,
@@ -263,7 +272,9 @@ describe("runtime strategy desk runner", () => {
       );
       expect(
         (
-          result.run.metadata as { artifacts?: Record<string, unknown> } | undefined
+          result.run.metadata as
+            | { artifacts?: Record<string, unknown> }
+            | undefined
         )?.artifacts,
       ).toBeDefined();
       expect(quoteSpotSwapMock).toHaveBeenCalledTimes(1);
@@ -365,9 +376,11 @@ describe("runtime strategy desk runner", () => {
         (legRun) => legRun.legId === "leg_flash_rebalance",
       );
       expect(flashLeg?.state).toBe("skipped");
-      const artifacts = (result.run.metadata as {
-        artifacts?: Record<string, { attemptCount: number; status: string }>;
-      }).artifacts;
+      const artifacts = (
+        result.run.metadata as {
+          artifacts?: Record<string, { attemptCount: number; status: string }>;
+        }
+      ).artifacts;
       expect(artifacts?.leg_prediction_overlay?.attemptCount).toBe(2);
       expect(artifacts?.leg_flash_rebalance?.status).toBe("skipped");
     } finally {

--- a/tests/unit/runtime_strategy_desk_runner.test.ts
+++ b/tests/unit/runtime_strategy_desk_runner.test.ts
@@ -1,0 +1,444 @@
+import { Database } from "bun:sqlite";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  executeRuntimeStrategyDeskScenarioWorkflow,
+} from "../../apps/worker/src/runtime_strategy_desk_runner";
+import { getRuntimeStrategyDeskScenarioWorkflow, upsertRuntimeStrategyDeskScenarioWorkflow } from "../../apps/worker/src/runtime_strategy_desk";
+import type { Env } from "../../apps/worker/src/types";
+import { createWorkerLiveEnv } from "../integration/_worker_live_test_utils";
+
+function createSqliteD1Adapter(db: Database): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          return {
+            async run() {
+              const statement = db.query(sql);
+              const result = statement.run(...(params as never[])) as {
+                changes?: number;
+              };
+              return {
+                meta: {
+                  changes:
+                    typeof result.changes === "number" ? result.changes : 0,
+                },
+              };
+            },
+            async first() {
+              const statement = db.query(sql);
+              return (statement.get(...(params as never[])) as unknown) ?? null;
+            },
+            async all() {
+              const statement = db.query(sql);
+              return {
+                results: (statement.all(...(params as never[])) ??
+                  []) as unknown[],
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+function createOpsEnv(overrides?: Partial<Env>) {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA foreign_keys = ON;");
+
+  for (const migrationName of [
+    "0025_execution_fabric.sql",
+    "0026_execution_canary.sql",
+    "0027_runtime_canary.sql",
+    "0028_strategy_lab_promotions.sql",
+    "0029_strategy_lab_readiness.sql",
+    "0030_strategy_lab_post_live.sql",
+    "0031_strategy_desk_registry.sql",
+    "0032_strategy_desk_leg_intent.sql",
+  ]) {
+    const migrationPath = resolve(
+      import.meta.dir,
+      "..",
+      "..",
+      "apps/worker/migrations",
+      migrationName,
+    );
+    sqlite.exec(readFileSync(migrationPath, "utf8"));
+  }
+
+  const env = createWorkerLiveEnv({
+    overrides: {
+      WAITLIST_DB: createSqliteD1Adapter(sqlite),
+      ADMIN_TOKEN: "admin-secret",
+      RPC_ENDPOINT: "https://rpc.example.test",
+      JUPITER_BASE_URL: "https://jupiter.example.test",
+      ...overrides,
+    },
+  });
+
+  return { env, sqlite };
+}
+
+function readFixture(fileName: string): Record<string, unknown> {
+  return JSON.parse(
+    readFileSync(
+      resolve(
+        import.meta.dir,
+        "..",
+        "..",
+        "docs/runtime-contracts/fixtures",
+        fileName,
+      ),
+      "utf8",
+    ),
+  ) as Record<string, unknown>;
+}
+
+const quoteSpotSwapMock = mock(async (input: {
+  venueKey?: string;
+  inputMint: string;
+  outputMint: string;
+  amountAtomic: string;
+}) => ({
+  venueKey: input.venueKey ?? "jupiter",
+  quoteProvider: "mock-quote",
+  quoteResponse: {
+    inputMint: input.inputMint,
+    outputMint: input.outputMint,
+    inAmount: input.amountAtomic,
+    outAmount: "7000000000",
+    priceImpactPct: 0.001,
+    routePlan: [{ poolId: "pool_1", swapInfo: { label: "MockRoute" } }],
+  },
+  routeQuality: {
+    venueKey: input.venueKey ?? "jupiter",
+    quoteProvider: "mock-quote",
+    routeHopCount: 1,
+    routeLabels: ["MockRoute"],
+    poolIds: ["pool_1"],
+    quotedOutAmountAtomic: "7000000000",
+    minExpectedOutAmountAtomic: "6900000000",
+    priceImpactPct: 0.001,
+  },
+}));
+
+const executeIntentViaRouterMock = mock(async (input: {
+  intent: { family: string; venueKey?: string };
+  execution?: { adapter?: string };
+}) => ({
+  status: "simulated" as const,
+  signature: null,
+  usedQuote: {
+    inputMint: "mint_in",
+    outputMint: "mint_out",
+    inAmount: "100",
+    outAmount: "101",
+    priceImpactPct: 0,
+    routePlan: [],
+  },
+  refreshed: false,
+  lastValidBlockHeight: null,
+  executionMeta: {
+    route: input.execution?.adapter ?? input.intent.venueKey ?? "mock",
+    classification: "simulated" as const,
+    lifecycle: {
+      fillState: "pending" as const,
+      settlementState: "pending" as const,
+      notes: [`family:${input.intent.family}`],
+    },
+  },
+}));
+
+describe("runtime strategy desk runner", () => {
+  beforeEach(() => {
+    quoteSpotSwapMock.mockClear();
+    executeIntentViaRouterMock.mockClear();
+  });
+
+  test("executes a mixed paper scenario in dependency order and persists a passing report", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const scenario = readFixture(
+        "runtime.strategy_desk_scenario.valid.v1.json",
+      );
+      await upsertRuntimeStrategyDeskScenarioWorkflow({
+        env,
+        scenario: scenario as never,
+      });
+
+      const seenFamilies: string[] = [];
+      executeIntentViaRouterMock.mockImplementationOnce(async (input) => {
+        seenFamilies.push(input.intent.family);
+        return {
+          status: "simulated" as const,
+          signature: null,
+          usedQuote: {
+            inputMint: "mint_in",
+            outputMint: "mint_out",
+            inAmount: "100",
+            outAmount: "101",
+            priceImpactPct: 0,
+            routePlan: [],
+          },
+          refreshed: false,
+          lastValidBlockHeight: null,
+          executionMeta: {
+            route: input.execution?.adapter ?? "mock",
+            classification: "simulated" as const,
+            lifecycle: {
+              fillState: "pending" as const,
+              settlementState: "pending" as const,
+              notes: [`family:${input.intent.family}`],
+            },
+          },
+        };
+      });
+      executeIntentViaRouterMock.mockImplementation(async (input) => {
+        seenFamilies.push(input.intent.family);
+        return {
+          status: "simulated" as const,
+          signature: null,
+          usedQuote: {
+            inputMint: "mint_in",
+            outputMint: "mint_out",
+            inAmount: "100",
+            outAmount: "101",
+            priceImpactPct: 0,
+            routePlan: [],
+          },
+          refreshed: false,
+          lastValidBlockHeight: null,
+          executionMeta: {
+            route: input.execution?.adapter ?? "mock",
+            classification: "simulated" as const,
+          },
+        };
+      });
+
+      const result = await executeRuntimeStrategyDeskScenarioWorkflow(
+        {
+          env,
+          scenarioId: "desk_sol_composite_1",
+          runKind: "paper",
+          requestedBy: "operator_1",
+          walletAddress: "11111111111111111111111111111111",
+        },
+        {
+          createId(prefix) {
+            return `${prefix}_det`;
+          },
+          createRpc: () => ({}) as never,
+          createJupiterClient: () => ({}) as never,
+          createDFlowClient: () => ({}) as never,
+          createDriftClient: () => ({}) as never,
+          createRaydiumClient: () => ({}) as never,
+          createOrcaClient: () => ({}) as never,
+          createMangoClient: () => ({}) as never,
+          createOpenBookClient: () => ({}) as never,
+          quoteSpotSwap: quoteSpotSwapMock as never,
+          executeIntentViaRouter: executeIntentViaRouterMock as never,
+        },
+      );
+
+      expect(seenFamilies).toEqual([
+        "spot_swap",
+        "perp_order",
+        "prediction_order",
+        "flash_atomic",
+      ]);
+      expect(result.run.state).toBe("completed");
+      expect(result.report.status).toBe("pass");
+      expect(result.run.legRuns.every((legRun) => legRun.state === "completed")).toBe(true);
+      expect(result.report.legOutcomes.every((outcome) => outcome.status === "pass")).toBe(true);
+
+      const storedScenario = await getRuntimeStrategyDeskScenarioWorkflow({
+        env,
+        scenarioId: "desk_sol_composite_1",
+      });
+      expect(storedScenario.scenario.latestReportId).toBe(
+        "desk_report_desk_sol_composite_1_paper_det",
+      );
+      expect(
+        (
+          result.run.metadata as { artifacts?: Record<string, unknown> } | undefined
+        )?.artifacts,
+      ).toBeDefined();
+      expect(quoteSpotSwapMock).toHaveBeenCalledTimes(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("retries a failing leg and fails closed with later legs skipped", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const scenario = readFixture(
+        "runtime.strategy_desk_scenario.valid.v1.json",
+      );
+      await upsertRuntimeStrategyDeskScenarioWorkflow({
+        env,
+        scenario: scenario as never,
+      });
+
+      const attempts = new Map<string, number>();
+      executeIntentViaRouterMock.mockImplementation(async (input) => {
+        const family = input.intent.family;
+        const count = (attempts.get(family) ?? 0) + 1;
+        attempts.set(family, count);
+        if (family === "prediction_order") {
+          return {
+            status: "simulate_error" as const,
+            signature: null,
+            usedQuote: {
+              inputMint: "mint_in",
+              outputMint: "mint_out",
+              inAmount: "100",
+              outAmount: "101",
+              priceImpactPct: 0,
+              routePlan: [],
+            },
+            refreshed: false,
+            lastValidBlockHeight: null,
+            err: {
+              code: "prediction-preview-failed",
+              reason: "market blocked",
+            },
+            executionMeta: {
+              route: input.execution?.adapter ?? "mock",
+              classification: "error" as const,
+            },
+          };
+        }
+        return {
+          status: "simulated" as const,
+          signature: null,
+          usedQuote: {
+            inputMint: "mint_in",
+            outputMint: "mint_out",
+            inAmount: "100",
+            outAmount: "101",
+            priceImpactPct: 0,
+            routePlan: [],
+          },
+          refreshed: false,
+          lastValidBlockHeight: null,
+          executionMeta: {
+            route: input.execution?.adapter ?? "mock",
+            classification: "simulated" as const,
+          },
+        };
+      });
+
+      const result = await executeRuntimeStrategyDeskScenarioWorkflow(
+        {
+          env,
+          scenarioId: "desk_sol_composite_1",
+          runKind: "paper",
+          requestedBy: "operator_1",
+          walletAddress: "11111111111111111111111111111111",
+          maxRetriesPerLeg: 1,
+        },
+        {
+          createId(prefix) {
+            return `${prefix}_retry`;
+          },
+          createRpc: () => ({}) as never,
+          createJupiterClient: () => ({}) as never,
+          createDFlowClient: () => ({}) as never,
+          createDriftClient: () => ({}) as never,
+          createRaydiumClient: () => ({}) as never,
+          createOrcaClient: () => ({}) as never,
+          createMangoClient: () => ({}) as never,
+          createOpenBookClient: () => ({}) as never,
+          quoteSpotSwap: quoteSpotSwapMock as never,
+          executeIntentViaRouter: executeIntentViaRouterMock as never,
+        },
+      );
+
+      expect(result.run.state).toBe("failed");
+      expect(result.report.status).toBe("blocked");
+      expect(attempts.get("prediction_order")).toBe(2);
+      const flashLeg = result.run.legRuns.find(
+        (legRun) => legRun.legId === "leg_flash_rebalance",
+      );
+      expect(flashLeg?.state).toBe("skipped");
+      const artifacts = (result.run.metadata as {
+        artifacts?: Record<string, { attemptCount: number; status: string }>;
+      }).artifacts;
+      expect(artifacts?.leg_prediction_overlay?.attemptCount).toBe(2);
+      expect(artifacts?.leg_flash_rebalance?.status).toBe("skipped");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("rejects unsupported legs without bypassing scenario-level fail-closed behavior", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const scenario = readFixture(
+        "runtime.strategy_desk_scenario.valid.v1.json",
+      );
+      const mutatedScenario = {
+        ...scenario,
+        legs: (scenario.legs as Array<Record<string, unknown>>).map((leg) =>
+          leg.legId === "leg_perp_hedge"
+            ? {
+                ...leg,
+                enabledModes: ["shadow"],
+              }
+            : leg,
+        ),
+      };
+      await upsertRuntimeStrategyDeskScenarioWorkflow({
+        env,
+        scenario: mutatedScenario as never,
+      });
+
+      const result = await executeRuntimeStrategyDeskScenarioWorkflow(
+        {
+          env,
+          scenarioId: "desk_sol_composite_1",
+          runKind: "paper",
+          requestedBy: "operator_1",
+          walletAddress: "11111111111111111111111111111111",
+        },
+        {
+          createId(prefix) {
+            return `${prefix}_blocked`;
+          },
+          createRpc: () => ({}) as never,
+          createJupiterClient: () => ({}) as never,
+          createDFlowClient: () => ({}) as never,
+          createDriftClient: () => ({}) as never,
+          createRaydiumClient: () => ({}) as never,
+          createOrcaClient: () => ({}) as never,
+          createMangoClient: () => ({}) as never,
+          createOpenBookClient: () => ({}) as never,
+          quoteSpotSwap: quoteSpotSwapMock as never,
+          executeIntentViaRouter: executeIntentViaRouterMock as never,
+        },
+      );
+
+      expect(result.run.state).toBe("rejected");
+      expect(result.report.status).toBe("blocked");
+      expect(
+        result.run.legRuns.find((legRun) => legRun.legId === "leg_spot_alpha")
+          ?.state,
+      ).toBe("completed");
+      expect(
+        result.run.legRuns.find((legRun) => legRun.legId === "leg_perp_hedge")
+          ?.state,
+      ).toBe("failed");
+      expect(
+        result.run.legRuns.find(
+          (legRun) => legRun.legId === "leg_prediction_overlay",
+        )?.state,
+      ).toBe("skipped");
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/tests/unit/runtime_strategy_desk_runner.test.ts
+++ b/tests/unit/runtime_strategy_desk_runner.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import {
   getRuntimeStrategyDeskScenarioWorkflow,
+  listRuntimeStrategyDeskScenarioRunsWorkflow,
   upsertRuntimeStrategyDeskScenarioWorkflow,
 } from "../../apps/worker/src/runtime_strategy_desk";
 import { executeRuntimeStrategyDeskScenarioWorkflow } from "../../apps/worker/src/runtime_strategy_desk_runner";
@@ -450,6 +451,126 @@ describe("runtime strategy desk runner", () => {
           (legRun) => legRun.legId === "leg_prediction_overlay",
         )?.state,
       ).toBe("skipped");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("uses the venue default adapter for paper spot legs when the manifest omits one", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const scenario = readFixture(
+        "runtime.strategy_desk_scenario.valid.v1.json",
+      );
+      const mutatedScenario = {
+        ...scenario,
+        legs: (scenario.legs as Array<Record<string, unknown>>).map((leg) =>
+          leg.legId === "leg_spot_alpha"
+            ? {
+                ...leg,
+                venueKey: "magicblock",
+                enabledModes: ["shadow", "paper"],
+              }
+            : leg,
+        ),
+      };
+      await upsertRuntimeStrategyDeskScenarioWorkflow({
+        env,
+        scenario: mutatedScenario as never,
+      });
+
+      await executeRuntimeStrategyDeskScenarioWorkflow(
+        {
+          env,
+          scenarioId: "desk_sol_composite_1",
+          runKind: "paper",
+          requestedBy: "operator_1",
+          walletAddress: "11111111111111111111111111111111",
+        },
+        {
+          createId(prefix) {
+            return `${prefix}_magicblock`;
+          },
+          createRpc: () => ({}) as never,
+          createJupiterClient: () => ({}) as never,
+          createDFlowClient: () => ({}) as never,
+          createDriftClient: () => ({}) as never,
+          createRaydiumClient: () => ({}) as never,
+          createOrcaClient: () => ({}) as never,
+          createMangoClient: () => ({}) as never,
+          createOpenBookClient: () => ({}) as never,
+          quoteSpotSwap: quoteSpotSwapMock as never,
+          executeIntentViaRouter: executeIntentViaRouterMock as never,
+        },
+      );
+
+      const spotCall = executeIntentViaRouterMock.mock.calls.find(
+        ([input]) => input.intent.family === "spot_swap",
+      );
+      expect(spotCall?.[0].execution?.adapter).toBe(
+        "magicblock_ephemeral_rollup",
+      );
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("validates the dependency graph before persisting a pending run", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const scenario = readFixture(
+        "runtime.strategy_desk_scenario.valid.v1.json",
+      );
+      const mutatedScenario = {
+        ...scenario,
+        legs: (scenario.legs as Array<Record<string, unknown>>).map((leg) =>
+          leg.legId === "leg_perp_hedge"
+            ? {
+                ...leg,
+                dependencies: ["missing_leg"],
+              }
+            : leg,
+        ),
+      };
+      await upsertRuntimeStrategyDeskScenarioWorkflow({
+        env,
+        scenario: mutatedScenario as never,
+      });
+
+      await expect(
+        executeRuntimeStrategyDeskScenarioWorkflow(
+          {
+            env,
+            scenarioId: "desk_sol_composite_1",
+            runKind: "paper",
+            requestedBy: "operator_1",
+            walletAddress: "11111111111111111111111111111111",
+          },
+          {
+            createId(prefix) {
+              return `${prefix}_invalid_graph`;
+            },
+            createRpc: () => ({}) as never,
+            createJupiterClient: () => ({}) as never,
+            createDFlowClient: () => ({}) as never,
+            createDriftClient: () => ({}) as never,
+            createRaydiumClient: () => ({}) as never,
+            createOrcaClient: () => ({}) as never,
+            createMangoClient: () => ({}) as never,
+            createOpenBookClient: () => ({}) as never,
+            quoteSpotSwap: quoteSpotSwapMock as never,
+            executeIntentViaRouter: executeIntentViaRouterMock as never,
+          },
+        ),
+      ).rejects.toThrow(
+        "runtime-strategy-desk-leg-dependency-unknown:desk_sol_composite_1:leg_perp_hedge:missing_leg",
+      );
+
+      const storedRuns = await listRuntimeStrategyDeskScenarioRunsWorkflow({
+        env,
+        scenarioId: "desk_sol_composite_1",
+      });
+      expect(storedRuns.runs).toHaveLength(0);
     } finally {
       sqlite.close();
     }

--- a/tests/unit/worker_execution_migrations.test.ts
+++ b/tests/unit/worker_execution_migrations.test.ts
@@ -15,6 +15,7 @@ function withExecutionSchema(run: (db: Database) => void): void {
       "0029_strategy_lab_readiness.sql",
       "0030_strategy_lab_post_live.sql",
       "0031_strategy_desk_registry.sql",
+      "0032_strategy_desk_leg_intent.sql",
     ]) {
       const migrationPath = resolve(
         import.meta.dir,

--- a/tests/unit/worker_runtime_strategy_desk_execute_route.test.ts
+++ b/tests/unit/worker_runtime_strategy_desk_execute_route.test.ts
@@ -8,77 +8,79 @@ import {
   createWorkerLiveEnv,
 } from "../integration/_worker_live_test_utils";
 
-const executeRuntimeStrategyDeskScenarioWorkflowMock = mock(async (input: {
-  scenarioId: string;
-  runKind: "shadow" | "paper";
-  requestedBy: string;
-  walletAddress: string;
-}) => ({
-  scenario: {
-    schemaVersion: "v1",
-    scenarioId: input.scenarioId,
-    title: "Mock desk scenario",
-    summary: "Mock scenario summary",
-    ownerUserId: "user_1",
-    strategyKey: "strategy_desk::mock",
-    thesis: "Mock thesis",
-    state: "paper_ready",
-    createdAt: "2026-03-17T03:00:00Z",
-    updatedAt: "2026-03-17T03:05:00Z",
-    legs: [],
-    evidence: [],
-    implementationReferences: [],
-    tags: [],
-  },
-  run: {
-    schemaVersion: "v1",
-    scenarioRunId: "desk_run_mock_1",
-    scenarioId: input.scenarioId,
-    scenarioState: "paper_ready",
-    runKind: input.runKind,
-    state: "completed",
-    requestedBy: input.requestedBy,
-    trigger: {
-      kind: "operator",
-      source: "strategy_desk_runner",
-      observedAt: "2026-03-17T03:06:00Z",
+const executeRuntimeStrategyDeskScenarioWorkflowMock = mock(
+  async (input: {
+    scenarioId: string;
+    runKind: "shadow" | "paper";
+    requestedBy: string;
+    walletAddress: string;
+  }) => ({
+    scenario: {
+      schemaVersion: "v1",
+      scenarioId: input.scenarioId,
+      title: "Mock desk scenario",
+      summary: "Mock scenario summary",
+      ownerUserId: "user_1",
+      strategyKey: "strategy_desk::mock",
+      thesis: "Mock thesis",
+      state: "paper_ready",
+      createdAt: "2026-03-17T03:00:00Z",
+      updatedAt: "2026-03-17T03:05:00Z",
+      legs: [],
+      evidence: [],
+      implementationReferences: [],
+      tags: [],
     },
-    createdAt: "2026-03-17T03:06:00Z",
-    updatedAt: "2026-03-17T03:06:01Z",
-    legRuns: [],
-  },
-  report: {
-    schemaVersion: "v1",
-    reportId: "desk_report_mock_1",
-    scenarioId: input.scenarioId,
-    scenarioRunId: "desk_run_mock_1",
-    stage: input.runKind,
-    status: "pass",
-    summary: "Mock report",
-    generatedAt: "2026-03-17T03:06:02Z",
-    legOutcomes: [
-      {
-        legId: "leg_1",
-        status: "pass",
-        evidenceRefs: [
-          {
-            kind: "strategy_desk_leg_receipt",
-            ref: "desk_run_mock_1:leg_1",
-          },
-        ],
+    run: {
+      schemaVersion: "v1",
+      scenarioRunId: "desk_run_mock_1",
+      scenarioId: input.scenarioId,
+      scenarioState: "paper_ready",
+      runKind: input.runKind,
+      state: "completed",
+      requestedBy: input.requestedBy,
+      trigger: {
+        kind: "operator",
+        source: "strategy_desk_runner",
+        observedAt: "2026-03-17T03:06:00Z",
       },
-    ],
-    evidence: [],
-    checks: [
-      {
-        checkId: "mock",
-        status: "pass",
-        message: "mock",
-      },
-    ],
-    approvals: [],
-  },
-}));
+      createdAt: "2026-03-17T03:06:00Z",
+      updatedAt: "2026-03-17T03:06:01Z",
+      legRuns: [],
+    },
+    report: {
+      schemaVersion: "v1",
+      reportId: "desk_report_mock_1",
+      scenarioId: input.scenarioId,
+      scenarioRunId: "desk_run_mock_1",
+      stage: input.runKind,
+      status: "pass",
+      summary: "Mock report",
+      generatedAt: "2026-03-17T03:06:02Z",
+      legOutcomes: [
+        {
+          legId: "leg_1",
+          status: "pass",
+          evidenceRefs: [
+            {
+              kind: "strategy_desk_leg_receipt",
+              ref: "desk_run_mock_1:leg_1",
+            },
+          ],
+        },
+      ],
+      evidence: [],
+      checks: [
+        {
+          checkId: "mock",
+          status: "pass",
+          message: "mock",
+        },
+      ],
+      approvals: [],
+    },
+  }),
+);
 
 mock.module("../../apps/worker/src/runtime_strategy_desk_runner", () => ({
   executeRuntimeStrategyDeskScenarioWorkflow:
@@ -229,7 +231,9 @@ describe("worker runtime strategy desk execute route", () => {
       expect(payload.ok).toBe(true);
       expect(payload.run.scenarioRunId).toBe("desk_run_mock_1");
       expect(payload.report.reportId).toBe("desk_report_mock_1");
-      expect(executeRuntimeStrategyDeskScenarioWorkflowMock).toHaveBeenCalledWith(
+      expect(
+        executeRuntimeStrategyDeskScenarioWorkflowMock,
+      ).toHaveBeenCalledWith(
         expect.objectContaining({
           scenarioId: "desk_sol_composite_1",
           runKind: "paper",

--- a/tests/unit/worker_runtime_strategy_desk_execute_route.test.ts
+++ b/tests/unit/worker_runtime_strategy_desk_execute_route.test.ts
@@ -1,0 +1,248 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Env } from "../../apps/worker/src/types";
+import {
+  createExecutionContextStub,
+  createWorkerLiveEnv,
+} from "../integration/_worker_live_test_utils";
+
+const executeRuntimeStrategyDeskScenarioWorkflowMock = mock(async (input: {
+  scenarioId: string;
+  runKind: "shadow" | "paper";
+  requestedBy: string;
+  walletAddress: string;
+}) => ({
+  scenario: {
+    schemaVersion: "v1",
+    scenarioId: input.scenarioId,
+    title: "Mock desk scenario",
+    summary: "Mock scenario summary",
+    ownerUserId: "user_1",
+    strategyKey: "strategy_desk::mock",
+    thesis: "Mock thesis",
+    state: "paper_ready",
+    createdAt: "2026-03-17T03:00:00Z",
+    updatedAt: "2026-03-17T03:05:00Z",
+    legs: [],
+    evidence: [],
+    implementationReferences: [],
+    tags: [],
+  },
+  run: {
+    schemaVersion: "v1",
+    scenarioRunId: "desk_run_mock_1",
+    scenarioId: input.scenarioId,
+    scenarioState: "paper_ready",
+    runKind: input.runKind,
+    state: "completed",
+    requestedBy: input.requestedBy,
+    trigger: {
+      kind: "operator",
+      source: "strategy_desk_runner",
+      observedAt: "2026-03-17T03:06:00Z",
+    },
+    createdAt: "2026-03-17T03:06:00Z",
+    updatedAt: "2026-03-17T03:06:01Z",
+    legRuns: [],
+  },
+  report: {
+    schemaVersion: "v1",
+    reportId: "desk_report_mock_1",
+    scenarioId: input.scenarioId,
+    scenarioRunId: "desk_run_mock_1",
+    stage: input.runKind,
+    status: "pass",
+    summary: "Mock report",
+    generatedAt: "2026-03-17T03:06:02Z",
+    legOutcomes: [
+      {
+        legId: "leg_1",
+        status: "pass",
+        evidenceRefs: [
+          {
+            kind: "strategy_desk_leg_receipt",
+            ref: "desk_run_mock_1:leg_1",
+          },
+        ],
+      },
+    ],
+    evidence: [],
+    checks: [
+      {
+        checkId: "mock",
+        status: "pass",
+        message: "mock",
+      },
+    ],
+    approvals: [],
+  },
+}));
+
+mock.module("../../apps/worker/src/runtime_strategy_desk_runner", () => ({
+  executeRuntimeStrategyDeskScenarioWorkflow:
+    executeRuntimeStrategyDeskScenarioWorkflowMock,
+}));
+mock.module("../../apps/worker/src/auth", () => ({
+  requireUser: mock(async () => ({
+    privyUserId: "did:privy:user_1",
+    email: "user@example.com",
+  })),
+}));
+
+const worker = (await import("../../apps/worker/src/index")).default;
+
+function createSqliteD1Adapter(db: Database): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          return {
+            async run() {
+              const statement = db.query(sql);
+              const result = statement.run(...(params as never[])) as {
+                changes?: number;
+              };
+              return {
+                meta: {
+                  changes:
+                    typeof result.changes === "number" ? result.changes : 0,
+                },
+              };
+            },
+            async first() {
+              const statement = db.query(sql);
+              return (statement.get(...(params as never[])) as unknown) ?? null;
+            },
+            async all() {
+              const statement = db.query(sql);
+              return {
+                results: (statement.all(...(params as never[])) ??
+                  []) as unknown[],
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+function createOpsEnv(overrides?: Partial<Env>) {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA foreign_keys = ON;");
+
+  for (const migrationName of [
+    "0025_execution_fabric.sql",
+    "0026_execution_canary.sql",
+    "0027_runtime_canary.sql",
+    "0028_strategy_lab_promotions.sql",
+    "0029_strategy_lab_readiness.sql",
+    "0030_strategy_lab_post_live.sql",
+    "0031_strategy_desk_registry.sql",
+    "0032_strategy_desk_leg_intent.sql",
+  ]) {
+    const migrationPath = resolve(
+      import.meta.dir,
+      "..",
+      "..",
+      "apps/worker/migrations",
+      migrationName,
+    );
+    sqlite.exec(readFileSync(migrationPath, "utf8"));
+  }
+
+  const env = createWorkerLiveEnv({
+    overrides: {
+      WAITLIST_DB: createSqliteD1Adapter(sqlite),
+      ADMIN_TOKEN: "admin-secret",
+      ...overrides,
+    },
+  });
+
+  return { env, sqlite };
+}
+
+describe("worker runtime strategy desk execute route", () => {
+  test("requires admin auth", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/execute",
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              runKind: "paper",
+              requestedBy: "operator_1",
+              walletAddress: "11111111111111111111111111111111",
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(401);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("dispatches scenario execution through the runner workflow", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const response = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/execute",
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              runKind: "paper",
+              requestedBy: "operator_1",
+              walletAddress: "11111111111111111111111111111111",
+              maxRetriesPerLeg: 1,
+              trigger: {
+                reason: "manual-eval",
+              },
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+
+      expect(response.status).toBe(200);
+      const payload = (await response.json()) as {
+        ok: boolean;
+        run: { scenarioRunId: string };
+        report: { reportId: string };
+      };
+      expect(payload.ok).toBe(true);
+      expect(payload.run.scenarioRunId).toBe("desk_run_mock_1");
+      expect(payload.report.reportId).toBe("desk_report_mock_1");
+      expect(executeRuntimeStrategyDeskScenarioWorkflowMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scenarioId: "desk_sol_composite_1",
+          runKind: "paper",
+          requestedBy: "operator_1",
+          walletAddress: "11111111111111111111111111111111",
+          maxRetriesPerLeg: 1,
+          trigger: {
+            reason: "manual-eval",
+          },
+        }),
+      );
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/tests/unit/worker_runtime_strategy_desk_route.test.ts
+++ b/tests/unit/worker_runtime_strategy_desk_route.test.ts
@@ -65,6 +65,7 @@ function createOpsEnv(overrides?: Partial<Env>) {
     "0029_strategy_lab_readiness.sql",
     "0030_strategy_lab_post_live.sql",
     "0031_strategy_desk_registry.sql",
+    "0032_strategy_desk_leg_intent.sql",
   ]) {
     const migrationPath = resolve(
       import.meta.dir,


### PR DESCRIPTION
## Summary
- add the composite strategy-desk scenario runner, execute route, CLI execute action, and leg intent persistence needed to orchestrate mixed paper/shadow runs through the existing Worker router
- tighten local harness support for admin-authenticated desk proofs and worker-side RPC configuration so the new execute route is reachable in a real harness session
- add focused runner/route/migration coverage and refresh the canonical strategy-desk fixture/schema bundle for per-leg intent payloads

## Validation
- `bun test tests/unit/runtime_strategy_desk_runner.test.ts tests/unit/worker_runtime_strategy_desk_execute_route.test.ts tests/unit/worker_runtime_strategy_desk_route.test.ts tests/unit/runtime_protocol_schema_fixtures.test.ts tests/unit/worker_runtime_contracts.test.ts tests/unit/worker_execution_migrations.test.ts`
- `bun run typecheck`
- `bun run lint`
- local harness proof:
  - `ADMIN_TOKEN=admin-secret RPC_ENDPOINT=https://solana-rpc.publicnode.com bun run harness:up`
  - `bun run strategy-desk:registry --resource scenario --action upsert --base-url http://127.0.0.1:9043 --admin-token admin-secret --request-file .tmp/strategy-desk-proof/scenario.paper.request.json --output-dir .tmp/strategy-desk-proof`
  - `bun run strategy-desk:registry --resource scenario --action execute --base-url http://127.0.0.1:9043 --admin-token admin-secret --request-file .tmp/strategy-desk-proof/execute.paper.request.json --output-dir .tmp/strategy-desk-proof`
  - artifact: `.tmp/strategy-desk-proof/scenario.execute.json` showing simulated `prediction_order`, `flash_atomic`, and `perp_order` legs with a fail-closed `spot_swap` block on safe-lane simulation

Closes #438.
