### PR TITLE
[Phase SD4] Build strategy desk study matrix workflow

### DIFF
--- a/apps/worker/migrations/0034_strategy_desk_research_matrix.sql
+++ b/apps/worker/migrations/0034_strategy_desk_research_matrix.sql
@@ -1,0 +1,5 @@
+ALTER TABLE strategy_desk_scenarios
+ADD COLUMN research_matrix_json TEXT;
+
+ALTER TABLE strategy_desk_reports
+ADD COLUMN study_matrix_json TEXT;

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -232,6 +232,7 @@ import {
   upsertRuntimeStrategyDeskScenarioWorkflow,
 } from "./runtime_strategy_desk";
 import { executeRuntimeStrategyDeskScenarioWorkflow } from "./runtime_strategy_desk_runner";
+import { executeRuntimeStrategyDeskStudyWorkflow } from "./runtime_strategy_desk_study";
 import { SolanaRpc } from "./solana_rpc";
 import type { Env, ExecutionConfig } from "./types";
 import type { UserRow } from "./users_db";
@@ -679,6 +680,56 @@ function parseRuntimeStrategyDeskExecuteRequest(payload: unknown): {
               : {}),
           },
         }
+      : {}),
+  };
+}
+
+function parseRuntimeStrategyDeskStudyRequest(payload: unknown): {
+  runKind: "replay" | "backtest";
+  requestedBy: string;
+  variantIds?: string[];
+  windowIds?: string[];
+  scenarioRunId?: string;
+  reportId?: string;
+  selectionMetric?: "net_return_bps" | "excess_vs_flat_cash_bps";
+} {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("runtime-strategy-desk-study-invalid-body");
+  }
+  const record = payload as Record<string, unknown>;
+  const runKind =
+    record.runKind === "replay" || record.runKind === "backtest"
+      ? record.runKind
+      : null;
+  const requestedBy = String(record.requestedBy ?? "").trim();
+  const scenarioRunId = String(record.scenarioRunId ?? "").trim();
+  const reportId = String(record.reportId ?? "").trim();
+  const selectionMetric =
+    record.selectionMetric === "net_return_bps" ||
+    record.selectionMetric === "excess_vs_flat_cash_bps"
+      ? record.selectionMetric
+      : undefined;
+  const readStringArray = (value: unknown): string[] | undefined => {
+    if (!Array.isArray(value)) return undefined;
+    const items = value
+      .map((entry) => String(entry ?? "").trim())
+      .filter(Boolean);
+    return items.length > 0 ? items : undefined;
+  };
+  if (!runKind || !requestedBy) {
+    throw new Error("runtime-strategy-desk-study-invalid-body");
+  }
+  return {
+    runKind,
+    requestedBy,
+    ...(scenarioRunId ? { scenarioRunId } : {}),
+    ...(reportId ? { reportId } : {}),
+    ...(selectionMetric ? { selectionMetric } : {}),
+    ...(readStringArray(record.variantIds)
+      ? { variantIds: readStringArray(record.variantIds) }
+      : {}),
+    ...(readStringArray(record.windowIds)
+      ? { windowIds: readStringArray(record.windowIds) }
       : {}),
   };
 }
