### PR TITLE
[Phase SD5] Build portal strategy desk

### DIFF
--- a/apps/portal/app/api/runtime/strategy-desk/route.ts
+++ b/apps/portal/app/api/runtime/strategy-desk/route.ts
@@ -1,0 +1,573 @@
+import { NextResponse } from "next/server";
+import {
+  type RuntimeStrategyDeskScenarioManifest,
+  type RuntimeStrategyDeskScenarioReport,
+  type RuntimeStrategyDeskScenarioRun,
+  safeParseRuntimeStrategyDeskScenarioManifest,
+  safeParseRuntimeStrategyDeskScenarioReport,
+  safeParseRuntimeStrategyDeskScenarioRun,
+} from "../../../../lib/runtime-strategy-desk";
+
+const LOCAL_EDGE_API_BASE = "http://127.0.0.1:8888";
+const BEARER_RE = /^bearer\s+/i;
+
+type WorkerJsonResult = {
+  status: number;
+  payload: Record<string, unknown>;
+};
+
+function parseCsvSet(value: string | undefined): Set<string> {
+  return new Set(
+    String(value ?? "")
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return normalized ? normalized : null;
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => Boolean(readString(entry)));
+}
+
+function normalizeAuthHeader(value: string | null): string | null {
+  const token = String(value ?? "").trim();
+  if (!token) return null;
+  return BEARER_RE.test(token) ? token : `Bearer ${token}`;
+}
+
+function resolveEdgeApiBase(): string {
+  const configured = String(process.env.NEXT_PUBLIC_EDGE_API_BASE ?? "")
+    .trim()
+    .replace(/\/+$/, "");
+  if (configured) return configured;
+  return process.env.NODE_ENV === "production" ? "" : LOCAL_EDGE_API_BASE;
+}
+
+function resolveAdminToken(): string {
+  return String(
+    process.env.RUNTIME_OPERATOR_ADMIN_TOKEN ?? process.env.ADMIN_TOKEN ?? "",
+  ).trim();
+}
+
+function isAuthorizedRuntimeOperator(
+  payload: Record<string, unknown>,
+): boolean {
+  const user = isRecord(payload.user) ? payload.user : null;
+  if (!user) return false;
+
+  const allowedUserIds = parseCsvSet(
+    process.env.RUNTIME_OPERATOR_USER_ALLOWLIST,
+  );
+  const allowedPrivyUserIds = parseCsvSet(
+    process.env.RUNTIME_OPERATOR_PRIVY_USER_ALLOWLIST,
+  );
+  if (allowedUserIds.size === 0 && allowedPrivyUserIds.size === 0) {
+    return false;
+  }
+
+  const userId = readString(user.id);
+  if (userId && allowedUserIds.has(userId)) return true;
+
+  const privyUserId = readString(user.privyUserId);
+  if (privyUserId && allowedPrivyUserIds.has(privyUserId)) return true;
+
+  return false;
+}
+
+async function requestWorkerJson(input: {
+  path: string;
+  method?: "GET" | "POST";
+  authHeader: string;
+  body?: unknown;
+}): Promise<WorkerJsonResult> {
+  const base = resolveEdgeApiBase();
+  if (!base) {
+    return {
+      status: 503,
+      payload: { ok: false, error: "missing NEXT_PUBLIC_EDGE_API_BASE" },
+    };
+  }
+
+  const response = await fetch(`${base}${input.path}`, {
+    method: input.method ?? "GET",
+    headers: {
+      authorization: input.authHeader,
+      ...(input.body !== undefined
+        ? { "content-type": "application/json" }
+        : {}),
+    },
+    ...(input.body !== undefined ? { body: JSON.stringify(input.body) } : {}),
+    cache: "no-store",
+  });
+  const payload = (await response.json().catch(() => null)) as unknown;
+  return {
+    status: response.status,
+    payload:
+      isRecord(payload) && Object.keys(payload).length > 0
+        ? payload
+        : { ok: false, error: `http-${response.status}` },
+  };
+}
+
+async function validateOperatorSession(
+  userAuthHeader: string,
+): Promise<WorkerJsonResult> {
+  return await requestWorkerJson({
+    path: "/api/me",
+    authHeader: userAuthHeader,
+  });
+}
+
+function parseScenarios(value: unknown): RuntimeStrategyDeskScenarioManifest[] {
+  if (!Array.isArray(value)) return [];
+  const scenarios: RuntimeStrategyDeskScenarioManifest[] = [];
+  for (const entry of value) {
+    const parsed = safeParseRuntimeStrategyDeskScenarioManifest(entry);
+    if (parsed.success) scenarios.push(parsed.data);
+  }
+  return scenarios;
+}
+
+function parseRuns(value: unknown): RuntimeStrategyDeskScenarioRun[] {
+  if (!Array.isArray(value)) return [];
+  const runs: RuntimeStrategyDeskScenarioRun[] = [];
+  for (const entry of value) {
+    const parsed = safeParseRuntimeStrategyDeskScenarioRun(entry);
+    if (parsed.success) runs.push(parsed.data);
+  }
+  return runs;
+}
+
+function parseReports(value: unknown): RuntimeStrategyDeskScenarioReport[] {
+  if (!Array.isArray(value)) return [];
+  const reports: RuntimeStrategyDeskScenarioReport[] = [];
+  for (const entry of value) {
+    const parsed = safeParseRuntimeStrategyDeskScenarioReport(entry);
+    if (parsed.success) reports.push(parsed.data);
+  }
+  return reports;
+}
+
+function latestByTimestamp<
+  T extends { generatedAt?: string; updatedAt?: string },
+>(items: T[], timestampKey: "generatedAt" | "updatedAt"): T | null {
+  return (
+    [...items].sort((left, right) =>
+      String(right[timestampKey] ?? "").localeCompare(
+        String(left[timestampKey] ?? ""),
+      ),
+    )[0] ?? null
+  );
+}
+
+async function ensureAuthorizedOperator(request: Request): Promise<
+  | {
+      ok: true;
+      adminAuthHeader: string;
+    }
+  | {
+      ok: false;
+      response: NextResponse;
+    }
+> {
+  const userAuthHeader = normalizeAuthHeader(
+    request.headers.get("authorization"),
+  );
+  if (!userAuthHeader) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { ok: false, error: "auth-required" },
+        { status: 401 },
+      ),
+    };
+  }
+
+  const session = await validateOperatorSession(userAuthHeader);
+  if (session.status !== 200 || session.payload.ok !== true) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        {
+          ok: false,
+          error: readString(session.payload.error) ?? "operator-auth-failed",
+        },
+        { status: 401 },
+      ),
+    };
+  }
+
+  if (!isAuthorizedRuntimeOperator(session.payload)) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { ok: false, error: "operator-access-required" },
+        { status: 403 },
+      ),
+    };
+  }
+
+  const adminToken = resolveAdminToken();
+  const adminAuthHeader = normalizeAuthHeader(adminToken);
+  if (!adminAuthHeader) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { ok: false, error: "missing RUNTIME_OPERATOR_ADMIN_TOKEN" },
+        { status: 503 },
+      ),
+    };
+  }
+
+  return {
+    ok: true,
+    adminAuthHeader,
+  };
+}
+
+function parseExecutePayload(value: unknown): {
+  scenarioId: string;
+  runKind: "shadow" | "paper";
+  requestedBy: string;
+  walletAddress: string;
+  trigger?: Record<string, unknown>;
+  maxRetriesPerLeg?: number;
+} | null {
+  if (!isRecord(value)) return null;
+  const scenarioId = readString(value.scenarioId);
+  const runKind =
+    value.runKind === "shadow" || value.runKind === "paper"
+      ? value.runKind
+      : null;
+  const requestedBy = readString(value.requestedBy);
+  const walletAddress = readString(value.walletAddress);
+  const maxRetriesPerLeg = Number(value.maxRetriesPerLeg);
+  if (!scenarioId || !runKind || !requestedBy || !walletAddress) return null;
+  return {
+    scenarioId,
+    runKind,
+    requestedBy,
+    walletAddress,
+    ...(isRecord(value.trigger) ? { trigger: value.trigger } : {}),
+    ...(Number.isFinite(maxRetriesPerLeg) && maxRetriesPerLeg >= 0
+      ? { maxRetriesPerLeg: Math.trunc(maxRetriesPerLeg) }
+      : {}),
+  };
+}
+
+function parseStudyPayload(value: unknown): {
+  scenarioId: string;
+  runKind: "replay" | "backtest";
+  requestedBy: string;
+  selectionMetric?: "net_return_bps" | "excess_vs_flat_cash_bps";
+  variantIds?: string[];
+  windowIds?: string[];
+} | null {
+  if (!isRecord(value)) return null;
+  const scenarioId = readString(value.scenarioId);
+  const runKind =
+    value.runKind === "replay" || value.runKind === "backtest"
+      ? value.runKind
+      : null;
+  const requestedBy = readString(value.requestedBy);
+  const selectionMetric =
+    value.selectionMetric === "net_return_bps" ||
+    value.selectionMetric === "excess_vs_flat_cash_bps"
+      ? value.selectionMetric
+      : undefined;
+  if (!scenarioId || !runKind || !requestedBy) return null;
+  const variantIds = readStringArray(value.variantIds);
+  const windowIds = readStringArray(value.windowIds);
+  return {
+    scenarioId,
+    runKind,
+    requestedBy,
+    ...(selectionMetric ? { selectionMetric } : {}),
+    ...(variantIds.length > 0 ? { variantIds } : {}),
+    ...(windowIds.length > 0 ? { windowIds } : {}),
+  };
+}
+
+export async function GET(request: Request) {
+  const auth = await ensureAuthorizedOperator(request);
+  if (!auth.ok) return auth.response;
+
+  const url = new URL(request.url);
+  const requestedScenarioId = readString(url.searchParams.get("scenarioId"));
+  const listQuery = new URLSearchParams();
+  listQuery.set("limit", "20");
+  for (const key of [
+    "ownerUserId",
+    "strategyKey",
+    "state",
+    "venueKey",
+    "intentFamily",
+    "marketType",
+  ] as const) {
+    const value = readString(url.searchParams.get(key));
+    if (value) listQuery.set(key, value);
+  }
+
+  const scenariosResult = await requestWorkerJson({
+    path: `/api/admin/ops/runtime/strategy-desk/scenarios?${listQuery.toString()}`,
+    authHeader: auth.adminAuthHeader,
+  });
+  if (scenariosResult.status !== 200 || scenariosResult.payload.ok !== true) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          readString(scenariosResult.payload.error) ??
+          "strategy-desk-scenarios-load-failed",
+      },
+      { status: scenariosResult.status || 502 },
+    );
+  }
+
+  const scenarios = parseScenarios(scenariosResult.payload.scenarios);
+  let selectedScenario =
+    (requestedScenarioId
+      ? scenarios.find(
+          (scenario) => scenario.scenarioId === requestedScenarioId,
+        )
+      : null) ?? null;
+
+  if (!selectedScenario && requestedScenarioId) {
+    const detailResult = await requestWorkerJson({
+      path: `/api/admin/ops/runtime/strategy-desk/scenarios/${encodeURIComponent(
+        requestedScenarioId,
+      )}`,
+      authHeader: auth.adminAuthHeader,
+    });
+    if (detailResult.status === 200 && detailResult.payload.ok === true) {
+      const parsed = safeParseRuntimeStrategyDeskScenarioManifest(
+        detailResult.payload.scenario,
+      );
+      if (parsed.success) selectedScenario = parsed.data;
+    }
+  }
+
+  selectedScenario ??= scenarios[0] ?? null;
+  const selectedScenarioId = selectedScenario?.scenarioId ?? null;
+
+  let runs: RuntimeStrategyDeskScenarioRun[] = [];
+  let reports: RuntimeStrategyDeskScenarioReport[] = [];
+
+  if (selectedScenarioId) {
+    const [runsResult, reportsResult] = await Promise.all([
+      requestWorkerJson({
+        path: `/api/admin/ops/runtime/strategy-desk/runs?scenarioId=${encodeURIComponent(
+          selectedScenarioId,
+        )}&limit=20`,
+        authHeader: auth.adminAuthHeader,
+      }),
+      requestWorkerJson({
+        path: `/api/admin/ops/runtime/strategy-desk/reports?scenarioId=${encodeURIComponent(
+          selectedScenarioId,
+        )}&limit=20`,
+        authHeader: auth.adminAuthHeader,
+      }),
+    ]);
+
+    if (runsResult.status === 200 && runsResult.payload.ok === true) {
+      runs = parseRuns(runsResult.payload.runs);
+    }
+    if (reportsResult.status === 200 && reportsResult.payload.ok === true) {
+      reports = parseReports(reportsResult.payload.reports);
+    }
+  }
+
+  return NextResponse.json({
+    ok: true,
+    snapshot: {
+      scenarios,
+      selectedScenarioId,
+      selectedScenario,
+      runs,
+      reports,
+      latestRun: latestByTimestamp(runs, "updatedAt"),
+      latestReport: latestByTimestamp(reports, "generatedAt"),
+    },
+  });
+}
+
+export async function POST(request: Request) {
+  const auth = await ensureAuthorizedOperator(request);
+  if (!auth.ok) return auth.response;
+
+  const body = (await request.json().catch(() => null)) as unknown;
+  if (!isRecord(body)) {
+    return NextResponse.json(
+      { ok: false, error: "strategy-desk-invalid-body" },
+      { status: 400 },
+    );
+  }
+
+  const action = readString(body.action);
+  if (action === "upsert_scenario") {
+    const parsed = safeParseRuntimeStrategyDeskScenarioManifest(body.scenario);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { ok: false, error: parsed.error },
+        { status: 400 },
+      );
+    }
+    const result = await requestWorkerJson({
+      path: "/api/admin/ops/runtime/strategy-desk/scenarios",
+      method: "POST",
+      authHeader: auth.adminAuthHeader,
+      body: parsed.data,
+    });
+    if (result.status !== 200 || result.payload.ok !== true) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error:
+            readString(result.payload.error) ??
+            "strategy-desk-upsert-scenario-failed",
+        },
+        { status: result.status || 502 },
+      );
+    }
+    const scenario = safeParseRuntimeStrategyDeskScenarioManifest(
+      result.payload.scenario,
+    );
+    if (!scenario.success) {
+      return NextResponse.json(
+        { ok: false, error: scenario.error },
+        { status: 502 },
+      );
+    }
+    return NextResponse.json({
+      ok: true,
+      scenario: scenario.data,
+    });
+  }
+
+  if (action === "execute_scenario") {
+    const parsed = parseExecutePayload(body);
+    if (!parsed) {
+      return NextResponse.json(
+        { ok: false, error: "strategy-desk-execute-invalid" },
+        { status: 400 },
+      );
+    }
+    const result = await requestWorkerJson({
+      path: `/api/admin/ops/runtime/strategy-desk/scenarios/${encodeURIComponent(
+        parsed.scenarioId,
+      )}/execute`,
+      method: "POST",
+      authHeader: auth.adminAuthHeader,
+      body: {
+        runKind: parsed.runKind,
+        requestedBy: parsed.requestedBy,
+        walletAddress: parsed.walletAddress,
+        ...(parsed.trigger ? { trigger: parsed.trigger } : {}),
+        ...(parsed.maxRetriesPerLeg !== undefined
+          ? { maxRetriesPerLeg: parsed.maxRetriesPerLeg }
+          : {}),
+      },
+    });
+    if (result.status !== 200 || result.payload.ok !== true) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error:
+            readString(result.payload.error) ??
+            "strategy-desk-execute-scenario-failed",
+        },
+        { status: result.status || 502 },
+      );
+    }
+    const scenario = safeParseRuntimeStrategyDeskScenarioManifest(
+      result.payload.scenario,
+    );
+    const run = safeParseRuntimeStrategyDeskScenarioRun(result.payload.run);
+    const report = safeParseRuntimeStrategyDeskScenarioReport(
+      result.payload.report,
+    );
+    if (!scenario.success || !run.success || !report.success) {
+      return NextResponse.json(
+        { ok: false, error: "strategy-desk-execute-response-invalid" },
+        { status: 502 },
+      );
+    }
+    return NextResponse.json({
+      ok: true,
+      scenario: scenario.data,
+      run: run.data,
+      report: report.data,
+    });
+  }
+
+  if (action === "study_scenario") {
+    const parsed = parseStudyPayload(body);
+    if (!parsed) {
+      return NextResponse.json(
+        { ok: false, error: "strategy-desk-study-invalid" },
+        { status: 400 },
+      );
+    }
+    const result = await requestWorkerJson({
+      path: `/api/admin/ops/runtime/strategy-desk/scenarios/${encodeURIComponent(
+        parsed.scenarioId,
+      )}/study`,
+      method: "POST",
+      authHeader: auth.adminAuthHeader,
+      body: {
+        runKind: parsed.runKind,
+        requestedBy: parsed.requestedBy,
+        ...(parsed.selectionMetric
+          ? { selectionMetric: parsed.selectionMetric }
+          : {}),
+        ...(parsed.variantIds ? { variantIds: parsed.variantIds } : {}),
+        ...(parsed.windowIds ? { windowIds: parsed.windowIds } : {}),
+      },
+    });
+    if (result.status !== 200 || result.payload.ok !== true) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error:
+            readString(result.payload.error) ??
+            "strategy-desk-study-scenario-failed",
+        },
+        { status: result.status || 502 },
+      );
+    }
+    const scenario = safeParseRuntimeStrategyDeskScenarioManifest(
+      result.payload.scenario,
+    );
+    const run = safeParseRuntimeStrategyDeskScenarioRun(result.payload.run);
+    const report = safeParseRuntimeStrategyDeskScenarioReport(
+      result.payload.report,
+    );
+    if (!scenario.success || !run.success || !report.success) {
+      return NextResponse.json(
+        { ok: false, error: "strategy-desk-study-response-invalid" },
+        { status: 502 },
+      );
+    }
+    return NextResponse.json({
+      ok: true,
+      scenario: scenario.data,
+      run: run.data,
+      report: report.data,
+    });
+  }
+
+  return NextResponse.json(
+    { ok: false, error: "strategy-desk-action-unsupported" },
+    { status: 400 },
+  );
+}