@@ -3938,6 +3989,57 @@ const worker = {
                   error instanceof Error
                     ? error.message
                     : "runtime-strategy-desk-scenario-execute-failed",
+              },
+              { status: 400 },
+            ),
+            env,
+          );
+        }
+      }
+
+      const strategyDeskStudyScenarioId =
+        request.method === "POST"
+          ? parseAdminEntityActionPath(
+              url.pathname,
+              "/api/admin/ops/runtime/strategy-desk/scenarios/",
+              "/study",
+            )
+          : null;
+      if (request.method === "POST" && strategyDeskStudyScenarioId) {
+        const auth = authorizeAdminRoute(request, env);
+        if (!auth.ok) {
+          return withCors(
+            json({ ok: false, error: auth.error }, { status: auth.status }),
+            env,
+          );
+        }
+        try {
+          const parsed = parseRuntimeStrategyDeskStudyRequest(
+            await request.json(),
+          );
+          const result = await executeRuntimeStrategyDeskStudyWorkflow({
+            env,
+            scenarioId: strategyDeskStudyScenarioId,
+            ...parsed,
+          });
+          return withCors(
+            json({
+              ok: true,
+              scenario: result.scenario,
+              run: result.run,
+              report: result.report,
+            }),
+            env,
+          );
+        } catch (error) {
+          return withCors(
+            json(
+              {
+                ok: false,
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "runtime-strategy-desk-scenario-study-failed",
               },
               { status: 400 },
             ),

--- a/apps/worker/src/runtime_strategy_desk_study.ts
+++ b/apps/worker/src/runtime_strategy_desk_study.ts
@@ -403,6 +403,26 @@ function scenarioLegById(
   return leg;
 }
 
+function assertVariantOverridesAreBacktestBound(input: {
+  scenario: RuntimeStrategyDeskScenarioManifest;
+  variants: StrategyDeskResearchMatrixVariant[];
+  backtestLegs: StrategyDeskResearchMatrixLeg[];
+}) {
+  const configuredBacktestLegIds = new Set(
+    input.backtestLegs.map((leg) => leg.legId),
+  );
+
+  for (const variant of input.variants) {
+    for (const override of variant.legOverrides ?? []) {
+      scenarioLegById(input.scenario, override.legId);
+      if (configuredBacktestLegIds.has(override.legId)) continue;
+      throw new Error(
+        `runtime-strategy-desk-study-variant-override-leg-missing:${input.scenario.scenarioId}:${variant.variantId}:${override.legId}`,
+      );
+    }
+  }
+}
+
 function studySelectionMetricValue(input: {
   summary: StrategyDeskStudyVariantSummary;
   metric: StrategyDeskStudySelectionMetric;
@@ -835,6 +855,11 @@ export async function executeRuntimeStrategyDeskStudyWorkflow(
   for (const legConfig of researchMatrix.backtestLegs) {
     scenarioLegById(scenario, legConfig.legId);
   }
+  assertVariantOverridesAreBacktestBound({
+    scenario,
+    variants,
+    backtestLegs: researchMatrix.backtestLegs,
+  });
 
   const createdAt = nowIso(deps);
   let run = (

--- a/apps/worker/src/runtime_strategy_desk_study.ts
+++ b/apps/worker/src/runtime_strategy_desk_study.ts
@@ -75,6 +75,7 @@ export type RuntimeStrategyDeskStudyWorkflowResult = {
 
 const DEFAULT_SELECTION_METRIC: StrategyDeskStudySelectionMetric =
   "excess_vs_flat_cash_bps";
+const MAX_STRATEGY_DESK_EVIDENCE_BUCKETS = 8;
 
 function nowIso(deps?: StrategyDeskStudyDeps): string {
   return deps?.now?.() ?? new Date().toISOString();
@@ -98,6 +99,30 @@ function formatUsd(value: number): string {
 
 function formatBps(value: number): string {
   return value.toFixed(4);
+}
+
+function scenarioStateAllowsStudy(
+  scenario: RuntimeStrategyDeskScenarioManifest,
+  runKind: StrategyDeskStudyRunKind,
+): boolean {
+  if (runKind === "replay") {
+    return (
+      scenario.state === "replay_ready" ||
+      scenario.state === "shadow_ready" ||
+      scenario.state === "paper_ready" ||
+      scenario.state === "operator_review" ||
+      scenario.state === "execution_ready" ||
+      scenario.state === "execution_bound"
+    );
+  }
+  return (
+    scenario.state === "replay_ready" ||
+    scenario.state === "shadow_ready" ||
+    scenario.state === "paper_ready" ||
+    scenario.state === "operator_review" ||
+    scenario.state === "execution_ready" ||
+    scenario.state === "execution_bound"
+  );
 }
 
 function zeroMetrics(): StrategyDeskBacktestMetrics {
@@ -362,7 +387,7 @@ function upsertStageEvidenceBucket(input: {
     ].slice(0, 32),
     latestReportId: input.reportId,
   });
-  return next;
+  return next.slice(-MAX_STRATEGY_DESK_EVIDENCE_BUCKETS);
 }
 
 function scenarioLegById(
@@ -774,6 +799,11 @@ export async function executeRuntimeStrategyDeskStudyWorkflow(
     env: input.env,
     scenarioId: input.scenarioId,
   });
+  if (!scenarioStateAllowsStudy(scenario, input.runKind)) {
+    throw new Error(
+      `runtime-strategy-desk-scenario-state-not-ready:${scenario.scenarioId}:${scenario.state}:${input.runKind}`,
+    );
+  }
   const researchMatrix = scenario.researchMatrix;
   if (!researchMatrix) {
     throw new Error(

--- a/apps/worker/src/runtime_strategy_desk_study.ts
+++ b/apps/worker/src/runtime_strategy_desk_study.ts
@@ -1,0 +1,1146 @@
+import type { RuntimeBacktestRunRequest } from "../../../src/runtime/research/curation.js";
+import type {
+  RuntimeStrategyDeskRunKind,
+  RuntimeStrategyDeskScenarioLeg,
+  RuntimeStrategyDeskScenarioManifest,
+  RuntimeStrategyDeskScenarioReport,
+  RuntimeStrategyDeskScenarioRun,
+} from "./runtime_contracts";
+import { parseRuntimeBacktestReport } from "./runtime_contracts";
+import { runRuntimeBacktest } from "./runtime_internal";
+import {
+  getRuntimeStrategyDeskScenarioWorkflow,
+  upsertRuntimeStrategyDeskScenarioReportWorkflow,
+  upsertRuntimeStrategyDeskScenarioRunWorkflow,
+} from "./runtime_strategy_desk";
+import type { Env } from "./types";
+
+type StrategyDeskStudyRunKind = Extract<
+  RuntimeStrategyDeskRunKind,
+  "replay" | "backtest"
+>;
+
+type StrategyDeskStudySelectionMetric = NonNullable<
+  NonNullable<
+    RuntimeStrategyDeskScenarioManifest["researchMatrix"]
+  >["selectionMetric"]
+>;
+
+type StrategyDeskStudyMatrix = NonNullable<
+  RuntimeStrategyDeskScenarioReport["studyMatrix"]
+>;
+type StrategyDeskStudyCell = StrategyDeskStudyMatrix["cells"][number];
+type StrategyDeskStudyWindow = StrategyDeskStudyMatrix["windows"][number];
+type StrategyDeskStudyVariantSummary =
+  StrategyDeskStudyMatrix["variantSummaries"][number];
+type StrategyDeskStudyLegResult = StrategyDeskStudyCell["legResults"][number];
+type StrategyDeskBacktestMetrics = StrategyDeskStudyLegResult["metrics"];
+type StrategyDeskBacktestBaselineComparison = NonNullable<
+  StrategyDeskStudyLegResult["baselineComparisons"]
+>[number];
+type StrategyDeskBacktestStatus = StrategyDeskStudyLegResult["status"];
+type StrategyDeskResearchMatrix = NonNullable<
+  RuntimeStrategyDeskScenarioManifest["researchMatrix"]
+>;
+type StrategyDeskResearchMatrixLeg =
+  StrategyDeskResearchMatrix["backtestLegs"][number];
+type StrategyDeskResearchMatrixWindow =
+  StrategyDeskResearchMatrix["windows"][number];
+type StrategyDeskResearchMatrixVariant =
+  StrategyDeskResearchMatrix["variants"][number];
+
+export type RuntimeStrategyDeskStudyWorkflowInput = {
+  env: Env;
+  scenarioId: string;
+  runKind: StrategyDeskStudyRunKind;
+  requestedBy: string;
+  scenarioRunId?: string;
+  reportId?: string;
+  variantIds?: string[];
+  windowIds?: string[];
+  selectionMetric?: StrategyDeskStudySelectionMetric;
+};
+
+type StrategyDeskStudyDeps = {
+  now?: () => string;
+  createId?: (prefix: string) => string;
+  runRuntimeBacktest?: typeof runRuntimeBacktest;
+};
+
+export type RuntimeStrategyDeskStudyWorkflowResult = {
+  scenario: RuntimeStrategyDeskScenarioManifest;
+  run: RuntimeStrategyDeskScenarioRun;
+  report: RuntimeStrategyDeskScenarioReport;
+};
+
+const DEFAULT_SELECTION_METRIC: StrategyDeskStudySelectionMetric =
+  "excess_vs_flat_cash_bps";
+
+function nowIso(deps?: StrategyDeskStudyDeps): string {
+  return deps?.now?.() ?? new Date().toISOString();
+}
+
+function createDeskId(prefix: string, deps?: StrategyDeskStudyDeps): string {
+  if (deps?.createId) {
+    return deps.createId(prefix);
+  }
+  return `${prefix}_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+}
+
+function readNumber(value: string | number | null | undefined): number {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function formatUsd(value: number): string {
+  return value.toFixed(2);
+}
+
+function formatBps(value: number): string {
+  return value.toFixed(4);
+}
+
+function zeroMetrics(): StrategyDeskBacktestMetrics {
+  return {
+    observationCount: 0,
+    tradeCount: 0,
+    grossReturnBps: "0.0000",
+    netReturnBps: "0.0000",
+    totalCostBps: "0.0000",
+    winRateBps: 0,
+    maxDrawdownBps: "0.0000",
+  };
+}
+
+function readLegReserveUsd(leg: RuntimeStrategyDeskScenarioLeg): number {
+  return readNumber(leg.sizing.reserveUsd ?? leg.sizing.targetNotionalUsd);
+}
+
+function readLegTargetUsd(leg: RuntimeStrategyDeskScenarioLeg): number {
+  return readNumber(leg.sizing.targetNotionalUsd);
+}
+
+function readLegBudgetUsd(leg: RuntimeStrategyDeskScenarioLeg): number {
+  return readNumber(leg.sizing.maxNotionalUsd ?? leg.sizing.targetNotionalUsd);
+}
+
+function readLegNetExposureUsd(leg: RuntimeStrategyDeskScenarioLeg): number {
+  const notional = readLegTargetUsd(leg);
+  const side = String(leg.intent?.side ?? "")
+    .trim()
+    .toLowerCase();
+  switch (leg.intentFamily) {
+    case "spot_swap":
+    case "conditional_spot_order":
+    case "clob_order":
+      return side === "sell" ? -notional : notional;
+    case "perp_order":
+      return side === "short" || side === "close_long" ? -notional : notional;
+    case "prediction_order":
+      if (side === "buy_no" || side === "sell_yes") return -notional;
+      return notional;
+    default:
+      return 0;
+  }
+}
+
+function aggregateMetrics(
+  entries: Array<{
+    metrics: StrategyDeskBacktestMetrics;
+    weight: number;
+  }>,
+): StrategyDeskBacktestMetrics {
+  if (entries.length === 0) return zeroMetrics();
+
+  const weighted = entries.filter((entry) => entry.weight > 0);
+  const returnDenominator =
+    weighted.reduce((sum, entry) => sum + entry.weight, 0) || entries.length;
+  const winRateDenominator =
+    entries.reduce(
+      (sum, entry) => sum + Math.max(entry.metrics.observationCount, 1),
+      0,
+    ) || entries.length;
+
+  const observationCount = entries.reduce(
+    (sum, entry) => sum + entry.metrics.observationCount,
+    0,
+  );
+  const tradeCount = entries.reduce(
+    (sum, entry) => sum + entry.metrics.tradeCount,
+    0,
+  );
+  const grossReturnBps = entries.reduce(
+    (sum, entry) =>
+      sum +
+      readNumber(entry.metrics.grossReturnBps) *
+        (entry.weight > 0 ? entry.weight : 1),
+    0,
+  );
+  const netReturnBps = entries.reduce(
+    (sum, entry) =>
+      sum +
+      readNumber(entry.metrics.netReturnBps) *
+        (entry.weight > 0 ? entry.weight : 1),
+    0,
+  );
+  const totalCostBps = entries.reduce(
+    (sum, entry) =>
+      sum +
+      readNumber(entry.metrics.totalCostBps) *
+        (entry.weight > 0 ? entry.weight : 1),
+    0,
+  );
+  const winRateBps = entries.reduce(
+    (sum, entry) =>
+      sum +
+      entry.metrics.winRateBps * Math.max(entry.metrics.observationCount, 1),
+    0,
+  );
+  const maxDrawdownBps = entries.reduce(
+    (current, entry) =>
+      Math.max(current, readNumber(entry.metrics.maxDrawdownBps)),
+    0,
+  );
+
+  return {
+    observationCount,
+    tradeCount,
+    grossReturnBps: formatBps(grossReturnBps / returnDenominator),
+    netReturnBps: formatBps(netReturnBps / returnDenominator),
+    totalCostBps: formatBps(totalCostBps / returnDenominator),
+    winRateBps: Math.round(winRateBps / winRateDenominator),
+    maxDrawdownBps: formatBps(maxDrawdownBps),
+  };
+}
+
+function aggregateBaselineComparisons(
+  entries: Array<{
+    comparisons?: StrategyDeskBacktestBaselineComparison[];
+    weight: number;
+  }>,
+): StrategyDeskBacktestBaselineComparison[] | undefined {
+  const baselineOrder: string[] = [];
+  const aggregate = new Map<
+    string,
+    {
+      weight: number;
+      baselineReturnBps: number;
+      excessReturnBps: number;
+    }
+  >();
+
+  for (const entry of entries) {
+    const comparisons = entry.comparisons ?? [];
+    for (const comparison of comparisons) {
+      if (!baselineOrder.includes(comparison.baseline)) {
+        baselineOrder.push(comparison.baseline);
+      }
+      const current = aggregate.get(comparison.baseline) ?? {
+        weight: 0,
+        baselineReturnBps: 0,
+        excessReturnBps: 0,
+      };
+      const weight = entry.weight > 0 ? entry.weight : 1;
+      current.weight += weight;
+      current.baselineReturnBps +=
+        readNumber(comparison.baselineReturnBps) * weight;
+      current.excessReturnBps +=
+        readNumber(comparison.excessReturnBps) * weight;
+      aggregate.set(comparison.baseline, current);
+    }
+  }
+
+  if (aggregate.size === 0) return undefined;
+
+  return baselineOrder.map((baseline) => {
+    const current = aggregate.get(baseline);
+    if (!current || current.weight <= 0) {
+      return {
+        baseline,
+        baselineReturnBps: "0.0000",
+        excessReturnBps: "0.0000",
+      };
+    }
+    return {
+      baseline,
+      baselineReturnBps: formatBps(current.baselineReturnBps / current.weight),
+      excessReturnBps: formatBps(current.excessReturnBps / current.weight),
+    };
+  });
+}
+
+function baselineExcessReturnBps(
+  comparisons: StrategyDeskBacktestBaselineComparison[] | undefined,
+  baseline: string,
+): number | null {
+  const match = comparisons?.find(
+    (comparison) => comparison.baseline === baseline,
+  );
+  return match ? readNumber(match.excessReturnBps) : null;
+}
+
+function matrixLegWeight(
+  scenario: RuntimeStrategyDeskScenarioManifest,
+  legId: string,
+): number {
+  const leg = scenario.legs.find((entry) => entry.legId === legId);
+  return leg ? Math.max(readLegReserveUsd(leg), readLegTargetUsd(leg), 1) : 1;
+}
+
+function mergeBacktestLegConfig(input: {
+  leg: StrategyDeskResearchMatrixLeg;
+  variant: StrategyDeskResearchMatrixVariant;
+  window: StrategyDeskResearchMatrixWindow;
+}): RuntimeBacktestRunRequest {
+  const override = input.variant.legOverrides?.find(
+    (candidate) => candidate.legId === input.leg.legId,
+  );
+  return {
+    reportId: undefined,
+    experimentId: override?.experimentId ?? input.leg.experimentId,
+    replayCorpusId: override?.replayCorpusId ?? input.leg.replayCorpusId,
+    venueKey: override?.venueKey ?? input.leg.venueKey,
+    pairSymbol: override?.pairSymbol ?? input.leg.pairSymbol,
+    marketType: override?.marketType ?? input.leg.marketType,
+    windowMode: override?.windowMode ?? input.window.windowMode ?? "rolling",
+    trainingWindowObservations:
+      override?.trainingWindowObservations ??
+      input.window.trainingWindowObservations,
+    testingWindowObservations:
+      override?.testingWindowObservations ??
+      input.window.testingWindowObservations,
+    stepObservations:
+      override?.stepObservations ?? input.window.stepObservations,
+    purgeObservations:
+      override?.purgeObservations ?? input.window.purgeObservations,
+    baselineStrategies: override?.baselineStrategies ??
+      input.leg.baselineStrategies ?? ["flat_cash", "buy_and_hold"],
+  };
+}
+
+function buildLegRunNotes(input: {
+  variantCount: number;
+  windowCount: number;
+  selectedVariantIds: string[];
+}): string {
+  return `study:${input.variantCount} variants x ${input.windowCount} windows:${input.selectedVariantIds.join(",")}`;
+}
+
+function upsertStageEvidenceBucket(input: {
+  scenario: RuntimeStrategyDeskScenarioManifest;
+  runKind: StrategyDeskStudyRunKind;
+  reportId: string;
+  selectedVariantId?: string;
+  reproducibilityRefs: string[];
+}): RuntimeStrategyDeskScenarioReport["evidence"] {
+  const next = input.scenario.evidence.filter(
+    (bucket) => bucket.stage !== input.runKind,
+  );
+  next.push({
+    stage: input.runKind,
+    summary:
+      input.runKind === "backtest"
+        ? "Composite backtest study matrix with selection and holdout windows."
+        : "Composite replay study matrix with selection and holdout windows.",
+    evidenceRefs: [
+      {
+        kind: "strategy_desk_report",
+        ref: input.reportId,
+      },
+      ...(input.selectedVariantId
+        ? [
+            {
+              kind: "strategy_desk_variant",
+              ref: input.selectedVariantId,
+            },
+          ]
+        : []),
+      ...input.reproducibilityRefs.map((ref) => ({
+        kind: "reproducibility_bundle",
+        ref,
+      })),
+    ].slice(0, 32),
+    latestReportId: input.reportId,
+  });
+  return next;
+}
+
+function scenarioLegById(
+  scenario: RuntimeStrategyDeskScenarioManifest,
+  legId: string,
+): RuntimeStrategyDeskScenarioLeg {
+  const leg = scenario.legs.find((entry) => entry.legId === legId);
+  if (!leg) {
+    throw new Error(
+      `runtime-strategy-desk-study-leg-unknown:${scenario.scenarioId}:${legId}`,
+    );
+  }
+  return leg;
+}
+
+function studySelectionMetricValue(input: {
+  summary: StrategyDeskStudyVariantSummary;
+  metric: StrategyDeskStudySelectionMetric;
+}): number | null {
+  if (input.metric === "net_return_bps") {
+    return input.summary.selectionMetrics
+      ? readNumber(input.summary.selectionMetrics.netReturnBps)
+      : null;
+  }
+  return baselineExcessReturnBps(
+    input.summary.selectionBaselineComparisons,
+    "flat_cash",
+  );
+}
+
+function buildVariantSummary(input: {
+  variant: StrategyDeskResearchMatrixVariant;
+  cells: StrategyDeskStudyCell[];
+}): StrategyDeskStudyVariantSummary {
+  const selectionCells = input.cells.filter(
+    (cell) => cell.cohort === "selection",
+  );
+  const holdoutCells = input.cells.filter((cell) => cell.cohort === "holdout");
+  const aggregateCellMetrics = (
+    cells: StrategyDeskStudyCell[],
+  ): StrategyDeskBacktestMetrics | undefined => {
+    if (cells.length === 0) return undefined;
+    return aggregateMetrics(
+      cells.map((cell) => ({
+        metrics: cell.aggregateMetrics,
+        weight: Math.max(cell.aggregateMetrics.observationCount, 1),
+      })),
+    );
+  };
+  const aggregateCellBaselines = (
+    cells: StrategyDeskStudyCell[],
+  ): StrategyDeskBacktestBaselineComparison[] | undefined =>
+    aggregateBaselineComparisons(
+      cells.map((cell) => ({
+        comparisons: cell.aggregateBaselineComparisons,
+        weight: Math.max(cell.aggregateMetrics.observationCount, 1),
+      })),
+    );
+
+  return {
+    variantId: input.variant.variantId,
+    label: input.variant.label,
+    parameterManifest: input.variant.parameterManifest,
+    selectionWindowCount: selectionCells.length,
+    holdoutWindowCount: holdoutCells.length,
+    ...(selectionCells.length > 0
+      ? {
+          selectionMetrics: aggregateCellMetrics(selectionCells),
+          selectionBaselineComparisons: aggregateCellBaselines(selectionCells),
+        }
+      : {}),
+    ...(holdoutCells.length > 0
+      ? {
+          holdoutMetrics: aggregateCellMetrics(holdoutCells),
+          holdoutBaselineComparisons: aggregateCellBaselines(holdoutCells),
+        }
+      : {}),
+    ...(input.variant.notes ? { notes: input.variant.notes } : {}),
+  };
+}
+
+function summarizeScenarioLegs(input: {
+  scenario: RuntimeStrategyDeskScenarioManifest;
+  studyMatrix: StrategyDeskStudyMatrix;
+}): {
+  legOutcomes: RuntimeStrategyDeskScenarioReport["legOutcomes"];
+  scorecard: RuntimeStrategyDeskScenarioReport["scorecard"];
+  portfolioSummary: NonNullable<
+    RuntimeStrategyDeskScenarioReport["portfolioSummary"]
+  >;
+} {
+  const focusCells =
+    input.studyMatrix.selectedVariantId &&
+    input.studyMatrix.variantSummaries.find(
+      (summary) => summary.variantId === input.studyMatrix.selectedVariantId,
+    )?.holdoutWindowCount
+      ? input.studyMatrix.cells.filter(
+          (cell) =>
+            cell.variantId === input.studyMatrix.selectedVariantId &&
+            cell.cohort === "holdout",
+        )
+      : input.studyMatrix.selectedVariantId
+        ? input.studyMatrix.cells.filter(
+            (cell) => cell.variantId === input.studyMatrix.selectedVariantId,
+          )
+        : input.studyMatrix.cells;
+
+  const legOutcomes = input.scenario.legs.map((leg) => {
+    const legResults = focusCells.flatMap((cell) =>
+      cell.legResults.filter((result) => result.legId === leg.legId),
+    );
+    if (legResults.length === 0) {
+      return {
+        legId: leg.legId,
+        status: "not_applicable" as const,
+        evidenceRefs: [],
+        notes: ["No study matrix backtest config is attached to this leg."],
+      };
+    }
+
+    const aggregatedMetrics = aggregateMetrics(
+      legResults.map((result) => ({
+        metrics: result.metrics,
+        weight: Math.max(result.metrics.observationCount, 1),
+      })),
+    );
+    const targetUsd = readLegTargetUsd(leg);
+    const status: RuntimeStrategyDeskScenarioReport["legOutcomes"][number]["status"] =
+      legResults.some((result) => result.status !== "completed")
+        ? "blocked"
+        : "pass";
+
+    return {
+      legId: leg.legId,
+      status,
+      netPnlUsd: formatUsd(
+        (targetUsd * readNumber(aggregatedMetrics.netReturnBps)) / 10_000,
+      ),
+      costUsd: formatUsd(
+        (targetUsd * readNumber(aggregatedMetrics.totalCostBps)) / 10_000,
+      ),
+      evidenceRefs: Array.from(
+        new Map(
+          legResults.flatMap((result) => [
+            [
+              `backtest:${result.reportId}`,
+              {
+                kind: "backtest_report",
+                ref: result.reportId,
+              },
+            ],
+            [
+              `repro:${result.reproducibilityBundleId}`,
+              {
+                kind: "reproducibility_bundle",
+                ref: result.reproducibilityBundleId,
+              },
+            ],
+          ]),
+        ).values(),
+      ).slice(0, 16),
+      ...(legResults.some((result) => (result.blockingReasons?.length ?? 0) > 0)
+        ? {
+            notes: legResults
+              .flatMap((result) => result.blockingReasons ?? [])
+              .slice(0, 16),
+          }
+        : {}),
+    };
+  });
+
+  const selectedVariantSummary =
+    input.studyMatrix.variantSummaries.find(
+      (summary) => summary.variantId === input.studyMatrix.selectedVariantId,
+    ) ?? input.studyMatrix.variantSummaries[0];
+  const summaryMetrics =
+    selectedVariantSummary?.holdoutMetrics ??
+    selectedVariantSummary?.selectionMetrics ??
+    zeroMetrics();
+  const capitalAllocatedUsd = input.scenario.legs.reduce(
+    (sum, leg) => sum + readLegReserveUsd(leg),
+    0,
+  );
+  const grossExposureBudgetUsd = input.scenario.legs.reduce(
+    (sum, leg) => sum + readLegBudgetUsd(leg),
+    0,
+  );
+  const reservedUsd = capitalAllocatedUsd;
+  const grossPnlUsd =
+    (capitalAllocatedUsd * readNumber(summaryMetrics.grossReturnBps)) / 10_000;
+  const netPnlUsd =
+    (capitalAllocatedUsd * readNumber(summaryMetrics.netReturnBps)) / 10_000;
+  const totalCostUsd =
+    (capitalAllocatedUsd * readNumber(summaryMetrics.totalCostBps)) / 10_000;
+  const grossExposureUsd = input.scenario.legs.reduce(
+    (sum, leg) => sum + readLegTargetUsd(leg),
+    0,
+  );
+  const netExposureUsd = input.scenario.legs.reduce(
+    (sum, leg) => sum + readLegNetExposureUsd(leg),
+    0,
+  );
+  const venueExposureUsd = Object.fromEntries(
+    Array.from(
+      input.scenario.legs.reduce((map, leg) => {
+        map.set(
+          leg.venueKey,
+          (map.get(leg.venueKey) ?? 0) + readLegTargetUsd(leg),
+        );
+        return map;
+      }, new Map<string, number>()),
+    ).map(([key, value]) => [key, formatUsd(value)]),
+  );
+  const venueFamilyExposureUsd = Object.fromEntries(
+    Array.from(
+      input.scenario.legs.reduce((map, leg) => {
+        map.set(
+          leg.intentFamily,
+          (map.get(leg.intentFamily) ?? 0) + readLegTargetUsd(leg),
+        );
+        return map;
+      }, new Map<string, number>()),
+    ).map(([key, value]) => [key, formatUsd(value)]),
+  );
+  const marketTypeExposureUsd = Object.fromEntries(
+    Array.from(
+      input.scenario.legs.reduce((map, leg) => {
+        map.set(
+          leg.marketType,
+          (map.get(leg.marketType) ?? 0) + readLegTargetUsd(leg),
+        );
+        return map;
+      }, new Map<string, number>()),
+    ).map(([key, value]) => [key, formatUsd(value)]),
+  );
+  const activeLegCount = legOutcomes.filter(
+    (outcome) => outcome.status !== "not_applicable",
+  ).length;
+
+  const portfolioSummary = {
+    capitalAllocatedUsd: formatUsd(capitalAllocatedUsd),
+    grossExposureBudgetUsd: formatUsd(grossExposureBudgetUsd),
+    equityUsd: formatUsd(capitalAllocatedUsd + netPnlUsd),
+    availableUsd: formatUsd(
+      Math.max(capitalAllocatedUsd + netPnlUsd - reservedUsd, 0),
+    ),
+    reservedUsd: formatUsd(reservedUsd),
+    grossPnlUsd: formatUsd(grossPnlUsd),
+    netPnlUsd: formatUsd(netPnlUsd),
+    grossExposureUsd: formatUsd(grossExposureUsd),
+    netExposureUsd: formatUsd(netExposureUsd),
+    maxDrawdownBps: Math.round(readNumber(summaryMetrics.maxDrawdownBps)),
+    tradeCount: summaryMetrics.tradeCount,
+    activeLegCount,
+    venueExposureUsd,
+    venueFamilyExposureUsd,
+    marketTypeExposureUsd,
+    notes: [
+      `Selected variant: ${selectedVariantSummary?.variantId ?? "none"}`,
+      selectedVariantSummary?.holdoutMetrics
+        ? "Portfolio summary is based on holdout metrics for the selected variant."
+        : "Portfolio summary is based on selection metrics for the selected variant.",
+    ],
+  } satisfies NonNullable<
+    RuntimeStrategyDeskScenarioReport["portfolioSummary"]
+  >;
+
+  const legMetrics = input.scenario.legs.map((leg, index) => ({
+    legId: leg.legId,
+    venueKey: leg.venueKey,
+    intentFamily: leg.intentFamily,
+    marketType: leg.marketType,
+    status: legOutcomes[index]?.status ?? "not_applicable",
+    targetNotionalUsd: formatUsd(readLegTargetUsd(leg)),
+    reservedCapitalUsd: formatUsd(readLegReserveUsd(leg)),
+    grossExposureUsd: formatUsd(readLegTargetUsd(leg)),
+    netExposureUsd: formatUsd(readLegNetExposureUsd(leg)),
+    ...(legOutcomes[index]?.netPnlUsd
+      ? { netPnlUsd: legOutcomes[index].netPnlUsd }
+      : {}),
+    ...(legOutcomes[index]?.costUsd
+      ? { costUsd: legOutcomes[index].costUsd }
+      : {}),
+    ...(legOutcomes[index]?.notes ? { notes: legOutcomes[index].notes } : {}),
+  }));
+
+  const scorecard = {
+    aggregate: {
+      passedLegCount: legOutcomes.filter((outcome) => outcome.status === "pass")
+        .length,
+      blockedLegCount: legOutcomes.filter(
+        (outcome) => outcome.status === "blocked",
+      ).length,
+      skippedLegCount: legOutcomes.filter(
+        (outcome) => outcome.status === "not_applicable",
+      ).length,
+      activeLegCount,
+      tradeCount: summaryMetrics.tradeCount,
+      reservedCapitalUsd: portfolioSummary.reservedUsd,
+      grossExposureUsd: portfolioSummary.grossExposureUsd,
+      netExposureUsd: portfolioSummary.netExposureUsd,
+      grossPnlUsd: portfolioSummary.grossPnlUsd,
+      netPnlUsd: portfolioSummary.netPnlUsd,
+      totalCostUsd: formatUsd(totalCostUsd),
+      maxDrawdownBps: portfolioSummary.maxDrawdownBps,
+    },
+    legMetrics,
+  } satisfies NonNullable<RuntimeStrategyDeskScenarioReport["scorecard"]>;
+
+  return { legOutcomes, scorecard, portfolioSummary };
+}
+
+async function runStudyCellLeg(input: {
+  env: Env;
+  scenario: RuntimeStrategyDeskScenarioManifest;
+  scenarioRunId: string;
+  runKind: StrategyDeskStudyRunKind;
+  variant: StrategyDeskResearchMatrixVariant;
+  window: StrategyDeskResearchMatrixWindow;
+  legConfig: StrategyDeskResearchMatrixLeg;
+  deps?: StrategyDeskStudyDeps;
+}): Promise<StrategyDeskStudyLegResult> {
+  const leg = scenarioLegById(input.scenario, input.legConfig.legId);
+  const payload = mergeBacktestLegConfig({
+    leg: input.legConfig,
+    variant: input.variant,
+    window: input.window,
+  });
+  const reportId = createDeskId(
+    `desk_${input.scenario.scenarioId}_${input.variant.variantId}_${input.window.windowId}_${input.legConfig.legId}_${input.runKind ?? "study"}`,
+    input.deps,
+  );
+  try {
+    const result = await (input.deps?.runRuntimeBacktest ?? runRuntimeBacktest)(
+      {
+        env: input.env,
+        payload: {
+          ...payload,
+          reportId,
+        },
+      },
+    );
+    if (!result.ok) {
+      const reason = String(result.payload.error ?? "runtime-backtest-failed");
+      return {
+        legId: input.legConfig.legId,
+        reportId,
+        reproducibilityBundleId: `repro_${reportId}`,
+        status: "failed",
+        metrics: zeroMetrics(),
+        blockingReasons: [reason],
+      };
+    }
+    const report = parseRuntimeBacktestReport(
+      (result.payload.report ?? result.payload) as Record<string, unknown>,
+    );
+    return {
+      legId: input.legConfig.legId,
+      reportId: report.reportId,
+      reproducibilityBundleId: `repro_${report.reportId}`,
+      status: report.status,
+      metrics: report.aggregateMetrics,
+      ...(report.aggregateBaselineComparisons.length > 0
+        ? {
+            baselineComparisons: report.aggregateBaselineComparisons,
+          }
+        : {}),
+      ...(report.blockingReasons.length > 0
+        ? { blockingReasons: report.blockingReasons }
+        : {}),
+    };
+  } catch (error) {
+    return {
+      legId: leg.legId,
+      reportId,
+      reproducibilityBundleId: `repro_${reportId}`,
+      status: "failed",
+      metrics: zeroMetrics(),
+      blockingReasons: [
+        error instanceof Error ? error.message : "runtime-backtest-threw",
+      ],
+    };
+  }
+}
+
+function selectVariantId(input: {
+  variantSummaries: StrategyDeskStudyVariantSummary[];
+  selectionMetric: StrategyDeskStudySelectionMetric;
+}): string | undefined {
+  let best: { variantId: string; value: number } | null = null;
+  for (const summary of input.variantSummaries) {
+    const value = studySelectionMetricValue({
+      summary,
+      metric: input.selectionMetric,
+    });
+    if (value === null) continue;
+    if (!best || value > best.value + Number.EPSILON) {
+      best = { variantId: summary.variantId, value };
+    }
+  }
+  return best?.variantId;
+}
+
+export async function executeRuntimeStrategyDeskStudyWorkflow(
+  input: RuntimeStrategyDeskStudyWorkflowInput,
+  deps?: StrategyDeskStudyDeps,
+): Promise<RuntimeStrategyDeskStudyWorkflowResult> {
+  const { scenario } = await getRuntimeStrategyDeskScenarioWorkflow({
+    env: input.env,
+    scenarioId: input.scenarioId,
+  });
+  const researchMatrix = scenario.researchMatrix;
+  if (!researchMatrix) {
+    throw new Error(
+      `runtime-strategy-desk-study-matrix-missing:${scenario.scenarioId}`,
+    );
+  }
+
+  const windows = researchMatrix.windows.filter((window) =>
+    !input.windowIds || input.windowIds.length === 0
+      ? true
+      : input.windowIds.includes(window.windowId),
+  );
+  const variants = researchMatrix.variants.filter((variant) =>
+    !input.variantIds || input.variantIds.length === 0
+      ? true
+      : input.variantIds.includes(variant.variantId),
+  );
+  if (windows.length === 0) {
+    throw new Error(
+      `runtime-strategy-desk-study-window-selection-empty:${scenario.scenarioId}`,
+    );
+  }
+  if (variants.length === 0) {
+    throw new Error(
+      `runtime-strategy-desk-study-variant-selection-empty:${scenario.scenarioId}`,
+    );
+  }
+
+  for (const legConfig of researchMatrix.backtestLegs) {
+    scenarioLegById(scenario, legConfig.legId);
+  }
+
+  const createdAt = nowIso(deps);
+  let run = (
+    await upsertRuntimeStrategyDeskScenarioRunWorkflow({
+      env: input.env,
+      run: {
+        schemaVersion: scenario.schemaVersion,
+        scenarioRunId:
+          input.scenarioRunId ??
+          createDeskId(
+            `desk_run_${scenario.scenarioId}_${input.runKind}`,
+            deps,
+          ),
+        scenarioId: scenario.scenarioId,
+        scenarioState: scenario.state,
+        runKind: input.runKind,
+        state: "pending",
+        requestedBy: input.requestedBy,
+        trigger: {
+          kind: "operator",
+          source: "portal.strategy-desk-study",
+          observedAt: createdAt,
+          reason: `${input.runKind} matrix study`,
+        },
+        createdAt,
+        updatedAt: createdAt,
+        legRuns: scenario.legs.map((leg) => ({
+          legId: leg.legId,
+          stage: input.runKind,
+          state: "pending",
+          requestRef: `study:${leg.legId}`,
+        })),
+      },
+    })
+  ).run;
+
+  const requestedAt = nowIso(deps);
+  run = (
+    await upsertRuntimeStrategyDeskScenarioRunWorkflow({
+      env: input.env,
+      run: {
+        ...run,
+        state: "legs_requested",
+        updatedAt: requestedAt,
+      },
+    })
+  ).run;
+
+  const runningAt = nowIso(deps);
+  run = (
+    await upsertRuntimeStrategyDeskScenarioRunWorkflow({
+      env: input.env,
+      run: {
+        ...run,
+        state: "legs_running",
+        startedAt: run.startedAt ?? runningAt,
+        updatedAt: runningAt,
+      },
+    })
+  ).run;
+
+  const cells: StrategyDeskStudyCell[] = [];
+  for (const variant of variants) {
+    for (const window of windows) {
+      const legResults: StrategyDeskStudyLegResult[] = [];
+      for (const legConfig of researchMatrix.backtestLegs) {
+        legResults.push(
+          await runStudyCellLeg({
+            env: input.env,
+            scenario,
+            scenarioRunId: run.scenarioRunId,
+            runKind: input.runKind,
+            variant,
+            window,
+            legConfig,
+            deps,
+          }),
+        );
+      }
+
+      const aggregateMetricsResult = aggregateMetrics(
+        legResults.map((result) => ({
+          metrics: result.metrics,
+          weight: matrixLegWeight(scenario, result.legId),
+        })),
+      );
+      const aggregateBaselineComparisonResults = aggregateBaselineComparisons(
+        legResults.map((result) => ({
+          comparisons: result.baselineComparisons,
+          weight: matrixLegWeight(scenario, result.legId),
+        })),
+      );
+      const status: StrategyDeskBacktestStatus = legResults.some(
+        (result) => result.status === "failed",
+      )
+        ? "failed"
+        : legResults.some((result) => result.status === "blocked")
+          ? "blocked"
+          : "completed";
+
+      cells.push({
+        cellId: `${variant.variantId}:${window.windowId}`,
+        variantId: variant.variantId,
+        variantLabel: variant.label,
+        windowId: window.windowId,
+        windowLabel: window.label,
+        cohort: window.cohort,
+        status,
+        legResults,
+        aggregateMetrics: aggregateMetricsResult,
+        ...(aggregateBaselineComparisonResults
+          ? {
+              aggregateBaselineComparisons: aggregateBaselineComparisonResults,
+            }
+          : {}),
+        notes: [`window=${window.windowMode}`, `variant=${variant.variantId}`],
+      });
+    }
+  }
+
+  const collectingAt = nowIso(deps);
+  run = (
+    await upsertRuntimeStrategyDeskScenarioRunWorkflow({
+      env: input.env,
+      run: {
+        ...run,
+        state: "collecting_evidence",
+        updatedAt: collectingAt,
+      },
+    })
+  ).run;
+
+  const selectionMetric =
+    input.selectionMetric ??
+    researchMatrix.selectionMetric ??
+    DEFAULT_SELECTION_METRIC;
+  const variantSummaries = variants.map((variant) =>
+    buildVariantSummary({
+      variant,
+      cells: cells.filter((cell) => cell.variantId === variant.variantId),
+    }),
+  );
+  const selectedVariantId = selectVariantId({
+    variantSummaries,
+    selectionMetric,
+  });
+  const studyMatrix: StrategyDeskStudyMatrix = {
+    matrixId: createDeskId(
+      `desk_matrix_${scenario.scenarioId}_${input.runKind}`,
+      deps,
+    ),
+    runKind: input.runKind,
+    selectionMetric,
+    generatedAt: nowIso(deps),
+    ...(selectedVariantId ? { selectedVariantId } : {}),
+    windows: windows.map<StrategyDeskStudyWindow>((window) => ({
+      windowId: window.windowId,
+      label: window.label,
+      cohort: window.cohort,
+    })),
+    variantSummaries,
+    cells,
+  };
+
+  const { legOutcomes, scorecard, portfolioSummary } = summarizeScenarioLegs({
+    scenario,
+    studyMatrix,
+  });
+  const blockedCells = cells.filter((cell) => cell.status !== "completed");
+  const holdoutWindowCount = windows.filter(
+    (window) => window.cohort === "holdout",
+  ).length;
+  const selectedVariant = variantSummaries.find(
+    (summary) => summary.variantId === selectedVariantId,
+  );
+  const checks: RuntimeStrategyDeskScenarioReport["checks"] = [
+    {
+      checkId: "matrix-generated",
+      status: "pass",
+      observedValue: `${variants.length} variants x ${windows.length} windows`,
+      thresholdValue: "at least one variant and one window",
+      message: "Composite study matrix generated successfully.",
+    },
+    {
+      checkId: "holdout-coverage",
+      status: holdoutWindowCount > 0 ? "pass" : "requires_human_approval",
+      observedValue: String(holdoutWindowCount),
+      thresholdValue: ">= 1",
+      message:
+        holdoutWindowCount > 0
+          ? "Holdout windows are present for out-of-sample comparison."
+          : "No holdout windows are configured, so selection performance is in-sample only.",
+    },
+    {
+      checkId: "variant-selection",
+      status: selectedVariantId ? "pass" : "blocked",
+      observedValue: selectedVariantId ?? "none",
+      thresholdValue: "selected variant id",
+      message: selectedVariantId
+        ? "A study winner was selected from the configured matrix."
+        : "No variant could be selected from the configured matrix.",
+    },
+  ];
+
+  const reportStatus: RuntimeStrategyDeskScenarioReport["status"] =
+    blockedCells.length > 0 || !selectedVariantId
+      ? "blocked"
+      : holdoutWindowCount === 0
+        ? "requires_human_approval"
+        : "pass";
+  const completedAt = nowIso(deps);
+  const reportId =
+    input.reportId ??
+    createDeskId(`desk_report_${scenario.scenarioId}_${input.runKind}`, deps);
+  const reproducibilityRefs = Array.from(
+    new Set(
+      cells
+        .filter((cell) =>
+          selectedVariantId ? cell.variantId === selectedVariantId : true,
+        )
+        .flatMap((cell) =>
+          cell.legResults.map((result) => result.reproducibilityBundleId),
+        ),
+    ),
+  ).slice(0, 12);
+  const report = (
+    await upsertRuntimeStrategyDeskScenarioReportWorkflow({
+      env: input.env,
+      report: {
+        schemaVersion: scenario.schemaVersion,
+        reportId,
+        scenarioId: scenario.scenarioId,
+        scenarioRunId: run.scenarioRunId,
+        stage: input.runKind,
+        status: reportStatus,
+        summary:
+          reportStatus === "blocked"
+            ? `Composite ${input.runKind} study found ${blockedCells.length} blocked or failed matrix cells.`
+            : reportStatus === "requires_human_approval"
+              ? `Composite ${input.runKind} study completed without holdout coverage and requires operator review.`
+              : `Composite ${input.runKind} study completed with ${variants.length} variants across ${windows.length} windows.`,
+        generatedAt: completedAt,
+        legOutcomes,
+        portfolioSummary,
+        scorecard,
+        studyMatrix,
+        evidence: upsertStageEvidenceBucket({
+          scenario,
+          runKind: input.runKind,
+          reportId,
+          selectedVariantId,
+          reproducibilityRefs,
+        }),
+        checks,
+        approvals: [],
+        metadata: {
+          selectionMetric,
+          blockedCellCount: blockedCells.length,
+          selectedVariantLabel: selectedVariant?.label ?? null,
+        },
+      },
+    })
+  ).report;
+
+  const legRuns = scenario.legs.map((leg) => {
+    const hasBacktestConfig = researchMatrix.backtestLegs.some(
+      (config) => config.legId === leg.legId,
+    );
+    if (!hasBacktestConfig) {
+      return {
+        legId: leg.legId,
+        stage: input.runKind,
+        state: "skipped" as const,
+        requestRef: `study:${leg.legId}`,
+        notes: "No study matrix config defined for this leg.",
+      };
+    }
+    const selectedLegCells = cells.filter((cell) =>
+      selectedVariantId ? cell.variantId === selectedVariantId : true,
+    );
+    const states = selectedLegCells.flatMap((cell) =>
+      cell.legResults
+        .filter((result) => result.legId === leg.legId)
+        .map((result) => result.status),
+    );
+    const state = states.some((status) => status !== "completed")
+      ? "failed"
+      : "completed";
+    return {
+      legId: leg.legId,
+      stage: input.runKind,
+      state,
+      requestRef: `study:${leg.legId}`,
+      notes: buildLegRunNotes({
+        variantCount: variants.length,
+        windowCount: windows.length,
+        selectedVariantIds: selectedVariantId ? [selectedVariantId] : [],
+      }),
+    };
+  });
+
+  const terminalState: RuntimeStrategyDeskScenarioRun["state"] =
+    report.status === "blocked"
+      ? "rejected"
+      : report.status === "requires_human_approval"
+        ? "needs_review"
+        : "completed";
+  run = (
+    await upsertRuntimeStrategyDeskScenarioRunWorkflow({
+      env: input.env,
+      run: {
+        ...run,
+        state: terminalState,
+        updatedAt: completedAt,
+        completedAt,
+        legRuns,
+        ...(report.status === "blocked"
+          ? {
+              failureCode: "strategy-desk-study-blocked",
+              failureMessage: report.summary,
+            }
+          : {}),
+        metadata: {
+          ...(run.metadata ?? {}),
+          latestReportId: report.reportId,
+          selectedVariantId,
+          variantCount: variants.length,
+          windowCount: windows.length,
+        },
+      },
+    })
+  ).run;
+
+  return {
+    scenario,
+    run,
+    report,
+  };
+}

--- a/apps/worker/src/strategy_desk_repository.ts
+++ b/apps/worker/src/strategy_desk_repository.ts
@@ -21,6 +21,9 @@ function stringOrNull(value: unknown): string | null {
 }
 
 function parseJsonValue(value: unknown): unknown {
+  if (Array.isArray(value) || isRecord(value)) {
+    return value;
+  }
   if (typeof value !== "string" || !value.trim()) return undefined;
   try {
     return JSON.parse(value) as unknown;

--- a/apps/worker/src/strategy_desk_repository.ts
+++ b/apps/worker/src/strategy_desk_repository.ts
@@ -92,6 +92,7 @@ function mapScenarioRow(
   const activeHandoffId = stringOrNull(row.activeHandoffId);
   const latestReportId = stringOrNull(row.latestReportId);
   const riskLimits = parseJsonValue(row.riskLimits);
+  const researchMatrix = parseJsonValue(row.researchMatrix);
   const evidence = parseJsonValue(row.evidence);
   const implementationReferences = parseJsonValue(row.implementationReferences);
   const tags = parseJsonValue(row.tags);
@@ -115,6 +116,7 @@ function mapScenarioRow(
     ...(activeHandoffId ? { activeHandoffId } : {}),
     ...(latestReportId ? { latestReportId } : {}),
     ...(isRecord(riskLimits) ? { riskLimits } : {}),
+    ...(isRecord(researchMatrix) ? { researchMatrix } : {}),
     legs,
     evidence: Array.isArray(evidence) ? evidence : [],
     implementationReferences: Array.isArray(implementationReferences)
@@ -167,6 +169,7 @@ function mapScenarioReportRow(
   const portfolioSummary = parseJsonValue(row.portfolioSummary);
   const scorecard = parseJsonValue(row.scorecard);
   const riskOverlays = parseJsonValue(row.riskOverlays);
+  const studyMatrix = parseJsonValue(row.studyMatrix);
   const evidence = parseJsonValue(row.evidence);
   const checks = parseJsonValue(row.checks);
   const approvals = parseJsonValue(row.approvals);
@@ -187,6 +190,7 @@ function mapScenarioReportRow(
     ...(isRecord(portfolioSummary) ? { portfolioSummary } : {}),
     ...(isRecord(scorecard) ? { scorecard } : {}),
     ...(Array.isArray(riskOverlays) ? { riskOverlays } : {}),
+    ...(isRecord(studyMatrix) ? { studyMatrix } : {}),
     evidence: Array.isArray(evidence) ? evidence : [],
     checks: Array.isArray(checks) ? checks : [],
     approvals: Array.isArray(approvals) ? approvals : [],
@@ -263,6 +267,7 @@ export async function writeStrategyDeskScenarioManifest(
         active_handoff_id,
         latest_report_id,
         risk_limits_json,
+        research_matrix_json,
         evidence_json,
         implementation_references_json,
         tags_json,
@@ -270,7 +275,7 @@ export async function writeStrategyDeskScenarioManifest(
         created_at,
         updated_at
       ) VALUES (
-        ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19
+        ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20
       )
       ON CONFLICT(scenario_id) DO UPDATE SET
         schema_version = excluded.schema_version,
@@ -285,6 +290,7 @@ export async function writeStrategyDeskScenarioManifest(
         active_handoff_id = excluded.active_handoff_id,
         latest_report_id = excluded.latest_report_id,
         risk_limits_json = excluded.risk_limits_json,
+        research_matrix_json = excluded.research_matrix_json,
         evidence_json = excluded.evidence_json,
         implementation_references_json = excluded.implementation_references_json,
         tags_json = excluded.tags_json,
@@ -307,6 +313,7 @@ export async function writeStrategyDeskScenarioManifest(
       scenario.activeHandoffId ?? null,
       scenario.latestReportId ?? null,
       stringifyJson(scenario.riskLimits),
+      stringifyJson(scenario.researchMatrix),
       stringifyJson(scenario.evidence) ?? "[]",
       stringifyJson(scenario.implementationReferences) ?? "[]",
       stringifyJson(scenario.tags) ?? "[]",
@@ -420,6 +427,7 @@ export async function getStrategyDeskScenarioManifest(
         active_handoff_id AS activeHandoffId,
         latest_report_id AS latestReportId,
         risk_limits_json AS riskLimits,
+        research_matrix_json AS researchMatrix,
         evidence_json AS evidence,
         implementation_references_json AS implementationReferences,
         tags_json AS tags,
@@ -470,6 +478,7 @@ export async function listStrategyDeskScenarioManifests(
         active_handoff_id AS activeHandoffId,
         latest_report_id AS latestReportId,
         risk_limits_json AS riskLimits,
+        research_matrix_json AS researchMatrix,
         evidence_json AS evidence,
         implementation_references_json AS implementationReferences,
         tags_json AS tags,
@@ -686,13 +695,14 @@ export async function writeStrategyDeskScenarioReport(
         portfolio_summary_json,
         scorecard_json,
         risk_overlays_json,
+        study_matrix_json,
         evidence_json,
         checks_json,
         approvals_json,
         metadata_json,
         generated_at
       ) VALUES (
-        ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16
+        ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17
       )
       ON CONFLICT(report_id) DO UPDATE SET
         scenario_id = excluded.scenario_id,
@@ -705,6 +715,7 @@ export async function writeStrategyDeskScenarioReport(
         portfolio_summary_json = excluded.portfolio_summary_json,
         scorecard_json = excluded.scorecard_json,
         risk_overlays_json = excluded.risk_overlays_json,
+        study_matrix_json = excluded.study_matrix_json,
         evidence_json = excluded.evidence_json,
         checks_json = excluded.checks_json,
         approvals_json = excluded.approvals_json,
@@ -724,6 +735,7 @@ export async function writeStrategyDeskScenarioReport(
       stringifyJson(report.portfolioSummary),
       stringifyJson(report.scorecard),
       stringifyJson(report.riskOverlays) ?? "[]",
+      stringifyJson(report.studyMatrix),
       stringifyJson(report.evidence) ?? "[]",
       stringifyJson(report.checks) ?? "[]",
       stringifyJson(report.approvals) ?? "[]",
@@ -753,6 +765,7 @@ export async function getStrategyDeskScenarioReport(
         portfolio_summary_json AS portfolioSummary,
         scorecard_json AS scorecard,
         risk_overlays_json AS riskOverlays,
+        study_matrix_json AS studyMatrix,
         evidence_json AS evidence,
         checks_json AS checks,
         approvals_json AS approvals,
@@ -795,6 +808,7 @@ export async function listStrategyDeskScenarioReports(
         portfolio_summary_json AS portfolioSummary,
         scorecard_json AS scorecard,
         risk_overlays_json AS riskOverlays,
+        study_matrix_json AS studyMatrix,
         evidence_json AS evidence,
         checks_json AS checks,
         approvals_json AS approvals,

--- a/docs/runtime-contracts/fixtures/runtime.strategy_desk_report.valid.v1.json
+++ b/docs/runtime-contracts/fixtures/runtime.strategy_desk_report.valid.v1.json
@@ -157,6 +157,119 @@
       "message": "Composite execution completed without fail-closed demotion."
     }
   ],
+  "studyMatrix": {
+    "matrixId": "desk_matrix_sol_composite_backtest_1",
+    "runKind": "backtest",
+    "selectionMetric": "excess_vs_flat_cash_bps",
+    "generatedAt": "2026-03-17T03:08:15Z",
+    "selectedVariantId": "fast",
+    "windows": [
+      {
+        "windowId": "selection_week_1",
+        "label": "Selection week 1",
+        "cohort": "selection"
+      },
+      {
+        "windowId": "holdout_week_1",
+        "label": "Holdout week 1",
+        "cohort": "holdout"
+      }
+    ],
+    "variantSummaries": [
+      {
+        "variantId": "fast",
+        "label": "Fast",
+        "parameterManifest": {
+          "threshold": "fast"
+        },
+        "selectionWindowCount": 1,
+        "holdoutWindowCount": 1,
+        "selectionMetrics": {
+          "observationCount": 8,
+          "tradeCount": 5,
+          "grossReturnBps": "75.0000",
+          "netReturnBps": "60.0000",
+          "totalCostBps": "15.0000",
+          "winRateBps": 5000,
+          "maxDrawdownBps": "45.0000"
+        },
+        "selectionBaselineComparisons": [
+          {
+            "baseline": "flat_cash",
+            "baselineReturnBps": "0.0000",
+            "excessReturnBps": "60.0000"
+          }
+        ],
+        "holdoutMetrics": {
+          "observationCount": 8,
+          "tradeCount": 4,
+          "grossReturnBps": "18.0000",
+          "netReturnBps": "10.0000",
+          "totalCostBps": "8.0000",
+          "winRateBps": 5000,
+          "maxDrawdownBps": "32.0000"
+        },
+        "holdoutBaselineComparisons": [
+          {
+            "baseline": "flat_cash",
+            "baselineReturnBps": "0.0000",
+            "excessReturnBps": "10.0000"
+          }
+        ]
+      }
+    ],
+    "cells": [
+      {
+        "cellId": "fast:selection_week_1",
+        "variantId": "fast",
+        "variantLabel": "Fast",
+        "windowId": "selection_week_1",
+        "windowLabel": "Selection week 1",
+        "cohort": "selection",
+        "status": "completed",
+        "legResults": [
+          {
+            "legId": "leg_spot_alpha",
+            "reportId": "backtest_fast_selection_spot",
+            "reproducibilityBundleId": "repro_backtest_fast_selection_spot",
+            "status": "completed",
+            "metrics": {
+              "observationCount": 4,
+              "tradeCount": 3,
+              "grossReturnBps": "90.0000",
+              "netReturnBps": "70.0000",
+              "totalCostBps": "20.0000",
+              "winRateBps": 5000,
+              "maxDrawdownBps": "45.0000"
+            },
+            "baselineComparisons": [
+              {
+                "baseline": "flat_cash",
+                "baselineReturnBps": "0.0000",
+                "excessReturnBps": "70.0000"
+              }
+            ]
+          }
+        ],
+        "aggregateMetrics": {
+          "observationCount": 4,
+          "tradeCount": 3,
+          "grossReturnBps": "90.0000",
+          "netReturnBps": "70.0000",
+          "totalCostBps": "20.0000",
+          "winRateBps": 5000,
+          "maxDrawdownBps": "45.0000"
+        },
+        "aggregateBaselineComparisons": [
+          {
+            "baseline": "flat_cash",
+            "baselineReturnBps": "0.0000",
+            "excessReturnBps": "70.0000"
+          }
+        ]
+      }
+    ]
+  },
   "evidence": [
     {
       "stage": "backtest",

--- a/docs/runtime-contracts/fixtures/runtime.strategy_desk_scenario.valid.v1.json
+++ b/docs/runtime-contracts/fixtures/runtime.strategy_desk_scenario.valid.v1.json
@@ -20,6 +20,77 @@
     "maxVenueFamilyConcentrationBps": 9000,
     "maxDrawdownBps": 750
   },
+  "researchMatrix": {
+    "selectionMetric": "excess_vs_flat_cash_bps",
+    "backtestLegs": [
+      {
+        "legId": "leg_spot_alpha",
+        "experimentId": "exp_sol_spot",
+        "replayCorpusId": "replay_sol_usdc",
+        "venueKey": "jupiter",
+        "pairSymbol": "SOL/USDC",
+        "marketType": "spot",
+        "windowMode": "rolling",
+        "trainingWindowObservations": 8,
+        "testingWindowObservations": 4,
+        "stepObservations": 4,
+        "purgeObservations": 1,
+        "baselineStrategies": ["flat_cash", "buy_and_hold"]
+      },
+      {
+        "legId": "leg_perp_hedge",
+        "experimentId": "exp_sol_perp",
+        "replayCorpusId": "replay_sol_perp",
+        "venueKey": "drift",
+        "pairSymbol": "SOL-PERP",
+        "marketType": "perp",
+        "windowMode": "rolling",
+        "trainingWindowObservations": 8,
+        "testingWindowObservations": 4,
+        "stepObservations": 4,
+        "purgeObservations": 1,
+        "baselineStrategies": ["flat_cash", "buy_and_hold"]
+      }
+    ],
+    "windows": [
+      {
+        "windowId": "selection_week_1",
+        "label": "Selection week 1",
+        "cohort": "selection",
+        "windowMode": "rolling",
+        "trainingWindowObservations": 8,
+        "testingWindowObservations": 4,
+        "stepObservations": 4,
+        "purgeObservations": 1
+      },
+      {
+        "windowId": "holdout_week_1",
+        "label": "Holdout week 1",
+        "cohort": "holdout",
+        "windowMode": "rolling",
+        "trainingWindowObservations": 8,
+        "testingWindowObservations": 4,
+        "stepObservations": 4,
+        "purgeObservations": 1
+      }
+    ],
+    "variants": [
+      {
+        "variantId": "fast",
+        "label": "Fast",
+        "parameterManifest": {
+          "threshold": "fast"
+        }
+      },
+      {
+        "variantId": "slow",
+        "label": "Slow",
+        "parameterManifest": {
+          "threshold": "slow"
+        }
+      }
+    ]
+  },
   "legs": [
     {
       "legId": "leg_spot_alpha",

--- a/docs/runtime-contracts/schemas/runtime.strategy_desk_report.v1.schema.json
+++ b/docs/runtime-contracts/schemas/runtime.strategy_desk_report.v1.schema.json
@@ -408,6 +408,505 @@
         "additionalProperties": false
       }
     },
+    "studyMatrix": {
+      "type": "object",
+      "properties": {
+        "matrixId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "runKind": {
+          "type": "string",
+          "enum": ["replay", "backtest"]
+        },
+        "selectionMetric": {
+          "type": "string",
+          "enum": ["net_return_bps", "excess_vs_flat_cash_bps"]
+        },
+        "generatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "selectedVariantId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "windows": {
+          "minItems": 1,
+          "maxItems": 16,
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "windowId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "label": {
+                "type": "string",
+                "minLength": 1
+              },
+              "cohort": {
+                "type": "string",
+                "enum": ["selection", "holdout"]
+              }
+            },
+            "required": ["windowId", "label", "cohort"],
+            "additionalProperties": false
+          }
+        },
+        "variantSummaries": {
+          "minItems": 1,
+          "maxItems": 16,
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "variantId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "label": {
+                "type": "string",
+                "minLength": 1
+              },
+              "parameterManifest": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {}
+              },
+              "selectionWindowCount": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "holdoutWindowCount": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "selectionMetrics": {
+                "type": "object",
+                "properties": {
+                  "observationCount": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "tradeCount": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "grossReturnBps": {
+                    "type": "string",
+                    "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                  },
+                  "netReturnBps": {
+                    "type": "string",
+                    "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                  },
+                  "totalCostBps": {
+                    "type": "string",
+                    "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                  },
+                  "winRateBps": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 10000
+                  },
+                  "maxDrawdownBps": {
+                    "type": "string",
+                    "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                  }
+                },
+                "required": [
+                  "observationCount",
+                  "tradeCount",
+                  "grossReturnBps",
+                  "netReturnBps",
+                  "totalCostBps",
+                  "winRateBps",
+                  "maxDrawdownBps"
+                ],
+                "additionalProperties": false
+              },
+              "selectionBaselineComparisons": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "baseline": {
+                      "type": "string",
+                      "enum": ["flat_cash", "buy_and_hold"]
+                    },
+                    "baselineReturnBps": {
+                      "type": "string",
+                      "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                    },
+                    "excessReturnBps": {
+                      "type": "string",
+                      "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                    }
+                  },
+                  "required": [
+                    "baseline",
+                    "baselineReturnBps",
+                    "excessReturnBps"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "holdoutMetrics": {
+                "type": "object",
+                "properties": {
+                  "observationCount": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "tradeCount": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "grossReturnBps": {
+                    "type": "string",
+                    "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                  },
+                  "netReturnBps": {
+                    "type": "string",
+                    "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                  },
+                  "totalCostBps": {
+                    "type": "string",
+                    "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                  },
+                  "winRateBps": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 10000
+                  },
+                  "maxDrawdownBps": {
+                    "type": "string",
+                    "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                  }
+                },
+                "required": [
+                  "observationCount",
+                  "tradeCount",
+                  "grossReturnBps",
+                  "netReturnBps",
+                  "totalCostBps",
+                  "winRateBps",
+                  "maxDrawdownBps"
+                ],
+                "additionalProperties": false
+              },
+              "holdoutBaselineComparisons": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "baseline": {
+                      "type": "string",
+                      "enum": ["flat_cash", "buy_and_hold"]
+                    },
+                    "baselineReturnBps": {
+                      "type": "string",
+                      "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                    },
+                    "excessReturnBps": {
+                      "type": "string",
+                      "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                    }
+                  },
+                  "required": [
+                    "baseline",
+                    "baselineReturnBps",
+                    "excessReturnBps"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "notes": {
+                "maxItems": 16,
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "required": [
+              "variantId",
+              "label",
+              "parameterManifest",
+              "selectionWindowCount",
+              "holdoutWindowCount"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "cells": {
+          "minItems": 1,
+          "maxItems": 256,
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "cellId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "variantId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "variantLabel": {
+                "type": "string",
+                "minLength": 1
+              },
+              "windowId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "windowLabel": {
+                "type": "string",
+                "minLength": 1
+              },
+              "cohort": {
+                "type": "string",
+                "enum": ["selection", "holdout"]
+              },
+              "status": {
+                "type": "string",
+                "enum": ["completed", "blocked", "failed"]
+              },
+              "legResults": {
+                "minItems": 1,
+                "maxItems": 16,
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "legId": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "reportId": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "reproducibilityBundleId": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": ["completed", "blocked", "failed"]
+                    },
+                    "metrics": {
+                      "type": "object",
+                      "properties": {
+                        "observationCount": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
+                        },
+                        "tradeCount": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
+                        },
+                        "grossReturnBps": {
+                          "type": "string",
+                          "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                        },
+                        "netReturnBps": {
+                          "type": "string",
+                          "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                        },
+                        "totalCostBps": {
+                          "type": "string",
+                          "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                        },
+                        "winRateBps": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 10000
+                        },
+                        "maxDrawdownBps": {
+                          "type": "string",
+                          "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                        }
+                      },
+                      "required": [
+                        "observationCount",
+                        "tradeCount",
+                        "grossReturnBps",
+                        "netReturnBps",
+                        "totalCostBps",
+                        "winRateBps",
+                        "maxDrawdownBps"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "baselineComparisons": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "baseline": {
+                            "type": "string",
+                            "enum": ["flat_cash", "buy_and_hold"]
+                          },
+                          "baselineReturnBps": {
+                            "type": "string",
+                            "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                          },
+                          "excessReturnBps": {
+                            "type": "string",
+                            "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                          }
+                        },
+                        "required": [
+                          "baseline",
+                          "baselineReturnBps",
+                          "excessReturnBps"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "blockingReasons": {
+                      "maxItems": 16,
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    }
+                  },
+                  "required": [
+                    "legId",
+                    "reportId",
+                    "reproducibilityBundleId",
+                    "status",
+                    "metrics"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "aggregateMetrics": {
+                "type": "object",
+                "properties": {
+                  "observationCount": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "tradeCount": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "grossReturnBps": {
+                    "type": "string",
+                    "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                  },
+                  "netReturnBps": {
+                    "type": "string",
+                    "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                  },
+                  "totalCostBps": {
+                    "type": "string",
+                    "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                  },
+                  "winRateBps": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 10000
+                  },
+                  "maxDrawdownBps": {
+                    "type": "string",
+                    "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                  }
+                },
+                "required": [
+                  "observationCount",
+                  "tradeCount",
+                  "grossReturnBps",
+                  "netReturnBps",
+                  "totalCostBps",
+                  "winRateBps",
+                  "maxDrawdownBps"
+                ],
+                "additionalProperties": false
+              },
+              "aggregateBaselineComparisons": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "baseline": {
+                      "type": "string",
+                      "enum": ["flat_cash", "buy_and_hold"]
+                    },
+                    "baselineReturnBps": {
+                      "type": "string",
+                      "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                    },
+                    "excessReturnBps": {
+                      "type": "string",
+                      "pattern": "^-?\\d+(?:\\.\\d+)?$"
+                    }
+                  },
+                  "required": [
+                    "baseline",
+                    "baselineReturnBps",
+                    "excessReturnBps"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "notes": {
+                "maxItems": 16,
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "required": [
+              "cellId",
+              "variantId",
+              "variantLabel",
+              "windowId",
+              "windowLabel",
+              "cohort",
+              "status",
+              "legResults",
+              "aggregateMetrics"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "matrixId",
+        "runKind",
+        "selectionMetric",
+        "generatedAt",
+        "windows",
+        "variantSummaries",
+        "cells"
+      ],
+      "additionalProperties": false
+    },
     "evidence": {
       "maxItems": 8,
       "type": "array",

--- a/docs/runtime-contracts/schemas/runtime.strategy_desk_scenario.v1.schema.json
+++ b/docs/runtime-contracts/schemas/runtime.strategy_desk_scenario.v1.schema.json
@@ -105,6 +105,267 @@
       },
       "additionalProperties": false
     },
+    "researchMatrix": {
+      "type": "object",
+      "properties": {
+        "selectionMetric": {
+          "type": "string",
+          "enum": ["net_return_bps", "excess_vs_flat_cash_bps"]
+        },
+        "backtestLegs": {
+          "minItems": 1,
+          "maxItems": 16,
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "legId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "experimentId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "replayCorpusId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "venueKey": {
+                "type": "string",
+                "minLength": 1
+              },
+              "pairSymbol": {
+                "type": "string",
+                "minLength": 1
+              },
+              "marketType": {
+                "type": "string",
+                "enum": ["spot", "perp", "options", "prediction"]
+              },
+              "windowMode": {
+                "type": "string",
+                "enum": ["rolling", "anchored"]
+              },
+              "trainingWindowObservations": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "testingWindowObservations": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "stepObservations": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "purgeObservations": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "baselineStrategies": {
+                "minItems": 1,
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": ["flat_cash", "buy_and_hold"]
+                }
+              },
+              "notes": {
+                "maxItems": 16,
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "required": [
+              "legId",
+              "experimentId",
+              "replayCorpusId",
+              "venueKey",
+              "pairSymbol",
+              "marketType"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "windows": {
+          "minItems": 1,
+          "maxItems": 16,
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "windowId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "label": {
+                "type": "string",
+                "minLength": 1
+              },
+              "cohort": {
+                "type": "string",
+                "enum": ["selection", "holdout"]
+              },
+              "windowMode": {
+                "type": "string",
+                "enum": ["rolling", "anchored"]
+              },
+              "trainingWindowObservations": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "testingWindowObservations": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "stepObservations": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "purgeObservations": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "notes": {
+                "maxItems": 16,
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "required": [
+              "windowId",
+              "label",
+              "cohort",
+              "windowMode",
+              "trainingWindowObservations",
+              "testingWindowObservations",
+              "stepObservations",
+              "purgeObservations"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "variants": {
+          "minItems": 1,
+          "maxItems": 16,
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "variantId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "label": {
+                "type": "string",
+                "minLength": 1
+              },
+              "parameterManifest": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {}
+              },
+              "legOverrides": {
+                "maxItems": 16,
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "legId": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "experimentId": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "replayCorpusId": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "venueKey": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "pairSymbol": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "marketType": {
+                      "type": "string",
+                      "enum": ["spot", "perp", "options", "prediction"]
+                    },
+                    "windowMode": {
+                      "type": "string",
+                      "enum": ["rolling", "anchored"]
+                    },
+                    "trainingWindowObservations": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "testingWindowObservations": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "stepObservations": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "purgeObservations": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "baselineStrategies": {
+                      "minItems": 1,
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": ["flat_cash", "buy_and_hold"]
+                      }
+                    }
+                  },
+                  "required": ["legId"],
+                  "additionalProperties": false
+                }
+              },
+              "notes": {
+                "maxItems": 16,
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "required": ["variantId", "label", "parameterManifest"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": ["backtestLegs", "windows", "variants"],
+      "additionalProperties": false
+    },
     "legs": {
       "minItems": 1,
       "maxItems": 16,

--- a/src/bin/strategy_desk_registry.ts
+++ b/src/bin/strategy_desk_registry.ts
@@ -7,7 +7,7 @@ import {
 } from "../runtime/contracts/autonomous_runtime.js";
 
 type Resource = "scenario" | "run" | "report";
-type Action = "upsert" | "list" | "execute";
+type Action = "upsert" | "list" | "execute" | "study";
 
 function readArg(flag: string): string | null {
   const index = process.argv.indexOf(flag);
@@ -29,7 +29,12 @@ function resolveResource(): Resource {
 
 function resolveAction(): Action {
   const raw = readArg("--action") ?? "upsert";
-  if (raw === "upsert" || raw === "list" || raw === "execute") {
+  if (
+    raw === "upsert" ||
+    raw === "list" ||
+    raw === "execute" ||
+    raw === "study"
+  ) {
     return raw;
   }
   throw new Error("invalid-arg:--action");
@@ -59,6 +64,25 @@ function endpointFor(input: {
       scenarioId,
     )}/execute`;
   }
+  if (input.action === "study") {
+    if (input.resource !== "scenario") {
+      throw new Error("strategy-desk-study-scenario-resource-required");
+    }
+    const scenarioId =
+      typeof input.requestPayload === "object" &&
+      input.requestPayload &&
+      !Array.isArray(input.requestPayload)
+        ? String(
+            (input.requestPayload as Record<string, unknown>).scenarioId ?? "",
+          ).trim()
+        : "";
+    if (!scenarioId) {
+      throw new Error("strategy-desk-study-scenario-id-required");
+    }
+    return `/api/admin/ops/runtime/strategy-desk/scenarios/${encodeURIComponent(
+      scenarioId,
+    )}/study`;
+  }
   const resource = input.resource;
   switch (resource) {
     case "scenario":
@@ -84,6 +108,17 @@ function buildUpsertBody(resource: Resource, payload: unknown): unknown {
 function buildExecuteBody(payload: unknown): unknown {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
     throw new Error("strategy-desk-execute-invalid-body");
+  }
+  const { scenarioId: _scenarioId, ...rest } = payload as Record<
+    string,
+    unknown
+  >;
+  return rest;
+}
+
+function buildStudyBody(payload: unknown): unknown {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("strategy-desk-study-invalid-body");
   }
   const { scenarioId: _scenarioId, ...rest } = payload as Record<
     string,
@@ -127,7 +162,10 @@ async function main(): Promise<void> {
   const requestPayload = requestFile
     ? readJsonFile(resolve(requestFile))
     : null;
-  if ((action === "upsert" || action === "execute") && !requestPayload) {
+  if (
+    (action === "upsert" || action === "execute" || action === "study") &&
+    !requestPayload
+  ) {
     throw new Error("missing-arg:--request-file");
   }
 
@@ -156,7 +194,11 @@ async function main(): Promise<void> {
           ? {
               body: JSON.stringify(buildExecuteBody(requestPayload as unknown)),
             }
-          : {}),
+          : action === "study"
+            ? {
+                body: JSON.stringify(buildStudyBody(requestPayload as unknown)),
+              }
+            : {}),
     },
   );
 

--- a/src/runtime/contracts/autonomous_runtime.ts
+++ b/src/runtime/contracts/autonomous_runtime.ts
@@ -19,6 +19,32 @@ const NUMERIC_STRING_SCHEMA = z
   .regex(/^-?\d+(?:\.\d+)?$/, "invalid-numeric-string");
 const BPS_SCHEMA = z.number().int().min(0).max(10_000);
 
+function addDuplicateIdIssues<
+  TEntry extends Record<string, unknown>,
+  TKey extends keyof TEntry & string,
+>(
+  ctx: z.RefinementCtx,
+  entries: TEntry[],
+  collectionKey: string,
+  idKey: TKey,
+) {
+  const seen = new Map<string, number>();
+  for (const [index, entry] of entries.entries()) {
+    const value = entry[idKey];
+    if (typeof value !== "string" || value.length === 0) continue;
+    const firstIndex = seen.get(value);
+    if (typeof firstIndex === "number") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `duplicate-${collectionKey}-${idKey}:${value}`,
+        path: [collectionKey, index, idKey],
+      });
+      continue;
+    }
+    seen.set(value, index);
+  }
+}
+
 const VersionedSchema = z
   .object({
     schemaVersion: z.literal(RUNTIME_PROTOCOL_SCHEMA_VERSION),
@@ -298,7 +324,11 @@ export const RuntimeBacktestStatusSchema = z.enum([
   "failed",
 ]);
 
-export const RuntimeBacktestWindowModeSchema = z.enum(["rolling", "expanding"]);
+export const RuntimeBacktestWindowModeSchema = z.enum([
+  "rolling",
+  "expanding",
+  "anchored",
+]);
 
 export const RuntimeBacktestBaselineSchema = z.enum([
   "flat_cash",
@@ -1653,6 +1683,11 @@ const RuntimeStrategyDeskResearchMatrixSchema = z
       .max(16),
     windows: z.array(RuntimeStrategyDeskStudyWindowSchema).min(1).max(16),
     variants: z.array(RuntimeStrategyDeskStudyVariantSchema).min(1).max(16),
+  })
+  .superRefine((value, ctx) => {
+    addDuplicateIdIssues(ctx, value.backtestLegs, "backtestLegs", "legId");
+    addDuplicateIdIssues(ctx, value.windows, "windows", "windowId");
+    addDuplicateIdIssues(ctx, value.variants, "variants", "variantId");
   })
   .strict();
 

--- a/src/runtime/contracts/autonomous_runtime.ts
+++ b/src/runtime/contracts/autonomous_runtime.ts
@@ -22,12 +22,7 @@ const BPS_SCHEMA = z.number().int().min(0).max(10_000);
 function addDuplicateIdIssues<
   TEntry extends Record<string, unknown>,
   TKey extends keyof TEntry & string,
->(
-  ctx: z.RefinementCtx,
-  entries: TEntry[],
-  collectionKey: string,
-  idKey: TKey,
-) {
+>(ctx: z.RefinementCtx, entries: TEntry[], collectionKey: string, idKey: TKey) {
   const seen = new Map<string, number>();
   for (const [index, entry] of entries.entries()) {
     const value = entry[idKey];

--- a/src/runtime/contracts/autonomous_runtime.ts
+++ b/src/runtime/contracts/autonomous_runtime.ts
@@ -1569,6 +1569,93 @@ const RuntimeStrategyDeskRiskLimitsSchema = z
   })
   .strict();
 
+const RuntimeStrategyDeskStudySelectionMetricSchema = z.enum([
+  "net_return_bps",
+  "excess_vs_flat_cash_bps",
+]);
+
+const RuntimeStrategyDeskStudyCohortSchema = z.enum(["selection", "holdout"]);
+
+const RuntimeStrategyDeskBacktestLegConfigSchema = z
+  .object({
+    legId: NON_EMPTY_STRING_SCHEMA,
+    experimentId: NON_EMPTY_STRING_SCHEMA,
+    replayCorpusId: NON_EMPTY_STRING_SCHEMA,
+    venueKey: NON_EMPTY_STRING_SCHEMA,
+    pairSymbol: NON_EMPTY_STRING_SCHEMA,
+    marketType: RuntimeVenueMarketTypeSchema,
+    windowMode: z.enum(["rolling", "anchored"]).optional(),
+    trainingWindowObservations: z.number().int().positive().optional(),
+    testingWindowObservations: z.number().int().positive().optional(),
+    stepObservations: z.number().int().positive().optional(),
+    purgeObservations: z.number().int().nonnegative().optional(),
+    baselineStrategies: z
+      .array(RuntimeBacktestBaselineSchema)
+      .min(1)
+      .optional(),
+    notes: z.array(NON_EMPTY_STRING_SCHEMA).max(16).optional(),
+  })
+  .strict();
+
+const RuntimeStrategyDeskStudyWindowSchema = z
+  .object({
+    windowId: NON_EMPTY_STRING_SCHEMA,
+    label: NON_EMPTY_STRING_SCHEMA,
+    cohort: RuntimeStrategyDeskStudyCohortSchema,
+    windowMode: z.enum(["rolling", "anchored"]),
+    trainingWindowObservations: z.number().int().positive(),
+    testingWindowObservations: z.number().int().positive(),
+    stepObservations: z.number().int().positive(),
+    purgeObservations: z.number().int().nonnegative(),
+    notes: z.array(NON_EMPTY_STRING_SCHEMA).max(16).optional(),
+  })
+  .strict();
+
+const RuntimeStrategyDeskStudyVariantLegOverrideSchema = z
+  .object({
+    legId: NON_EMPTY_STRING_SCHEMA,
+    experimentId: NON_EMPTY_STRING_SCHEMA.optional(),
+    replayCorpusId: NON_EMPTY_STRING_SCHEMA.optional(),
+    venueKey: NON_EMPTY_STRING_SCHEMA.optional(),
+    pairSymbol: NON_EMPTY_STRING_SCHEMA.optional(),
+    marketType: RuntimeVenueMarketTypeSchema.optional(),
+    windowMode: z.enum(["rolling", "anchored"]).optional(),
+    trainingWindowObservations: z.number().int().positive().optional(),
+    testingWindowObservations: z.number().int().positive().optional(),
+    stepObservations: z.number().int().positive().optional(),
+    purgeObservations: z.number().int().nonnegative().optional(),
+    baselineStrategies: z
+      .array(RuntimeBacktestBaselineSchema)
+      .min(1)
+      .optional(),
+  })
+  .strict();
+
+const RuntimeStrategyDeskStudyVariantSchema = z
+  .object({
+    variantId: NON_EMPTY_STRING_SCHEMA,
+    label: NON_EMPTY_STRING_SCHEMA,
+    parameterManifest: z.record(z.string(), z.unknown()),
+    legOverrides: z
+      .array(RuntimeStrategyDeskStudyVariantLegOverrideSchema)
+      .max(16)
+      .optional(),
+    notes: z.array(NON_EMPTY_STRING_SCHEMA).max(16).optional(),
+  })
+  .strict();
+
+const RuntimeStrategyDeskResearchMatrixSchema = z
+  .object({
+    selectionMetric: RuntimeStrategyDeskStudySelectionMetricSchema.optional(),
+    backtestLegs: z
+      .array(RuntimeStrategyDeskBacktestLegConfigSchema)
+      .min(1)
+      .max(16),
+    windows: z.array(RuntimeStrategyDeskStudyWindowSchema).min(1).max(16),
+    variants: z.array(RuntimeStrategyDeskStudyVariantSchema).min(1).max(16),
+  })
+  .strict();
+
 export const RuntimeStrategyDeskScenarioLegSchema = z
   .object({
     legId: NON_EMPTY_STRING_SCHEMA,
@@ -1605,6 +1692,7 @@ export const RuntimeStrategyDeskScenarioManifestSchema = VersionedSchema.extend(
     activeHandoffId: NON_EMPTY_STRING_SCHEMA.optional(),
     latestReportId: NON_EMPTY_STRING_SCHEMA.optional(),
     riskLimits: RuntimeStrategyDeskRiskLimitsSchema.optional(),
+    researchMatrix: RuntimeStrategyDeskResearchMatrixSchema.optional(),
     legs: z.array(RuntimeStrategyDeskScenarioLegSchema).min(1).max(16),
     evidence: z.array(RuntimeStrategyDeskEvidenceBucketSchema).max(8),
     implementationReferences: z
@@ -1746,6 +1834,81 @@ const RuntimeStrategyDeskScenarioScorecardSchema = z
   })
   .strict();
 
+const RuntimeStrategyDeskStudyLegResultSchema = z
+  .object({
+    legId: NON_EMPTY_STRING_SCHEMA,
+    reportId: NON_EMPTY_STRING_SCHEMA,
+    reproducibilityBundleId: NON_EMPTY_STRING_SCHEMA,
+    status: RuntimeBacktestStatusSchema,
+    metrics: RuntimeBacktestMetricsSchema,
+    baselineComparisons: z
+      .array(RuntimeBacktestBaselineComparisonSchema)
+      .optional(),
+    blockingReasons: z.array(NON_EMPTY_STRING_SCHEMA).max(16).optional(),
+  })
+  .strict();
+
+const RuntimeStrategyDeskStudyMatrixWindowSchema = z
+  .object({
+    windowId: NON_EMPTY_STRING_SCHEMA,
+    label: NON_EMPTY_STRING_SCHEMA,
+    cohort: RuntimeStrategyDeskStudyCohortSchema,
+  })
+  .strict();
+
+const RuntimeStrategyDeskStudyMatrixCellSchema = z
+  .object({
+    cellId: NON_EMPTY_STRING_SCHEMA,
+    variantId: NON_EMPTY_STRING_SCHEMA,
+    variantLabel: NON_EMPTY_STRING_SCHEMA,
+    windowId: NON_EMPTY_STRING_SCHEMA,
+    windowLabel: NON_EMPTY_STRING_SCHEMA,
+    cohort: RuntimeStrategyDeskStudyCohortSchema,
+    status: RuntimeBacktestStatusSchema,
+    legResults: z.array(RuntimeStrategyDeskStudyLegResultSchema).min(1).max(16),
+    aggregateMetrics: RuntimeBacktestMetricsSchema,
+    aggregateBaselineComparisons: z
+      .array(RuntimeBacktestBaselineComparisonSchema)
+      .optional(),
+    notes: z.array(NON_EMPTY_STRING_SCHEMA).max(16).optional(),
+  })
+  .strict();
+
+const RuntimeStrategyDeskStudyVariantSummarySchema = z
+  .object({
+    variantId: NON_EMPTY_STRING_SCHEMA,
+    label: NON_EMPTY_STRING_SCHEMA,
+    parameterManifest: z.record(z.string(), z.unknown()),
+    selectionWindowCount: z.number().int().nonnegative(),
+    holdoutWindowCount: z.number().int().nonnegative(),
+    selectionMetrics: RuntimeBacktestMetricsSchema.optional(),
+    selectionBaselineComparisons: z
+      .array(RuntimeBacktestBaselineComparisonSchema)
+      .optional(),
+    holdoutMetrics: RuntimeBacktestMetricsSchema.optional(),
+    holdoutBaselineComparisons: z
+      .array(RuntimeBacktestBaselineComparisonSchema)
+      .optional(),
+    notes: z.array(NON_EMPTY_STRING_SCHEMA).max(16).optional(),
+  })
+  .strict();
+
+const RuntimeStrategyDeskStudyMatrixSchema = z
+  .object({
+    matrixId: NON_EMPTY_STRING_SCHEMA,
+    runKind: z.enum(["replay", "backtest"]),
+    selectionMetric: RuntimeStrategyDeskStudySelectionMetricSchema,
+    generatedAt: ISO_DATETIME_SCHEMA,
+    selectedVariantId: NON_EMPTY_STRING_SCHEMA.optional(),
+    windows: z.array(RuntimeStrategyDeskStudyMatrixWindowSchema).min(1).max(16),
+    variantSummaries: z
+      .array(RuntimeStrategyDeskStudyVariantSummarySchema)
+      .min(1)
+      .max(16),
+    cells: z.array(RuntimeStrategyDeskStudyMatrixCellSchema).min(1).max(256),
+  })
+  .strict();
+
 export const RuntimeStrategyDeskScenarioReportSchema = VersionedSchema.extend({
   reportId: NON_EMPTY_STRING_SCHEMA,
   scenarioId: NON_EMPTY_STRING_SCHEMA,
@@ -1761,6 +1924,7 @@ export const RuntimeStrategyDeskScenarioReportSchema = VersionedSchema.extend({
     .array(RuntimeStrategyDeskRiskOverlaySchema)
     .max(16)
     .optional(),
+  studyMatrix: RuntimeStrategyDeskStudyMatrixSchema.optional(),
   evidence: z.array(RuntimeStrategyDeskEvidenceBucketSchema).max(8),
   checks: z.array(RuntimeStrategyLabCheckSchema).min(1),
   approvals: z.array(RuntimeResearchHumanApprovalRecordSchema).max(16),

--- a/tests/unit/runtime_protocol_contracts.test.ts
+++ b/tests/unit/runtime_protocol_contracts.test.ts
@@ -1724,6 +1724,202 @@ describe("runtime protocol contracts", () => {
     ).toEqual([]);
   });
 
+  test("accepts anchored runtime backtest reports", () => {
+    const report = parseRuntimeBacktestReport({
+      schemaVersion: "v1",
+      reportId: "backtest_anchored_report",
+      experimentId: "experiment_anchored",
+      strategyKey: "strategy_desk::sol_composite",
+      status: "completed",
+      generatedAt: "2026-03-17T05:00:00.000Z",
+      venueKeys: ["jupiter"],
+      assetKeys: ["SOL", "USDC"],
+      codeRevision: {
+        vcs: "git",
+        repository: "github.com/GuiBibeau/serious-trader-ralph",
+        revision: "356b539e3ec730663c4025b8f00cd6b47b823d1a",
+        treeDirty: false,
+      },
+      datasetSnapshots: [
+        {
+          datasetId: "dataset_feature_cache_sol_usdc_market_events",
+          snapshotId: "snapshot_2026_03_17_backtest",
+          capturedAt: "2026-03-17T05:00:00.000Z",
+        },
+      ],
+      strategySpecDigest: "sha256:anchored-report",
+      config: {
+        replayCorpusId: "replay_corpus_sol_usdc_feature_cache",
+        venueKey: "jupiter",
+        pairSymbol: "SOL/USDC",
+        marketType: "spot",
+        windowMode: "anchored",
+        trainingWindowObservations: 8,
+        testingWindowObservations: 4,
+        stepObservations: 4,
+        purgeObservations: 1,
+        baselineStrategies: ["flat_cash", "buy_and_hold"],
+      },
+      foldReports: [
+        {
+          foldId: "fold_0",
+          foldIndex: 0,
+          trainingStartAt: "2026-03-10T00:00:00Z",
+          trainingEndAt: "2026-03-16T23:55:00Z",
+          testStartAt: "2026-03-16T23:55:00Z",
+          testEndAt: "2026-03-17T05:00:00Z",
+          trainObservationCount: 8,
+          purgedObservationCount: 1,
+          testObservationCount: 4,
+          metrics: {
+            observationCount: 4,
+            tradeCount: 2,
+            grossReturnBps: "18.0000",
+            netReturnBps: "12.0000",
+            totalCostBps: "6.0000",
+            winRateBps: 5000,
+            maxDrawdownBps: "5.0000",
+          },
+          baselineComparisons: [
+            {
+              baseline: "flat_cash",
+              baselineReturnBps: "0.0000",
+              excessReturnBps: "12.0000",
+            },
+          ],
+          regimeMetrics: [],
+        },
+      ],
+      aggregateMetrics: {
+        observationCount: 4,
+        tradeCount: 2,
+        grossReturnBps: "18.0000",
+        netReturnBps: "12.0000",
+        totalCostBps: "6.0000",
+        winRateBps: 5000,
+        maxDrawdownBps: "5.0000",
+      },
+      aggregateBaselineComparisons: [
+        {
+          baseline: "flat_cash",
+          baselineReturnBps: "0.0000",
+          excessReturnBps: "12.0000",
+        },
+      ],
+      aggregateRegimeMetrics: [],
+      promotionEligible: true,
+      blockingReasons: [],
+      summary: "Anchored study report.",
+      tags: ["anchored"],
+    });
+
+    expect(report.config.windowMode).toBe("anchored");
+  });
+
+  test("rejects duplicate strategy desk research matrix ids", () => {
+    expect(() =>
+      parseRuntimeStrategyDeskScenarioManifest({
+        schemaVersion: "v1",
+        scenarioId: "desk_sol_composite_duplicates",
+        title: "Duplicate matrix ids",
+        summary: "Ensure malformed study matrices fail closed.",
+        ownerUserId: "user_1",
+        strategyKey: "strategy_desk::sol_composite",
+        thesis: "Duplicate ids should never be accepted.",
+        state: "replay_ready",
+        createdAt: "2026-03-17T03:00:00Z",
+        updatedAt: "2026-03-17T03:05:00Z",
+        researchMatrix: {
+          selectionMetric: "excess_vs_flat_cash_bps",
+          backtestLegs: [
+            {
+              legId: "leg_spot_alpha",
+              experimentId: "exp_sol_spot",
+              replayCorpusId: "replay_sol_usdc",
+              venueKey: "jupiter",
+              pairSymbol: "SOL/USDC",
+              marketType: "spot",
+              windowMode: "rolling",
+              trainingWindowObservations: 8,
+              testingWindowObservations: 4,
+              stepObservations: 4,
+              purgeObservations: 1,
+              baselineStrategies: ["flat_cash", "buy_and_hold"],
+            },
+            {
+              legId: "leg_spot_alpha",
+              experimentId: "exp_sol_spot_alt",
+              replayCorpusId: "replay_sol_usdc",
+              venueKey: "jupiter",
+              pairSymbol: "SOL/USDC",
+              marketType: "spot",
+              windowMode: "rolling",
+              trainingWindowObservations: 8,
+              testingWindowObservations: 4,
+              stepObservations: 4,
+              purgeObservations: 1,
+              baselineStrategies: ["flat_cash", "buy_and_hold"],
+            },
+          ],
+          windows: [
+            {
+              windowId: "selection_week_1",
+              label: "Selection week 1",
+              cohort: "selection",
+              windowMode: "rolling",
+              trainingWindowObservations: 8,
+              testingWindowObservations: 4,
+              stepObservations: 4,
+              purgeObservations: 1,
+            },
+          ],
+          variants: [
+            {
+              variantId: "fast",
+              label: "Fast",
+              parameterManifest: {
+                threshold: "fast",
+              },
+            },
+            {
+              variantId: "fast",
+              label: "Fast duplicate",
+              parameterManifest: {
+                threshold: "slow",
+              },
+            },
+          ],
+        },
+        legs: [
+          {
+            legId: "leg_spot_alpha",
+            label: "Spot alpha",
+            role: "primary_alpha",
+            venueKey: "jupiter",
+            intentFamily: "spot_swap",
+            marketType: "spot",
+            pair: {
+              symbol: "SOL/USDC",
+              baseMint: SOL_MINT,
+              quoteMint: USDC_MINT,
+            },
+            assetKeys: ["SOL", "USDC"],
+            enabledModes: ["shadow", "paper"],
+            sizing: {
+              targetNotionalUsd: "1000",
+              maxNotionalUsd: "2500",
+              reserveUsd: "1000",
+              maxSlippageBps: 50,
+            },
+          },
+        ],
+        evidence: [],
+        implementationReferences: [],
+        tags: ["strategy-desk"],
+      }),
+    ).toThrow("duplicate-backtestLegs-legId:leg_spot_alpha");
+  });
+
   test("generates deterministic JSON schema documents", () => {
     for (const entry of Object.values(RUNTIME_PROTOCOL_SCHEMA_REGISTRY)) {
       const schemaA = z.toJSONSchema(entry.schema);

--- a/tests/unit/runtime_protocol_contracts.test.ts
+++ b/tests/unit/runtime_protocol_contracts.test.ts
@@ -1018,6 +1018,77 @@ describe("runtime protocol contracts", () => {
         maxVenueFamilyConcentrationBps: 9000,
         maxDrawdownBps: 750,
       },
+      researchMatrix: {
+        selectionMetric: "excess_vs_flat_cash_bps",
+        backtestLegs: [
+          {
+            legId: "leg_spot_alpha",
+            experimentId: "exp_sol_spot",
+            replayCorpusId: "replay_sol_usdc",
+            venueKey: "jupiter",
+            pairSymbol: "SOL/USDC",
+            marketType: "spot",
+            windowMode: "rolling",
+            trainingWindowObservations: 8,
+            testingWindowObservations: 4,
+            stepObservations: 4,
+            purgeObservations: 1,
+            baselineStrategies: ["flat_cash", "buy_and_hold"],
+          },
+          {
+            legId: "leg_perp_hedge",
+            experimentId: "exp_sol_perp",
+            replayCorpusId: "replay_sol_perp",
+            venueKey: "drift",
+            pairSymbol: "SOL-PERP",
+            marketType: "perp",
+            windowMode: "rolling",
+            trainingWindowObservations: 8,
+            testingWindowObservations: 4,
+            stepObservations: 4,
+            purgeObservations: 1,
+            baselineStrategies: ["flat_cash", "buy_and_hold"],
+          },
+        ],
+        windows: [
+          {
+            windowId: "selection_week_1",
+            label: "Selection week 1",
+            cohort: "selection",
+            windowMode: "rolling",
+            trainingWindowObservations: 8,
+            testingWindowObservations: 4,
+            stepObservations: 4,
+            purgeObservations: 1,
+          },
+          {
+            windowId: "holdout_week_1",
+            label: "Holdout week 1",
+            cohort: "holdout",
+            windowMode: "rolling",
+            trainingWindowObservations: 8,
+            testingWindowObservations: 4,
+            stepObservations: 4,
+            purgeObservations: 1,
+          },
+        ],
+        variants: [
+          {
+            variantId: "fast",
+            label: "Fast",
+            parameterManifest: {
+              threshold: "fast",
+            },
+          },
+          {
+            variantId: "slow",
+            label: "Slow",
+            parameterManifest: {
+              threshold: "slow",
+            },
+          },
+        ],
+      },
       legs: [
         strategyDeskLeg,
         {
@@ -1336,6 +1407,119 @@ describe("runtime protocol contracts", () => {
             "Composite execution completed without fail-closed demotion.",
         },
       ],
+      studyMatrix: {
+        matrixId: "desk_matrix_sol_composite_backtest_1",
+        runKind: "backtest",
+        selectionMetric: "excess_vs_flat_cash_bps",
+        generatedAt: "2026-03-17T03:08:15Z",
+        selectedVariantId: "fast",
+        windows: [
+          {
+            windowId: "selection_week_1",
+            label: "Selection week 1",
+            cohort: "selection",
+          },
+          {
+            windowId: "holdout_week_1",
+            label: "Holdout week 1",
+            cohort: "holdout",
+          },
+        ],
+        variantSummaries: [
+          {
+            variantId: "fast",
+            label: "Fast",
+            parameterManifest: {
+              threshold: "fast",
+            },
+            selectionWindowCount: 1,
+            holdoutWindowCount: 1,
+            selectionMetrics: {
+              observationCount: 8,
+              tradeCount: 5,
+              grossReturnBps: "75.0000",
+              netReturnBps: "60.0000",
+              totalCostBps: "15.0000",
+              winRateBps: 5000,
+              maxDrawdownBps: "45.0000",
+            },
+            selectionBaselineComparisons: [
+              {
+                baseline: "flat_cash",
+                baselineReturnBps: "0.0000",
+                excessReturnBps: "60.0000",
+              },
+            ],
+            holdoutMetrics: {
+              observationCount: 8,
+              tradeCount: 4,
+              grossReturnBps: "18.0000",
+              netReturnBps: "10.0000",
+              totalCostBps: "8.0000",
+              winRateBps: 5000,
+              maxDrawdownBps: "32.0000",
+            },
+            holdoutBaselineComparisons: [
+              {
+                baseline: "flat_cash",
+                baselineReturnBps: "0.0000",
+                excessReturnBps: "10.0000",
+              },
+            ],
+          },
+        ],
+        cells: [
+          {
+            cellId: "fast:selection_week_1",
+            variantId: "fast",
+            variantLabel: "Fast",
+            windowId: "selection_week_1",
+            windowLabel: "Selection week 1",
+            cohort: "selection",
+            status: "completed",
+            legResults: [
+              {
+                legId: "leg_spot_alpha",
+                reportId: "backtest_fast_selection_spot",
+                reproducibilityBundleId: "repro_backtest_fast_selection_spot",
+                status: "completed",
+                metrics: {
+                  observationCount: 4,
+                  tradeCount: 3,
+                  grossReturnBps: "90.0000",
+                  netReturnBps: "70.0000",
+                  totalCostBps: "20.0000",
+                  winRateBps: 5000,
+                  maxDrawdownBps: "45.0000",
+                },
+                baselineComparisons: [
+                  {
+                    baseline: "flat_cash",
+                    baselineReturnBps: "0.0000",
+                    excessReturnBps: "70.0000",
+                  },
+                ],
+              },
+            ],
+            aggregateMetrics: {
+              observationCount: 4,
+              tradeCount: 3,
+              grossReturnBps: "90.0000",
+              netReturnBps: "70.0000",
+              totalCostBps: "20.0000",
+              winRateBps: 5000,
+              maxDrawdownBps: "45.0000",
+            },
+            aggregateBaselineComparisons: [
+              {
+                baseline: "flat_cash",
+                baselineReturnBps: "0.0000",
+                excessReturnBps: "70.0000",
+              },
+            ],
+          },
+        ],
+      },
       evidence: strategyDeskScenario.evidence,
       checks: [
         {

--- a/tests/unit/runtime_strategy_desk_runner.test.ts
+++ b/tests/unit/runtime_strategy_desk_runner.test.ts
@@ -64,6 +64,7 @@ function createOpsEnv(overrides?: Partial<Env>) {
     "0031_strategy_desk_registry.sql",
     "0032_strategy_desk_leg_intent.sql",
     "0033_strategy_desk_scorecards.sql",
+    "0034_strategy_desk_research_matrix.sql",
   ]) {
     const migrationPath = resolve(
       import.meta.dir,

--- a/tests/unit/runtime_strategy_desk_study.test.ts
+++ b/tests/unit/runtime_strategy_desk_study.test.ts
@@ -683,7 +683,8 @@ describe("runtime strategy desk study workflow", () => {
       expect(result.report.studyMatrix?.cells).toHaveLength(1);
       expect(result.report.studyMatrix?.cells[0]?.status).toBe("completed");
       expect(
-        result.report.studyMatrix?.cells[0]?.legResults[0]?.metrics.netReturnBps,
+        result.report.studyMatrix?.cells[0]?.legResults[0]?.metrics
+          .netReturnBps,
       ).toBe("12.0000");
     } finally {
       sqlite.close();

--- a/tests/unit/runtime_strategy_desk_study.test.ts
+++ b/tests/unit/runtime_strategy_desk_study.test.ts
@@ -107,6 +107,7 @@ function buildBacktestReport(input: {
   tradeCount: number;
   maxDrawdownBps: string;
   excessVsFlatCashBps: string;
+  windowMode?: "rolling" | "expanding" | "anchored";
 }) {
   const base = readFixture("runtime.backtest_report.valid.v1.json") as Record<
     string,
@@ -121,6 +122,7 @@ function buildBacktestReport(input: {
     config: {
       ...(base.config as Record<string, unknown>),
       venueKey: input.venueKey,
+      windowMode: input.windowMode ?? "rolling",
     },
     aggregateMetrics: {
       observationCount: 4,
@@ -600,6 +602,89 @@ describe("runtime strategy desk study workflow", () => {
       expect(
         result.report.evidence.filter((bucket) => bucket.stage === "backtest"),
       ).toHaveLength(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("accepts anchored study windows when the runtime backtest report echoes anchored mode", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const baseScenario = buildStudyScenario();
+      const baseMatrix = baseScenario.researchMatrix as Record<string, unknown>;
+      await upsertRuntimeStrategyDeskScenarioWorkflow({
+        env,
+        scenario: {
+          ...baseScenario,
+          researchMatrix: {
+            ...baseMatrix,
+            windows: [
+              {
+                windowId: "anchored_week_1",
+                label: "Anchored week 1",
+                cohort: "selection",
+                windowMode: "anchored",
+                trainingWindowObservations: 8,
+                testingWindowObservations: 4,
+                stepObservations: 4,
+                purgeObservations: 1,
+              },
+            ],
+          },
+        } as never,
+      });
+
+      const executeRuntimeStrategyDeskStudyWorkflow = await getStudyWorkflow();
+      const result = await executeRuntimeStrategyDeskStudyWorkflow(
+        {
+          env,
+          scenarioId: "desk_sol_composite_1",
+          runKind: "backtest",
+          requestedBy: "operator_1",
+        },
+        {
+          createId(prefix) {
+            return prefix;
+          },
+          now() {
+            return "2026-03-17T05:00:00Z";
+          },
+          async runRuntimeBacktest({ payload }) {
+            const request = payload as {
+              reportId: string;
+              experimentId: string;
+            };
+            return {
+              status: 201,
+              ok: true,
+              payload: {
+                ok: true,
+                source: "stub",
+                created: true,
+                report: buildBacktestReport({
+                  reportId: request.reportId,
+                  experimentId: request.experimentId,
+                  venueKey: "jupiter",
+                  netReturnBps: "12.0000",
+                  grossReturnBps: "18.0000",
+                  totalCostBps: "6.0000",
+                  tradeCount: 2,
+                  maxDrawdownBps: "5.0000",
+                  excessVsFlatCashBps: "12.0000",
+                  windowMode: "anchored",
+                }),
+              },
+            };
+          },
+        },
+      );
+
+      expect(result.report.status).toBe("requires_human_approval");
+      expect(result.report.studyMatrix?.cells).toHaveLength(1);
+      expect(result.report.studyMatrix?.cells[0]?.status).toBe("completed");
+      expect(
+        result.report.studyMatrix?.cells[0]?.legResults[0]?.metrics.netReturnBps,
+      ).toBe("12.0000");
     } finally {
       sqlite.close();
     }

--- a/tests/unit/runtime_strategy_desk_study.test.ts
+++ b/tests/unit/runtime_strategy_desk_study.test.ts
@@ -1,12 +1,11 @@
 import { Database } from "bun:sqlite";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import {
   getRuntimeStrategyDeskScenarioWorkflow,
   upsertRuntimeStrategyDeskScenarioWorkflow,
 } from "../../apps/worker/src/runtime_strategy_desk";
-import { executeRuntimeStrategyDeskStudyWorkflow } from "../../apps/worker/src/runtime_strategy_desk_study";
 import type { Env } from "../../apps/worker/src/types";
 import { createWorkerLiveEnv } from "../integration/_worker_live_test_utils";
 
@@ -202,10 +201,25 @@ function buildStudyScenario(
   };
 }
 
+let studyWorkflowImport:
+  | Promise<
+      typeof import("../../apps/worker/src/runtime_strategy_desk_study.ts")
+    >
+  | undefined;
+
+async function getStudyWorkflow() {
+  mock.restore();
+  studyWorkflowImport ??= import(
+    "../../apps/worker/src/runtime_strategy_desk_study.ts?runtime-study-real"
+  );
+  return (await studyWorkflowImport).executeRuntimeStrategyDeskStudyWorkflow;
+}
+
 describe("runtime strategy desk study workflow", () => {
   test("builds a multi-window study matrix and preserves holdout summaries", async () => {
     const { env, sqlite } = createOpsEnv();
     try {
+      const executeRuntimeStrategyDeskStudyWorkflow = await getStudyWorkflow();
       const scenario = readFixture(
         "runtime.strategy_desk_scenario.valid.v1.json",
       ) as Record<string, unknown>;
@@ -482,6 +496,7 @@ describe("runtime strategy desk study workflow", () => {
   test("blocks study runs when the scenario is paused", async () => {
     const { env, sqlite } = createOpsEnv();
     try {
+      const executeRuntimeStrategyDeskStudyWorkflow = await getStudyWorkflow();
       await upsertRuntimeStrategyDeskScenarioWorkflow({
         env,
         scenario: buildStudyScenario({
@@ -514,6 +529,7 @@ describe("runtime strategy desk study workflow", () => {
   test("caps propagated evidence buckets to the report schema limit", async () => {
     const { env, sqlite } = createOpsEnv();
     try {
+      const executeRuntimeStrategyDeskStudyWorkflow = await getStudyWorkflow();
       await upsertRuntimeStrategyDeskScenarioWorkflow({
         env,
         scenario: buildStudyScenario({

--- a/tests/unit/runtime_strategy_desk_study.test.ts
+++ b/tests/unit/runtime_strategy_desk_study.test.ts
@@ -149,6 +149,59 @@ function buildBacktestReport(input: {
   };
 }
 
+function buildStudyScenario(
+  overrides?: Record<string, unknown>,
+): Record<string, unknown> {
+  const scenario = readFixture(
+    "runtime.strategy_desk_scenario.valid.v1.json",
+  ) as Record<string, unknown>;
+  return {
+    ...scenario,
+    state: "replay_ready",
+    researchMatrix: {
+      selectionMetric: "excess_vs_flat_cash_bps",
+      backtestLegs: [
+        {
+          legId: "leg_spot_alpha",
+          experimentId: "exp_spot_base",
+          replayCorpusId: "replay_sol_usdc",
+          venueKey: "jupiter",
+          pairSymbol: "SOL/USDC",
+          marketType: "spot",
+          windowMode: "rolling",
+          trainingWindowObservations: 8,
+          testingWindowObservations: 4,
+          stepObservations: 4,
+          purgeObservations: 1,
+          baselineStrategies: ["flat_cash", "buy_and_hold"],
+        },
+      ],
+      windows: [
+        {
+          windowId: "selection_week_1",
+          label: "Selection week 1",
+          cohort: "selection",
+          windowMode: "rolling",
+          trainingWindowObservations: 8,
+          testingWindowObservations: 4,
+          stepObservations: 4,
+          purgeObservations: 1,
+        },
+      ],
+      variants: [
+        {
+          variantId: "fast",
+          label: "Fast",
+          parameterManifest: {
+            threshold: "fast",
+          },
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
 describe("runtime strategy desk study workflow", () => {
   test("builds a multi-window study matrix and preserves holdout summaries", async () => {
     const { env, sqlite } = createOpsEnv();
@@ -421,6 +474,116 @@ describe("runtime strategy desk study workflow", () => {
       expect(persisted.scenario.latestReportId).toBe(
         "desk_report_desk_sol_composite_1_backtest",
       );
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("blocks study runs when the scenario is paused", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      await upsertRuntimeStrategyDeskScenarioWorkflow({
+        env,
+        scenario: buildStudyScenario({
+          state: "paused",
+        }) as never,
+      });
+
+      await expect(
+        executeRuntimeStrategyDeskStudyWorkflow(
+          {
+            env,
+            scenarioId: "desk_sol_composite_1",
+            runKind: "backtest",
+            requestedBy: "operator_1",
+          },
+          {
+            async runRuntimeBacktest() {
+              throw new Error("should-not-run-backtest");
+            },
+          },
+        ),
+      ).rejects.toThrow(
+        "runtime-strategy-desk-scenario-state-not-ready:desk_sol_composite_1:paused:backtest",
+      );
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("caps propagated evidence buckets to the report schema limit", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      await upsertRuntimeStrategyDeskScenarioWorkflow({
+        env,
+        scenario: buildStudyScenario({
+          evidence: Array.from({ length: 8 }, (_, index) => ({
+            stage:
+              index % 4 === 0
+                ? "shadow"
+                : index % 4 === 1
+                  ? "paper"
+                  : index % 4 === 2
+                    ? "replay"
+                    : "bounded_execution",
+            summary: `existing-${index}`,
+            evidenceRefs: [
+              {
+                kind: "strategy_desk_report",
+                ref: `existing_report_${index}`,
+              },
+            ],
+          })),
+        }) as never,
+      });
+
+      const result = await executeRuntimeStrategyDeskStudyWorkflow(
+        {
+          env,
+          scenarioId: "desk_sol_composite_1",
+          runKind: "backtest",
+          requestedBy: "operator_1",
+        },
+        {
+          createId(prefix) {
+            return prefix;
+          },
+          now() {
+            return "2026-03-17T05:00:00Z";
+          },
+          async runRuntimeBacktest({ payload }) {
+            const request = payload as {
+              reportId: string;
+              experimentId: string;
+            };
+            return {
+              status: 201,
+              ok: true,
+              payload: {
+                ok: true,
+                source: "stub",
+                created: true,
+                report: buildBacktestReport({
+                  reportId: request.reportId,
+                  experimentId: request.experimentId,
+                  venueKey: "jupiter",
+                  netReturnBps: "12.0000",
+                  grossReturnBps: "18.0000",
+                  totalCostBps: "6.0000",
+                  tradeCount: 2,
+                  maxDrawdownBps: "5.0000",
+                  excessVsFlatCashBps: "12.0000",
+                }),
+              },
+            };
+          },
+        },
+      );
+
+      expect(result.report.evidence).toHaveLength(8);
+      expect(
+        result.report.evidence.filter((bucket) => bucket.stage === "backtest"),
+      ).toHaveLength(1);
     } finally {
       sqlite.close();
     }

--- a/tests/unit/runtime_strategy_desk_study.test.ts
+++ b/tests/unit/runtime_strategy_desk_study.test.ts
@@ -1,0 +1,428 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  getRuntimeStrategyDeskScenarioWorkflow,
+  upsertRuntimeStrategyDeskScenarioWorkflow,
+} from "../../apps/worker/src/runtime_strategy_desk";
+import { executeRuntimeStrategyDeskStudyWorkflow } from "../../apps/worker/src/runtime_strategy_desk_study";
+import type { Env } from "../../apps/worker/src/types";
+import { createWorkerLiveEnv } from "../integration/_worker_live_test_utils";
+
+function createSqliteD1Adapter(db: Database): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          return {
+            async run() {
+              const statement = db.query(sql);
+              const result = statement.run(...(params as never[])) as {
+                changes?: number;
+              };
+              return {
+                meta: {
+                  changes:
+                    typeof result.changes === "number" ? result.changes : 0,
+                },
+              };
+            },
+            async first() {
+              const statement = db.query(sql);
+              return (statement.get(...(params as never[])) as unknown) ?? null;
+            },
+            async all() {
+              const statement = db.query(sql);
+              return {
+                results: (statement.all(...(params as never[])) ??
+                  []) as unknown[],
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+function createOpsEnv(overrides?: Partial<Env>) {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA foreign_keys = ON;");
+
+  for (const migrationName of [
+    "0025_execution_fabric.sql",
+    "0026_execution_canary.sql",
+    "0027_runtime_canary.sql",
+    "0028_strategy_lab_promotions.sql",
+    "0029_strategy_lab_readiness.sql",
+    "0030_strategy_lab_post_live.sql",
+    "0031_strategy_desk_registry.sql",
+    "0032_strategy_desk_leg_intent.sql",
+    "0033_strategy_desk_scorecards.sql",
+    "0034_strategy_desk_research_matrix.sql",
+  ]) {
+    const migrationPath = resolve(
+      import.meta.dir,
+      "..",
+      "..",
+      "apps/worker/migrations",
+      migrationName,
+    );
+    sqlite.exec(readFileSync(migrationPath, "utf8"));
+  }
+
+  const env = createWorkerLiveEnv({
+    overrides: {
+      WAITLIST_DB: createSqliteD1Adapter(sqlite),
+      ADMIN_TOKEN: "admin-secret",
+      ...overrides,
+    },
+  });
+
+  return { env, sqlite };
+}
+
+function readFixture(fileName: string): Record<string, unknown> {
+  return JSON.parse(
+    readFileSync(
+      resolve(
+        import.meta.dir,
+        "..",
+        "..",
+        "docs/runtime-contracts/fixtures",
+        fileName,
+      ),
+      "utf8",
+    ),
+  ) as Record<string, unknown>;
+}
+
+function buildBacktestReport(input: {
+  reportId: string;
+  experimentId: string;
+  venueKey: string;
+  netReturnBps: string;
+  grossReturnBps: string;
+  totalCostBps: string;
+  tradeCount: number;
+  maxDrawdownBps: string;
+  excessVsFlatCashBps: string;
+}) {
+  const base = readFixture("runtime.backtest_report.valid.v1.json") as Record<
+    string,
+    unknown
+  >;
+  return {
+    ...base,
+    reportId: input.reportId,
+    experimentId: input.experimentId,
+    generatedAt: "2026-03-17T05:00:00Z",
+    venueKeys: [input.venueKey],
+    config: {
+      ...(base.config as Record<string, unknown>),
+      venueKey: input.venueKey,
+    },
+    aggregateMetrics: {
+      observationCount: 4,
+      tradeCount: input.tradeCount,
+      grossReturnBps: input.grossReturnBps,
+      netReturnBps: input.netReturnBps,
+      totalCostBps: input.totalCostBps,
+      winRateBps: 5000,
+      maxDrawdownBps: input.maxDrawdownBps,
+    },
+    aggregateBaselineComparisons: [
+      {
+        baseline: "flat_cash",
+        baselineReturnBps: "0.0000",
+        excessReturnBps: input.excessVsFlatCashBps,
+      },
+      {
+        baseline: "buy_and_hold",
+        baselineReturnBps: "12.0000",
+        excessReturnBps: (Number(input.netReturnBps) - 12).toFixed(4),
+      },
+    ],
+    blockingReasons: [],
+    summary: `Synthetic report ${input.reportId}`,
+  };
+}
+
+describe("runtime strategy desk study workflow", () => {
+  test("builds a multi-window study matrix and preserves holdout summaries", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const scenario = readFixture(
+        "runtime.strategy_desk_scenario.valid.v1.json",
+      ) as Record<string, unknown>;
+      const studyScenario = {
+        ...scenario,
+        state: "replay_ready",
+        researchMatrix: {
+          selectionMetric: "excess_vs_flat_cash_bps",
+          backtestLegs: [
+            {
+              legId: "leg_spot_alpha",
+              experimentId: "exp_spot_base",
+              replayCorpusId: "replay_sol_usdc",
+              venueKey: "jupiter",
+              pairSymbol: "SOL/USDC",
+              marketType: "spot",
+              windowMode: "rolling",
+              trainingWindowObservations: 8,
+              testingWindowObservations: 4,
+              stepObservations: 4,
+              purgeObservations: 1,
+              baselineStrategies: ["flat_cash", "buy_and_hold"],
+            },
+            {
+              legId: "leg_perp_hedge",
+              experimentId: "exp_perp_base",
+              replayCorpusId: "replay_sol_perp",
+              venueKey: "drift",
+              pairSymbol: "SOL-PERP",
+              marketType: "perp",
+              windowMode: "rolling",
+              trainingWindowObservations: 8,
+              testingWindowObservations: 4,
+              stepObservations: 4,
+              purgeObservations: 1,
+              baselineStrategies: ["flat_cash", "buy_and_hold"],
+            },
+          ],
+          windows: [
+            {
+              windowId: "selection_week_1",
+              label: "Selection week 1",
+              cohort: "selection",
+              windowMode: "rolling",
+              trainingWindowObservations: 8,
+              testingWindowObservations: 4,
+              stepObservations: 4,
+              purgeObservations: 1,
+            },
+            {
+              windowId: "holdout_week_1",
+              label: "Holdout week 1",
+              cohort: "holdout",
+              windowMode: "rolling",
+              trainingWindowObservations: 8,
+              testingWindowObservations: 4,
+              stepObservations: 4,
+              purgeObservations: 1,
+            },
+          ],
+          variants: [
+            {
+              variantId: "fast",
+              label: "Fast",
+              parameterManifest: {
+                threshold: "fast",
+              },
+              legOverrides: [
+                {
+                  legId: "leg_spot_alpha",
+                  experimentId: "fast_spot",
+                },
+                {
+                  legId: "leg_perp_hedge",
+                  experimentId: "fast_perp",
+                },
+              ],
+            },
+            {
+              variantId: "slow",
+              label: "Slow",
+              parameterManifest: {
+                threshold: "slow",
+              },
+              legOverrides: [
+                {
+                  legId: "leg_spot_alpha",
+                  experimentId: "slow_spot",
+                },
+                {
+                  legId: "leg_perp_hedge",
+                  experimentId: "slow_perp",
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      await upsertRuntimeStrategyDeskScenarioWorkflow({
+        env,
+        scenario: studyScenario as never,
+      });
+
+      const result = await executeRuntimeStrategyDeskStudyWorkflow(
+        {
+          env,
+          scenarioId: "desk_sol_composite_1",
+          runKind: "backtest",
+          requestedBy: "operator_1",
+        },
+        {
+          createId(prefix) {
+            return prefix;
+          },
+          now() {
+            return "2026-03-17T05:00:00Z";
+          },
+          async runRuntimeBacktest({ payload }) {
+            const request = payload as {
+              reportId: string;
+              experimentId: string;
+            };
+            const reportId = request.reportId;
+            const report = reportId.includes(
+              "fast_selection_week_1_leg_spot_alpha",
+            )
+              ? buildBacktestReport({
+                  reportId,
+                  experimentId: request.experimentId,
+                  venueKey: "jupiter",
+                  netReturnBps: "80.0000",
+                  grossReturnBps: "95.0000",
+                  totalCostBps: "15.0000",
+                  tradeCount: 6,
+                  maxDrawdownBps: "35.0000",
+                  excessVsFlatCashBps: "80.0000",
+                })
+              : reportId.includes("fast_selection_week_1_leg_perp_hedge")
+                ? buildBacktestReport({
+                    reportId,
+                    experimentId: request.experimentId,
+                    venueKey: "drift",
+                    netReturnBps: "20.0000",
+                    grossReturnBps: "28.0000",
+                    totalCostBps: "8.0000",
+                    tradeCount: 3,
+                    maxDrawdownBps: "18.0000",
+                    excessVsFlatCashBps: "20.0000",
+                  })
+                : reportId.includes("fast_holdout_week_1_leg_spot_alpha")
+                  ? buildBacktestReport({
+                      reportId,
+                      experimentId: request.experimentId,
+                      venueKey: "jupiter",
+                      netReturnBps: "-12.0000",
+                      grossReturnBps: "3.0000",
+                      totalCostBps: "15.0000",
+                      tradeCount: 4,
+                      maxDrawdownBps: "60.0000",
+                      excessVsFlatCashBps: "-12.0000",
+                    })
+                  : reportId.includes("fast_holdout_week_1_leg_perp_hedge")
+                    ? buildBacktestReport({
+                        reportId,
+                        experimentId: request.experimentId,
+                        venueKey: "drift",
+                        netReturnBps: "-6.0000",
+                        grossReturnBps: "2.0000",
+                        totalCostBps: "8.0000",
+                        tradeCount: 2,
+                        maxDrawdownBps: "24.0000",
+                        excessVsFlatCashBps: "-6.0000",
+                      })
+                    : reportId.includes("slow_selection_week_1_leg_spot_alpha")
+                      ? buildBacktestReport({
+                          reportId,
+                          experimentId: request.experimentId,
+                          venueKey: "jupiter",
+                          netReturnBps: "42.0000",
+                          grossReturnBps: "50.0000",
+                          totalCostBps: "8.0000",
+                          tradeCount: 4,
+                          maxDrawdownBps: "20.0000",
+                          excessVsFlatCashBps: "42.0000",
+                        })
+                      : reportId.includes(
+                            "slow_selection_week_1_leg_perp_hedge",
+                          )
+                        ? buildBacktestReport({
+                            reportId,
+                            experimentId: request.experimentId,
+                            venueKey: "drift",
+                            netReturnBps: "8.0000",
+                            grossReturnBps: "11.0000",
+                            totalCostBps: "3.0000",
+                            tradeCount: 2,
+                            maxDrawdownBps: "10.0000",
+                            excessVsFlatCashBps: "8.0000",
+                          })
+                        : reportId.includes(
+                              "slow_holdout_week_1_leg_spot_alpha",
+                            )
+                          ? buildBacktestReport({
+                              reportId,
+                              experimentId: request.experimentId,
+                              venueKey: "jupiter",
+                              netReturnBps: "30.0000",
+                              grossReturnBps: "38.0000",
+                              totalCostBps: "8.0000",
+                              tradeCount: 3,
+                              maxDrawdownBps: "16.0000",
+                              excessVsFlatCashBps: "30.0000",
+                            })
+                          : buildBacktestReport({
+                              reportId,
+                              experimentId: request.experimentId,
+                              venueKey: "drift",
+                              netReturnBps: "5.0000",
+                              grossReturnBps: "7.0000",
+                              totalCostBps: "2.0000",
+                              tradeCount: 1,
+                              maxDrawdownBps: "8.0000",
+                              excessVsFlatCashBps: "5.0000",
+                            });
+
+            return {
+              status: 201,
+              ok: true,
+              payload: {
+                ok: true,
+                source: "stub",
+                created: true,
+                report,
+              },
+            };
+          },
+        },
+      );
+
+      expect(result.run.runKind).toBe("backtest");
+      expect(result.run.state).toBe("completed");
+      expect(result.report.stage).toBe("backtest");
+      expect(result.report.status).toBe("pass");
+      expect(result.report.studyMatrix?.selectedVariantId).toBe("fast");
+      expect(result.report.studyMatrix?.cells).toHaveLength(4);
+
+      const fastSummary = result.report.studyMatrix?.variantSummaries.find(
+        (summary) => summary.variantId === "fast",
+      );
+      expect(fastSummary?.selectionWindowCount).toBe(1);
+      expect(fastSummary?.holdoutWindowCount).toBe(1);
+      expect(fastSummary?.selectionMetrics?.netReturnBps).toBe("60.0000");
+      expect(fastSummary?.holdoutMetrics?.netReturnBps).toBe("-10.0000");
+
+      expect(result.report.checks.map((check) => check.checkId)).toEqual([
+        "matrix-generated",
+        "holdout-coverage",
+        "variant-selection",
+      ]);
+
+      const persisted = await getRuntimeStrategyDeskScenarioWorkflow({
+        env,
+        scenarioId: "desk_sol_composite_1",
+      });
+      expect(persisted.scenario.latestReportId).toBe(
+        "desk_report_desk_sol_composite_1_backtest",
+      );
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/tests/unit/runtime_strategy_desk_study.test.ts
+++ b/tests/unit/runtime_strategy_desk_study.test.ts
@@ -607,6 +607,60 @@ describe("runtime strategy desk study workflow", () => {
     }
   });
 
+  test("rejects selected variants whose override leg ids are not backtest-bound", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const baseScenario = buildStudyScenario();
+      const baseMatrix = baseScenario.researchMatrix as Record<string, unknown>;
+      await upsertRuntimeStrategyDeskScenarioWorkflow({
+        env,
+        scenario: {
+          ...baseScenario,
+          researchMatrix: {
+            ...baseMatrix,
+            variants: [
+              {
+                variantId: "broken",
+                label: "Broken",
+                parameterManifest: {
+                  threshold: "broken",
+                },
+                legOverrides: [
+                  {
+                    legId: "leg_missing_override",
+                    experimentId: "exp_missing_override",
+                  },
+                ],
+              },
+            ],
+          },
+        } as never,
+      });
+
+      const executeRuntimeStrategyDeskStudyWorkflow = await getStudyWorkflow();
+      await expect(
+        executeRuntimeStrategyDeskStudyWorkflow(
+          {
+            env,
+            scenarioId: "desk_sol_composite_1",
+            runKind: "backtest",
+            requestedBy: "operator_1",
+            variantIds: ["broken"],
+          },
+          {
+            async runRuntimeBacktest() {
+              throw new Error("should-not-run-backtest");
+            },
+          },
+        ),
+      ).rejects.toThrow(
+        "runtime-strategy-desk-study-leg-unknown:desk_sol_composite_1:leg_missing_override",
+      );
+    } finally {
+      sqlite.close();
+    }
+  });
+
   test("accepts anchored study windows when the runtime backtest report echoes anchored mode", async () => {
     const { env, sqlite } = createOpsEnv();
     try {

--- a/tests/unit/strategy_desk_repository.test.ts
+++ b/tests/unit/strategy_desk_repository.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  getStrategyDeskScenarioManifest,
+  getStrategyDeskScenarioReport,
+} from "../../apps/worker/src/strategy_desk_repository";
+
+function readFixture(fileName: string): Record<string, unknown> {
+  return JSON.parse(
+    readFileSync(
+      resolve(
+        import.meta.dir,
+        "..",
+        "..",
+        "docs/runtime-contracts/fixtures",
+        fileName,
+      ),
+      "utf8",
+    ),
+  ) as Record<string, unknown>;
+}
+
+function createDb(input: {
+  scenarioRow?: Record<string, unknown>;
+  legs?: Record<string, unknown>[];
+  reportRow?: Record<string, unknown>;
+}): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(..._params: unknown[]) {
+          return {
+            async first() {
+              if (/FROM strategy_desk_scenarios/i.test(sql)) {
+                return input.scenarioRow ?? null;
+              }
+              if (/FROM strategy_desk_reports/i.test(sql)) {
+                return input.reportRow ?? null;
+              }
+              return null;
+            },
+            async all() {
+              if (/FROM strategy_desk_scenario_legs/i.test(sql)) {
+                return { results: input.legs ?? [] };
+              }
+              return { results: [] };
+            },
+            async run() {
+              return { meta: { changes: 1 } };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+describe("strategy desk repository", () => {
+  test("hydrates scenario manifests when D1 rows already contain parsed JSON values", async () => {
+    const scenario = readFixture(
+      "runtime.strategy_desk_scenario.valid.v1.json",
+    ) as Record<string, unknown>;
+    const legs = (scenario.legs as Record<string, unknown>[]) ?? [];
+
+    const db = createDb({
+      scenarioRow: {
+        scenarioId: scenario.scenarioId,
+        schemaVersion: scenario.schemaVersion,
+        title: scenario.title,
+        summary: scenario.summary,
+        ownerUserId: scenario.ownerUserId,
+        strategyKey: scenario.strategyKey,
+        thesis: scenario.thesis,
+        sleeveId: scenario.sleeveId,
+        state: scenario.state,
+        reviewedAt: scenario.reviewedAt,
+        activeHandoffId: scenario.activeHandoffId,
+        latestReportId: scenario.latestReportId,
+        riskLimits: scenario.riskLimits,
+        researchMatrix: scenario.researchMatrix,
+        evidence: scenario.evidence,
+        implementationReferences: scenario.implementationReferences,
+        tags: scenario.tags,
+        metadata: scenario.metadata,
+        createdAt: scenario.createdAt,
+        updatedAt: scenario.updatedAt,
+      },
+      legs: legs.map((leg, index) => ({
+        scenarioId: scenario.scenarioId,
+        legId: leg.legId,
+        sortOrder: index,
+        label: leg.label,
+        role: leg.role,
+        venueKey: leg.venueKey,
+        intentFamily: leg.intentFamily,
+        marketType: leg.marketType,
+        pair: leg.pair,
+        instrumentId: leg.instrumentId,
+        assetKeys: leg.assetKeys,
+        enabledModes: leg.enabledModes,
+        sizing: leg.sizing,
+        intent: leg.intent,
+        thesis: leg.thesis,
+        dependencies: leg.dependencies,
+        tags: leg.tags,
+      })),
+    });
+
+    const persisted = await getStrategyDeskScenarioManifest(
+      db,
+      String(scenario.scenarioId),
+    );
+
+    expect(persisted?.researchMatrix?.variants).toHaveLength(
+      ((scenario.researchMatrix as Record<string, unknown>).variants as unknown[])
+        .length,
+    );
+    expect(persisted?.researchMatrix?.windows).toHaveLength(
+      ((scenario.researchMatrix as Record<string, unknown>).windows as unknown[])
+        .length,
+    );
+    expect(persisted?.evidence).toHaveLength(
+      (scenario.evidence as unknown[]).length,
+    );
+    expect(persisted?.legs).toHaveLength(legs.length);
+  });
+
+  test("hydrates scenario reports when D1 rows already contain parsed JSON values", async () => {
+    const report = readFixture(
+      "runtime.strategy_desk_report.valid.v1.json",
+    ) as Record<string, unknown>;
+
+    const db = createDb({
+      reportRow: {
+        reportId: report.reportId,
+        scenarioId: report.scenarioId,
+        scenarioRunId: report.scenarioRunId,
+        schemaVersion: report.schemaVersion,
+        stage: report.stage,
+        status: report.status,
+        summary: report.summary,
+        legOutcomes: report.legOutcomes,
+        portfolioSummary: report.portfolioSummary,
+        scorecard: report.scorecard,
+        riskOverlays: report.riskOverlays,
+        studyMatrix: report.studyMatrix,
+        evidence: report.evidence,
+        checks: report.checks,
+        approvals: report.approvals,
+        metadata: report.metadata,
+        generatedAt: report.generatedAt,
+      },
+    });
+
+    const persisted = await getStrategyDeskScenarioReport(
+      db,
+      String(report.reportId),
+    );
+
+    expect(persisted?.studyMatrix?.cells).toHaveLength(
+      (((report.studyMatrix as Record<string, unknown>)?.cells ??
+        []) as unknown[]).length,
+    );
+    expect(persisted?.evidence).toHaveLength(
+      (report.evidence as unknown[]).length,
+    );
+    expect(persisted?.checks).toHaveLength(
+      (report.checks as unknown[]).length,
+    );
+  });
+});

--- a/tests/unit/strategy_desk_repository.test.ts
+++ b/tests/unit/strategy_desk_repository.test.ts
@@ -113,12 +113,16 @@ describe("strategy desk repository", () => {
     );
 
     expect(persisted?.researchMatrix?.variants).toHaveLength(
-      ((scenario.researchMatrix as Record<string, unknown>).variants as unknown[])
-        .length,
+      (
+        (scenario.researchMatrix as Record<string, unknown>)
+          .variants as unknown[]
+      ).length,
     );
     expect(persisted?.researchMatrix?.windows).toHaveLength(
-      ((scenario.researchMatrix as Record<string, unknown>).windows as unknown[])
-        .length,
+      (
+        (scenario.researchMatrix as Record<string, unknown>)
+          .windows as unknown[]
+      ).length,
     );
     expect(persisted?.evidence).toHaveLength(
       (scenario.evidence as unknown[]).length,
@@ -159,14 +163,14 @@ describe("strategy desk repository", () => {
     );
 
     expect(persisted?.studyMatrix?.cells).toHaveLength(
-      (((report.studyMatrix as Record<string, unknown>)?.cells ??
-        []) as unknown[]).length,
+      (
+        ((report.studyMatrix as Record<string, unknown>)?.cells ??
+          []) as unknown[]
+      ).length,
     );
     expect(persisted?.evidence).toHaveLength(
       (report.evidence as unknown[]).length,
     );
-    expect(persisted?.checks).toHaveLength(
-      (report.checks as unknown[]).length,
-    );
+    expect(persisted?.checks).toHaveLength((report.checks as unknown[]).length);
   });
 });

--- a/tests/unit/worker_execution_migrations.test.ts
+++ b/tests/unit/worker_execution_migrations.test.ts
@@ -17,6 +17,7 @@ function withExecutionSchema(run: (db: Database) => void): void {
       "0031_strategy_desk_registry.sql",
       "0032_strategy_desk_leg_intent.sql",
       "0033_strategy_desk_scorecards.sql",
+      "0034_strategy_desk_research_matrix.sql",
     ]) {
       const migrationPath = resolve(
         import.meta.dir,

--- a/tests/unit/worker_runtime_strategy_desk_route.test.ts
+++ b/tests/unit/worker_runtime_strategy_desk_route.test.ts
@@ -67,6 +67,7 @@ function createOpsEnv(overrides?: Partial<Env>) {
     "0031_strategy_desk_registry.sql",
     "0032_strategy_desk_leg_intent.sql",
     "0033_strategy_desk_scorecards.sql",
+    "0034_strategy_desk_research_matrix.sql",
   ]) {
     const migrationPath = resolve(
       import.meta.dir,

--- a/tests/unit/worker_runtime_strategy_desk_study_route.test.ts
+++ b/tests/unit/worker_runtime_strategy_desk_study_route.test.ts
@@ -8,73 +8,167 @@ import {
   createWorkerLiveEnv,
 } from "../integration/_worker_live_test_utils";
 
-const executeRuntimeStrategyDeskScenarioWorkflowMock = mock(
+const executeRuntimeStrategyDeskStudyWorkflowMock = mock(
   async (input: {
     scenarioId: string;
-    runKind: "shadow" | "paper";
+    runKind: "replay" | "backtest";
     requestedBy: string;
-    walletAddress: string;
+    variantIds?: string[];
+    windowIds?: string[];
   }) => ({
     scenario: {
       schemaVersion: "v1",
       scenarioId: input.scenarioId,
-      title: "Mock desk scenario",
-      summary: "Mock scenario summary",
+      title: "Mock study scenario",
+      summary: "Mock study summary",
       ownerUserId: "user_1",
       strategyKey: "strategy_desk::mock",
       thesis: "Mock thesis",
-      state: "paper_ready",
+      state: "replay_ready",
       createdAt: "2026-03-17T03:00:00Z",
       updatedAt: "2026-03-17T03:05:00Z",
       legs: [],
       evidence: [],
       implementationReferences: [],
       tags: [],
+      researchMatrix: {
+        selectionMetric: "excess_vs_flat_cash_bps",
+        backtestLegs: [],
+        windows: [],
+        variants: [],
+      },
     },
     run: {
       schemaVersion: "v1",
-      scenarioRunId: "desk_run_mock_1",
+      scenarioRunId: "desk_run_study_mock_1",
       scenarioId: input.scenarioId,
-      scenarioState: "paper_ready",
+      scenarioState: "replay_ready",
       runKind: input.runKind,
       state: "completed",
       requestedBy: input.requestedBy,
       trigger: {
         kind: "operator",
-        source: "strategy_desk_runner",
+        source: "strategy_desk_study",
         observedAt: "2026-03-17T03:06:00Z",
       },
       createdAt: "2026-03-17T03:06:00Z",
       updatedAt: "2026-03-17T03:06:01Z",
+      completedAt: "2026-03-17T03:06:30Z",
       legRuns: [],
     },
     report: {
       schemaVersion: "v1",
-      reportId: "desk_report_mock_1",
+      reportId: "desk_report_study_mock_1",
       scenarioId: input.scenarioId,
-      scenarioRunId: "desk_run_mock_1",
+      scenarioRunId: "desk_run_study_mock_1",
       stage: input.runKind,
       status: "pass",
-      summary: "Mock report",
-      generatedAt: "2026-03-17T03:06:02Z",
+      summary: "Mock study report",
+      generatedAt: "2026-03-17T03:06:30Z",
       legOutcomes: [
         {
           legId: "leg_1",
           status: "pass",
-          evidenceRefs: [
-            {
-              kind: "strategy_desk_leg_receipt",
-              ref: "desk_run_mock_1:leg_1",
-            },
-          ],
+          evidenceRefs: [],
         },
       ],
+      studyMatrix: {
+        matrixId: "matrix_1",
+        runKind: input.runKind,
+        selectionMetric: "excess_vs_flat_cash_bps",
+        generatedAt: "2026-03-17T03:06:30Z",
+        selectedVariantId: "fast",
+        windows: [
+          {
+            windowId: "selection_1",
+            label: "Selection 1",
+            cohort: "selection",
+          },
+        ],
+        variantSummaries: [
+          {
+            variantId: "fast",
+            label: "Fast",
+            parameterManifest: { threshold: "fast" },
+            selectionWindowCount: 1,
+            holdoutWindowCount: 0,
+            selectionMetrics: {
+              observationCount: 2,
+              tradeCount: 1,
+              grossReturnBps: "10.0000",
+              netReturnBps: "8.0000",
+              totalCostBps: "2.0000",
+              winRateBps: 5000,
+              maxDrawdownBps: "5.0000",
+            },
+            selectionBaselineComparisons: [
+              {
+                baseline: "flat_cash",
+                baselineReturnBps: "0.0000",
+                excessReturnBps: "8.0000",
+              },
+            ],
+          },
+        ],
+        cells: [
+          {
+            cellId: "fast:selection_1",
+            variantId: "fast",
+            variantLabel: "Fast",
+            windowId: "selection_1",
+            windowLabel: "Selection 1",
+            cohort: "selection",
+            status: "completed",
+            legResults: [
+              {
+                legId: "leg_1",
+                reportId: "backtest_fast_selection_1_leg_1",
+                reproducibilityBundleId:
+                  "repro_backtest_fast_selection_1_leg_1",
+                status: "completed",
+                metrics: {
+                  observationCount: 2,
+                  tradeCount: 1,
+                  grossReturnBps: "10.0000",
+                  netReturnBps: "8.0000",
+                  totalCostBps: "2.0000",
+                  winRateBps: 5000,
+                  maxDrawdownBps: "5.0000",
+                },
+                baselineComparisons: [
+                  {
+                    baseline: "flat_cash",
+                    baselineReturnBps: "0.0000",
+                    excessReturnBps: "8.0000",
+                  },
+                ],
+              },
+            ],
+            aggregateMetrics: {
+              observationCount: 2,
+              tradeCount: 1,
+              grossReturnBps: "10.0000",
+              netReturnBps: "8.0000",
+              totalCostBps: "2.0000",
+              winRateBps: 5000,
+              maxDrawdownBps: "5.0000",
+            },
+            aggregateBaselineComparisons: [
+              {
+                baseline: "flat_cash",
+                baselineReturnBps: "0.0000",
+                excessReturnBps: "8.0000",
+              },
+            ],
+          },
+        ],
+      },
       evidence: [],
       checks: [
         {
-          checkId: "mock",
+          checkId: "matrix-generated",
           status: "pass",
-          message: "mock",
+          message: "matrix ok",
         },
       ],
       approvals: [],
@@ -82,9 +176,9 @@ const executeRuntimeStrategyDeskScenarioWorkflowMock = mock(
   }),
 );
 
-mock.module("../../apps/worker/src/runtime_strategy_desk_runner", () => ({
-  executeRuntimeStrategyDeskScenarioWorkflow:
-    executeRuntimeStrategyDeskScenarioWorkflowMock,
+mock.module("../../apps/worker/src/runtime_strategy_desk_study", () => ({
+  executeRuntimeStrategyDeskStudyWorkflow:
+    executeRuntimeStrategyDeskStudyWorkflowMock,
 }));
 mock.module("../../apps/worker/src/auth", () => ({
   requireUser: mock(async () => ({
@@ -168,22 +262,21 @@ function createOpsEnv(overrides?: Partial<Env>) {
   return { env, sqlite };
 }
 
-describe("worker runtime strategy desk execute route", () => {
+describe("worker runtime strategy desk study route", () => {
   test("requires admin auth", async () => {
     const { env, sqlite } = createOpsEnv();
     try {
       const response = await worker.fetch(
         new Request(
-          "http://localhost/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/execute",
+          "http://localhost/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/study",
           {
             method: "POST",
             headers: {
               "content-type": "application/json",
             },
             body: JSON.stringify({
-              runKind: "paper",
+              runKind: "backtest",
               requestedBy: "operator_1",
-              walletAddress: "11111111111111111111111111111111",
             }),
           },
         ),
@@ -197,12 +290,12 @@ describe("worker runtime strategy desk execute route", () => {
     }
   });
 
-  test("dispatches scenario execution through the runner workflow", async () => {
+  test("dispatches scenario study through the study workflow", async () => {
     const { env, sqlite } = createOpsEnv();
     try {
       const response = await worker.fetch(
         new Request(
-          "http://localhost/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/execute",
+          "http://localhost/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/study",
           {
             method: "POST",
             headers: {
@@ -210,13 +303,11 @@ describe("worker runtime strategy desk execute route", () => {
               "content-type": "application/json",
             },
             body: JSON.stringify({
-              runKind: "paper",
+              runKind: "backtest",
               requestedBy: "operator_1",
-              walletAddress: "11111111111111111111111111111111",
-              maxRetriesPerLeg: 1,
-              trigger: {
-                reason: "manual-eval",
-              },
+              variantIds: ["fast"],
+              windowIds: ["selection_1"],
+              selectionMetric: "excess_vs_flat_cash_bps",
             }),
           },
         ),
@@ -228,23 +319,23 @@ describe("worker runtime strategy desk execute route", () => {
       const payload = (await response.json()) as {
         ok: boolean;
         run: { scenarioRunId: string };
-        report: { reportId: string };
+        report: {
+          reportId: string;
+          studyMatrix?: { selectedVariantId?: string };
+        };
       };
       expect(payload.ok).toBe(true);
-      expect(payload.run.scenarioRunId).toBe("desk_run_mock_1");
-      expect(payload.report.reportId).toBe("desk_report_mock_1");
-      expect(
-        executeRuntimeStrategyDeskScenarioWorkflowMock,
-      ).toHaveBeenCalledWith(
+      expect(payload.run.scenarioRunId).toBe("desk_run_study_mock_1");
+      expect(payload.report.reportId).toBe("desk_report_study_mock_1");
+      expect(payload.report.studyMatrix?.selectedVariantId).toBe("fast");
+      expect(executeRuntimeStrategyDeskStudyWorkflowMock).toHaveBeenCalledWith(
         expect.objectContaining({
           scenarioId: "desk_sol_composite_1",
-          runKind: "paper",
+          runKind: "backtest",
           requestedBy: "operator_1",
-          walletAddress: "11111111111111111111111111111111",
-          maxRetriesPerLeg: 1,
-          trigger: {
-            reason: "manual-eval",
-          },
+          variantIds: ["fast"],
+          windowIds: ["selection_1"],
+          selectionMetric: "excess_vs_flat_cash_bps",
         }),
       );
     } finally {


### PR DESCRIPTION
Closes #440

## Summary
- add first-class strategy-desk `researchMatrix` and `studyMatrix` contracts plus persistence
- add a harness-native `/study` workflow and CLI path that fan out runtime backtests across variants and windows
- aggregate selection vs holdout summaries, selected variant metadata, reproducibility refs, and desk-level checks into strategy-desk reports

## Validation
- `bun test tests/unit/runtime_strategy_desk_runner.test.ts tests/unit/runtime_strategy_desk_study.test.ts tests/unit/worker_runtime_strategy_desk_route.test.ts tests/unit/worker_runtime_strategy_desk_execute_route.test.ts tests/unit/worker_runtime_strategy_desk_study_route.test.ts tests/unit/runtime_protocol_contracts.test.ts tests/unit/runtime_protocol_schema_fixtures.test.ts tests/unit/worker_runtime_contracts.test.ts tests/unit/worker_execution_migrations.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run contracts:runtime:schemas`

## Harness Proof
- `ADMIN_TOKEN=admin-secret bun run harness:up`
- `bun run strategy-desk:registry --resource scenario --action upsert --base-url http://127.0.0.1:9043 --admin-token admin-secret --request-file docs/runtime-contracts/fixtures/runtime.strategy_desk_scenario.valid.v1.json --output-dir .tmp/strategy-desk-study-proof`
- `bun run strategy-desk:registry --resource scenario --action study --base-url http://127.0.0.1:9043 --admin-token admin-secret --request-file .tmp/strategy-desk-study-proof/study.request.json --output-dir .tmp/strategy-desk-study-proof`
- proof artifact: `.tmp/strategy-desk-study-proof/scenario.study.json` with `run.state=completed`, `report.stage=backtest`, `report.status=pass`, `selectedVariantId=fast`, `2` variants, `2` windows, `4` cells
- `bun run harness:down`