--- a/apps/portal/app/api/runtime/strategy-desk/route.ts
+++ b/apps/portal/app/api/runtime/strategy-desk/route.ts
@@ -349,12 +349,27 @@ export async function GET(request: Request) {
       )}`,
       authHeader: auth.adminAuthHeader,
     });
-    if (detailResult.status === 200 && detailResult.payload.ok === true) {
-      const parsed = safeParseRuntimeStrategyDeskScenarioManifest(
-        detailResult.payload.scenario,
+    if (detailResult.status !== 200 || detailResult.payload.ok !== true) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error:
+            readString(detailResult.payload.error) ??
+            "strategy-desk-scenario-load-failed",
+        },
+        { status: detailResult.status || 502 },
       );
-      if (parsed.success) selectedScenario = parsed.data;
     }
+    const parsed = safeParseRuntimeStrategyDeskScenarioManifest(
+      detailResult.payload.scenario,
+    );
+    if (!parsed.success) {
+      return NextResponse.json(
+        { ok: false, error: "strategy-desk-scenario-parse-failed" },
+        { status: 502 },
+      );
+    }
+    selectedScenario = parsed.data;
   }
 
   selectedScenario ??= scenarios[0] ?? null;
@@ -379,12 +394,30 @@ export async function GET(request: Request) {
       }),
     ]);
 
-    if (runsResult.status === 200 && runsResult.payload.ok === true) {
-      runs = parseRuns(runsResult.payload.runs);
+    if (runsResult.status !== 200 || runsResult.payload.ok !== true) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error:
+            readString(runsResult.payload.error) ??
+            "strategy-desk-runs-load-failed",
+        },
+        { status: runsResult.status || 502 },
+      );
     }
-    if (reportsResult.status === 200 && reportsResult.payload.ok === true) {
-      reports = parseReports(reportsResult.payload.reports);
+    if (reportsResult.status !== 200 || reportsResult.payload.ok !== true) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error:
+            readString(reportsResult.payload.error) ??
+            "strategy-desk-reports-load-failed",
+        },
+        { status: reportsResult.status || 502 },
+      );
     }
+    runs = parseRuns(runsResult.payload.runs);
+    reports = parseReports(reportsResult.payload.reports);
   }
 
   return NextResponse.json({

--- a/apps/portal/app/proof/strategy-desk/page.tsx
+++ b/apps/portal/app/proof/strategy-desk/page.tsx
@@ -1,0 +1,557 @@
+"use client";
+
+import { useState } from "react";
+import type {
+  RuntimeStrategyDeskScenarioManifest,
+  RuntimeStrategyDeskScenarioReport,
+  RuntimeStrategyDeskScenarioRun,
+} from "../../../lib/runtime-strategy-desk";
+import { StrategyDeskView } from "../../terminal/strategy-desk/strategy-desk-view";
+import type { StrategyDeskApiPayload } from "../../terminal/strategy-desk/types";
+
+const FIXTURE_TIME = "2026-03-17T03:08:10Z";
+const WALLET_ADDRESS = "11111111111111111111111111111111";
+
+function scenarioFixture(): RuntimeStrategyDeskScenarioManifest {
+  return {
+    schemaVersion: "v1",
+    scenarioId: "desk_sol_composite_1",
+    title: "SOL composite desk scenario",
+    summary:
+      "Composite spot, perp, prediction, and flash scenario staged through the harness.",
+    ownerUserId: "user_1",
+    strategyKey: "strategy_desk::sol_composite",
+    thesis:
+      "Pair trend spot exposure with bounded perp hedge, event overlay, and flash rebalancing.",
+    sleeveId: "sleeve_1",
+    state: "paper_ready",
+    createdAt: "2026-03-17T03:00:00Z",
+    updatedAt: FIXTURE_TIME,
+    reviewedAt: "2026-03-17T03:06:00Z",
+    latestReportId: "desk_report_sol_composite_paper_1",
+    riskLimits: {
+      maxReservedCapitalUsd: "1600",
+      maxGrossExposureUsd: "3500",
+      maxNetExposureUsd: "1500",
+    },
+    researchMatrix: {
+      selectionMetric: "excess_vs_flat_cash_bps",
+      backtestLegs: [
+        {
+          legId: "leg_spot_alpha",
+          experimentId: "exp_sol_spot",
+          replayCorpusId: "replay_sol_usdc",
+        },
+      ],
+      windows: [
+        {
+          windowId: "selection_week_1",
+          label: "Selection week 1",
+          cohort: "selection",
+        },
+        {
+          windowId: "holdout_week_1",
+          label: "Holdout week 1",
+          cohort: "holdout",
+        },
+      ],
+      variants: [
+        {
+          variantId: "fast",
+          label: "Fast",
+          parameterManifest: {
+            threshold: "fast",
+          },
+        },
+        {
+          variantId: "slow",
+          label: "Slow",
+          parameterManifest: {
+            threshold: "slow",
+          },
+        },
+      ],
+    },
+    legs: [
+      {
+        legId: "leg_spot_alpha",
+        label: "Spot alpha",
+        role: "primary_alpha",
+        venueKey: "jupiter",
+        intentFamily: "spot_swap",
+        marketType: "spot",
+        pair: {
+          symbol: "SOL/USDC",
+          baseMint: "So11111111111111111111111111111111111111112",
+          quoteMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          marketType: "spot",
+        },
+        assetKeys: ["SOL", "USDC"],
+        enabledModes: ["shadow", "paper", "live"],
+        sizing: {
+          targetNotionalUsd: "1000",
+          maxNotionalUsd: "2500",
+          reserveUsd: "1000",
+        },
+        intent: {
+          side: "buy",
+        },
+      },
+      {
+        legId: "leg_perp_hedge",
+        label: "Perp hedge",
+        role: "hedge",
+        venueKey: "drift",
+        intentFamily: "perp_order",
+        marketType: "perp",
+        instrumentId: "SOL-PERP",
+        assetKeys: ["SOL", "USDC"],
+        enabledModes: ["shadow", "paper"],
+        sizing: {
+          targetNotionalUsd: "500",
+          maxNotionalUsd: "750",
+          reserveUsd: "250",
+        },
+        intent: {
+          side: "short",
+          quantityAtomic: "3521126760",
+        },
+      },
+      {
+        legId: "leg_prediction_overlay",
+        label: "Prediction overlay",
+        role: "prediction",
+        venueKey: "dflow",
+        intentFamily: "prediction_order",
+        marketType: "prediction",
+        instrumentId: "macro-fed-cut-jun-2026",
+        assetKeys: ["SOL", "USDC"],
+        enabledModes: ["shadow", "paper"],
+        sizing: {
+          targetNotionalUsd: "150",
+          maxNotionalUsd: "250",
+          reserveUsd: "100",
+        },
+      },
+    ],
+    evidence: [
+      {
+        stage: "backtest",
+        summary: "Walk-forward backtest bundle for the composite thesis.",
+      },
+      {
+        stage: "paper",
+        summary: "Composite paper report and leg receipts.",
+        latestReportId: "desk_report_sol_composite_paper_1",
+      },
+    ],
+    implementationReferences: [
+      {
+        kind: "issue",
+        ref: "#441",
+      },
+    ],
+    tags: ["strategy-desk", "composite"],
+    metadata: {
+      operatorWalletAddress: WALLET_ADDRESS,
+    },
+  };
+}
+
+function backtestRunFixture(): RuntimeStrategyDeskScenarioRun {
+  return {
+    schemaVersion: "v1",
+    scenarioRunId: "desk_run_sol_composite_backtest_1",
+    scenarioId: "desk_sol_composite_1",
+    scenarioState: "paper_ready",
+    runKind: "backtest",
+    state: "completed",
+    requestedBy: "operator_1",
+    trigger: {
+      kind: "operator",
+      source: "portal.strategy-desk",
+      observedAt: FIXTURE_TIME,
+      reason: "browser-proof-backtest",
+    },
+    createdAt: FIXTURE_TIME,
+    updatedAt: FIXTURE_TIME,
+    completedAt: FIXTURE_TIME,
+    legRuns: [],
+  };
+}
+
+function paperRunFixture(): RuntimeStrategyDeskScenarioRun {
+  return {
+    schemaVersion: "v1",
+    scenarioRunId: "desk_run_sol_composite_paper_1",
+    scenarioId: "desk_sol_composite_1",
+    scenarioState: "paper_ready",
+    runKind: "paper",
+    state: "completed",
+    requestedBy: "operator_1",
+    trigger: {
+      kind: "operator",
+      source: "portal.strategy-desk",
+      observedAt: FIXTURE_TIME,
+      reason: "browser-proof-paper",
+    },
+    createdAt: FIXTURE_TIME,
+    updatedAt: FIXTURE_TIME,
+    completedAt: FIXTURE_TIME,
+    legRuns: [],
+  };
+}
+
+function backtestReportFixture(): RuntimeStrategyDeskScenarioReport {
+  return {
+    schemaVersion: "v1",
+    reportId: "desk_report_sol_composite_backtest_1",
+    scenarioId: "desk_sol_composite_1",
+    scenarioRunId: "desk_run_sol_composite_backtest_1",
+    stage: "backtest",
+    status: "pass",
+    summary:
+      "Backtest matrix selected the fast variant with positive holdout excess.",
+    generatedAt: FIXTURE_TIME,
+    legOutcomes: [
+      {
+        legId: "leg_spot_alpha",
+        status: "pass",
+        evidenceRefs: [],
+      },
+    ],
+    studyMatrix: {
+      matrixId: "desk_matrix_sol_composite_backtest_1",
+      runKind: "backtest",
+      selectionMetric: "excess_vs_flat_cash_bps",
+      generatedAt: FIXTURE_TIME,
+      selectedVariantId: "fast",
+      windows: [
+        {
+          windowId: "selection_week_1",
+          label: "Selection week 1",
+          cohort: "selection",
+        },
+        {
+          windowId: "holdout_week_1",
+          label: "Holdout week 1",
+          cohort: "holdout",
+        },
+      ],
+      variantSummaries: [
+        {
+          variantId: "fast",
+          label: "Fast",
+          selectionMetrics: {
+            netReturnBps: "60.0000",
+          },
+          holdoutMetrics: {
+            netReturnBps: "10.0000",
+          },
+          selectionBaselineComparisons: [
+            {
+              baseline: "flat_cash",
+              excessReturnBps: "60.0000",
+            },
+          ],
+        },
+        {
+          variantId: "slow",
+          label: "Slow",
+          selectionMetrics: {
+            netReturnBps: "34.0000",
+          },
+          holdoutMetrics: {
+            netReturnBps: "4.0000",
+          },
+          selectionBaselineComparisons: [
+            {
+              baseline: "flat_cash",
+              excessReturnBps: "34.0000",
+            },
+          ],
+        },
+      ],
+      cells: [
+        {
+          cellId: "fast:selection_week_1",
+          variantId: "fast",
+          windowId: "selection_week_1",
+          legResults: [
+            {
+              legId: "leg_spot_alpha",
+              reproducibilityBundleId: "repro_backtest_fast_selection_spot_1",
+            },
+          ],
+        },
+      ],
+    },
+    evidence: [
+      {
+        stage: "backtest",
+        summary: "Walk-forward study bundle recorded from the proof route.",
+      },
+    ],
+    checks: [
+      {
+        checkId: "matrix-generated",
+        status: "pass",
+        message: "Study matrix completed successfully.",
+      },
+    ],
+    approvals: [],
+    riskOverlays: [],
+  };
+}
+
+function paperReportFixture(): RuntimeStrategyDeskScenarioReport {
+  return {
+    schemaVersion: "v1",
+    reportId: "desk_report_sol_composite_paper_1",
+    scenarioId: "desk_sol_composite_1",
+    scenarioRunId: "desk_run_sol_composite_paper_1",
+    stage: "paper",
+    status: "requires_human_approval",
+    summary:
+      "Composite paper evidence is sufficient for operator review, but not for self-arming.",
+    generatedAt: FIXTURE_TIME,
+    legOutcomes: [
+      {
+        legId: "leg_spot_alpha",
+        status: "pass",
+        netPnlUsd: "42.15",
+        costUsd: "6.80",
+      },
+      {
+        legId: "leg_perp_hedge",
+        status: "pass",
+        netPnlUsd: "8.25",
+        costUsd: "3.10",
+      },
+      {
+        legId: "leg_prediction_overlay",
+        status: "requires_human_approval",
+        costUsd: "1.25",
+      },
+    ],
+    portfolioSummary: {
+      netPnlUsd: "49.30",
+      grossExposureUsd: "1650.00",
+      maxDrawdownBps: 180,
+    },
+    scorecard: {
+      aggregate: {
+        tradeCount: 11,
+      },
+    },
+    riskOverlays: [
+      {
+        overlayId: "reserved-capital",
+        status: "pass",
+        message: "Reserved capital remains within the configured desk budget.",
+      },
+      {
+        overlayId: "gross-exposure",
+        status: "pass",
+        message:
+          "Gross exposure remains within the configured composite budget.",
+      },
+    ],
+    evidence: [
+      {
+        stage: "paper",
+        summary: "Composite paper report and leg receipts.",
+      },
+    ],
+    checks: [
+      {
+        checkId: "paper-scorecards",
+        status: "pass",
+        message: "Paper evidence is sufficient for operator review.",
+      },
+    ],
+    approvals: [],
+  };
+}
+
+function buildPayload(): StrategyDeskApiPayload {
+  const scenario = scenarioFixture();
+  const runs = [paperRunFixture(), backtestRunFixture()];
+  const reports = [paperReportFixture(), backtestReportFixture()];
+  return {
+    ok: true,
+    snapshot: {
+      scenarios: [scenario],
+      selectedScenarioId: scenario.scenarioId,
+      selectedScenario: scenario,
+      runs,
+      reports,
+      latestRun: runs[0],
+      latestReport: reports[0],
+    },
+  };
+}
+
+export default function StrategyDeskProofPage() {
+  const [payload, setPayload] = useState<StrategyDeskApiPayload>(buildPayload);
+  const [editorValue, setEditorValue] = useState(
+    JSON.stringify(buildPayload().snapshot.selectedScenario, null, 2),
+  );
+  const [walletAddress, setWalletAddress] = useState(WALLET_ADDRESS);
+  const [actionPending, setActionPending] = useState<string | null>(null);
+
+  function syncScenario(nextScenario: RuntimeStrategyDeskScenarioManifest) {
+    setPayload((current) => {
+      const scenarios = current.snapshot.scenarios.map((scenario) =>
+        scenario.scenarioId === nextScenario.scenarioId
+          ? nextScenario
+          : scenario,
+      );
+      return {
+        ok: true,
+        snapshot: {
+          ...current.snapshot,
+          scenarios,
+          selectedScenarioId: nextScenario.scenarioId,
+          selectedScenario: nextScenario,
+        },
+      };
+    });
+    setEditorValue(JSON.stringify(nextScenario, null, 2));
+  }
+
+  function patchDraft(mutator: (draft: Record<string, unknown>) => void) {
+    try {
+      const parsed = JSON.parse(editorValue) as Record<string, unknown>;
+      mutator(parsed);
+      setEditorValue(JSON.stringify(parsed, null, 2));
+    } catch {
+      return;
+    }
+  }
+
+  function applyStudy(kind: "replay" | "backtest") {
+    setActionPending(`study:${kind}`);
+    const report = backtestReportFixture();
+    const run = backtestRunFixture();
+    report.reportId = `desk_report_sol_composite_${kind}_proof`;
+    report.scenarioRunId = `desk_run_sol_composite_${kind}_proof`;
+    report.stage = kind;
+    report.summary =
+      kind === "replay"
+        ? "Replay matrix completed with the fast variant still selected."
+        : report.summary;
+    run.scenarioRunId = report.scenarioRunId;
+    run.runKind = kind;
+    run.updatedAt = new Date().toISOString();
+    report.generatedAt = run.updatedAt;
+    setPayload((current) => ({
+      ok: true,
+      snapshot: {
+        ...current.snapshot,
+        runs: [
+          run,
+          ...current.snapshot.runs.filter((entry) => entry.runKind !== kind),
+        ],
+        reports: [
+          report,
+          ...current.snapshot.reports.filter((entry) => entry.stage !== kind),
+        ],
+        latestRun: run,
+        latestReport: report,
+      },
+    }));
+    setActionPending(null);
+  }
+
+  function applyExecution(kind: "shadow" | "paper") {
+    setActionPending(`execute:${kind}`);
+    const run = paperRunFixture();
+    const report = paperReportFixture();
+    run.scenarioRunId = `desk_run_sol_composite_${kind}_proof`;
+    run.runKind = kind;
+    run.updatedAt = new Date().toISOString();
+    report.reportId = `desk_report_sol_composite_${kind}_proof`;
+    report.scenarioRunId = run.scenarioRunId;
+    report.stage = kind;
+    report.generatedAt = run.updatedAt;
+    report.summary =
+      kind === "shadow"
+        ? "Composite shadow run completed without wallet mutation."
+        : report.summary;
+    setPayload((current) => ({
+      ok: true,
+      snapshot: {
+        ...current.snapshot,
+        runs: [
+          run,
+          ...current.snapshot.runs.filter((entry) => entry.runKind !== kind),
+        ],
+        reports: [
+          report,
+          ...current.snapshot.reports.filter((entry) => entry.stage !== kind),
+        ],
+        latestRun: run,
+        latestReport: report,
+      },
+    }));
+    setActionPending(null);
+  }
+
+  return (
+    <div data-testid="strategy-desk-proof-page">
+      <StrategyDeskView
+        authenticated
+        loading={false}
+        error={null}
+        payload={payload}
+        editorValue={editorValue}
+        walletAddress={walletAddress}
+        actionPending={actionPending}
+        onRefresh={() => setPayload(buildPayload())}
+        onSelectScenario={() => undefined}
+        onEditorChange={setEditorValue}
+        onTitleChange={(value) => {
+          patchDraft((draft) => {
+            draft.title = value;
+          });
+        }}
+        onSummaryChange={(value) => {
+          patchDraft((draft) => {
+            draft.summary = value;
+          });
+        }}
+        onWalletAddressChange={(value) => {
+          setWalletAddress(value);
+          patchDraft((draft) => {
+            const metadata =
+              draft.metadata &&
+              typeof draft.metadata === "object" &&
+              !Array.isArray(draft.metadata)
+                ? (draft.metadata as Record<string, unknown>)
+                : {};
+            metadata.operatorWalletAddress = value;
+            draft.metadata = metadata;
+          });
+        }}
+        onResetEditor={() =>
+          setEditorValue(
+            JSON.stringify(payload.snapshot.selectedScenario, null, 2),
+          )
+        }
+        onSaveScenario={() => {
+          try {
+            const parsed = JSON.parse(
+              editorValue,
+            ) as RuntimeStrategyDeskScenarioManifest;
+            syncScenario(parsed);
+          } catch {
+            return;
+          }
+        }}
+        onRunStudy={(runKind) => applyStudy(runKind)}
+        onRunExecute={(runKind) => applyExecution(runKind)}
+      />
+    </div>
+  );
+}

--- a/apps/portal/app/terminal/strategy-desk/page.tsx
+++ b/apps/portal/app/terminal/strategy-desk/page.tsx
@@ -1,0 +1,5 @@
+import { StrategyDeskClient } from "./strategy-desk-client";
+
+export default function StrategyDeskPage() {
+  return <StrategyDeskClient />;
+}

--- a/apps/portal/app/terminal/strategy-desk/strategy-desk-client.tsx
+++ b/apps/portal/app/terminal/strategy-desk/strategy-desk-client.tsx
@@ -124,10 +124,12 @@ function detectWalletAddressFromDraft(draft: string): string {
     if (
       metadata &&
       typeof metadata === "object" &&
-      !Array.isArray(metadata) &&
-      typeof metadata.operatorWalletAddress === "string"
+      !Array.isArray(metadata)
     ) {
-      return metadata.operatorWalletAddress.trim();
+      const metadataRecord = metadata as Record<string, unknown>;
+      if (typeof metadataRecord.operatorWalletAddress === "string") {
+        return metadataRecord.operatorWalletAddress.trim();
+      }
     }
   } catch {
     return "";

--- a/apps/portal/app/terminal/strategy-desk/strategy-desk-client.tsx
+++ b/apps/portal/app/terminal/strategy-desk/strategy-desk-client.tsx
@@ -1,0 +1,434 @@
+"use client";
+
+import { usePrivy } from "@privy-io/react-auth";
+import { useEffect, useState, useTransition } from "react";
+import { StrategyDeskView } from "./strategy-desk-view";
+import type {
+  StrategyDeskApiPayload,
+  StrategyDeskExecuteRunKind,
+  StrategyDeskMutationResult,
+  StrategyDeskStudyRunKind,
+  StrategyDeskStudySelectionMetric,
+} from "./types";
+
+async function readJson<T>(response: Response): Promise<T | null> {
+  return (await response.json().catch(() => null)) as T | null;
+}
+
+async function fetchStrategyDeskPayload(input: {
+  accessToken: string;
+  scenarioId?: string;
+}): Promise<StrategyDeskApiPayload> {
+  const query = input.scenarioId
+    ? `?scenarioId=${encodeURIComponent(input.scenarioId)}`
+    : "";
+  const response = await fetch(`/api/runtime/strategy-desk${query}`, {
+    headers: {
+      authorization: `Bearer ${input.accessToken}`,
+    },
+    cache: "no-store",
+  });
+  const body = await readJson<StrategyDeskApiPayload & { error?: string }>(
+    response,
+  );
+  if (!response.ok || !body?.ok) {
+    throw new Error(body?.error ?? `http-${response.status}`);
+  }
+  return body;
+}
+
+function draftStateFromPayload(payload: StrategyDeskApiPayload): {
+  editorValue: string;
+  walletAddress: string;
+} {
+  const scenario = payload.snapshot.selectedScenario;
+  if (scenario) {
+    const nextDraft = JSON.stringify(scenario, null, 2);
+    return {
+      editorValue: nextDraft,
+      walletAddress: detectWalletAddressFromDraft(nextDraft),
+    };
+  }
+  const nextDraft = defaultScenarioDraft();
+  return {
+    editorValue: nextDraft,
+    walletAddress: detectWalletAddressFromDraft(nextDraft),
+  };
+}
+
+function defaultScenarioDraft(): string {
+  return JSON.stringify(
+    {
+      schemaVersion: "v1",
+      scenarioId: "desk_new_strategy",
+      title: "New composite strategy desk scenario",
+      summary:
+        "Mixed spot, perp, prediction, and flash scenario staged from the portal.",
+      ownerUserId: "operator_user",
+      strategyKey: "strategy_desk::new_composite",
+      thesis: "Start with a primary alpha leg, then layer bounded hedges.",
+      state: "draft",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      riskLimits: {
+        maxReservedCapitalUsd: "1000",
+        maxGrossExposureUsd: "2500",
+        maxNetExposureUsd: "1000",
+      },
+      legs: [
+        {
+          legId: "leg_spot_alpha",
+          label: "Spot alpha",
+          role: "primary_alpha",
+          venueKey: "jupiter",
+          intentFamily: "spot_swap",
+          marketType: "spot",
+          pair: {
+            symbol: "SOL/USDC",
+            baseMint: "So11111111111111111111111111111111111111112",
+            quoteMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            marketType: "spot",
+          },
+          assetKeys: ["SOL", "USDC"],
+          enabledModes: ["shadow", "paper"],
+          sizing: {
+            targetNotionalUsd: "500",
+            maxNotionalUsd: "1000",
+            reserveUsd: "250",
+            maxSlippageBps: 50,
+          },
+          intent: {
+            side: "buy",
+          },
+        },
+      ],
+      evidence: [],
+      implementationReferences: [],
+      tags: ["strategy-desk", "draft"],
+      metadata: {
+        operatorWalletAddress: "11111111111111111111111111111111",
+      },
+    },
+    null,
+    2,
+  );
+}
+
+function detectWalletAddressFromDraft(draft: string): string {
+  try {
+    const parsed = JSON.parse(draft) as Record<string, unknown>;
+    const metadata =
+      parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? parsed.metadata
+        : null;
+    if (
+      metadata &&
+      typeof metadata === "object" &&
+      !Array.isArray(metadata) &&
+      typeof metadata.operatorWalletAddress === "string"
+    ) {
+      return metadata.operatorWalletAddress.trim();
+    }
+  } catch {
+    return "";
+  }
+  return "";
+}
+
+export function StrategyDeskClient() {
+  const { ready, authenticated, getAccessToken, user } = usePrivy();
+  const [payload, setPayload] = useState<StrategyDeskApiPayload | null>(null);
+  const [editorValue, setEditorValue] = useState<string>(defaultScenarioDraft);
+  const [walletAddress, setWalletAddress] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [actionPending, setActionPending] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const requestedBy =
+    String(
+      (user as { id?: string } | null | undefined)?.id ??
+        "portal.strategy-desk",
+    ).trim() || "portal.strategy-desk";
+
+  async function loadStrategyDesk(scenarioId?: string) {
+    const token = await getAccessToken();
+    if (!token) {
+      setPayload(null);
+      setError("operator-auth-token-unavailable");
+      return;
+    }
+    const body = await fetchStrategyDeskPayload({
+      accessToken: token,
+      scenarioId,
+    });
+    const nextDraftState = draftStateFromPayload(body);
+    setPayload(body);
+    setEditorValue(nextDraftState.editorValue);
+    setWalletAddress(nextDraftState.walletAddress);
+    setError(null);
+  }
+
+  function patchDraft(mutator: (draft: Record<string, unknown>) => void) {
+    try {
+      const parsed = JSON.parse(editorValue) as Record<string, unknown>;
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error("strategy-desk-editor-not-object");
+      }
+      mutator(parsed);
+      const nextDraft = JSON.stringify(parsed, null, 2);
+      setEditorValue(nextDraft);
+    } catch (cause) {
+      setError(
+        cause instanceof Error
+          ? cause.message
+          : "strategy-desk-editor-parse-failed",
+      );
+    }
+  }
+
+  async function runAction(
+    requestBody: Record<string, unknown>,
+    actionKey: string,
+    scenarioId?: string,
+  ) {
+    const token = await getAccessToken();
+    if (!token) {
+      setError("operator-auth-token-unavailable");
+      return null;
+    }
+
+    setActionPending(actionKey);
+    try {
+      const response = await fetch("/api/runtime/strategy-desk", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+      });
+      const body = await readJson<StrategyDeskMutationResult>(response);
+      if (!response.ok || body?.ok === false) {
+        setError(body?.error ?? `http-${response.status}`);
+        return null;
+      }
+      const nextScenarioId =
+        scenarioId ??
+        body?.scenario?.scenarioId ??
+        payload?.snapshot.selectedScenarioId ??
+        undefined;
+      await loadStrategyDesk(nextScenarioId);
+      return body;
+    } finally {
+      setActionPending(null);
+    }
+  }
+
+  useEffect(() => {
+    if (!ready) return;
+    if (!authenticated) {
+      setPayload(null);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    startTransition(() => {
+      void getAccessToken()
+        .then((token) => {
+          if (!token) {
+            setPayload(null);
+            setError("operator-auth-token-unavailable");
+            return null;
+          }
+          return fetchStrategyDeskPayload({ accessToken: token });
+        })
+        .then((nextPayload) => {
+          if (cancelled || !nextPayload) return;
+          const nextDraftState = draftStateFromPayload(nextPayload);
+          setPayload(nextPayload);
+          setEditorValue(nextDraftState.editorValue);
+          setWalletAddress(nextDraftState.walletAddress);
+          setError(null);
+        })
+        .catch((cause) => {
+          if (cancelled) return;
+          setError(
+            cause instanceof Error
+              ? cause.message
+              : "strategy-desk-load-failed",
+          );
+        });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authenticated, ready, getAccessToken]);
+
+  return (
+    <StrategyDeskView
+      authenticated={authenticated}
+      loading={!ready || isPending}
+      error={error}
+      payload={payload}
+      editorValue={editorValue}
+      walletAddress={walletAddress}
+      actionPending={actionPending}
+      onRefresh={() => {
+        startTransition(() => {
+          void loadStrategyDesk(
+            payload?.snapshot.selectedScenarioId ?? undefined,
+          ).catch((cause) => {
+            setError(
+              cause instanceof Error
+                ? cause.message
+                : "strategy-desk-refresh-failed",
+            );
+          });
+        });
+      }}
+      onSelectScenario={(scenarioId) => {
+        startTransition(() => {
+          void loadStrategyDesk(scenarioId).catch((cause) => {
+            setError(
+              cause instanceof Error
+                ? cause.message
+                : "strategy-desk-select-failed",
+            );
+          });
+        });
+      }}
+      onEditorChange={setEditorValue}
+      onTitleChange={(title) => {
+        patchDraft((draft) => {
+          draft.title = title;
+          draft.updatedAt = new Date().toISOString();
+        });
+      }}
+      onSummaryChange={(summary) => {
+        patchDraft((draft) => {
+          draft.summary = summary;
+          draft.updatedAt = new Date().toISOString();
+        });
+      }}
+      onWalletAddressChange={(nextWalletAddress) => {
+        setWalletAddress(nextWalletAddress);
+        patchDraft((draft) => {
+          const metadata =
+            draft.metadata &&
+            typeof draft.metadata === "object" &&
+            !Array.isArray(draft.metadata)
+              ? (draft.metadata as Record<string, unknown>)
+              : {};
+          metadata.operatorWalletAddress = nextWalletAddress;
+          draft.metadata = metadata;
+          draft.updatedAt = new Date().toISOString();
+        });
+      }}
+      onResetEditor={() => {
+        const scenario = payload?.snapshot.selectedScenario;
+        if (scenario) {
+          const nextDraft = JSON.stringify(scenario, null, 2);
+          setEditorValue(nextDraft);
+          setWalletAddress(detectWalletAddressFromDraft(nextDraft));
+          return;
+        }
+        const nextDraft = defaultScenarioDraft();
+        setEditorValue(nextDraft);
+        setWalletAddress(detectWalletAddressFromDraft(nextDraft));
+      }}
+      onSaveScenario={() => {
+        startTransition(() => {
+          let scenario: Record<string, unknown>;
+          try {
+            scenario = JSON.parse(editorValue) as Record<string, unknown>;
+          } catch (cause) {
+            setError(
+              cause instanceof Error
+                ? cause.message
+                : "strategy-desk-editor-parse-failed",
+            );
+            return;
+          }
+          if (walletAddress) {
+            const metadata =
+              scenario.metadata &&
+              typeof scenario.metadata === "object" &&
+              !Array.isArray(scenario.metadata)
+                ? (scenario.metadata as Record<string, unknown>)
+                : {};
+            metadata.operatorWalletAddress = walletAddress;
+            scenario.metadata = metadata;
+          }
+          void runAction(
+            {
+              action: "upsert_scenario",
+              scenario,
+            },
+            "upsert_scenario",
+            String(scenario.scenarioId ?? ""),
+          ).catch((cause) => {
+            setError(
+              cause instanceof Error
+                ? cause.message
+                : "strategy-desk-save-failed",
+            );
+          });
+        });
+      }}
+      onRunStudy={(
+        runKind: StrategyDeskStudyRunKind,
+        selectionMetric?: StrategyDeskStudySelectionMetric,
+      ) => {
+        const scenarioId = payload?.snapshot.selectedScenarioId;
+        if (!scenarioId) return;
+        startTransition(() => {
+          void runAction(
+            {
+              action: "study_scenario",
+              scenarioId,
+              runKind,
+              requestedBy,
+              ...(selectionMetric ? { selectionMetric } : {}),
+            },
+            `study:${runKind}`,
+            scenarioId,
+          ).catch((cause) => {
+            setError(
+              cause instanceof Error
+                ? cause.message
+                : "strategy-desk-study-failed",
+            );
+          });
+        });
+      }}
+      onRunExecute={(runKind: StrategyDeskExecuteRunKind) => {
+        const scenarioId = payload?.snapshot.selectedScenarioId;
+        if (!scenarioId) return;
+        startTransition(() => {
+          void runAction(
+            {
+              action: "execute_scenario",
+              scenarioId,
+              runKind,
+              requestedBy,
+              walletAddress,
+              trigger: {
+                reason: "portal-strategy-desk",
+              },
+            },
+            `execute:${runKind}`,
+            scenarioId,
+          ).catch((cause) => {
+            setError(
+              cause instanceof Error
+                ? cause.message
+                : "strategy-desk-execute-failed",
+            );
+          });
+        });
+      }}
+    />
+  );
+}

--- a/apps/portal/app/terminal/strategy-desk/strategy-desk-view.tsx
+++ b/apps/portal/app/terminal/strategy-desk/strategy-desk-view.tsx
@@ -1,0 +1,866 @@
+"use client";
+
+import Link from "next/link";
+import type {
+  RuntimeStrategyDeskScenarioReport,
+  RuntimeStrategyDeskScenarioRun,
+} from "../../../lib/runtime-strategy-desk";
+import { BTN_PRIMARY, BTN_SECONDARY, formatTick } from "../../lib";
+import type {
+  StrategyDeskApiPayload,
+  StrategyDeskExecuteRunKind,
+  StrategyDeskStudyRunKind,
+  StrategyDeskStudySelectionMetric,
+} from "./types";
+
+type StrategyDeskViewProps = {
+  authenticated: boolean;
+  loading: boolean;
+  error: string | null;
+  payload: StrategyDeskApiPayload | null;
+  editorValue: string;
+  walletAddress: string;
+  actionPending: string | null;
+  onRefresh?: () => void;
+  onSelectScenario?: (scenarioId: string) => void;
+  onEditorChange?: (value: string) => void;
+  onTitleChange?: (value: string) => void;
+  onSummaryChange?: (value: string) => void;
+  onWalletAddressChange?: (value: string) => void;
+  onResetEditor?: () => void;
+  onSaveScenario?: () => void;
+  onRunStudy?: (
+    runKind: StrategyDeskStudyRunKind,
+    selectionMetric?: StrategyDeskStudySelectionMetric,
+  ) => void;
+  onRunExecute?: (runKind: StrategyDeskExecuteRunKind) => void;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return normalized ? normalized : null;
+}
+
+function readRecordArray(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is Record<string, unknown> =>
+    isRecord(entry),
+  );
+}
+
+function statusClasses(status: string | null): string {
+  switch (status) {
+    case "healthy":
+    case "pass":
+    case "success":
+    case "completed":
+    case "paper_ready":
+    case "shadow_ready":
+      return "border-emerald-500/40 bg-emerald-500/10 text-emerald-200";
+    case "requires_human_approval":
+    case "blocked":
+    case "needs_review":
+    case "paper":
+    case "shadow":
+    case "replay":
+    case "backtest":
+      return "border-amber-500/40 bg-amber-500/10 text-amber-200";
+    case "rejected":
+    case "failed":
+    case "killed":
+      return "border-rose-500/40 bg-rose-500/10 text-rose-200";
+    default:
+      return "border-border bg-surface text-muted";
+  }
+}
+
+function renderBadge(status: string | null, label?: string) {
+  return (
+    <span
+      className={`inline-flex rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.24em] ${statusClasses(
+        status,
+      )}`}
+    >
+      {(label ?? status ?? "unknown").replaceAll("_", " ")}
+    </span>
+  );
+}
+
+function formatMoney(value: unknown): string {
+  const numeric = Number(String(value ?? "").replace(/,/g, ""));
+  if (!Number.isFinite(numeric)) return "--";
+  return `$${numeric.toFixed(2)}`;
+}
+
+function formatBps(value: unknown): string {
+  const numeric = Number(String(value ?? "").replace(/,/g, ""));
+  if (!Number.isFinite(numeric)) return "--";
+  return `${numeric.toFixed(2)} bps`;
+}
+
+function summaryItem(label: string, value: string) {
+  return (
+    <div className="rounded border border-border bg-surface/80 p-3">
+      <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+        {label}
+      </p>
+      <p className="mt-2 text-sm font-medium text-ink">{value}</p>
+    </div>
+  );
+}
+
+function collectReproducibilityRefs(
+  report: RuntimeStrategyDeskScenarioReport | null,
+): string[] {
+  const studyMatrix = isRecord(report?.studyMatrix) ? report?.studyMatrix : {};
+  const cells = readRecordArray(studyMatrix.cells);
+  const refs = new Set<string>();
+  for (const cell of cells) {
+    for (const legResult of readRecordArray(cell.legResults)) {
+      const ref = readString(legResult.reproducibilityBundleId);
+      if (ref) refs.add(ref);
+    }
+  }
+  return [...refs];
+}
+
+function buildRunComparison(
+  runs: RuntimeStrategyDeskScenarioRun[],
+  reports: RuntimeStrategyDeskScenarioReport[],
+) {
+  const reportsByRunId = new Map(
+    reports.map((report) => [report.scenarioRunId, report] as const),
+  );
+  return runs.map((run) => {
+    const report = reportsByRunId.get(run.scenarioRunId) ?? null;
+    const portfolio = isRecord(report?.portfolioSummary)
+      ? report.portfolioSummary
+      : {};
+    const studyMatrix = isRecord(report?.studyMatrix) ? report.studyMatrix : {};
+    const scorecard = isRecord(report?.scorecard) ? report.scorecard : {};
+    return {
+      scenarioRunId: run.scenarioRunId,
+      runKind: run.runKind,
+      runState: run.state,
+      reportStatus: report?.status ?? null,
+      generatedAt: report?.generatedAt ?? run.updatedAt,
+      netPnlUsd:
+        readString(portfolio.netPnlUsd) ?? readString(scorecard.netPnlUsd),
+      maxDrawdownBps: readString(portfolio.maxDrawdownBps),
+      selectedVariantId: readString(studyMatrix.selectedVariantId),
+    };
+  });
+}
+
+function reportForDisplay(
+  latestReport: RuntimeStrategyDeskScenarioReport | null,
+  reports: RuntimeStrategyDeskScenarioReport[],
+) {
+  return latestReport ?? reports[0] ?? null;
+}
+
+export function StrategyDeskView({
+  authenticated,
+  loading,
+  error,
+  payload,
+  editorValue,
+  walletAddress,
+  actionPending,
+  onRefresh,
+  onSelectScenario,
+  onEditorChange,
+  onTitleChange,
+  onSummaryChange,
+  onWalletAddressChange,
+  onResetEditor,
+  onSaveScenario,
+  onRunStudy,
+  onRunExecute,
+}: StrategyDeskViewProps) {
+  const snapshot = payload?.snapshot ?? null;
+  const selectedScenario = snapshot?.selectedScenario ?? null;
+  const latestRun = snapshot?.latestRun ?? null;
+  const latestReport = reportForDisplay(
+    snapshot?.latestReport ?? null,
+    snapshot?.reports ?? [],
+  );
+  const comparison = buildRunComparison(
+    snapshot?.runs ?? [],
+    snapshot?.reports ?? [],
+  );
+  const reproducibilityRefs = collectReproducibilityRefs(latestReport);
+
+  let draftScenario: Record<string, unknown> | null = null;
+  try {
+    const parsed = JSON.parse(editorValue) as unknown;
+    if (isRecord(parsed)) draftScenario = parsed;
+  } catch {
+    draftScenario = null;
+  }
+  const draftTitle =
+    readString(draftScenario?.title) ?? selectedScenario?.title ?? "";
+  const draftSummary =
+    readString(draftScenario?.summary) ?? selectedScenario?.summary ?? "";
+  const selectedScenarioSummary = isRecord(selectedScenario?.riskLimits)
+    ? selectedScenario.riskLimits
+    : {};
+  const studyMatrix = isRecord(latestReport?.studyMatrix)
+    ? latestReport?.studyMatrix
+    : {};
+  const variantSummaries = readRecordArray(studyMatrix.variantSummaries);
+  const latestPortfolio = isRecord(latestReport?.portfolioSummary)
+    ? latestReport.portfolioSummary
+    : {};
+
+  if (!authenticated) {
+    return (
+      <main className="mx-auto max-w-6xl px-6 py-10">
+        <section className="rounded border border-border bg-paper/80 p-8">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                Strategy desk
+              </p>
+              <h1 className="mt-3 text-2xl font-semibold text-ink">
+                Composite research and bounded execution surface
+              </h1>
+              <p className="mt-3 max-w-2xl text-sm text-muted">
+                Sign in with an operator account to author scenarios, launch
+                replay or paper runs, and inspect promotion readiness.
+              </p>
+            </div>
+            <div className="flex gap-3">
+              <Link className={BTN_PRIMARY} href="/login">
+                Sign in
+              </Link>
+              <Link className={BTN_SECONDARY} href="/terminal">
+                Terminal
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main
+      className="mx-auto max-w-[1600px] px-6 py-8"
+      data-testid="strategy-desk-page"
+    >
+      <section className="rounded border border-border bg-paper/80 p-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+              Strategy desk
+            </p>
+            <h1 className="mt-2 text-2xl font-semibold text-ink">
+              Author composite scenarios, test them, then decide whether to arm
+            </h1>
+            <p className="mt-3 max-w-3xl text-sm text-muted">
+              This desk sits above the harness-native execution fabric. It keeps
+              scenario authoring, replay and paper evidence, per-leg
+              diagnostics, and promotion-readiness in one operator surface.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <button className={BTN_SECONDARY} onClick={onRefresh} type="button">
+              Refresh
+            </button>
+            <Link className={BTN_SECONDARY} href="/terminal/runtime">
+              Runtime ops
+            </Link>
+            <Link className={BTN_PRIMARY} href="/proof/strategy-desk">
+              Proof route
+            </Link>
+          </div>
+        </div>
+        {error ? (
+          <div className="mt-4 rounded border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+            {error}
+          </div>
+        ) : null}
+      </section>
+
+      <section className="mt-6 grid gap-6 xl:grid-cols-[320px_minmax(0,1fr)]">
+        <aside className="space-y-6">
+          <article className="rounded border border-border bg-surface/80 p-4">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                  Scenarios
+                </p>
+                <h2 className="mt-2 text-sm font-medium text-ink">
+                  Composite registry
+                </h2>
+              </div>
+              {renderBadge(
+                selectedScenario?.state ?? null,
+                selectedScenario?.state ?? "none",
+              )}
+            </div>
+            <div
+              className="mt-4 space-y-3"
+              data-testid="strategy-desk-scenario-list"
+            >
+              {(snapshot?.scenarios ?? []).length === 0 ? (
+                <div className="rounded border border-dashed border-border p-4 text-sm text-muted">
+                  No scenarios loaded yet. Save the draft on the right to seed
+                  the desk.
+                </div>
+              ) : (
+                (snapshot?.scenarios ?? []).map((scenario) => {
+                  const isSelected =
+                    scenario.scenarioId === snapshot?.selectedScenarioId;
+                  return (
+                    <button
+                      key={scenario.scenarioId}
+                      className={`w-full rounded border px-4 py-3 text-left transition-colors ${
+                        isSelected
+                          ? "border-accent bg-accent/10"
+                          : "border-border bg-paper/70 hover:bg-paper"
+                      }`}
+                      onClick={() => onSelectScenario?.(scenario.scenarioId)}
+                      type="button"
+                    >
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <p className="text-sm font-medium text-ink">
+                          {scenario.title}
+                        </p>
+                        {renderBadge(scenario.state)}
+                      </div>
+                      <p className="mt-2 text-xs text-muted">
+                        {scenario.strategyKey}
+                      </p>
+                      <p className="mt-2 text-xs text-muted">
+                        {scenario.legs.length} legs · updated{" "}
+                        {formatTick(scenario.updatedAt)}
+                      </p>
+                    </button>
+                  );
+                })
+              )}
+            </div>
+          </article>
+
+          <article className="rounded border border-border bg-surface/80 p-4">
+            <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+              Selected scenario
+            </p>
+            <h2 className="mt-2 text-sm font-medium text-ink">
+              {selectedScenario?.scenarioId ?? "draft"}
+            </h2>
+            <div className="mt-4 grid gap-3">
+              {summaryItem(
+                "Reserved cap",
+                formatMoney(selectedScenarioSummary.maxReservedCapitalUsd),
+              )}
+              {summaryItem(
+                "Gross cap",
+                formatMoney(selectedScenarioSummary.maxGrossExposureUsd),
+              )}
+              {summaryItem(
+                "Net cap",
+                formatMoney(selectedScenarioSummary.maxNetExposureUsd),
+              )}
+              {summaryItem(
+                "Leg count",
+                String(selectedScenario?.legs.length ?? 0),
+              )}
+            </div>
+          </article>
+        </aside>
+
+        <div className="space-y-6">
+          <article className="rounded border border-border bg-surface/80 p-5">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                  Author scenario
+                </p>
+                <h2 className="mt-2 text-lg font-medium text-ink">
+                  Edit the composite manifest, then persist it through the
+                  harness-backed registry
+                </h2>
+              </div>
+              <div className="flex gap-3">
+                <button
+                  className={BTN_SECONDARY}
+                  onClick={onResetEditor}
+                  type="button"
+                >
+                  Reset draft
+                </button>
+                <button
+                  className={BTN_PRIMARY}
+                  data-testid="strategy-desk-save-scenario"
+                  disabled={actionPending === "upsert_scenario"}
+                  onClick={onSaveScenario}
+                  type="button"
+                >
+                  {actionPending === "upsert_scenario"
+                    ? "Saving..."
+                    : "Save scenario"}
+                </button>
+              </div>
+            </div>
+
+            <div className="mt-4 grid gap-4 lg:grid-cols-2">
+              <label className="block">
+                <span className="text-[10px] uppercase tracking-[0.24em] text-muted">
+                  Title
+                </span>
+                <input
+                  className="mt-2 w-full rounded border border-border bg-paper px-3 py-2 text-sm text-ink"
+                  data-testid="strategy-desk-title-input"
+                  onChange={(event) => onTitleChange?.(event.target.value)}
+                  value={draftTitle}
+                />
+              </label>
+              <label className="block">
+                <span className="text-[10px] uppercase tracking-[0.24em] text-muted">
+                  Operator wallet
+                </span>
+                <input
+                  className="mt-2 w-full rounded border border-border bg-paper px-3 py-2 text-sm text-ink"
+                  data-testid="strategy-desk-wallet-input"
+                  onChange={(event) =>
+                    onWalletAddressChange?.(event.target.value)
+                  }
+                  placeholder="11111111111111111111111111111111"
+                  value={walletAddress}
+                />
+              </label>
+            </div>
+
+            <label className="mt-4 block">
+              <span className="text-[10px] uppercase tracking-[0.24em] text-muted">
+                Summary
+              </span>
+              <textarea
+                className="mt-2 min-h-[88px] w-full rounded border border-border bg-paper px-3 py-2 text-sm text-ink"
+                data-testid="strategy-desk-summary-input"
+                onChange={(event) => onSummaryChange?.(event.target.value)}
+                value={draftSummary}
+              />
+            </label>
+
+            <label className="mt-4 block">
+              <span className="text-[10px] uppercase tracking-[0.24em] text-muted">
+                Full scenario manifest
+              </span>
+              <textarea
+                className="mt-2 min-h-[420px] w-full rounded border border-border bg-[#091017] px-4 py-3 font-mono text-xs leading-6 text-slate-100"
+                data-testid="strategy-desk-scenario-editor"
+                onChange={(event) => onEditorChange?.(event.target.value)}
+                value={editorValue}
+              />
+            </label>
+          </article>
+
+          <article className="rounded border border-border bg-surface/80 p-5">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                  Run controls
+                </p>
+                <h2 className="mt-2 text-lg font-medium text-ink">
+                  Launch study, shadow, and paper flows
+                </h2>
+                <p className="mt-2 text-sm text-muted">
+                  Study runs compare parameter variants across windows. Shadow
+                  and paper runs hit the harness-backed composite runner using
+                  the selected scenario and wallet binding.
+                </p>
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <button
+                  className={BTN_SECONDARY}
+                  data-testid="strategy-desk-run-replay"
+                  disabled={
+                    actionPending === "study:replay" || !selectedScenario
+                  }
+                  onClick={() =>
+                    onRunStudy?.("replay", "excess_vs_flat_cash_bps")
+                  }
+                  type="button"
+                >
+                  {actionPending === "study:replay"
+                    ? "Running replay..."
+                    : "Run replay study"}
+                </button>
+                <button
+                  className={BTN_PRIMARY}
+                  data-testid="strategy-desk-run-backtest"
+                  disabled={
+                    actionPending === "study:backtest" || !selectedScenario
+                  }
+                  onClick={() =>
+                    onRunStudy?.("backtest", "excess_vs_flat_cash_bps")
+                  }
+                  type="button"
+                >
+                  {actionPending === "study:backtest"
+                    ? "Running backtest..."
+                    : "Run backtest study"}
+                </button>
+                <button
+                  className={BTN_SECONDARY}
+                  data-testid="strategy-desk-run-shadow"
+                  disabled={
+                    actionPending === "execute:shadow" || !selectedScenario
+                  }
+                  onClick={() => onRunExecute?.("shadow")}
+                  type="button"
+                >
+                  {actionPending === "execute:shadow"
+                    ? "Running shadow..."
+                    : "Run shadow"}
+                </button>
+                <button
+                  className={BTN_PRIMARY}
+                  data-testid="strategy-desk-run-paper"
+                  disabled={
+                    actionPending === "execute:paper" || !selectedScenario
+                  }
+                  onClick={() => onRunExecute?.("paper")}
+                  type="button"
+                >
+                  {actionPending === "execute:paper"
+                    ? "Running paper..."
+                    : "Run paper"}
+                </button>
+              </div>
+            </div>
+          </article>
+
+          <div className="grid gap-6 xl:grid-cols-[1.15fr_0.85fr]">
+            <article
+              className="rounded border border-border bg-surface/80 p-5"
+              data-testid="strategy-desk-report-summary"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                    Latest report
+                  </p>
+                  <h2 className="mt-2 text-lg font-medium text-ink">
+                    {latestReport?.reportId ?? "No report yet"}
+                  </h2>
+                </div>
+                <div className="flex gap-2">
+                  {renderBadge(latestReport?.stage ?? null)}
+                  {renderBadge(latestReport?.status ?? null)}
+                </div>
+              </div>
+              <p className="mt-3 text-sm text-muted">
+                {latestReport?.summary ??
+                  "Run a backtest, replay, shadow, or paper workflow to populate the report surface."}
+              </p>
+              <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                {summaryItem("Net PnL", formatMoney(latestPortfolio.netPnlUsd))}
+                {summaryItem(
+                  "Gross exposure",
+                  formatMoney(latestPortfolio.grossExposureUsd),
+                )}
+                {summaryItem(
+                  "Max drawdown",
+                  formatBps(latestPortfolio.maxDrawdownBps),
+                )}
+                {summaryItem(
+                  "Latest run",
+                  latestRun
+                    ? `${latestRun.runKind} · ${latestRun.state}`
+                    : "none",
+                )}
+              </div>
+
+              <div className="mt-5 grid gap-4 xl:grid-cols-2">
+                <div className="rounded border border-border bg-paper/70 p-4">
+                  <p className="text-[10px] uppercase tracking-[0.24em] text-muted">
+                    Per-leg outcomes
+                  </p>
+                  <div
+                    className="mt-3 space-y-3"
+                    data-testid="strategy-desk-leg-outcomes"
+                  >
+                    {readRecordArray(latestReport?.legOutcomes).length === 0 ? (
+                      <p className="text-sm text-muted">
+                        No leg outcomes recorded yet.
+                      </p>
+                    ) : (
+                      readRecordArray(latestReport?.legOutcomes).map(
+                        (outcome) => (
+                          <div
+                            key={`${readString(outcome.legId) ?? "leg"}-${readString(outcome.status) ?? "unknown"}`}
+                            className="rounded border border-border bg-surface/80 p-3"
+                          >
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                              <p className="text-sm font-medium text-ink">
+                                {readString(outcome.legId) ?? "leg"}
+                              </p>
+                              {renderBadge(readString(outcome.status))}
+                            </div>
+                            <p className="mt-2 text-xs text-muted">
+                              PnL {formatMoney(outcome.netPnlUsd)} · Cost{" "}
+                              {formatMoney(outcome.costUsd)}
+                            </p>
+                          </div>
+                        ),
+                      )
+                    )}
+                  </div>
+                </div>
+
+                <div className="rounded border border-border bg-paper/70 p-4">
+                  <p className="text-[10px] uppercase tracking-[0.24em] text-muted">
+                    Risk overlays
+                  </p>
+                  <div className="mt-3 space-y-3">
+                    {readRecordArray(latestReport?.riskOverlays).length ===
+                    0 ? (
+                      <p className="text-sm text-muted">
+                        No overlays recorded yet.
+                      </p>
+                    ) : (
+                      readRecordArray(latestReport?.riskOverlays).map(
+                        (overlay) => (
+                          <div
+                            key={`${readString(overlay.overlayId) ?? "overlay"}-${readString(overlay.status) ?? "unknown"}`}
+                            className="rounded border border-border bg-surface/80 p-3"
+                          >
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                              <p className="text-sm font-medium text-ink">
+                                {readString(overlay.overlayId) ?? "overlay"}
+                              </p>
+                              {renderBadge(readString(overlay.status))}
+                            </div>
+                            <p className="mt-2 text-xs text-muted">
+                              {readString(overlay.message) ?? "No message"}
+                            </p>
+                          </div>
+                        ),
+                      )
+                    )}
+                  </div>
+                </div>
+              </div>
+            </article>
+
+            <article className="rounded border border-border bg-surface/80 p-5">
+              <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                Run history
+              </p>
+              <h2 className="mt-2 text-lg font-medium text-ink">
+                Compare study, shadow, and paper outcomes
+              </h2>
+              <div
+                className="mt-4 overflow-x-auto"
+                data-testid="strategy-desk-run-history"
+              >
+                <table className="min-w-full text-left text-sm">
+                  <thead className="text-[10px] uppercase tracking-[0.24em] text-muted">
+                    <tr>
+                      <th className="pb-2 pr-4">Run</th>
+                      <th className="pb-2 pr-4">State</th>
+                      <th className="pb-2 pr-4">Report</th>
+                      <th className="pb-2 pr-4">Net</th>
+                      <th className="pb-2 pr-4">Drawdown</th>
+                      <th className="pb-2">Variant</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {comparison.length === 0 ? (
+                      <tr>
+                        <td className="py-3 text-muted" colSpan={6}>
+                          No run history yet.
+                        </td>
+                      </tr>
+                    ) : (
+                      comparison.map((row) => (
+                        <tr
+                          className="border-t border-border/60"
+                          key={row.scenarioRunId}
+                        >
+                          <td className="py-3 pr-4 text-ink">{row.runKind}</td>
+                          <td className="py-3 pr-4">
+                            {renderBadge(row.runState)}
+                          </td>
+                          <td className="py-3 pr-4">
+                            {row.reportStatus
+                              ? renderBadge(row.reportStatus)
+                              : "--"}
+                          </td>
+                          <td className="py-3 pr-4 text-muted">
+                            {formatMoney(row.netPnlUsd)}
+                          </td>
+                          <td className="py-3 pr-4 text-muted">
+                            {formatBps(row.maxDrawdownBps)}
+                          </td>
+                          <td className="py-3 text-muted">
+                            {row.selectedVariantId ?? "--"}
+                          </td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </article>
+          </div>
+
+          <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
+            <article
+              className="rounded border border-border bg-surface/80 p-5"
+              data-testid="strategy-desk-variant-table"
+            >
+              <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                Study comparison
+              </p>
+              <h2 className="mt-2 text-lg font-medium text-ink">
+                Parameter variants and holdout posture
+              </h2>
+              <div className="mt-4 overflow-x-auto">
+                <table className="min-w-full text-left text-sm">
+                  <thead className="text-[10px] uppercase tracking-[0.24em] text-muted">
+                    <tr>
+                      <th className="pb-2 pr-4">Variant</th>
+                      <th className="pb-2 pr-4">Selection</th>
+                      <th className="pb-2 pr-4">Holdout</th>
+                      <th className="pb-2 pr-4">Excess</th>
+                      <th className="pb-2">Selected</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {variantSummaries.length === 0 ? (
+                      <tr>
+                        <td className="py-3 text-muted" colSpan={5}>
+                          Run a replay or backtest study to compare variants.
+                        </td>
+                      </tr>
+                    ) : (
+                      variantSummaries.map((variant) => {
+                        const selectionMetrics = isRecord(
+                          variant.selectionMetrics,
+                        )
+                          ? variant.selectionMetrics
+                          : {};
+                        const holdoutMetrics = isRecord(variant.holdoutMetrics)
+                          ? variant.holdoutMetrics
+                          : {};
+                        const baseline =
+                          readRecordArray(
+                            variant.selectionBaselineComparisons,
+                          )[0] ?? null;
+                        return (
+                          <tr
+                            className="border-t border-border/60"
+                            key={
+                              readString(variant.variantId) ??
+                              Math.random().toString()
+                            }
+                          >
+                            <td className="py-3 pr-4 text-ink">
+                              {readString(variant.label) ??
+                                readString(variant.variantId) ??
+                                "variant"}
+                            </td>
+                            <td className="py-3 pr-4 text-muted">
+                              {formatBps(selectionMetrics.netReturnBps)}
+                            </td>
+                            <td className="py-3 pr-4 text-muted">
+                              {formatBps(holdoutMetrics.netReturnBps)}
+                            </td>
+                            <td className="py-3 pr-4 text-muted">
+                              {formatBps(baseline?.excessReturnBps)}
+                            </td>
+                            <td className="py-3">
+                              {readString(studyMatrix.selectedVariantId) ===
+                              readString(variant.variantId)
+                                ? renderBadge("pass", "selected")
+                                : "--"}
+                            </td>
+                          </tr>
+                        );
+                      })
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </article>
+
+            <article className="rounded border border-border bg-surface/80 p-5">
+              <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                Evidence and reproducibility
+              </p>
+              <h2 className="mt-2 text-lg font-medium text-ink">
+                Promotion context for the selected scenario
+              </h2>
+              <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                {summaryItem(
+                  "Latest report",
+                  latestReport?.reportId ??
+                    selectedScenario?.latestReportId ??
+                    "--",
+                )}
+                {summaryItem(
+                  "Repro refs",
+                  reproducibilityRefs.length > 0
+                    ? String(reproducibilityRefs.length)
+                    : "0",
+                )}
+              </div>
+
+              <div className="mt-4 rounded border border-border bg-paper/70 p-4">
+                <p className="text-[10px] uppercase tracking-[0.24em] text-muted">
+                  Evidence refs
+                </p>
+                <div className="mt-3 space-y-2">
+                  {readRecordArray(latestReport?.evidence).length === 0 &&
+                  reproducibilityRefs.length === 0 ? (
+                    <p className="text-sm text-muted">
+                      Evidence will appear here after the first successful run.
+                    </p>
+                  ) : (
+                    <>
+                      {readRecordArray(latestReport?.evidence).map((entry) => (
+                        <div
+                          className="rounded border border-border bg-surface/80 p-3 text-xs text-muted"
+                          key={`${readString(entry.stage) ?? "stage"}-${readString(entry.latestReportId) ?? readString(entry.summary) ?? "summary"}`}
+                        >
+                          <p className="font-medium text-ink">
+                            {readString(entry.stage) ?? "stage"}
+                          </p>
+                          <p className="mt-1">
+                            {readString(entry.summary) ?? "No summary"}
+                          </p>
+                        </div>
+                      ))}
+                      {reproducibilityRefs.map((ref) => (
+                        <div
+                          className="rounded border border-border bg-surface/80 p-3 text-xs text-muted"
+                          key={ref}
+                        >
+                          <p className="font-medium text-ink">{ref}</p>
+                        </div>
+                      ))}
+                    </>
+                  )}
+                </div>
+              </div>
+            </article>
+          </div>
+
+          {loading ? (
+            <p className="text-sm text-muted">Refreshing strategy desk…</p>
+          ) : null}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/portal/app/terminal/strategy-desk/strategy-desk-view.tsx
+++ b/apps/portal/app/terminal/strategy-desk/strategy-desk-view.tsx
@@ -128,7 +128,7 @@ function collectReproducibilityRefs(
   return [...refs];
 }
 
-function buildRunComparison(
+export function buildRunComparison(
   runs: RuntimeStrategyDeskScenarioRun[],
   reports: RuntimeStrategyDeskScenarioReport[],
 ) {
@@ -142,6 +142,9 @@ function buildRunComparison(
       : {};
     const studyMatrix = isRecord(report?.studyMatrix) ? report.studyMatrix : {};
     const scorecard = isRecord(report?.scorecard) ? report.scorecard : {};
+    const scorecardAggregate = isRecord(scorecard.aggregate)
+      ? scorecard.aggregate
+      : {};
     return {
       scenarioRunId: run.scenarioRunId,
       runKind: run.runKind,
@@ -149,7 +152,9 @@ function buildRunComparison(
       reportStatus: report?.status ?? null,
       generatedAt: report?.generatedAt ?? run.updatedAt,
       netPnlUsd:
-        readString(portfolio.netPnlUsd) ?? readString(scorecard.netPnlUsd),
+        readString(portfolio.netPnlUsd) ??
+        readString(scorecardAggregate.netPnlUsd) ??
+        readString(scorecard.netPnlUsd),
       maxDrawdownBps: readString(portfolio.maxDrawdownBps),
       selectedVariantId: readString(studyMatrix.selectedVariantId),
     };

--- a/apps/portal/app/terminal/strategy-desk/types.ts
+++ b/apps/portal/app/terminal/strategy-desk/types.ts
@@ -1,0 +1,32 @@
+import type {
+  RuntimeStrategyDeskScenarioManifest,
+  RuntimeStrategyDeskScenarioReport,
+  RuntimeStrategyDeskScenarioRun,
+} from "../../../lib/runtime-strategy-desk";
+
+export type StrategyDeskExecuteRunKind = "shadow" | "paper";
+export type StrategyDeskStudyRunKind = "replay" | "backtest";
+export type StrategyDeskStudySelectionMetric =
+  | "net_return_bps"
+  | "excess_vs_flat_cash_bps";
+
+export type StrategyDeskApiPayload = {
+  ok: boolean;
+  snapshot: {
+    scenarios: RuntimeStrategyDeskScenarioManifest[];
+    selectedScenarioId: string | null;
+    selectedScenario: RuntimeStrategyDeskScenarioManifest | null;
+    runs: RuntimeStrategyDeskScenarioRun[];
+    reports: RuntimeStrategyDeskScenarioReport[];
+    latestRun: RuntimeStrategyDeskScenarioRun | null;
+    latestReport: RuntimeStrategyDeskScenarioReport | null;
+  };
+};
+
+export type StrategyDeskMutationResult = {
+  ok: boolean;
+  scenario?: RuntimeStrategyDeskScenarioManifest;
+  run?: RuntimeStrategyDeskScenarioRun;
+  report?: RuntimeStrategyDeskScenarioReport;
+  error?: string;
+};

--- a/apps/portal/lib/runtime-strategy-desk.ts
+++ b/apps/portal/lib/runtime-strategy-desk.ts
@@ -1,0 +1,320 @@
+export type RuntimeStrategyDeskScenarioLeg = {
+  legId: string;
+  label: string;
+  role: string;
+  venueKey: string;
+  intentFamily: string;
+  marketType: string;
+  pair?: Record<string, unknown>;
+  instrumentId?: string;
+  assetKeys: readonly string[];
+  enabledModes: readonly string[];
+  sizing: Record<string, unknown>;
+  intent?: Record<string, unknown>;
+  thesis?: string;
+  dependencies?: readonly string[];
+  tags?: readonly string[];
+};
+
+export type RuntimeStrategyDeskScenarioManifest = {
+  schemaVersion?: string;
+  scenarioId: string;
+  title: string;
+  summary: string;
+  ownerUserId: string;
+  strategyKey: string;
+  thesis: string;
+  sleeveId?: string;
+  state: string;
+  createdAt: string;
+  updatedAt: string;
+  reviewedAt?: string;
+  activeHandoffId?: string;
+  latestReportId?: string;
+  riskLimits?: Record<string, unknown>;
+  researchMatrix?: Record<string, unknown>;
+  legs: readonly RuntimeStrategyDeskScenarioLeg[];
+  evidence: readonly Record<string, unknown>[];
+  implementationReferences: readonly Record<string, unknown>[];
+  tags: readonly string[];
+  metadata?: Record<string, unknown>;
+};
+
+export type RuntimeStrategyDeskScenarioRun = {
+  schemaVersion?: string;
+  scenarioRunId: string;
+  scenarioId: string;
+  scenarioState: string;
+  runKind: string;
+  state: string;
+  requestedBy: string;
+  trigger: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+  startedAt?: string;
+  completedAt?: string;
+  legRuns: readonly Record<string, unknown>[];
+  failureCode?: string;
+  failureMessage?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type RuntimeStrategyDeskScenarioReport = {
+  schemaVersion?: string;
+  reportId: string;
+  scenarioId: string;
+  scenarioRunId: string;
+  stage: string;
+  status: string;
+  summary: string;
+  generatedAt: string;
+  legOutcomes: readonly Record<string, unknown>[];
+  portfolioSummary?: Record<string, unknown>;
+  scorecard?: Record<string, unknown>;
+  riskOverlays: readonly Record<string, unknown>[];
+  studyMatrix?: Record<string, unknown>;
+  evidence: readonly Record<string, unknown>[];
+  checks: readonly Record<string, unknown>[];
+  approvals: readonly Record<string, unknown>[];
+  metadata?: Record<string, unknown>;
+};
+
+type ParseSuccess<T> = {
+  success: true;
+  data: T;
+};
+
+type ParseFailure = {
+  success: false;
+  error: string;
+};
+
+type ParseResult<T> = ParseSuccess<T> | ParseFailure;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return readString(value) ?? undefined;
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => Boolean(readString(entry)));
+}
+
+function readRecordArray(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is Record<string, unknown> =>
+    isRecord(entry),
+  );
+}
+
+function fail<T>(error: string): ParseResult<T> {
+  return { success: false, error };
+}
+
+function safeParseScenarioLeg(
+  value: unknown,
+): ParseResult<RuntimeStrategyDeskScenarioLeg> {
+  if (!isRecord(value)) return fail("strategy-desk-leg-not-object");
+  const legId = readString(value.legId);
+  const label = readString(value.label);
+  const role = readString(value.role);
+  const venueKey = readString(value.venueKey);
+  const intentFamily = readString(value.intentFamily);
+  const marketType = readString(value.marketType);
+  if (!legId || !label || !role || !venueKey || !intentFamily || !marketType) {
+    return fail("strategy-desk-leg-invalid");
+  }
+
+  return {
+    success: true,
+    data: {
+      legId,
+      label,
+      role,
+      venueKey,
+      intentFamily,
+      marketType,
+      pair: isRecord(value.pair) ? value.pair : undefined,
+      instrumentId: readOptionalString(value.instrumentId),
+      assetKeys: readStringArray(value.assetKeys),
+      enabledModes: readStringArray(value.enabledModes),
+      sizing: isRecord(value.sizing) ? value.sizing : {},
+      intent: isRecord(value.intent) ? value.intent : undefined,
+      thesis: readOptionalString(value.thesis),
+      dependencies: readStringArray(value.dependencies),
+      tags: readStringArray(value.tags),
+    },
+  };
+}
+
+export function safeParseRuntimeStrategyDeskScenarioManifest(
+  value: unknown,
+): ParseResult<RuntimeStrategyDeskScenarioManifest> {
+  if (!isRecord(value)) return fail("strategy-desk-scenario-not-object");
+  const scenarioId = readString(value.scenarioId);
+  const title = readString(value.title);
+  const summary = readString(value.summary);
+  const ownerUserId = readString(value.ownerUserId);
+  const strategyKey = readString(value.strategyKey);
+  const thesis = readString(value.thesis);
+  const state = readString(value.state);
+  const createdAt = readString(value.createdAt);
+  const updatedAt = readString(value.updatedAt);
+  if (
+    !scenarioId ||
+    !title ||
+    !summary ||
+    !ownerUserId ||
+    !strategyKey ||
+    !thesis ||
+    !state ||
+    !createdAt ||
+    !updatedAt
+  ) {
+    return fail("strategy-desk-scenario-invalid");
+  }
+
+  const legs = Array.isArray(value.legs)
+    ? value.legs.flatMap((entry) => {
+        const parsed = safeParseScenarioLeg(entry);
+        return parsed.success ? [parsed.data] : [];
+      })
+    : [];
+  if (legs.length === 0) return fail("strategy-desk-scenario-legs-invalid");
+
+  return {
+    success: true,
+    data: {
+      scenarioId,
+      schemaVersion: readOptionalString(value.schemaVersion),
+      title,
+      summary,
+      ownerUserId,
+      strategyKey,
+      thesis,
+      sleeveId: readOptionalString(value.sleeveId),
+      state,
+      createdAt,
+      updatedAt,
+      reviewedAt: readOptionalString(value.reviewedAt),
+      activeHandoffId: readOptionalString(value.activeHandoffId),
+      latestReportId: readOptionalString(value.latestReportId),
+      riskLimits: isRecord(value.riskLimits) ? value.riskLimits : undefined,
+      researchMatrix: isRecord(value.researchMatrix)
+        ? value.researchMatrix
+        : undefined,
+      legs,
+      evidence: readRecordArray(value.evidence),
+      implementationReferences: readRecordArray(value.implementationReferences),
+      tags: readStringArray(value.tags),
+      metadata: isRecord(value.metadata) ? value.metadata : undefined,
+    },
+  };
+}
+
+export function safeParseRuntimeStrategyDeskScenarioRun(
+  value: unknown,
+): ParseResult<RuntimeStrategyDeskScenarioRun> {
+  if (!isRecord(value)) return fail("strategy-desk-run-not-object");
+  const trigger = isRecord(value.trigger) ? value.trigger : null;
+  const scenarioRunId = readString(value.scenarioRunId);
+  const scenarioId = readString(value.scenarioId);
+  const scenarioState = readString(value.scenarioState);
+  const runKind = readString(value.runKind);
+  const state = readString(value.state);
+  const requestedBy = readString(value.requestedBy);
+  const createdAt = readString(value.createdAt);
+  const updatedAt = readString(value.updatedAt);
+  if (
+    !trigger ||
+    !scenarioRunId ||
+    !scenarioId ||
+    !scenarioState ||
+    !runKind ||
+    !state ||
+    !requestedBy ||
+    !createdAt ||
+    !updatedAt
+  ) {
+    return fail("strategy-desk-run-invalid");
+  }
+
+  return {
+    success: true,
+    data: {
+      scenarioRunId,
+      schemaVersion: readOptionalString(value.schemaVersion),
+      scenarioId,
+      scenarioState,
+      runKind,
+      state,
+      requestedBy,
+      trigger,
+      createdAt,
+      updatedAt,
+      startedAt: readOptionalString(value.startedAt),
+      completedAt: readOptionalString(value.completedAt),
+      legRuns: readRecordArray(value.legRuns),
+      failureCode: readOptionalString(value.failureCode),
+      failureMessage: readOptionalString(value.failureMessage),
+      metadata: isRecord(value.metadata) ? value.metadata : undefined,
+    },
+  };
+}
+
+export function safeParseRuntimeStrategyDeskScenarioReport(
+  value: unknown,
+): ParseResult<RuntimeStrategyDeskScenarioReport> {
+  if (!isRecord(value)) return fail("strategy-desk-report-not-object");
+  const reportId = readString(value.reportId);
+  const scenarioId = readString(value.scenarioId);
+  const scenarioRunId = readString(value.scenarioRunId);
+  const stage = readString(value.stage);
+  const status = readString(value.status);
+  const summary = readString(value.summary);
+  const generatedAt = readString(value.generatedAt);
+  if (
+    !reportId ||
+    !scenarioId ||
+    !scenarioRunId ||
+    !stage ||
+    !status ||
+    !summary ||
+    !generatedAt
+  ) {
+    return fail("strategy-desk-report-invalid");
+  }
+
+  return {
+    success: true,
+    data: {
+      reportId,
+      schemaVersion: readOptionalString(value.schemaVersion),
+      scenarioId,
+      scenarioRunId,
+      stage,
+      status,
+      summary,
+      generatedAt,
+      legOutcomes: readRecordArray(value.legOutcomes),
+      portfolioSummary: isRecord(value.portfolioSummary)
+        ? value.portfolioSummary
+        : undefined,
+      scorecard: isRecord(value.scorecard) ? value.scorecard : undefined,
+      riskOverlays: readRecordArray(value.riskOverlays),
+      studyMatrix: isRecord(value.studyMatrix) ? value.studyMatrix : undefined,
+      evidence: readRecordArray(value.evidence),
+      checks: readRecordArray(value.checks),
+      approvals: readRecordArray(value.approvals),
+      metadata: isRecord(value.metadata) ? value.metadata : undefined,
+    },
+  };
+}

--- a/apps/portal/lib/runtime-strategy-desk.ts
+++ b/apps/portal/lib/runtime-strategy-desk.ts
@@ -182,13 +182,16 @@ export function safeParseRuntimeStrategyDeskScenarioManifest(
     return fail("strategy-desk-scenario-invalid");
   }
 
-  const legs = Array.isArray(value.legs)
-    ? value.legs.flatMap((entry) => {
-        const parsed = safeParseScenarioLeg(entry);
-        return parsed.success ? [parsed.data] : [];
-      })
-    : [];
-  if (legs.length === 0) return fail("strategy-desk-scenario-legs-invalid");
+  if (!Array.isArray(value.legs) || value.legs.length === 0) {
+    return fail("strategy-desk-scenario-legs-invalid");
+  }
+  const parsedLegs = value.legs.map((entry) => safeParseScenarioLeg(entry));
+  if (parsedLegs.some((parsed) => !parsed.success)) {
+    return fail("strategy-desk-scenario-legs-invalid");
+  }
+  const legs = parsedLegs.map(
+    (parsed) => (parsed as ParseSuccess<RuntimeStrategyDeskScenarioLeg>).data,
+  );
 
   return {
     success: true,

--- a/tests/browser/harness-proof.spec.ts
+++ b/tests/browser/harness-proof.spec.ts
@@ -382,3 +382,43 @@ test("runtime operator proof shows deployment detail and control affordances", a
   ).toBeVisible();
   await captureCheckpoint(page, "runtime-operator-paused.png");
 });
+
+test("strategy desk proof covers author, run, inspect, and compare flows", async ({
+  page,
+}) => {
+  await page.goto("/proof/strategy-desk");
+
+  await expect(page.getByTestId("strategy-desk-proof-page")).toBeVisible();
+  await expect(page.getByTestId("strategy-desk-page")).toBeVisible();
+  await expect(page.getByTestId("strategy-desk-scenario-list")).toContainText(
+    "SOL composite desk scenario",
+  );
+  await captureCheckpoint(page, "strategy-desk-home.png");
+
+  await page
+    .getByTestId("strategy-desk-title-input")
+    .fill("SOL composite desk scenario proof");
+  await page.getByTestId("strategy-desk-save-scenario").click();
+  await expect(page.getByTestId("strategy-desk-scenario-list")).toContainText(
+    "SOL composite desk scenario proof",
+  );
+  await captureCheckpoint(page, "strategy-desk-author.png");
+
+  await page.getByTestId("strategy-desk-run-backtest").click();
+  await expect(page.getByTestId("strategy-desk-variant-table")).toContainText(
+    "Fast",
+  );
+  await expect(page.getByTestId("strategy-desk-run-history")).toContainText(
+    "backtest",
+  );
+  await captureCheckpoint(page, "strategy-desk-backtest.png");
+
+  await page.getByTestId("strategy-desk-run-paper").click();
+  await expect(page.getByTestId("strategy-desk-report-summary")).toContainText(
+    "requires human approval",
+  );
+  await expect(page.getByTestId("strategy-desk-leg-outcomes")).toContainText(
+    "leg_spot_alpha",
+  );
+  await captureCheckpoint(page, "strategy-desk-paper.png");
+});

--- a/tests/unit/portal_runtime_strategy_desk_contracts.test.ts
+++ b/tests/unit/portal_runtime_strategy_desk_contracts.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { buildRunComparison } from "../../apps/portal/app/terminal/strategy-desk/strategy-desk-view";
+import { safeParseRuntimeStrategyDeskScenarioManifest } from "../../apps/portal/lib/runtime-strategy-desk";
+
+const FIXTURE_TIME = "2026-03-17T03:08:10Z";
+
+describe("portal runtime strategy desk contracts", () => {
+  test("rejects scenario manifests when any leg is invalid", () => {
+    const parsed = safeParseRuntimeStrategyDeskScenarioManifest({
+      schemaVersion: "v1",
+      scenarioId: "desk_sol_composite_1",
+      title: "SOL composite desk scenario",
+      summary: "Composite desk scenario",
+      ownerUserId: "user_1",
+      strategyKey: "strategy_desk::sol_composite",
+      thesis: "Composite thesis",
+      state: "paper_ready",
+      createdAt: FIXTURE_TIME,
+      updatedAt: FIXTURE_TIME,
+      legs: [
+        {
+          legId: "leg_spot_alpha",
+          label: "Spot alpha",
+          role: "primary_alpha",
+          venueKey: "jupiter",
+          intentFamily: "spot_swap",
+          marketType: "spot",
+          assetKeys: ["SOL", "USDC"],
+          enabledModes: ["shadow", "paper"],
+          sizing: {
+            targetNotionalUsd: "1000",
+          },
+        },
+        {
+          legId: "leg_perp_hedge",
+          label: "Perp hedge",
+          role: "hedge",
+          venueKey: "drift",
+          intentFamily: "perp_order",
+          assetKeys: ["SOL"],
+          enabledModes: ["shadow"],
+          sizing: {
+            targetNotionalUsd: "250",
+          },
+        },
+      ],
+      evidence: [],
+      implementationReferences: [],
+      tags: ["strategy-desk"],
+    });
+
+    expect(parsed).toEqual({
+      success: false,
+      error: "strategy-desk-scenario-legs-invalid",
+    });
+  });
+
+  test("reads run comparison net pnl from scorecard aggregate when portfolio summary is absent", () => {
+    const comparison = buildRunComparison(
+      [
+        {
+          schemaVersion: "v1",
+          scenarioRunId: "desk_run_sol_composite_paper_1",
+          scenarioId: "desk_sol_composite_1",
+          scenarioState: "paper_ready",
+          runKind: "paper",
+          state: "completed",
+          requestedBy: "operator_1",
+          trigger: {
+            kind: "operator",
+            source: "portal.strategy-desk",
+            observedAt: FIXTURE_TIME,
+          },
+          createdAt: FIXTURE_TIME,
+          updatedAt: FIXTURE_TIME,
+          legRuns: [],
+        },
+      ],
+      [
+        {
+          schemaVersion: "v1",
+          reportId: "desk_report_sol_composite_paper_1",
+          scenarioId: "desk_sol_composite_1",
+          scenarioRunId: "desk_run_sol_composite_paper_1",
+          stage: "paper",
+          status: "pass",
+          summary: "Paper report",
+          generatedAt: FIXTURE_TIME,
+          legOutcomes: [],
+          scorecard: {
+            aggregate: {
+              netPnlUsd: "49.30",
+            },
+          },
+          riskOverlays: [],
+          evidence: [],
+          checks: [],
+          approvals: [],
+        },
+      ],
+    );
+
+    expect(comparison).toHaveLength(1);
+    expect(comparison[0]).toMatchObject({
+      scenarioRunId: "desk_run_sol_composite_paper_1",
+      netPnlUsd: "49.30",
+    });
+  });
+});

--- a/tests/unit/portal_runtime_strategy_desk_route.test.ts
+++ b/tests/unit/portal_runtime_strategy_desk_route.test.ts
@@ -1,0 +1,494 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  GET,
+  POST,
+} from "../../apps/portal/app/api/runtime/strategy-desk/route";
+
+const ORIGINAL_ENV = {
+  NEXT_PUBLIC_EDGE_API_BASE: process.env.NEXT_PUBLIC_EDGE_API_BASE,
+  RUNTIME_OPERATOR_ADMIN_TOKEN: process.env.RUNTIME_OPERATOR_ADMIN_TOKEN,
+  RUNTIME_OPERATOR_USER_ALLOWLIST: process.env.RUNTIME_OPERATOR_USER_ALLOWLIST,
+  RUNTIME_OPERATOR_PRIVY_USER_ALLOWLIST:
+    process.env.RUNTIME_OPERATOR_PRIVY_USER_ALLOWLIST,
+  ADMIN_TOKEN: process.env.ADMIN_TOKEN,
+  NODE_ENV: process.env.NODE_ENV,
+};
+
+const originalFetch = globalThis.fetch;
+const FIXTURE_TIME = "2026-03-17T03:08:10Z";
+
+function scenarioFixture() {
+  return {
+    schemaVersion: "v1",
+    scenarioId: "desk_sol_composite_1",
+    title: "SOL composite desk scenario",
+    summary: "Composite desk scenario",
+    ownerUserId: "user_1",
+    strategyKey: "strategy_desk::sol_composite",
+    thesis: "Composite thesis",
+    state: "paper_ready",
+    createdAt: FIXTURE_TIME,
+    updatedAt: FIXTURE_TIME,
+    legs: [
+      {
+        legId: "leg_spot_alpha",
+        label: "Spot alpha",
+        role: "primary_alpha",
+        venueKey: "jupiter",
+        intentFamily: "spot_swap",
+        marketType: "spot",
+        assetKeys: ["SOL", "USDC"],
+        enabledModes: ["shadow", "paper"],
+        sizing: {
+          targetNotionalUsd: "1000",
+        },
+      },
+    ],
+    evidence: [],
+    implementationReferences: [],
+    tags: ["strategy-desk"],
+    metadata: {
+      operatorWalletAddress: "11111111111111111111111111111111",
+    },
+  };
+}
+
+function runFixture() {
+  return {
+    schemaVersion: "v1",
+    scenarioRunId: "desk_run_sol_composite_paper_1",
+    scenarioId: "desk_sol_composite_1",
+    scenarioState: "paper_ready",
+    runKind: "paper",
+    state: "completed",
+    requestedBy: "operator_1",
+    trigger: {
+      kind: "operator",
+      source: "portal.strategy-desk",
+      observedAt: FIXTURE_TIME,
+    },
+    createdAt: FIXTURE_TIME,
+    updatedAt: FIXTURE_TIME,
+    legRuns: [],
+  };
+}
+
+function reportFixture() {
+  return {
+    schemaVersion: "v1",
+    reportId: "desk_report_sol_composite_paper_1",
+    scenarioId: "desk_sol_composite_1",
+    scenarioRunId: "desk_run_sol_composite_paper_1",
+    stage: "paper",
+    status: "pass",
+    summary: "Paper report",
+    generatedAt: FIXTURE_TIME,
+    legOutcomes: [
+      {
+        legId: "leg_spot_alpha",
+        status: "pass",
+      },
+    ],
+    portfolioSummary: {
+      netPnlUsd: "49.30",
+      grossExposureUsd: "1650.00",
+      maxDrawdownBps: 180,
+    },
+    riskOverlays: [],
+    evidence: [],
+    checks: [],
+    approvals: [],
+  };
+}
+
+afterEach(() => {
+  process.env.NEXT_PUBLIC_EDGE_API_BASE =
+    ORIGINAL_ENV.NEXT_PUBLIC_EDGE_API_BASE;
+  process.env.RUNTIME_OPERATOR_ADMIN_TOKEN =
+    ORIGINAL_ENV.RUNTIME_OPERATOR_ADMIN_TOKEN;
+  process.env.RUNTIME_OPERATOR_USER_ALLOWLIST =
+    ORIGINAL_ENV.RUNTIME_OPERATOR_USER_ALLOWLIST;
+  process.env.RUNTIME_OPERATOR_PRIVY_USER_ALLOWLIST =
+    ORIGINAL_ENV.RUNTIME_OPERATOR_PRIVY_USER_ALLOWLIST;
+  process.env.ADMIN_TOKEN = ORIGINAL_ENV.ADMIN_TOKEN;
+  process.env.NODE_ENV = ORIGINAL_ENV.NODE_ENV;
+  globalThis.fetch = originalFetch;
+});
+
+describe("portal runtime strategy desk route", () => {
+  test("requires operator auth", async () => {
+    process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
+
+    const response = await GET(
+      new Request("https://www.trader-ralph.com/api/runtime/strategy-desk"),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "auth-required",
+    });
+  });
+
+  test("fails closed when the admin token is missing", async () => {
+    process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
+    process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "";
+    process.env.RUNTIME_OPERATOR_USER_ALLOWLIST = "u_1";
+    process.env.ADMIN_TOKEN = "";
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/api/me")) {
+        return new Response(JSON.stringify({ ok: true, user: { id: "u_1" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const response = await GET(
+      new Request("https://www.trader-ralph.com/api/runtime/strategy-desk", {
+        headers: {
+          authorization: "Bearer user-token",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "missing RUNTIME_OPERATOR_ADMIN_TOKEN",
+    });
+  });
+
+  test("returns strategy desk snapshot with selected scenario detail", async () => {
+    process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
+    process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";
+    process.env.RUNTIME_OPERATOR_USER_ALLOWLIST = "u_1";
+
+    const seenAuthHeaders: string[] = [];
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url = String(input);
+      seenAuthHeaders.push(
+        String(
+          (init?.headers as Record<string, string> | undefined)
+            ?.authorization ?? "",
+        ),
+      );
+      if (url.endsWith("/api/me")) {
+        return new Response(JSON.stringify({ ok: true, user: { id: "u_1" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.includes("/api/admin/ops/runtime/strategy-desk/scenarios?")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            scenarios: [scenarioFixture()],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (url.includes("/api/admin/ops/runtime/strategy-desk/runs?")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            runs: [runFixture()],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (url.includes("/api/admin/ops/runtime/strategy-desk/reports?")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            reports: [reportFixture()],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const response = await GET(
+      new Request(
+        "https://www.trader-ralph.com/api/runtime/strategy-desk?scenarioId=desk_sol_composite_1",
+        {
+          headers: {
+            authorization: "Bearer user-token",
+          },
+        },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      snapshot: {
+        selectedScenarioId: "desk_sol_composite_1",
+        selectedScenario: {
+          scenarioId: "desk_sol_composite_1",
+          title: "SOL composite desk scenario",
+        },
+        runs: [
+          {
+            scenarioRunId: "desk_run_sol_composite_paper_1",
+          },
+        ],
+        reports: [
+          {
+            reportId: "desk_report_sol_composite_paper_1",
+          },
+        ],
+      },
+    });
+    expect(seenAuthHeaders).toContain("Bearer user-token");
+    expect(seenAuthHeaders).toContain("Bearer operator-admin");
+  });
+
+  test("forwards scenario upserts through the worker admin surface", async () => {
+    process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
+    process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";
+    process.env.RUNTIME_OPERATOR_USER_ALLOWLIST = "u_1";
+
+    let receivedBody: Record<string, unknown> | null = null;
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url = String(input);
+      if (url.endsWith("/api/me")) {
+        return new Response(JSON.stringify({ ok: true, user: { id: "u_1" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.endsWith("/api/admin/ops/runtime/strategy-desk/scenarios")) {
+        receivedBody = JSON.parse(String(init?.body ?? "{}")) as Record<
+          string,
+          unknown
+        >;
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            scenario: {
+              ...scenarioFixture(),
+              title: receivedBody.title,
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const response = await POST(
+      new Request("https://www.trader-ralph.com/api/runtime/strategy-desk", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer user-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          action: "upsert_scenario",
+          scenario: {
+            ...scenarioFixture(),
+            title: "Updated scenario title",
+          },
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      scenario: {
+        title: "Updated scenario title",
+      },
+    });
+    expect(receivedBody?.title).toBe("Updated scenario title");
+  });
+
+  test("forwards execute actions through the worker admin surface", async () => {
+    process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
+    process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";
+    process.env.RUNTIME_OPERATOR_USER_ALLOWLIST = "u_1";
+
+    let receivedBody: Record<string, unknown> | null = null;
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url = String(input);
+      if (url.endsWith("/api/me")) {
+        return new Response(JSON.stringify({ ok: true, user: { id: "u_1" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (
+        url.endsWith(
+          "/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/execute",
+        )
+      ) {
+        receivedBody = JSON.parse(String(init?.body ?? "{}")) as Record<
+          string,
+          unknown
+        >;
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            scenario: scenarioFixture(),
+            run: runFixture(),
+            report: reportFixture(),
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const response = await POST(
+      new Request("https://www.trader-ralph.com/api/runtime/strategy-desk", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer user-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          action: "execute_scenario",
+          scenarioId: "desk_sol_composite_1",
+          runKind: "paper",
+          requestedBy: "operator_1",
+          walletAddress: "11111111111111111111111111111111",
+          trigger: {
+            reason: "portal-test",
+          },
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      run: {
+        scenarioRunId: "desk_run_sol_composite_paper_1",
+      },
+      report: {
+        reportId: "desk_report_sol_composite_paper_1",
+      },
+    });
+    expect(receivedBody).toMatchObject({
+      runKind: "paper",
+      requestedBy: "operator_1",
+      walletAddress: "11111111111111111111111111111111",
+    });
+  });
+
+  test("forwards study actions through the worker admin surface", async () => {
+    process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
+    process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";
+    process.env.RUNTIME_OPERATOR_USER_ALLOWLIST = "u_1";
+
+    let receivedBody: Record<string, unknown> | null = null;
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url = String(input);
+      if (url.endsWith("/api/me")) {
+        return new Response(JSON.stringify({ ok: true, user: { id: "u_1" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (
+        url.endsWith(
+          "/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/study",
+        )
+      ) {
+        receivedBody = JSON.parse(String(init?.body ?? "{}")) as Record<
+          string,
+          unknown
+        >;
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            scenario: scenarioFixture(),
+            run: {
+              ...runFixture(),
+              scenarioRunId: "desk_run_sol_composite_backtest_1",
+              runKind: "backtest",
+            },
+            report: {
+              ...reportFixture(),
+              reportId: "desk_report_sol_composite_backtest_1",
+              scenarioRunId: "desk_run_sol_composite_backtest_1",
+              stage: "backtest",
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const response = await POST(
+      new Request("https://www.trader-ralph.com/api/runtime/strategy-desk", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer user-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          action: "study_scenario",
+          scenarioId: "desk_sol_composite_1",
+          runKind: "backtest",
+          requestedBy: "operator_1",
+          selectionMetric: "excess_vs_flat_cash_bps",
+          variantIds: ["fast"],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      run: {
+        runKind: "backtest",
+      },
+      report: {
+        stage: "backtest",
+      },
+    });
+    expect(receivedBody).toMatchObject({
+      runKind: "backtest",
+      requestedBy: "operator_1",
+      selectionMetric: "excess_vs_flat_cash_bps",
+      variantIds: ["fast"],
+    });
+  });
+});

--- a/tests/unit/portal_runtime_strategy_desk_route.test.ts
+++ b/tests/unit/portal_runtime_strategy_desk_route.test.ts
@@ -260,6 +260,144 @@ describe("portal runtime strategy desk route", () => {
     expect(seenAuthHeaders).toContain("Bearer operator-admin");
   });
 
+  test("fails closed when the requested scenario cannot be loaded", async () => {
+    process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
+    process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";
+    process.env.RUNTIME_OPERATOR_USER_ALLOWLIST = "u_1";
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/api/me")) {
+        return new Response(JSON.stringify({ ok: true, user: { id: "u_1" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.includes("/api/admin/ops/runtime/strategy-desk/scenarios?")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            scenarios: [
+              {
+                ...scenarioFixture(),
+                scenarioId: "desk_other",
+                title: "Other scenario",
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (
+        url.endsWith(
+          "/api/admin/ops/runtime/strategy-desk/scenarios/desk_missing",
+        )
+      ) {
+        return new Response(
+          JSON.stringify({
+            ok: false,
+            error: "strategy-desk-scenario-not-found",
+          }),
+          {
+            status: 404,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const response = await GET(
+      new Request(
+        "https://www.trader-ralph.com/api/runtime/strategy-desk?scenarioId=desk_missing",
+        {
+          headers: {
+            authorization: "Bearer user-token",
+          },
+        },
+      ),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "strategy-desk-scenario-not-found",
+    });
+  });
+
+  test("fails closed when reports cannot be loaded for the selected scenario", async () => {
+    process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
+    process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";
+    process.env.RUNTIME_OPERATOR_USER_ALLOWLIST = "u_1";
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/api/me")) {
+        return new Response(JSON.stringify({ ok: true, user: { id: "u_1" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.includes("/api/admin/ops/runtime/strategy-desk/scenarios?")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            scenarios: [scenarioFixture()],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (url.includes("/api/admin/ops/runtime/strategy-desk/runs?")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            runs: [runFixture()],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (url.includes("/api/admin/ops/runtime/strategy-desk/reports?")) {
+        return new Response(
+          JSON.stringify({
+            ok: false,
+            error: "strategy-desk-reports-load-failed",
+          }),
+          {
+            status: 500,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const response = await GET(
+      new Request(
+        "https://www.trader-ralph.com/api/runtime/strategy-desk?scenarioId=desk_sol_composite_1",
+        {
+          headers: {
+            authorization: "Bearer user-token",
+          },
+        },
+      ),
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "strategy-desk-reports-load-failed",
+    });
+  });
+
   test("forwards scenario upserts through the worker admin surface", async () => {
     process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
     process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";


### PR DESCRIPTION
## Summary
- add a portal strategy desk route that proxies harness-backed scenario, run, report, study, and execute flows
- add a dedicated terminal strategy desk UI with scenario authoring, study/shadow/paper controls, and unified report + comparison surfaces
- add proof coverage and route tests for author, run, inspect, and compare workflows

## Testing
- bun run lint
- bun run typecheck
- bun test tests/unit/portal_runtime_strategy_desk_route.test.ts
- bun run harness:proof --output-dir .tmp/browser-proof-sd5

Closes #441