### PR TITLE
[Phase SD6] Add strategy desk bounded execution handoffs

### DIFF
--- a/apps/portal/app/api/runtime/strategy-desk/route.ts
+++ b/apps/portal/app/api/runtime/strategy-desk/route.ts
@@ -368,7 +368,8 @@ function parsePrepareHandoffPayload(value: unknown): {
   if (!isRecord(value)) return null;
   const scenarioId = readString(value.scenarioId);
   const requestedBy = readString(value.requestedBy);
-  const targetMode = value.targetMode === "limited_live" ? "limited_live" : undefined;
+  const targetMode =
+    value.targetMode === "limited_live" ? "limited_live" : undefined;
   if (!scenarioId || !requestedBy) return null;
   return {
     scenarioId,

--- a/apps/portal/app/api/runtime/strategy-desk/route.ts
+++ b/apps/portal/app/api/runtime/strategy-desk/route.ts
@@ -1,8 +1,14 @@
 import { NextResponse } from "next/server";
 import {
+  type RuntimeStrategyDeskExecutionRecipe,
+  type RuntimeStrategyDeskPromotionHandoff,
+  type RuntimeStrategyDeskPromotionHandoffEvent,
   type RuntimeStrategyDeskScenarioManifest,
   type RuntimeStrategyDeskScenarioReport,
   type RuntimeStrategyDeskScenarioRun,
+  safeParseRuntimeStrategyDeskExecutionRecipe,
+  safeParseRuntimeStrategyDeskPromotionHandoff,
+  safeParseRuntimeStrategyDeskPromotionHandoffEvent,
   safeParseRuntimeStrategyDeskScenarioManifest,
   safeParseRuntimeStrategyDeskScenarioReport,
   safeParseRuntimeStrategyDeskScenarioRun,
@@ -166,6 +172,40 @@ function parseReports(value: unknown): RuntimeStrategyDeskScenarioReport[] {
   return reports;
 }
 
+function parseHandoffs(value: unknown): RuntimeStrategyDeskPromotionHandoff[] {
+  if (!Array.isArray(value)) return [];
+  const handoffs: RuntimeStrategyDeskPromotionHandoff[] = [];
+  for (const entry of value) {
+    const parsed = safeParseRuntimeStrategyDeskPromotionHandoff(entry);
+    if (parsed.success) handoffs.push(parsed.data);
+  }
+  return handoffs;
+}
+
+function parseHandoffEvents(
+  value: unknown,
+): RuntimeStrategyDeskPromotionHandoffEvent[] {
+  if (!Array.isArray(value)) return [];
+  const events: RuntimeStrategyDeskPromotionHandoffEvent[] = [];
+  for (const entry of value) {
+    const parsed = safeParseRuntimeStrategyDeskPromotionHandoffEvent(entry);
+    if (parsed.success) events.push(parsed.data);
+  }
+  return events;
+}
+
+function parseExecutionRecipes(
+  value: unknown,
+): RuntimeStrategyDeskExecutionRecipe[] {
+  if (!Array.isArray(value)) return [];
+  const recipes: RuntimeStrategyDeskExecutionRecipe[] = [];
+  for (const entry of value) {
+    const parsed = safeParseRuntimeStrategyDeskExecutionRecipe(entry);
+    if (parsed.success) recipes.push(parsed.data);
+  }
+  return recipes;
+}
+
 function latestByTimestamp<
   T extends { generatedAt?: string; updatedAt?: string },
 >(items: T[], timestampKey: "generatedAt" | "updatedAt"): T | null {
@@ -320,6 +360,61 @@ function parseStudyPayload(value: unknown): {
   };
 }
 
+function parsePrepareHandoffPayload(value: unknown): {
+  scenarioId: string;
+  requestedBy: string;
+  targetMode?: "limited_live";
+} | null {
+  if (!isRecord(value)) return null;
+  const scenarioId = readString(value.scenarioId);
+  const requestedBy = readString(value.requestedBy);
+  const targetMode = value.targetMode === "limited_live" ? "limited_live" : undefined;
+  if (!scenarioId || !requestedBy) return null;
+  return {
+    scenarioId,
+    requestedBy,
+    ...(targetMode ? { targetMode } : {}),
+  };
+}
+
+function parseTransitionHandoffPayload(value: unknown): {
+  handoffId: string;
+  actor: string;
+  handoffAction:
+    | "submit"
+    | "approve"
+    | "reject"
+    | "apply"
+    | "pause"
+    | "kill"
+    | "demote"
+    | "archive";
+  notes?: string;
+} | null {
+  if (!isRecord(value)) return null;
+  const handoffId = readString(value.handoffId);
+  const actor = readString(value.actor);
+  const handoffAction =
+    value.handoffAction === "submit" ||
+    value.handoffAction === "approve" ||
+    value.handoffAction === "reject" ||
+    value.handoffAction === "apply" ||
+    value.handoffAction === "pause" ||
+    value.handoffAction === "kill" ||
+    value.handoffAction === "demote" ||
+    value.handoffAction === "archive"
+      ? value.handoffAction
+      : null;
+  const notes = readString(value.notes);
+  if (!handoffId || !actor || !handoffAction) return null;
+  return {
+    handoffId,
+    actor,
+    handoffAction,
+    ...(notes ? { notes } : {}),
+  };
+}
+
 export async function GET(request: Request) {
   const auth = await ensureAuthorizedOperator(request);
   if (!auth.ok) return auth.response;
@@ -399,9 +494,13 @@ export async function GET(request: Request) {
 
   let runs: RuntimeStrategyDeskScenarioRun[] = [];
   let reports: RuntimeStrategyDeskScenarioReport[] = [];
+  let handoffs: RuntimeStrategyDeskPromotionHandoff[] = [];
+  let latestHandoff: RuntimeStrategyDeskPromotionHandoff | null = null;
+  let handoffEvents: RuntimeStrategyDeskPromotionHandoffEvent[] = [];
+  let executionRecipes: RuntimeStrategyDeskExecutionRecipe[] = [];
 
   if (selectedScenarioId) {
-    const [runsResult, reportsResult] = await Promise.all([
+    const [runsResult, reportsResult, handoffsResult] = await Promise.all([
       requestWorkerJson({
         path: `/api/admin/ops/runtime/strategy-desk/runs?scenarioId=${encodeURIComponent(
           selectedScenarioId,
@@ -410,6 +509,12 @@ export async function GET(request: Request) {
       }),
       requestWorkerJson({
         path: `/api/admin/ops/runtime/strategy-desk/reports?scenarioId=${encodeURIComponent(
+          selectedScenarioId,
+        )}&limit=20`,
+        authHeader: auth.adminAuthHeader,
+      }),
+      requestWorkerJson({
+        path: `/api/admin/ops/runtime/strategy-desk/handoffs?scenarioId=${encodeURIComponent(
           selectedScenarioId,
         )}&limit=20`,
         authHeader: auth.adminAuthHeader,
@@ -440,6 +545,29 @@ export async function GET(request: Request) {
     }
     runs = parseRuns(runsResult.payload.runs);
     reports = parseReports(reportsResult.payload.reports);
+    if (handoffsResult.status === 200 && handoffsResult.payload.ok === true) {
+      handoffs = parseHandoffs(handoffsResult.payload.handoffs);
+    }
+    latestHandoff = latestByTimestamp(handoffs, "updatedAt");
+
+    if (latestHandoff) {
+      const detailResult = await requestWorkerJson({
+        path: `/api/admin/ops/runtime/strategy-desk/handoffs/${encodeURIComponent(
+          latestHandoff.handoffId,
+        )}`,
+        authHeader: auth.adminAuthHeader,
+      });
+      if (detailResult.status === 200 && detailResult.payload.ok === true) {
+        const parsed = safeParseRuntimeStrategyDeskPromotionHandoff(
+          detailResult.payload.handoff,
+        );
+        if (parsed.success) latestHandoff = parsed.data;
+        handoffEvents = parseHandoffEvents(detailResult.payload.events);
+        executionRecipes = parseExecutionRecipes(
+          detailResult.payload.executionRecipes,
+        );
+      }
+    }
   }
 
   return NextResponse.json({
@@ -450,6 +578,10 @@ export async function GET(request: Request) {
       selectedScenario,
       runs,
       reports,
+      handoffs,
+      latestHandoff,
+      handoffEvents,
+      executionRecipes,
       latestRun: latestByTimestamp(runs, "updatedAt"),
       latestReport: latestByTimestamp(reports, "generatedAt"),
     },
@@ -618,6 +750,152 @@ export async function POST(request: Request) {
       scenario: scenario.data,
       run: run.data,
       report: report.data,
+    });
+  }
+
+  if (action === "prepare_handoff") {
+    const parsed = parsePrepareHandoffPayload(body);
+    if (!parsed) {
+      return NextResponse.json(
+        { ok: false, error: "strategy-desk-handoff-prepare-invalid" },
+        { status: 400 },
+      );
+    }
+    const result = await requestWorkerJson({
+      path: `/api/admin/ops/runtime/strategy-desk/scenarios/${encodeURIComponent(
+        parsed.scenarioId,
+      )}/handoffs/prepare`,
+      method: "POST",
+      authHeader: auth.adminAuthHeader,
+      body: {
+        requestedBy: parsed.requestedBy,
+        ...(parsed.targetMode ? { targetMode: parsed.targetMode } : {}),
+      },
+    });
+    if (result.status !== 200 || result.payload.ok !== true) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error:
+            readString(result.payload.error) ??
+            "strategy-desk-handoff-prepare-failed",
+        },
+        { status: result.status || 502 },
+      );
+    }
+    const scenario = safeParseRuntimeStrategyDeskScenarioManifest(
+      result.payload.scenario,
+    );
+    const handoff = safeParseRuntimeStrategyDeskPromotionHandoff(
+      result.payload.handoff,
+    );
+    if (!scenario.success || !handoff.success) {
+      return NextResponse.json(
+        { ok: false, error: "strategy-desk-handoff-prepare-response-invalid" },
+        { status: 502 },
+      );
+    }
+    return NextResponse.json({
+      ok: true,
+      scenario: scenario.data,
+      handoff: handoff.data,
+      events: parseHandoffEvents(result.payload.events),
+      executionRecipes: parseExecutionRecipes(result.payload.executionRecipes),
+    });
+  }
+
+  if (action === "transition_handoff") {
+    const parsed = parseTransitionHandoffPayload(body);
+    if (!parsed) {
+      return NextResponse.json(
+        { ok: false, error: "strategy-desk-handoff-transition-invalid" },
+        { status: 400 },
+      );
+    }
+    const result = await requestWorkerJson({
+      path: `/api/admin/ops/runtime/strategy-desk/handoffs/${encodeURIComponent(
+        parsed.handoffId,
+      )}/transition`,
+      method: "POST",
+      authHeader: auth.adminAuthHeader,
+      body: {
+        action: parsed.handoffAction,
+        actor: parsed.actor,
+        ...(parsed.notes ? { notes: parsed.notes } : {}),
+      },
+    });
+    if (result.status !== 200 || result.payload.ok !== true) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error:
+            readString(result.payload.error) ??
+            "strategy-desk-handoff-transition-failed",
+        },
+        { status: result.status || 502 },
+      );
+    }
+    const scenario = safeParseRuntimeStrategyDeskScenarioManifest(
+      result.payload.scenario,
+    );
+    const handoff = safeParseRuntimeStrategyDeskPromotionHandoff(
+      result.payload.handoff,
+    );
+    if (!scenario.success || !handoff.success) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: "strategy-desk-handoff-transition-response-invalid",
+        },
+        { status: 502 },
+      );
+    }
+    return NextResponse.json({
+      ok: true,
+      scenario: scenario.data,
+      handoff: handoff.data,
+      events: parseHandoffEvents(result.payload.events),
+      executionRecipes: parseExecutionRecipes(result.payload.executionRecipes),
+    });
+  }
+
+  if (action === "upsert_handoff") {
+    const parsed = safeParseRuntimeStrategyDeskPromotionHandoff(body.handoff);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { ok: false, error: parsed.error },
+        { status: 400 },
+      );
+    }
+    const result = await requestWorkerJson({
+      path: "/api/admin/ops/runtime/strategy-desk/handoffs",
+      method: "POST",
+      authHeader: auth.adminAuthHeader,
+      body: parsed.data,
+    });
+    if (result.status !== 200 || result.payload.ok !== true) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error:
+            readString(result.payload.error) ??
+            "strategy-desk-handoff-upsert-failed",
+        },
+        { status: result.status || 502 },
+      );
+    }
+    const handoff = safeParseRuntimeStrategyDeskPromotionHandoff(
+      result.payload.handoff,
+    );
+    if (!handoff.success) {
+      return NextResponse.json(
+        { ok: false, error: handoff.error },
+        { status: 502 },
+      );
+    }
+    return NextResponse.json({
+      ok: true,
+      handoff: handoff.data,
     });
   }
 

--- a/apps/portal/app/api/runtime/strategy-desk/route.ts
+++ b/apps/portal/app/api/runtime/strategy-desk/route.ts
@@ -497,6 +497,7 @@ export async function GET(request: Request) {
   let reports: RuntimeStrategyDeskScenarioReport[] = [];
   let handoffs: RuntimeStrategyDeskPromotionHandoff[] = [];
   let latestHandoff: RuntimeStrategyDeskPromotionHandoff | null = null;
+  let activeHandoff: RuntimeStrategyDeskPromotionHandoff | null = null;
   let handoffEvents: RuntimeStrategyDeskPromotionHandoffEvent[] = [];
   let executionRecipes: RuntimeStrategyDeskExecutionRecipe[] = [];
 
@@ -549,12 +550,20 @@ export async function GET(request: Request) {
     if (handoffsResult.status === 200 && handoffsResult.payload.ok === true) {
       handoffs = parseHandoffs(handoffsResult.payload.handoffs);
     }
-    latestHandoff = latestByTimestamp(handoffs, "updatedAt");
+    const latestHandoffSummary = latestByTimestamp(handoffs, "updatedAt");
+    const activeHandoffSummary = selectedScenario?.activeHandoffId
+      ? (handoffs.find(
+          (handoff) => handoff.handoffId === selectedScenario.activeHandoffId,
+        ) ?? null)
+      : null;
+    latestHandoff = latestHandoffSummary;
+    activeHandoff = activeHandoffSummary;
 
-    if (latestHandoff) {
+    const detailHandoff = activeHandoffSummary ?? latestHandoffSummary;
+    if (detailHandoff) {
       const detailResult = await requestWorkerJson({
         path: `/api/admin/ops/runtime/strategy-desk/handoffs/${encodeURIComponent(
-          latestHandoff.handoffId,
+          detailHandoff.handoffId,
         )}`,
         authHeader: auth.adminAuthHeader,
       });
@@ -562,7 +571,14 @@ export async function GET(request: Request) {
         const parsed = safeParseRuntimeStrategyDeskPromotionHandoff(
           detailResult.payload.handoff,
         );
-        if (parsed.success) latestHandoff = parsed.data;
+        if (parsed.success) {
+          if (activeHandoffSummary?.handoffId === parsed.data.handoffId) {
+            activeHandoff = parsed.data;
+          }
+          if (latestHandoffSummary?.handoffId === parsed.data.handoffId) {
+            latestHandoff = parsed.data;
+          }
+        }
         handoffEvents = parseHandoffEvents(detailResult.payload.events);
         executionRecipes = parseExecutionRecipes(
           detailResult.payload.executionRecipes,
@@ -580,6 +596,7 @@ export async function GET(request: Request) {
       runs,
       reports,
       handoffs,
+      activeHandoff,
       latestHandoff,
       handoffEvents,
       executionRecipes,

--- a/apps/portal/app/proof/strategy-desk/page.tsx
+++ b/apps/portal/app/proof/strategy-desk/page.tsx
@@ -499,7 +499,12 @@ function buildPayload(): StrategyDeskApiPayload {
       reports,
       handoffs,
       latestHandoff: handoffs[0],
-      handoffEvents: [handoffEventFixture("prepared", "Prepared a bounded execution handoff.")],
+      handoffEvents: [
+        handoffEventFixture(
+          "prepared",
+          "Prepared a bounded execution handoff.",
+        ),
+      ],
       executionRecipes: [],
       latestRun: runs[0],
       latestReport: reports[0],
@@ -652,13 +657,7 @@ export default function StrategyDeskProofPage() {
   }
 
   function applyHandoffAction(
-    action:
-      | "submit"
-      | "approve"
-      | "apply"
-      | "pause"
-      | "kill"
-      | "demote",
+    action: "submit" | "approve" | "apply" | "pause" | "kill" | "demote",
   ) {
     setActionPending(`handoff:${action}`);
     setPayload((current) => {
@@ -692,7 +691,7 @@ export default function StrategyDeskProofPage() {
               ? "applied"
               : action === "demote"
                 ? "archived"
-                : current.snapshot.latestHandoff?.status ?? "applied";
+                : (current.snapshot.latestHandoff?.status ?? "applied");
       const nextHandoff = handoffFixture(
         handoffStatus as RuntimeStrategyDeskPromotionHandoff["status"],
       );

--- a/apps/portal/app/proof/strategy-desk/page.tsx
+++ b/apps/portal/app/proof/strategy-desk/page.tsx
@@ -2,6 +2,9 @@
 
 import { useState } from "react";
 import type {
+  RuntimeStrategyDeskExecutionRecipe,
+  RuntimeStrategyDeskPromotionHandoff,
+  RuntimeStrategyDeskPromotionHandoffEvent,
   RuntimeStrategyDeskScenarioManifest,
   RuntimeStrategyDeskScenarioReport,
   RuntimeStrategyDeskScenarioRun,
@@ -374,10 +377,118 @@ function paperReportFixture(): RuntimeStrategyDeskScenarioReport {
   };
 }
 
+function handoffFixture(
+  status: RuntimeStrategyDeskPromotionHandoff["status"] = "draft",
+): RuntimeStrategyDeskPromotionHandoff {
+  return {
+    schemaVersion: "v1",
+    handoffId: "desk_handoff_sol_composite_live_1",
+    scenarioId: "desk_sol_composite_1",
+    currentState: "operator_review",
+    targetMode: "limited_live",
+    status,
+    summary:
+      "Bound the spot leg to limited live while keeping the hedge and prediction overlay paper-bound.",
+    requestedBy: "operator_1",
+    createdAt: FIXTURE_TIME,
+    updatedAt: FIXTURE_TIME,
+    ...(status === "applied" ? { appliedAt: FIXTURE_TIME } : {}),
+    evidenceRefs: [
+      {
+        kind: "strategy_desk_report",
+        ref: "desk_report_sol_composite_paper_1",
+      },
+    ],
+    checks: [
+      {
+        checkId: "paper-report-pass",
+        status: "pass",
+        message: "Paper report is green and ready for operator review.",
+      },
+      {
+        checkId: "limited-live-human-approval",
+        status: "requires_human_approval",
+        message:
+          "Limited-live promotion remains human-gated even when the desk report is green.",
+      },
+    ],
+    approvals:
+      status === "approved" || status === "applied"
+        ? [
+            {
+              targetMode: "limited_live",
+              approvedBy: "operator_1",
+              approvedAt: FIXTURE_TIME,
+            },
+          ]
+        : [],
+    bindings: [
+      {
+        bindingId: "binding_leg_spot_alpha_runtime",
+        bindingKind: "runtime_deployment",
+        legIds: ["leg_spot_alpha"],
+        venueKey: "jupiter",
+        targetMode: "limited_live",
+        deploymentId: "dep_desk_sol_live",
+        lane: "safe",
+      },
+      {
+        bindingId: "binding_leg_perp_hedge_recipe",
+        bindingKind: "worker_execution_recipe",
+        legIds: ["leg_perp_hedge"],
+        venueKey: "drift",
+        instrumentId: "SOL-PERP",
+        targetMode: "paper",
+      },
+    ],
+    actions: [
+      {
+        actionId: "record-desk-state",
+        actionType: "record_state_transition",
+        summary: "Move the scenario into operator review before arming.",
+        required: true,
+      },
+    ],
+  };
+}
+
+function handoffEventFixture(
+  eventType: RuntimeStrategyDeskPromotionHandoffEvent["eventType"],
+  summary: string,
+): RuntimeStrategyDeskPromotionHandoffEvent {
+  return {
+    eventId: `desk_handoff_evt_${eventType}`,
+    handoffId: "desk_handoff_sol_composite_live_1",
+    eventType,
+    actor: "operator_1",
+    summary,
+    createdAt: FIXTURE_TIME,
+  };
+}
+
+function executionRecipeFixture(
+  status: RuntimeStrategyDeskExecutionRecipe["status"] = "paper",
+): RuntimeStrategyDeskExecutionRecipe {
+  return {
+    recipeId: "desk_recipe_perp_1",
+    scenarioId: "desk_sol_composite_1",
+    handoffId: "desk_handoff_sol_composite_live_1",
+    bindingId: "binding_leg_perp_hedge_recipe",
+    status,
+    venueKey: "drift",
+    instrumentId: "SOL-PERP",
+    targetMode: "paper",
+    legIds: ["leg_perp_hedge"],
+    createdAt: FIXTURE_TIME,
+    updatedAt: FIXTURE_TIME,
+  };
+}
+
 function buildPayload(): StrategyDeskApiPayload {
   const scenario = scenarioFixture();
   const runs = [paperRunFixture(), backtestRunFixture()];
   const reports = [paperReportFixture(), backtestReportFixture()];
+  const handoffs = [handoffFixture()];
   return {
     ok: true,
     snapshot: {
@@ -386,6 +497,10 @@ function buildPayload(): StrategyDeskApiPayload {
       selectedScenario: scenario,
       runs,
       reports,
+      handoffs,
+      latestHandoff: handoffs[0],
+      handoffEvents: [handoffEventFixture("prepared", "Prepared a bounded execution handoff.")],
+      executionRecipes: [],
       latestRun: runs[0],
       latestReport: reports[0],
     },
@@ -498,6 +613,133 @@ export default function StrategyDeskProofPage() {
     setActionPending(null);
   }
 
+  function applyPrepareHandoff() {
+    setActionPending("handoff:prepare");
+    setPayload((current) => ({
+      ok: true,
+      snapshot: {
+        ...current.snapshot,
+        selectedScenario: current.snapshot.selectedScenario
+          ? {
+              ...current.snapshot.selectedScenario,
+              state: "operator_review",
+              activeHandoffId: "desk_handoff_sol_composite_live_1",
+            }
+          : null,
+        scenarios: current.snapshot.scenarios.map((scenario) => ({
+          ...scenario,
+          state:
+            scenario.scenarioId === "desk_sol_composite_1"
+              ? "operator_review"
+              : scenario.state,
+          activeHandoffId:
+            scenario.scenarioId === "desk_sol_composite_1"
+              ? "desk_handoff_sol_composite_live_1"
+              : scenario.activeHandoffId,
+        })),
+        handoffs: [handoffFixture(), ...current.snapshot.handoffs.slice(1)],
+        latestHandoff: handoffFixture(),
+        handoffEvents: [
+          handoffEventFixture(
+            "prepared",
+            "Prepared a bounded execution handoff from paper evidence.",
+          ),
+        ],
+        executionRecipes: [],
+      },
+    }));
+    setActionPending(null);
+  }
+
+  function applyHandoffAction(
+    action:
+      | "submit"
+      | "approve"
+      | "apply"
+      | "pause"
+      | "kill"
+      | "demote",
+  ) {
+    setActionPending(`handoff:${action}`);
+    setPayload((current) => {
+      const nextScenario =
+        current.snapshot.selectedScenario &&
+        current.snapshot.selectedScenario.scenarioId === "desk_sol_composite_1"
+          ? {
+              ...current.snapshot.selectedScenario,
+              state:
+                action === "submit"
+                  ? "operator_review"
+                  : action === "approve"
+                    ? "execution_ready"
+                    : action === "apply"
+                      ? "execution_bound"
+                      : action === "demote"
+                        ? "paper_ready"
+                        : "paused",
+              activeHandoffId:
+                action === "demote"
+                  ? undefined
+                  : "desk_handoff_sol_composite_live_1",
+            }
+          : current.snapshot.selectedScenario;
+      const handoffStatus =
+        action === "submit"
+          ? "awaiting_review"
+          : action === "approve"
+            ? "approved"
+            : action === "apply"
+              ? "applied"
+              : action === "demote"
+                ? "archived"
+                : current.snapshot.latestHandoff?.status ?? "applied";
+      const nextHandoff = handoffFixture(
+        handoffStatus as RuntimeStrategyDeskPromotionHandoff["status"],
+      );
+      const eventSummary =
+        action === "submit"
+          ? "Submitted bounded execution handoff for review."
+          : action === "approve"
+            ? "Approved bounded execution handoff."
+            : action === "apply"
+              ? "Applied bounded execution handoff."
+              : action === "pause"
+                ? "Paused bounded execution."
+                : action === "kill"
+                  ? "Killed bounded execution."
+                  : "Demoted bounded execution back to paper.";
+      return {
+        ok: true,
+        snapshot: {
+          ...current.snapshot,
+          selectedScenario: nextScenario,
+          scenarios: current.snapshot.scenarios.map((scenario) =>
+            scenario.scenarioId === "desk_sol_composite_1" && nextScenario
+              ? nextScenario
+              : scenario,
+          ),
+          handoffs: [nextHandoff],
+          latestHandoff: nextHandoff,
+          handoffEvents: [
+            ...current.snapshot.handoffEvents,
+            handoffEventFixture(action, eventSummary),
+          ],
+          executionRecipes:
+            action === "apply"
+              ? [executionRecipeFixture("paper")]
+              : action === "pause"
+                ? [executionRecipeFixture("paused")]
+                : action === "kill"
+                  ? [executionRecipeFixture("killed")]
+                  : action === "demote"
+                    ? [executionRecipeFixture("archived")]
+                    : current.snapshot.executionRecipes,
+        },
+      };
+    });
+    setActionPending(null);
+  }
+
   return (
     <div data-testid="strategy-desk-proof-page">
       <StrategyDeskView
@@ -551,6 +793,19 @@ export default function StrategyDeskProofPage() {
         }}
         onRunStudy={(runKind) => applyStudy(runKind)}
         onRunExecute={(runKind) => applyExecution(runKind)}
+        onPrepareHandoff={() => applyPrepareHandoff()}
+        onTransitionHandoff={(action) => {
+          if (
+            action === "submit" ||
+            action === "approve" ||
+            action === "apply" ||
+            action === "pause" ||
+            action === "kill" ||
+            action === "demote"
+          ) {
+            applyHandoffAction(action);
+          }
+        }}
       />
     </div>
   );

--- a/apps/portal/app/proof/strategy-desk/page.tsx
+++ b/apps/portal/app/proof/strategy-desk/page.tsx
@@ -498,6 +498,7 @@ function buildPayload(): StrategyDeskApiPayload {
       runs,
       reports,
       handoffs,
+      activeHandoff: handoffs[0],
       latestHandoff: handoffs[0],
       handoffEvents: [
         handoffEventFixture(
@@ -643,6 +644,7 @@ export default function StrategyDeskProofPage() {
               : scenario.activeHandoffId,
         })),
         handoffs: [handoffFixture(), ...current.snapshot.handoffs.slice(1)],
+        activeHandoff: handoffFixture(),
         latestHandoff: handoffFixture(),
         handoffEvents: [
           handoffEventFixture(
@@ -718,6 +720,7 @@ export default function StrategyDeskProofPage() {
               : scenario,
           ),
           handoffs: [nextHandoff],
+          activeHandoff: action === "demote" ? null : nextHandoff,
           latestHandoff: nextHandoff,
           handoffEvents: [
             ...current.snapshot.handoffEvents,

--- a/apps/portal/app/terminal/strategy-desk/strategy-desk-client.tsx
+++ b/apps/portal/app/terminal/strategy-desk/strategy-desk-client.tsx
@@ -3,12 +3,13 @@
 import { usePrivy } from "@privy-io/react-auth";
 import { useEffect, useState, useTransition } from "react";
 import { StrategyDeskView } from "./strategy-desk-view";
-import type {
-  StrategyDeskApiPayload,
-  StrategyDeskExecuteRunKind,
-  StrategyDeskMutationResult,
-  StrategyDeskStudyRunKind,
-  StrategyDeskStudySelectionMetric,
+import {
+  type StrategyDeskApiPayload,
+  type StrategyDeskExecuteRunKind,
+  type StrategyDeskMutationResult,
+  type StrategyDeskStudyRunKind,
+  type StrategyDeskStudySelectionMetric,
+  selectStrategyDeskHandoffForAction,
 } from "./types";
 
 async function readJson<T>(response: Response): Promise<T | null> {
@@ -252,7 +253,10 @@ export function StrategyDeskClient() {
       | "archive",
   ) {
     const scenarioId = payload?.snapshot.selectedScenarioId;
-    const handoffId = payload?.snapshot.latestHandoff?.handoffId;
+    const handoffId = selectStrategyDeskHandoffForAction(
+      payload?.snapshot,
+      action,
+    )?.handoffId;
     if (!scenarioId || !handoffId) {
       setError("strategy-desk-handoff-required");
       return;

--- a/apps/portal/app/terminal/strategy-desk/strategy-desk-client.tsx
+++ b/apps/portal/app/terminal/strategy-desk/strategy-desk-client.tsx
@@ -222,6 +222,53 @@ export function StrategyDeskClient() {
     }
   }
 
+  async function prepareHandoff() {
+    const scenarioId = payload?.snapshot.selectedScenarioId;
+    if (!scenarioId) {
+      setError("strategy-desk-scenario-required");
+      return;
+    }
+    await runAction(
+      {
+        action: "prepare_handoff",
+        scenarioId,
+        requestedBy,
+        targetMode: "limited_live",
+      },
+      "handoff:prepare",
+      scenarioId,
+    );
+  }
+
+  async function transitionHandoff(
+    action:
+      | "submit"
+      | "approve"
+      | "reject"
+      | "apply"
+      | "pause"
+      | "kill"
+      | "demote"
+      | "archive",
+  ) {
+    const scenarioId = payload?.snapshot.selectedScenarioId;
+    const handoffId = payload?.snapshot.latestHandoff?.handoffId;
+    if (!scenarioId || !handoffId) {
+      setError("strategy-desk-handoff-required");
+      return;
+    }
+    await runAction(
+      {
+        action: "transition_handoff",
+        handoffId,
+        handoffAction: action,
+        actor: requestedBy,
+      },
+      `handoff:${action}`,
+      scenarioId,
+    );
+  }
+
   useEffect(() => {
     if (!ready) return;
     if (!authenticated) {
@@ -423,6 +470,28 @@ export function StrategyDeskClient() {
               cause instanceof Error
                 ? cause.message
                 : "strategy-desk-execute-failed",
+            );
+          });
+        });
+      }}
+      onPrepareHandoff={() => {
+        startTransition(() => {
+          void prepareHandoff().catch((cause) => {
+            setError(
+              cause instanceof Error
+                ? cause.message
+                : "strategy-desk-handoff-prepare-failed",
+            );
+          });
+        });
+      }}
+      onTransitionHandoff={(action) => {
+        startTransition(() => {
+          void transitionHandoff(action).catch((cause) => {
+            setError(
+              cause instanceof Error
+                ? cause.message
+                : "strategy-desk-handoff-transition-failed",
             );
           });
         });

--- a/apps/portal/app/terminal/strategy-desk/strategy-desk-view.tsx
+++ b/apps/portal/app/terminal/strategy-desk/strategy-desk-view.tsx
@@ -192,7 +192,9 @@ function reportForDisplay(
   return latestReport ?? reports[0] ?? null;
 }
 
-function readCheckStatusCounts(handoff: RuntimeStrategyDeskPromotionHandoff | null) {
+function readCheckStatusCounts(
+  handoff: RuntimeStrategyDeskPromotionHandoff | null,
+) {
   let pass = 0;
   let blocked = 0;
   let human = 0;
@@ -598,9 +600,9 @@ export function StrategyDeskView({
                   Review, arm, and roll back from the desk
                 </h2>
                 <p className="mt-2 text-sm text-muted">
-                  Prepare a bounded handoff from the current paper evidence, then
-                  move it through explicit operator review before applying or
-                  rolling it back.
+                  Prepare a bounded handoff from the current paper evidence,
+                  then move it through explicit operator review before applying
+                  or rolling it back.
                 </p>
               </div>
               <div className="flex flex-wrap gap-2">
@@ -646,9 +648,7 @@ export function StrategyDeskView({
                 <button
                   className={BTN_PRIMARY}
                   data-testid="strategy-desk-apply-handoff"
-                  disabled={
-                    actionPending === "handoff:apply" || !latestHandoff
-                  }
+                  disabled={actionPending === "handoff:apply" || !latestHandoff}
                   onClick={() => onTransitionHandoff?.("apply")}
                   type="button"
                 >
@@ -659,9 +659,7 @@ export function StrategyDeskView({
                 <button
                   className={BTN_SECONDARY}
                   data-testid="strategy-desk-pause-handoff"
-                  disabled={
-                    actionPending === "handoff:pause" || !latestHandoff
-                  }
+                  disabled={actionPending === "handoff:pause" || !latestHandoff}
                   onClick={() => onTransitionHandoff?.("pause")}
                   type="button"
                 >
@@ -670,9 +668,7 @@ export function StrategyDeskView({
                 <button
                   className={BTN_SECONDARY}
                   data-testid="strategy-desk-kill-handoff"
-                  disabled={
-                    actionPending === "handoff:kill" || !latestHandoff
-                  }
+                  disabled={actionPending === "handoff:kill" || !latestHandoff}
                   onClick={() => onTransitionHandoff?.("kill")}
                   type="button"
                 >
@@ -718,7 +714,8 @@ export function StrategyDeskView({
                       Handoff summary
                     </p>
                     <h3 className="mt-2 text-sm font-medium text-ink">
-                      {latestHandoff?.summary ?? "No bounded execution handoff prepared yet."}
+                      {latestHandoff?.summary ??
+                        "No bounded execution handoff prepared yet."}
                     </h3>
                   </div>
                   <div className="flex gap-2">
@@ -727,12 +724,15 @@ export function StrategyDeskView({
                   </div>
                 </div>
                 <div className="mt-4 grid gap-3 sm:grid-cols-3">
-                  {summaryItem("Passed checks", String(handoffCheckCounts.pass))}
-                  {summaryItem("Blocked checks", String(handoffCheckCounts.blocked))}
                   {summaryItem(
-                    "Human gates",
-                    String(handoffCheckCounts.human),
+                    "Passed checks",
+                    String(handoffCheckCounts.pass),
                   )}
+                  {summaryItem(
+                    "Blocked checks",
+                    String(handoffCheckCounts.blocked),
+                  )}
+                  {summaryItem("Human gates", String(handoffCheckCounts.human))}
                 </div>
                 <div className="mt-4 space-y-3">
                   {readRecordArray(latestHandoff?.checks).length === 0 ? (
@@ -793,7 +793,11 @@ export function StrategyDeskView({
                         <p className="mt-2 text-xs text-muted">
                           {readString(binding.venueKey) ?? "venue"} ·{" "}
                           {readString(binding.instrumentId) ??
-                            readString(isRecord(binding.pair) ? binding.pair.symbol : null) ??
+                            readString(
+                              isRecord(binding.pair)
+                                ? binding.pair.symbol
+                                : null,
+                            ) ??
                             "pair"}
                         </p>
                       </div>

--- a/apps/portal/app/terminal/strategy-desk/strategy-desk-view.tsx
+++ b/apps/portal/app/terminal/strategy-desk/strategy-desk-view.tsx
@@ -7,11 +7,13 @@ import type {
   RuntimeStrategyDeskScenarioRun,
 } from "../../../lib/runtime-strategy-desk";
 import { BTN_PRIMARY, BTN_SECONDARY, formatTick } from "../../lib";
-import type {
-  StrategyDeskApiPayload,
-  StrategyDeskExecuteRunKind,
-  StrategyDeskStudyRunKind,
-  StrategyDeskStudySelectionMetric,
+import {
+  type StrategyDeskApiPayload,
+  type StrategyDeskExecuteRunKind,
+  type StrategyDeskStudyRunKind,
+  type StrategyDeskStudySelectionMetric,
+  selectStrategyDeskFocusHandoff,
+  selectStrategyDeskHandoffForAction,
 } from "./types";
 
 type StrategyDeskViewProps = {
@@ -235,7 +237,16 @@ export function StrategyDeskView({
     snapshot?.latestReport ?? null,
     snapshot?.reports ?? [],
   );
-  const latestHandoff = snapshot?.latestHandoff ?? null;
+  const latestHandoff = selectStrategyDeskFocusHandoff(snapshot);
+  const submitHandoff = selectStrategyDeskHandoffForAction(snapshot, "submit");
+  const approveHandoff = selectStrategyDeskHandoffForAction(
+    snapshot,
+    "approve",
+  );
+  const applyHandoff = selectStrategyDeskHandoffForAction(snapshot, "apply");
+  const pauseHandoff = selectStrategyDeskHandoffForAction(snapshot, "pause");
+  const killHandoff = selectStrategyDeskHandoffForAction(snapshot, "kill");
+  const demoteHandoff = selectStrategyDeskHandoffForAction(snapshot, "demote");
   const comparison = buildRunComparison(
     snapshot?.runs ?? [],
     snapshot?.reports ?? [],
@@ -623,7 +634,7 @@ export function StrategyDeskView({
                   className={BTN_SECONDARY}
                   data-testid="strategy-desk-submit-handoff"
                   disabled={
-                    actionPending === "handoff:submit" || !latestHandoff
+                    actionPending === "handoff:submit" || !submitHandoff
                   }
                   onClick={() => onTransitionHandoff?.("submit")}
                   type="button"
@@ -636,7 +647,7 @@ export function StrategyDeskView({
                   className={BTN_SECONDARY}
                   data-testid="strategy-desk-approve-handoff"
                   disabled={
-                    actionPending === "handoff:approve" || !latestHandoff
+                    actionPending === "handoff:approve" || !approveHandoff
                   }
                   onClick={() => onTransitionHandoff?.("approve")}
                   type="button"
@@ -648,7 +659,7 @@ export function StrategyDeskView({
                 <button
                   className={BTN_PRIMARY}
                   data-testid="strategy-desk-apply-handoff"
-                  disabled={actionPending === "handoff:apply" || !latestHandoff}
+                  disabled={actionPending === "handoff:apply" || !applyHandoff}
                   onClick={() => onTransitionHandoff?.("apply")}
                   type="button"
                 >
@@ -659,7 +670,7 @@ export function StrategyDeskView({
                 <button
                   className={BTN_SECONDARY}
                   data-testid="strategy-desk-pause-handoff"
-                  disabled={actionPending === "handoff:pause" || !latestHandoff}
+                  disabled={actionPending === "handoff:pause" || !pauseHandoff}
                   onClick={() => onTransitionHandoff?.("pause")}
                   type="button"
                 >
@@ -668,7 +679,7 @@ export function StrategyDeskView({
                 <button
                   className={BTN_SECONDARY}
                   data-testid="strategy-desk-kill-handoff"
-                  disabled={actionPending === "handoff:kill" || !latestHandoff}
+                  disabled={actionPending === "handoff:kill" || !killHandoff}
                   onClick={() => onTransitionHandoff?.("kill")}
                   type="button"
                 >
@@ -678,7 +689,7 @@ export function StrategyDeskView({
                   className={BTN_SECONDARY}
                   data-testid="strategy-desk-demote-handoff"
                   disabled={
-                    actionPending === "handoff:demote" || !latestHandoff
+                    actionPending === "handoff:demote" || !demoteHandoff
                   }
                   onClick={() => onTransitionHandoff?.("demote")}
                   type="button"

--- a/apps/portal/app/terminal/strategy-desk/strategy-desk-view.tsx
+++ b/apps/portal/app/terminal/strategy-desk/strategy-desk-view.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import type {
+  RuntimeStrategyDeskPromotionHandoff,
   RuntimeStrategyDeskScenarioReport,
   RuntimeStrategyDeskScenarioRun,
 } from "../../../lib/runtime-strategy-desk";
@@ -34,6 +35,18 @@ type StrategyDeskViewProps = {
     selectionMetric?: StrategyDeskStudySelectionMetric,
   ) => void;
   onRunExecute?: (runKind: StrategyDeskExecuteRunKind) => void;
+  onPrepareHandoff?: () => void;
+  onTransitionHandoff?: (
+    action:
+      | "submit"
+      | "approve"
+      | "reject"
+      | "apply"
+      | "pause"
+      | "kill"
+      | "demote"
+      | "archive",
+  ) => void;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -179,6 +192,19 @@ function reportForDisplay(
   return latestReport ?? reports[0] ?? null;
 }
 
+function readCheckStatusCounts(handoff: RuntimeStrategyDeskPromotionHandoff | null) {
+  let pass = 0;
+  let blocked = 0;
+  let human = 0;
+  for (const check of readRecordArray(handoff?.checks)) {
+    const status = readString(check.status);
+    if (status === "pass") pass += 1;
+    if (status === "blocked") blocked += 1;
+    if (status === "requires_human_approval") human += 1;
+  }
+  return { pass, blocked, human };
+}
+
 export function StrategyDeskView({
   authenticated,
   loading,
@@ -197,6 +223,8 @@ export function StrategyDeskView({
   onSaveScenario,
   onRunStudy,
   onRunExecute,
+  onPrepareHandoff,
+  onTransitionHandoff,
 }: StrategyDeskViewProps) {
   const snapshot = payload?.snapshot ?? null;
   const selectedScenario = snapshot?.selectedScenario ?? null;
@@ -205,11 +233,13 @@ export function StrategyDeskView({
     snapshot?.latestReport ?? null,
     snapshot?.reports ?? [],
   );
+  const latestHandoff = snapshot?.latestHandoff ?? null;
   const comparison = buildRunComparison(
     snapshot?.runs ?? [],
     snapshot?.reports ?? [],
   );
   const reproducibilityRefs = collectReproducibilityRefs(latestReport);
+  const handoffCheckCounts = readCheckStatusCounts(latestHandoff);
 
   let draftScenario: Record<string, unknown> | null = null;
   try {
@@ -551,6 +581,252 @@ export function StrategyDeskView({
                     ? "Running paper..."
                     : "Run paper"}
                 </button>
+              </div>
+            </div>
+          </article>
+
+          <article
+            className="rounded border border-border bg-surface/80 p-5"
+            data-testid="strategy-desk-bounded-execution"
+          >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.28em] text-muted">
+                  Bounded execution
+                </p>
+                <h2 className="mt-2 text-lg font-medium text-ink">
+                  Review, arm, and roll back from the desk
+                </h2>
+                <p className="mt-2 text-sm text-muted">
+                  Prepare a bounded handoff from the current paper evidence, then
+                  move it through explicit operator review before applying or
+                  rolling it back.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <button
+                  className={BTN_SECONDARY}
+                  data-testid="strategy-desk-prepare-handoff"
+                  disabled={
+                    actionPending === "handoff:prepare" || !selectedScenario
+                  }
+                  onClick={onPrepareHandoff}
+                  type="button"
+                >
+                  {actionPending === "handoff:prepare"
+                    ? "Preparing..."
+                    : "Prepare handoff"}
+                </button>
+                <button
+                  className={BTN_SECONDARY}
+                  data-testid="strategy-desk-submit-handoff"
+                  disabled={
+                    actionPending === "handoff:submit" || !latestHandoff
+                  }
+                  onClick={() => onTransitionHandoff?.("submit")}
+                  type="button"
+                >
+                  {actionPending === "handoff:submit"
+                    ? "Submitting..."
+                    : "Submit review"}
+                </button>
+                <button
+                  className={BTN_SECONDARY}
+                  data-testid="strategy-desk-approve-handoff"
+                  disabled={
+                    actionPending === "handoff:approve" || !latestHandoff
+                  }
+                  onClick={() => onTransitionHandoff?.("approve")}
+                  type="button"
+                >
+                  {actionPending === "handoff:approve"
+                    ? "Approving..."
+                    : "Approve"}
+                </button>
+                <button
+                  className={BTN_PRIMARY}
+                  data-testid="strategy-desk-apply-handoff"
+                  disabled={
+                    actionPending === "handoff:apply" || !latestHandoff
+                  }
+                  onClick={() => onTransitionHandoff?.("apply")}
+                  type="button"
+                >
+                  {actionPending === "handoff:apply"
+                    ? "Arming..."
+                    : "Arm bounded execution"}
+                </button>
+                <button
+                  className={BTN_SECONDARY}
+                  data-testid="strategy-desk-pause-handoff"
+                  disabled={
+                    actionPending === "handoff:pause" || !latestHandoff
+                  }
+                  onClick={() => onTransitionHandoff?.("pause")}
+                  type="button"
+                >
+                  {actionPending === "handoff:pause" ? "Pausing..." : "Pause"}
+                </button>
+                <button
+                  className={BTN_SECONDARY}
+                  data-testid="strategy-desk-kill-handoff"
+                  disabled={
+                    actionPending === "handoff:kill" || !latestHandoff
+                  }
+                  onClick={() => onTransitionHandoff?.("kill")}
+                  type="button"
+                >
+                  {actionPending === "handoff:kill" ? "Killing..." : "Kill"}
+                </button>
+                <button
+                  className={BTN_SECONDARY}
+                  data-testid="strategy-desk-demote-handoff"
+                  disabled={
+                    actionPending === "handoff:demote" || !latestHandoff
+                  }
+                  onClick={() => onTransitionHandoff?.("demote")}
+                  type="button"
+                >
+                  {actionPending === "handoff:demote"
+                    ? "Demoting..."
+                    : "Demote to paper"}
+                </button>
+              </div>
+            </div>
+
+            <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+              {summaryItem(
+                "Latest handoff",
+                latestHandoff?.handoffId ?? "none",
+              )}
+              {summaryItem("Status", latestHandoff?.status ?? "--")}
+              {summaryItem(
+                "Approvals",
+                String(readRecordArray(latestHandoff?.approvals).length),
+              )}
+              {summaryItem(
+                "Materialized recipes",
+                String(snapshot?.executionRecipes.length ?? 0),
+              )}
+            </div>
+
+            <div className="mt-5 grid gap-4 xl:grid-cols-2">
+              <div className="rounded border border-border bg-paper/70 p-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-[10px] uppercase tracking-[0.24em] text-muted">
+                      Handoff summary
+                    </p>
+                    <h3 className="mt-2 text-sm font-medium text-ink">
+                      {latestHandoff?.summary ?? "No bounded execution handoff prepared yet."}
+                    </h3>
+                  </div>
+                  <div className="flex gap-2">
+                    {renderBadge(latestHandoff?.status ?? null)}
+                    {renderBadge(latestHandoff?.targetMode ?? null)}
+                  </div>
+                </div>
+                <div className="mt-4 grid gap-3 sm:grid-cols-3">
+                  {summaryItem("Passed checks", String(handoffCheckCounts.pass))}
+                  {summaryItem("Blocked checks", String(handoffCheckCounts.blocked))}
+                  {summaryItem(
+                    "Human gates",
+                    String(handoffCheckCounts.human),
+                  )}
+                </div>
+                <div className="mt-4 space-y-3">
+                  {readRecordArray(latestHandoff?.checks).length === 0 ? (
+                    <p className="text-sm text-muted">
+                      Prepare a bounded handoff to surface checks and actions.
+                    </p>
+                  ) : (
+                    readRecordArray(latestHandoff?.checks).map((check) => (
+                      <div
+                        key={`${readString(check.checkId) ?? "check"}-${readString(check.status) ?? "status"}`}
+                        className="rounded border border-border bg-surface/80 p-3"
+                      >
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <p className="text-sm font-medium text-ink">
+                            {readString(check.checkId) ?? "check"}
+                          </p>
+                          {renderBadge(readString(check.status))}
+                        </div>
+                        <p className="mt-2 text-xs text-muted">
+                          {readString(check.message) ?? "No message"}
+                        </p>
+                      </div>
+                    ))
+                  )}
+                </div>
+              </div>
+
+              <div className="rounded border border-border bg-paper/70 p-4">
+                <p className="text-[10px] uppercase tracking-[0.24em] text-muted">
+                  Bindings and control timeline
+                </p>
+                <div
+                  className="mt-3 space-y-3"
+                  data-testid="strategy-desk-handoff-bindings"
+                >
+                  {readRecordArray(latestHandoff?.bindings).length === 0 ? (
+                    <p className="text-sm text-muted">
+                      No bindings materialized yet.
+                    </p>
+                  ) : (
+                    readRecordArray(latestHandoff?.bindings).map((binding) => (
+                      <div
+                        key={
+                          readString(binding.bindingId) ??
+                          `${readString(binding.venueKey) ?? "binding"}-${readString(binding.instrumentId) ?? readString(isRecord(binding.pair) ? binding.pair.symbol : null) ?? "target"}`
+                        }
+                        className="rounded border border-border bg-surface/80 p-3"
+                      >
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <p className="text-sm font-medium text-ink">
+                            {readString(binding.bindingId) ?? "binding"}
+                          </p>
+                          <div className="flex gap-2">
+                            {renderBadge(readString(binding.bindingKind))}
+                            {renderBadge(readString(binding.targetMode))}
+                          </div>
+                        </div>
+                        <p className="mt-2 text-xs text-muted">
+                          {readString(binding.venueKey) ?? "venue"} ·{" "}
+                          {readString(binding.instrumentId) ??
+                            readString(isRecord(binding.pair) ? binding.pair.symbol : null) ??
+                            "pair"}
+                        </p>
+                      </div>
+                    ))
+                  )}
+                  {snapshot?.handoffEvents.length ? (
+                    <div className="rounded border border-border bg-surface/80 p-3">
+                      <p className="text-[10px] uppercase tracking-[0.24em] text-muted">
+                        Timeline
+                      </p>
+                      <div className="mt-2 space-y-2">
+                        {snapshot.handoffEvents.map((event) => (
+                          <div
+                            className="rounded border border-border/60 bg-paper/60 p-2"
+                            key={event.eventId}
+                          >
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                              <p className="text-xs font-medium text-ink">
+                                {event.eventType}
+                              </p>
+                              <p className="text-[11px] text-muted">
+                                {formatTick(event.createdAt)}
+                              </p>
+                            </div>
+                            <p className="mt-1 text-xs text-muted">
+                              {event.summary}
+                            </p>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
               </div>
             </div>
           </article>

--- a/apps/portal/app/terminal/strategy-desk/types.ts
+++ b/apps/portal/app/terminal/strategy-desk/types.ts
@@ -22,6 +22,7 @@ export type StrategyDeskApiPayload = {
     runs: RuntimeStrategyDeskScenarioRun[];
     reports: RuntimeStrategyDeskScenarioReport[];
     handoffs: RuntimeStrategyDeskPromotionHandoff[];
+    activeHandoff: RuntimeStrategyDeskPromotionHandoff | null;
     latestHandoff: RuntimeStrategyDeskPromotionHandoff | null;
     handoffEvents: RuntimeStrategyDeskPromotionHandoffEvent[];
     executionRecipes: RuntimeStrategyDeskExecutionRecipe[];
@@ -29,6 +30,75 @@ export type StrategyDeskApiPayload = {
     latestReport: RuntimeStrategyDeskScenarioReport | null;
   };
 };
+
+export type StrategyDeskTransitionHandoffAction =
+  | "submit"
+  | "approve"
+  | "reject"
+  | "apply"
+  | "pause"
+  | "kill"
+  | "demote"
+  | "archive";
+
+function hasHandoffStatus(
+  handoff: RuntimeStrategyDeskPromotionHandoff | null | undefined,
+  statuses: readonly string[],
+): handoff is RuntimeStrategyDeskPromotionHandoff {
+  return Boolean(handoff && statuses.includes(handoff.status));
+}
+
+export function selectStrategyDeskHandoffForAction(
+  snapshot: StrategyDeskApiPayload["snapshot"] | null | undefined,
+  action: StrategyDeskTransitionHandoffAction,
+): RuntimeStrategyDeskPromotionHandoff | null {
+  const activeHandoff = snapshot?.activeHandoff ?? null;
+  const latestHandoff = snapshot?.latestHandoff ?? null;
+
+  switch (action) {
+    case "submit":
+      return hasHandoffStatus(latestHandoff, ["draft"]) ? latestHandoff : null;
+    case "approve":
+    case "reject":
+      if (hasHandoffStatus(activeHandoff, ["awaiting_review"])) {
+        return activeHandoff;
+      }
+      return hasHandoffStatus(latestHandoff, ["awaiting_review"])
+        ? latestHandoff
+        : null;
+    case "apply":
+      if (hasHandoffStatus(activeHandoff, ["approved"])) {
+        return activeHandoff;
+      }
+      return hasHandoffStatus(latestHandoff, ["approved"])
+        ? latestHandoff
+        : null;
+    case "pause":
+    case "kill":
+      return hasHandoffStatus(activeHandoff, ["applied"])
+        ? activeHandoff
+        : null;
+    case "demote":
+      if (hasHandoffStatus(activeHandoff, ["approved", "applied"])) {
+        return activeHandoff;
+      }
+      return hasHandoffStatus(latestHandoff, ["approved", "applied"])
+        ? latestHandoff
+        : null;
+    case "archive":
+      return latestHandoff ?? activeHandoff;
+    default: {
+      const exhaustiveCheck: never = action;
+      return exhaustiveCheck;
+    }
+  }
+}
+
+export function selectStrategyDeskFocusHandoff(
+  snapshot: StrategyDeskApiPayload["snapshot"] | null | undefined,
+): RuntimeStrategyDeskPromotionHandoff | null {
+  return snapshot?.activeHandoff ?? snapshot?.latestHandoff ?? null;
+}
 
 export type StrategyDeskMutationResult = {
   ok: boolean;

--- a/apps/portal/app/terminal/strategy-desk/types.ts
+++ b/apps/portal/app/terminal/strategy-desk/types.ts
@@ -1,4 +1,7 @@
 import type {
+  RuntimeStrategyDeskExecutionRecipe,
+  RuntimeStrategyDeskPromotionHandoff,
+  RuntimeStrategyDeskPromotionHandoffEvent,
   RuntimeStrategyDeskScenarioManifest,
   RuntimeStrategyDeskScenarioReport,
   RuntimeStrategyDeskScenarioRun,
@@ -18,6 +21,10 @@ export type StrategyDeskApiPayload = {
     selectedScenario: RuntimeStrategyDeskScenarioManifest | null;
     runs: RuntimeStrategyDeskScenarioRun[];
     reports: RuntimeStrategyDeskScenarioReport[];
+    handoffs: RuntimeStrategyDeskPromotionHandoff[];
+    latestHandoff: RuntimeStrategyDeskPromotionHandoff | null;
+    handoffEvents: RuntimeStrategyDeskPromotionHandoffEvent[];
+    executionRecipes: RuntimeStrategyDeskExecutionRecipe[];
     latestRun: RuntimeStrategyDeskScenarioRun | null;
     latestReport: RuntimeStrategyDeskScenarioReport | null;
   };
@@ -28,5 +35,8 @@ export type StrategyDeskMutationResult = {
   scenario?: RuntimeStrategyDeskScenarioManifest;
   run?: RuntimeStrategyDeskScenarioRun;
   report?: RuntimeStrategyDeskScenarioReport;
+  handoff?: RuntimeStrategyDeskPromotionHandoff;
+  events?: RuntimeStrategyDeskPromotionHandoffEvent[];
+  executionRecipes?: RuntimeStrategyDeskExecutionRecipe[];
   error?: string;
 };

--- a/apps/portal/lib/runtime-strategy-desk.ts
+++ b/apps/portal/lib/runtime-strategy-desk.ts
@@ -389,7 +389,14 @@ export function safeParseRuntimeStrategyDeskPromotionHandoffEvent(
   const actor = readString(value.actor);
   const summary = readString(value.summary);
   const createdAt = readString(value.createdAt);
-  if (!eventId || !handoffId || !eventType || !actor || !summary || !createdAt) {
+  if (
+    !eventId ||
+    !handoffId ||
+    !eventType ||
+    !actor ||
+    !summary ||
+    !createdAt
+  ) {
     return fail("strategy-desk-handoff-event-invalid");
   }
   return {
@@ -411,7 +418,8 @@ export function safeParseRuntimeStrategyDeskPromotionHandoffEvent(
 export function safeParseRuntimeStrategyDeskExecutionRecipe(
   value: unknown,
 ): ParseResult<RuntimeStrategyDeskExecutionRecipe> {
-  if (!isRecord(value)) return fail("strategy-desk-execution-recipe-not-object");
+  if (!isRecord(value))
+    return fail("strategy-desk-execution-recipe-not-object");
   const recipeId = readString(value.recipeId);
   const scenarioId = readString(value.scenarioId);
   const handoffId = readString(value.handoffId);

--- a/apps/portal/lib/runtime-strategy-desk.ts
+++ b/apps/portal/lib/runtime-strategy-desk.ts
@@ -79,6 +79,59 @@ export type RuntimeStrategyDeskScenarioReport = {
   metadata?: Record<string, unknown>;
 };
 
+export type RuntimeStrategyDeskPromotionHandoff = {
+  schemaVersion?: string;
+  handoffId: string;
+  scenarioId: string;
+  currentState: string;
+  targetMode: string;
+  status: string;
+  summary: string;
+  requestedBy: string;
+  createdAt: string;
+  updatedAt: string;
+  appliedAt?: string;
+  implementationReference?: Record<string, unknown>;
+  evidenceRefs: readonly Record<string, unknown>[];
+  checks: readonly Record<string, unknown>[];
+  approvals: readonly Record<string, unknown>[];
+  bindings: readonly Record<string, unknown>[];
+  actions: readonly Record<string, unknown>[];
+  metadata?: Record<string, unknown>;
+};
+
+export type RuntimeStrategyDeskPromotionHandoffEvent = {
+  eventId: string;
+  handoffId: string;
+  eventType: string;
+  actor: string;
+  fromStatus?: string;
+  toStatus?: string;
+  summary: string;
+  details?: Record<string, unknown>;
+  createdAt: string;
+};
+
+export type RuntimeStrategyDeskExecutionRecipe = {
+  recipeId: string;
+  scenarioId: string;
+  handoffId: string;
+  bindingId: string;
+  schemaVersion?: string;
+  status: string;
+  venueKey: string;
+  instrumentId?: string;
+  pair?: Record<string, unknown>;
+  targetMode: string;
+  lane?: string;
+  legIds: readonly string[];
+  budget?: Record<string, unknown>;
+  notes?: string;
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+};
+
 type ParseSuccess<T> = {
   success: true;
   data: T;
@@ -269,6 +322,138 @@ export function safeParseRuntimeStrategyDeskScenarioRun(
       failureCode: readOptionalString(value.failureCode),
       failureMessage: readOptionalString(value.failureMessage),
       metadata: isRecord(value.metadata) ? value.metadata : undefined,
+    },
+  };
+}
+
+export function safeParseRuntimeStrategyDeskPromotionHandoff(
+  value: unknown,
+): ParseResult<RuntimeStrategyDeskPromotionHandoff> {
+  if (!isRecord(value)) return fail("strategy-desk-handoff-not-object");
+  const handoffId = readString(value.handoffId);
+  const scenarioId = readString(value.scenarioId);
+  const currentState = readString(value.currentState);
+  const targetMode = readString(value.targetMode);
+  const status = readString(value.status);
+  const summary = readString(value.summary);
+  const requestedBy = readString(value.requestedBy);
+  const createdAt = readString(value.createdAt);
+  const updatedAt = readString(value.updatedAt);
+  if (
+    !handoffId ||
+    !scenarioId ||
+    !currentState ||
+    !targetMode ||
+    !status ||
+    !summary ||
+    !requestedBy ||
+    !createdAt ||
+    !updatedAt
+  ) {
+    return fail("strategy-desk-handoff-invalid");
+  }
+  return {
+    success: true,
+    data: {
+      handoffId,
+      schemaVersion: readOptionalString(value.schemaVersion),
+      scenarioId,
+      currentState,
+      targetMode,
+      status,
+      summary,
+      requestedBy,
+      createdAt,
+      updatedAt,
+      appliedAt: readOptionalString(value.appliedAt),
+      implementationReference: isRecord(value.implementationReference)
+        ? value.implementationReference
+        : undefined,
+      evidenceRefs: readRecordArray(value.evidenceRefs),
+      checks: readRecordArray(value.checks),
+      approvals: readRecordArray(value.approvals),
+      bindings: readRecordArray(value.bindings),
+      actions: readRecordArray(value.actions),
+      metadata: isRecord(value.metadata) ? value.metadata : undefined,
+    },
+  };
+}
+
+export function safeParseRuntimeStrategyDeskPromotionHandoffEvent(
+  value: unknown,
+): ParseResult<RuntimeStrategyDeskPromotionHandoffEvent> {
+  if (!isRecord(value)) return fail("strategy-desk-handoff-event-not-object");
+  const eventId = readString(value.eventId);
+  const handoffId = readString(value.handoffId);
+  const eventType = readString(value.eventType);
+  const actor = readString(value.actor);
+  const summary = readString(value.summary);
+  const createdAt = readString(value.createdAt);
+  if (!eventId || !handoffId || !eventType || !actor || !summary || !createdAt) {
+    return fail("strategy-desk-handoff-event-invalid");
+  }
+  return {
+    success: true,
+    data: {
+      eventId,
+      handoffId,
+      eventType,
+      actor,
+      fromStatus: readOptionalString(value.fromStatus),
+      toStatus: readOptionalString(value.toStatus),
+      summary,
+      details: isRecord(value.details) ? value.details : undefined,
+      createdAt,
+    },
+  };
+}
+
+export function safeParseRuntimeStrategyDeskExecutionRecipe(
+  value: unknown,
+): ParseResult<RuntimeStrategyDeskExecutionRecipe> {
+  if (!isRecord(value)) return fail("strategy-desk-execution-recipe-not-object");
+  const recipeId = readString(value.recipeId);
+  const scenarioId = readString(value.scenarioId);
+  const handoffId = readString(value.handoffId);
+  const bindingId = readString(value.bindingId);
+  const status = readString(value.status);
+  const venueKey = readString(value.venueKey);
+  const targetMode = readString(value.targetMode);
+  const createdAt = readString(value.createdAt);
+  const updatedAt = readString(value.updatedAt);
+  if (
+    !recipeId ||
+    !scenarioId ||
+    !handoffId ||
+    !bindingId ||
+    !status ||
+    !venueKey ||
+    !targetMode ||
+    !createdAt ||
+    !updatedAt
+  ) {
+    return fail("strategy-desk-execution-recipe-invalid");
+  }
+  return {
+    success: true,
+    data: {
+      recipeId,
+      scenarioId,
+      handoffId,
+      bindingId,
+      schemaVersion: readOptionalString(value.schemaVersion),
+      status,
+      venueKey,
+      instrumentId: readOptionalString(value.instrumentId),
+      pair: isRecord(value.pair) ? value.pair : undefined,
+      targetMode,
+      lane: readOptionalString(value.lane),
+      legIds: readStringArray(value.legIds),
+      budget: isRecord(value.budget) ? value.budget : undefined,
+      notes: readOptionalString(value.notes),
+      metadata: isRecord(value.metadata) ? value.metadata : undefined,
+      createdAt,
+      updatedAt,
     },
   };
 }

--- a/apps/worker/migrations/0035_strategy_desk_promotion_handoffs.sql
+++ b/apps/worker/migrations/0035_strategy_desk_promotion_handoffs.sql
@@ -1,0 +1,74 @@
+CREATE TABLE IF NOT EXISTS strategy_desk_promotion_handoffs (
+  handoff_id TEXT PRIMARY KEY,
+  scenario_id TEXT NOT NULL,
+  schema_version TEXT NOT NULL,
+  current_state TEXT NOT NULL,
+  target_mode TEXT NOT NULL,
+  status TEXT NOT NULL,
+  summary TEXT NOT NULL,
+  requested_by TEXT NOT NULL,
+  implementation_reference_json TEXT,
+  evidence_refs_json TEXT NOT NULL,
+  checks_json TEXT NOT NULL,
+  approvals_json TEXT NOT NULL,
+  bindings_json TEXT NOT NULL,
+  actions_json TEXT NOT NULL,
+  metadata_json TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  applied_at TEXT,
+  FOREIGN KEY (scenario_id) REFERENCES strategy_desk_scenarios(scenario_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_desk_promotion_handoffs_scenario
+ON strategy_desk_promotion_handoffs(scenario_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_desk_promotion_handoffs_status
+ON strategy_desk_promotion_handoffs(status, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS strategy_desk_promotion_handoff_events (
+  event_id TEXT PRIMARY KEY,
+  handoff_id TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  actor TEXT NOT NULL,
+  from_status TEXT,
+  to_status TEXT,
+  summary TEXT NOT NULL,
+  details_json TEXT,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY (handoff_id) REFERENCES strategy_desk_promotion_handoffs(handoff_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_desk_promotion_handoff_events_handoff
+ON strategy_desk_promotion_handoff_events(handoff_id, created_at ASC);
+
+CREATE TABLE IF NOT EXISTS strategy_desk_execution_recipes (
+  recipe_id TEXT PRIMARY KEY,
+  scenario_id TEXT NOT NULL,
+  handoff_id TEXT NOT NULL,
+  binding_id TEXT NOT NULL,
+  schema_version TEXT NOT NULL DEFAULT 'v1',
+  status TEXT NOT NULL,
+  venue_key TEXT NOT NULL,
+  instrument_id TEXT,
+  pair_json TEXT,
+  target_mode TEXT NOT NULL,
+  lane TEXT,
+  leg_ids_json TEXT NOT NULL,
+  budget_json TEXT,
+  notes TEXT,
+  metadata_json TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY (scenario_id) REFERENCES strategy_desk_scenarios(scenario_id) ON DELETE CASCADE,
+  FOREIGN KEY (handoff_id) REFERENCES strategy_desk_promotion_handoffs(handoff_id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_strategy_desk_execution_recipes_binding
+ON strategy_desk_execution_recipes(handoff_id, binding_id);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_desk_execution_recipes_scenario
+ON strategy_desk_execution_recipes(scenario_id, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_desk_execution_recipes_status
+ON strategy_desk_execution_recipes(status, updated_at DESC);

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -751,7 +751,8 @@ function parseRuntimeStrategyDeskPrepareHandoffRequest(payload: unknown): {
   }
   const record = payload as Record<string, unknown>;
   const requestedBy = String(record.requestedBy ?? "").trim();
-  const targetMode = record.targetMode === "limited_live" ? "limited_live" : undefined;
+  const targetMode =
+    record.targetMode === "limited_live" ? "limited_live" : undefined;
   if (!requestedBy) {
     throw new Error("runtime-strategy-desk-handoff-prepare-invalid-body");
   }
@@ -4384,12 +4385,11 @@ const worker = {
           const handoff = parseRuntimeStrategyDeskPromotionHandoff(
             await request.json(),
           );
-          const result = await upsertRuntimeStrategyDeskPromotionHandoffWorkflow(
-            {
+          const result =
+            await upsertRuntimeStrategyDeskPromotionHandoffWorkflow({
               env,
               handoff,
-            },
-          );
+            });
           return withCors(
             json({
               ok: true,
@@ -4427,15 +4427,17 @@ const worker = {
         }
         try {
           const limitRaw = Number(url.searchParams.get("limit"));
-          const result = await listRuntimeStrategyDeskPromotionHandoffsWorkflow({
-            env,
-            handoffId: url.searchParams.get("handoffId") ?? undefined,
-            scenarioId: url.searchParams.get("scenarioId") ?? undefined,
-            status: url.searchParams.get("status") ?? undefined,
-            ...(Number.isFinite(limitRaw) && limitRaw > 0
-              ? { limit: Math.trunc(limitRaw) }
-              : {}),
-          });
+          const result = await listRuntimeStrategyDeskPromotionHandoffsWorkflow(
+            {
+              env,
+              handoffId: url.searchParams.get("handoffId") ?? undefined,
+              scenarioId: url.searchParams.get("scenarioId") ?? undefined,
+              status: url.searchParams.get("status") ?? undefined,
+              ...(Number.isFinite(limitRaw) && limitRaw > 0
+                ? { limit: Math.trunc(limitRaw) }
+                : {}),
+            },
+          );
           return withCors(
             json({
               ok: true,

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  parseRuntimeStrategyDeskPromotionHandoff,
   parseRuntimeStrategyDeskScenarioManifest,
   parseRuntimeStrategyDeskScenarioReport,
   parseRuntimeStrategyDeskScenarioRun,
@@ -231,6 +232,13 @@ import {
   upsertRuntimeStrategyDeskScenarioRunWorkflow,
   upsertRuntimeStrategyDeskScenarioWorkflow,
 } from "./runtime_strategy_desk";
+import {
+  getRuntimeStrategyDeskPromotionHandoffWorkflow,
+  listRuntimeStrategyDeskPromotionHandoffsWorkflow,
+  prepareRuntimeStrategyDeskPromotionHandoffWorkflow,
+  transitionRuntimeStrategyDeskPromotionHandoffWorkflow,
+  upsertRuntimeStrategyDeskPromotionHandoffWorkflow,
+} from "./runtime_strategy_desk_promotion";
 import { executeRuntimeStrategyDeskScenarioWorkflow } from "./runtime_strategy_desk_runner";
 import { executeRuntimeStrategyDeskStudyWorkflow } from "./runtime_strategy_desk_study";
 import { SolanaRpc } from "./solana_rpc";
@@ -731,6 +739,65 @@ function parseRuntimeStrategyDeskStudyRequest(payload: unknown): {
     ...(readStringArray(record.windowIds)
       ? { windowIds: readStringArray(record.windowIds) }
       : {}),
+  };
+}
+
+function parseRuntimeStrategyDeskPrepareHandoffRequest(payload: unknown): {
+  requestedBy: string;
+  targetMode?: "limited_live";
+} {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("runtime-strategy-desk-handoff-prepare-invalid-body");
+  }
+  const record = payload as Record<string, unknown>;
+  const requestedBy = String(record.requestedBy ?? "").trim();
+  const targetMode = record.targetMode === "limited_live" ? "limited_live" : undefined;
+  if (!requestedBy) {
+    throw new Error("runtime-strategy-desk-handoff-prepare-invalid-body");
+  }
+  return {
+    requestedBy,
+    ...(targetMode ? { targetMode } : {}),
+  };
+}
+
+function parseRuntimeStrategyDeskTransitionHandoffRequest(payload: unknown): {
+  action:
+    | "submit"
+    | "approve"
+    | "reject"
+    | "apply"
+    | "pause"
+    | "kill"
+    | "demote"
+    | "archive";
+  actor: string;
+  notes?: string;
+} {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("runtime-strategy-desk-handoff-transition-invalid-body");
+  }
+  const record = payload as Record<string, unknown>;
+  const action =
+    record.action === "submit" ||
+    record.action === "approve" ||
+    record.action === "reject" ||
+    record.action === "apply" ||
+    record.action === "pause" ||
+    record.action === "kill" ||
+    record.action === "demote" ||
+    record.action === "archive"
+      ? record.action
+      : null;
+  const actor = String(record.actor ?? "").trim();
+  const notes = String(record.notes ?? "").trim();
+  if (!action || !actor) {
+    throw new Error("runtime-strategy-desk-handoff-transition-invalid-body");
+  }
+  return {
+    action,
+    actor,
+    ...(notes ? { notes } : {}),
   };
 }
 
@@ -4048,6 +4115,59 @@ const worker = {
         }
       }
 
+      const strategyDeskPrepareHandoffScenarioId =
+        request.method === "POST"
+          ? parseAdminEntityActionPath(
+              url.pathname,
+              "/api/admin/ops/runtime/strategy-desk/scenarios/",
+              "/handoffs/prepare",
+            )
+          : null;
+      if (request.method === "POST" && strategyDeskPrepareHandoffScenarioId) {
+        const auth = authorizeAdminRoute(request, env);
+        if (!auth.ok) {
+          return withCors(
+            json({ ok: false, error: auth.error }, { status: auth.status }),
+            env,
+          );
+        }
+        try {
+          const parsed = parseRuntimeStrategyDeskPrepareHandoffRequest(
+            await request.json(),
+          );
+          const result =
+            await prepareRuntimeStrategyDeskPromotionHandoffWorkflow({
+              env,
+              scenarioId: strategyDeskPrepareHandoffScenarioId,
+              ...parsed,
+            });
+          return withCors(
+            json({
+              ok: true,
+              scenario: result.scenario,
+              handoff: result.handoff,
+              events: result.events,
+              executionRecipes: result.executionRecipes,
+            }),
+            env,
+          );
+        } catch (error) {
+          return withCors(
+            json(
+              {
+                ok: false,
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "runtime-strategy-desk-handoff-prepare-failed",
+              },
+              { status: 400 },
+            ),
+            env,
+          );
+        }
+      }
+
       if (
         request.method === "POST" &&
         url.pathname === "/api/admin/ops/runtime/strategy-desk/scenarios"
@@ -4142,6 +4262,196 @@ const worker = {
                   error instanceof Error
                     ? error.message
                     : "runtime-strategy-desk-scenario-list-failed",
+              },
+              { status: 400 },
+            ),
+            env,
+          );
+        }
+      }
+
+      const strategyDeskHandoffId =
+        request.method === "GET"
+          ? parseAdminEntityDetailPath(
+              url.pathname,
+              "/api/admin/ops/runtime/strategy-desk/handoffs/",
+            )
+          : null;
+      if (request.method === "GET" && strategyDeskHandoffId) {
+        const auth = authorizeAdminRoute(request, env);
+        if (!auth.ok) {
+          return withCors(
+            json({ ok: false, error: auth.error }, { status: auth.status }),
+            env,
+          );
+        }
+        try {
+          const result = await getRuntimeStrategyDeskPromotionHandoffWorkflow({
+            env,
+            handoffId: strategyDeskHandoffId,
+          });
+          return withCors(
+            json({
+              ok: true,
+              handoff: result.handoff,
+              events: result.events,
+              executionRecipes: result.executionRecipes,
+            }),
+            env,
+          );
+        } catch (error) {
+          return withCors(
+            json(
+              {
+                ok: false,
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "runtime-strategy-desk-handoff-read-failed",
+              },
+              { status: 400 },
+            ),
+            env,
+          );
+        }
+      }
+
+      const strategyDeskTransitionHandoffId =
+        request.method === "POST"
+          ? parseAdminEntityActionPath(
+              url.pathname,
+              "/api/admin/ops/runtime/strategy-desk/handoffs/",
+              "/transition",
+            )
+          : null;
+      if (request.method === "POST" && strategyDeskTransitionHandoffId) {
+        const auth = authorizeAdminRoute(request, env);
+        if (!auth.ok) {
+          return withCors(
+            json({ ok: false, error: auth.error }, { status: auth.status }),
+            env,
+          );
+        }
+        try {
+          const parsed = parseRuntimeStrategyDeskTransitionHandoffRequest(
+            await request.json(),
+          );
+          const result =
+            await transitionRuntimeStrategyDeskPromotionHandoffWorkflow({
+              env,
+              handoffId: strategyDeskTransitionHandoffId,
+              ...parsed,
+            });
+          return withCors(
+            json({
+              ok: true,
+              scenario: result.scenario,
+              handoff: result.handoff,
+              events: result.events,
+              executionRecipes: result.executionRecipes,
+            }),
+            env,
+          );
+        } catch (error) {
+          return withCors(
+            json(
+              {
+                ok: false,
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "runtime-strategy-desk-handoff-transition-failed",
+              },
+              { status: 400 },
+            ),
+            env,
+          );
+        }
+      }
+
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/admin/ops/runtime/strategy-desk/handoffs"
+      ) {
+        const auth = authorizeAdminRoute(request, env);
+        if (!auth.ok) {
+          return withCors(
+            json({ ok: false, error: auth.error }, { status: auth.status }),
+            env,
+          );
+        }
+        try {
+          const handoff = parseRuntimeStrategyDeskPromotionHandoff(
+            await request.json(),
+          );
+          const result = await upsertRuntimeStrategyDeskPromotionHandoffWorkflow(
+            {
+              env,
+              handoff,
+            },
+          );
+          return withCors(
+            json({
+              ok: true,
+              handoff: result.handoff,
+            }),
+            env,
+          );
+        } catch (error) {
+          return withCors(
+            json(
+              {
+                ok: false,
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "runtime-strategy-desk-handoff-upsert-failed",
+              },
+              { status: 400 },
+            ),
+            env,
+          );
+        }
+      }
+
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/admin/ops/runtime/strategy-desk/handoffs"
+      ) {
+        const auth = authorizeAdminRoute(request, env);
+        if (!auth.ok) {
+          return withCors(
+            json({ ok: false, error: auth.error }, { status: auth.status }),
+            env,
+          );
+        }
+        try {
+          const limitRaw = Number(url.searchParams.get("limit"));
+          const result = await listRuntimeStrategyDeskPromotionHandoffsWorkflow({
+            env,
+            handoffId: url.searchParams.get("handoffId") ?? undefined,
+            scenarioId: url.searchParams.get("scenarioId") ?? undefined,
+            status: url.searchParams.get("status") ?? undefined,
+            ...(Number.isFinite(limitRaw) && limitRaw > 0
+              ? { limit: Math.trunc(limitRaw) }
+              : {}),
+          });
+          return withCors(
+            json({
+              ok: true,
+              handoffs: result.handoffs,
+            }),
+            env,
+          );
+        } catch (error) {
+          return withCors(
+            json(
+              {
+                ok: false,
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "runtime-strategy-desk-handoff-list-failed",
               },
               { status: 400 },
             ),

--- a/apps/worker/src/runtime_strategy_desk_promotion.ts
+++ b/apps/worker/src/runtime_strategy_desk_promotion.ts
@@ -712,6 +712,7 @@ async function applyControlToMaterializedObjects(input: {
 function buildStrategyLabPromotionArtifacts(input: {
   scenario: RuntimeStrategyDeskScenarioManifest;
   handoff: RuntimeStrategyDeskPromotionHandoff;
+  actor: string;
   now: string;
 }) {
   const deploymentId =
@@ -728,7 +729,7 @@ function buildStrategyLabPromotionArtifacts(input: {
     transitionType: "promote",
     status: "applied",
     summary: input.handoff.summary,
-    requestedBy: input.handoff.requestedBy,
+    requestedBy: input.actor,
     createdAt: input.handoff.createdAt,
     updatedAt: input.now,
     appliedAt: input.now,
@@ -750,6 +751,7 @@ function buildStrategyLabPromotionArtifacts(input: {
       source: "strategy_desk_handoff",
       scenarioId: input.scenario.scenarioId,
       handoffId: input.handoff.handoffId,
+      handoffRequestedBy: input.handoff.requestedBy,
     },
   });
   const event = parseRuntimeStrategyLabPromotionEvent({
@@ -757,7 +759,7 @@ function buildStrategyLabPromotionArtifacts(input: {
     eventId: createDeskId("promoevt"),
     promotionId,
     eventType: "applied",
-    actor: input.handoff.requestedBy,
+    actor: input.actor,
     fromState: "paper",
     toState: "limited_live",
     summary: "Strategy desk bounded execution handoff applied.",
@@ -1030,6 +1032,11 @@ export async function transitionRuntimeStrategyDeskPromotionHandoffWorkflow(
       break;
     }
     case "apply": {
+      if (handoff.status === "applied") {
+        throw new Error(
+          `runtime-strategy-desk-handoff-already-applied:${handoff.handoffId}`,
+        );
+      }
       if (handoff.approvals.length === 0 && nextApprovals.length === 0) {
         throw new Error(
           "runtime-strategy-desk-handoff-human-approval-required",
@@ -1067,6 +1074,7 @@ export async function transitionRuntimeStrategyDeskPromotionHandoffWorkflow(
           status: "applied",
           appliedAt: now,
         },
+        actor: input.actor,
         now,
       });
       await writeStrategyLabPromotion(input.env.WAITLIST_DB, promotion);

--- a/apps/worker/src/runtime_strategy_desk_promotion.ts
+++ b/apps/worker/src/runtime_strategy_desk_promotion.ts
@@ -532,6 +532,19 @@ function assertHandoffStateTransition(
   }
 }
 
+function assertScenarioActiveHandoff(
+  scenario: RuntimeStrategyDeskScenarioManifest,
+  handoff: RuntimeStrategyDeskPromotionHandoff,
+  action: "apply" | "pause" | "kill" | "demote",
+): void {
+  if (scenario.activeHandoffId === handoff.handoffId) {
+    return;
+  }
+  throw new Error(
+    `runtime-strategy-desk-handoff-not-active:${action}:${scenario.activeHandoffId ?? "none"}`,
+  );
+}
+
 function subjectControlKeyForBinding(
   scenario: RuntimeStrategyDeskScenarioManifest,
   binding: StrategyDeskPromotionBinding,
@@ -1074,6 +1087,7 @@ export async function transitionRuntimeStrategyDeskPromotionHandoffWorkflow(
           `runtime-strategy-desk-handoff-already-applied:${handoff.handoffId}`,
         );
       }
+      assertScenarioActiveHandoff(scenario, handoff, "apply");
       assertNoBlockedChecks(handoff);
       if (handoff.approvals.length === 0 && nextApprovals.length === 0) {
         throw new Error(
@@ -1128,6 +1142,7 @@ export async function transitionRuntimeStrategyDeskPromotionHandoffWorkflow(
           `runtime-strategy-desk-handoff-control-not-applied:${handoff.status}`,
         );
       }
+      assertScenarioActiveHandoff(scenario, handoff, "pause");
       assertScenarioStateTransition(scenario, "paused");
       await applyControlToMaterializedObjects({
         env: input.env,
@@ -1150,6 +1165,7 @@ export async function transitionRuntimeStrategyDeskPromotionHandoffWorkflow(
           `runtime-strategy-desk-handoff-control-not-applied:${handoff.status}`,
         );
       }
+      assertScenarioActiveHandoff(scenario, handoff, "kill");
       assertScenarioStateTransition(scenario, "paused");
       await applyControlToMaterializedObjects({
         env: input.env,
@@ -1172,6 +1188,7 @@ export async function transitionRuntimeStrategyDeskPromotionHandoffWorkflow(
           `runtime-strategy-desk-handoff-demote-not-ready:${handoff.status}`,
         );
       }
+      assertScenarioActiveHandoff(scenario, handoff, "demote");
       assertScenarioStateTransition(scenario, "paper_ready");
       if (handoff.status === "applied") {
         await applyControlToMaterializedObjects({

--- a/apps/worker/src/runtime_strategy_desk_promotion.ts
+++ b/apps/worker/src/runtime_strategy_desk_promotion.ts
@@ -6,6 +6,32 @@ import {
   parseRuntimeStrategyLabPromotionEvent,
   parseRuntimeStrategyLabPromotionRecord,
 } from "../../../src/runtime/contracts/autonomous_runtime.js";
+import type {
+  RuntimeStrategyDeskPromotionHandoff,
+  RuntimeStrategyDeskScenarioLeg,
+  RuntimeStrategyDeskScenarioManifest,
+} from "./runtime_contracts";
+import {
+  applyRuntimeDeploymentControl,
+  upsertRuntimeDeployment,
+} from "./runtime_internal";
+import {
+  getRuntimeStrategyDeskScenarioReportWorkflow,
+  getRuntimeStrategyDeskScenarioWorkflow,
+} from "./runtime_strategy_desk";
+import {
+  appendStrategyDeskPromotionHandoffEvent,
+  getStrategyDeskExecutionRecipeForBinding,
+  getStrategyDeskPromotionHandoff,
+  listStrategyDeskExecutionRecipes,
+  listStrategyDeskPromotionHandoffEvents,
+  listStrategyDeskPromotionHandoffs,
+  type StrategyDeskExecutionRecipeRecord,
+  type StrategyDeskPromotionHandoffEvent,
+  writeStrategyDeskExecutionRecipe,
+  writeStrategyDeskPromotionHandoff,
+} from "./strategy_desk_handoff_repository";
+import { updateStrategyDeskScenarioReviewState } from "./strategy_desk_repository";
 import {
   appendStrategyLabPromotionEvent,
   writeStrategyLabPromotion,
@@ -14,34 +40,6 @@ import {
   getStrategyLabSubjectControl,
   writeStrategyLabSubjectControl,
 } from "./strategy_lab_readiness_repository";
-import {
-  applyRuntimeDeploymentControl,
-  upsertRuntimeDeployment,
-} from "./runtime_internal";
-import type {
-  RuntimeStrategyDeskPromotionHandoff,
-  RuntimeStrategyDeskScenarioLeg,
-  RuntimeStrategyDeskScenarioManifest,
-} from "./runtime_contracts";
-import {
-  getRuntimeStrategyDeskScenarioReportWorkflow,
-  getRuntimeStrategyDeskScenarioWorkflow,
-} from "./runtime_strategy_desk";
-import {
-  StrategyDeskExecutionRecipeRecord,
-  StrategyDeskPromotionHandoffEvent,
-  appendStrategyDeskPromotionHandoffEvent,
-  getStrategyDeskExecutionRecipeForBinding,
-  getStrategyDeskPromotionHandoff,
-  listStrategyDeskExecutionRecipes,
-  listStrategyDeskPromotionHandoffEvents,
-  listStrategyDeskPromotionHandoffs,
-  writeStrategyDeskExecutionRecipe,
-  writeStrategyDeskPromotionHandoff,
-} from "./strategy_desk_handoff_repository";
-import {
-  updateStrategyDeskScenarioReviewState,
-} from "./strategy_desk_repository";
 import type { Env } from "./types";
 
 type StrategyDeskPrepareTargetMode = "limited_live";
@@ -123,7 +121,10 @@ function summarizeLabels(labels: string[]): string {
 }
 
 function legAllowsLimitedLive(leg: RuntimeStrategyDeskScenarioLeg): boolean {
-  return leg.enabledModes.includes("live") || leg.enabledModes.includes("limited_live");
+  return (
+    leg.enabledModes.includes("live") ||
+    leg.enabledModes.includes("limited_live")
+  );
 }
 
 function buildBindingForLeg(
@@ -131,7 +132,11 @@ function buildBindingForLeg(
   leg: RuntimeStrategyDeskScenarioLeg,
   targetMode: StrategyDeskPrepareTargetMode,
 ): StrategyDeskPromotionBinding {
-  if (legAllowsLimitedLive(leg) && leg.intentFamily === "spot_swap" && leg.pair) {
+  if (
+    legAllowsLimitedLive(leg) &&
+    leg.intentFamily === "spot_swap" &&
+    leg.pair
+  ) {
     return {
       bindingId: `binding_${leg.legId}_runtime`,
       bindingKind: "runtime_deployment",
@@ -145,7 +150,10 @@ function buildBindingForLeg(
     };
   }
 
-  if (leg.intentFamily === "prediction_order" || leg.marketType === "prediction") {
+  if (
+    leg.intentFamily === "prediction_order" ||
+    leg.marketType === "prediction"
+  ) {
     return {
       bindingId: `binding_${leg.legId}_control`,
       bindingKind: "subject_control",
@@ -165,7 +173,8 @@ function buildBindingForLeg(
     ...(leg.pair ? { pair: leg.pair } : {}),
     ...(leg.instrumentId ? { instrumentId: leg.instrumentId } : {}),
     targetMode: "paper",
-    notes: "Non-spot execution remains desk-managed and paper-bound for the first live arming pass.",
+    notes:
+      "Non-spot execution remains desk-managed and paper-bound for the first live arming pass.",
   };
 }
 
@@ -188,7 +197,9 @@ function buildBudgetForBinding(
   scenario: RuntimeStrategyDeskScenarioManifest,
   binding: StrategyDeskPromotionBinding,
 ): Record<string, unknown> {
-  const legs = scenario.legs.filter((leg) => binding.legIds.includes(leg.legId));
+  const legs = scenario.legs.filter((leg) =>
+    binding.legIds.includes(leg.legId),
+  );
   return {
     targetNotionalUsd: addDecimalStrings(
       legs.map((leg) => stringOrNull(leg.sizing.targetNotionalUsd)),
@@ -226,8 +237,7 @@ function buildRuntimeDeploymentPayload(input: {
     deploymentId: input.binding.deploymentId,
     strategyKey: input.scenario.strategyKey,
     sleeveId:
-      input.scenario.sleeveId ??
-      `desk_sleeve_${input.scenario.scenarioId}`,
+      input.scenario.sleeveId ?? `desk_sleeve_${input.scenario.scenarioId}`,
     ownerUserId: input.scenario.ownerUserId,
     venueKey: input.binding.venueKey,
     pair: input.binding.pair,
@@ -243,7 +253,9 @@ function buildRuntimeDeploymentPayload(input: {
         input.scenario.riskLimits?.maxDrawdownBps
           ? Math.max(
               1,
-              Math.round(Number(input.scenario.riskLimits.maxDrawdownBps) / 100),
+              Math.round(
+                Number(input.scenario.riskLimits.maxDrawdownBps) / 100,
+              ),
             )
           : 10,
       ),
@@ -266,7 +278,9 @@ function buildRuntimeDeploymentPayload(input: {
 }
 
 function flattenEvidenceRefs(
-  report: Awaited<ReturnType<typeof getRuntimeStrategyDeskScenarioReportWorkflow>>["report"],
+  report: Awaited<
+    ReturnType<typeof getRuntimeStrategyDeskScenarioReportWorkflow>
+  >["report"],
 ): RuntimeStrategyDeskPromotionHandoff["evidenceRefs"] {
   const refs: RuntimeStrategyDeskPromotionHandoff["evidenceRefs"] = [
     {
@@ -323,7 +337,9 @@ function readImplementationReference(
 
 function buildChecks(input: {
   scenario: RuntimeStrategyDeskScenarioManifest;
-  report: Awaited<ReturnType<typeof getRuntimeStrategyDeskScenarioReportWorkflow>>["report"];
+  report: Awaited<
+    ReturnType<typeof getRuntimeStrategyDeskScenarioReportWorkflow>
+  >["report"];
   bindings: StrategyDeskPromotionBinding[];
 }): RuntimeStrategyDeskPromotionHandoff["checks"] {
   const liveBindings = input.bindings.filter(
@@ -425,9 +441,23 @@ function buildHandoffSummary(bindings: StrategyDeskPromotionBinding[]): string {
   return `Bound ${summarizeLabels(liveLabels)} to limited live while keeping ${summarizeLabels(paperLabels)} under paper-bound desk controls.`;
 }
 
+function assertNoBlockedChecks(
+  handoff: RuntimeStrategyDeskPromotionHandoff,
+): void {
+  const blockedCheckIds = handoff.checks
+    .filter((check) => check.status === "blocked")
+    .map((check) => check.checkId);
+  if (blockedCheckIds.length === 0) return;
+  throw new Error(
+    `runtime-strategy-desk-handoff-checks-blocked:${handoff.handoffId}:${blockedCheckIds.join(",")}`,
+  );
+}
+
 function buildDefaultHandoff(input: {
   scenario: RuntimeStrategyDeskScenarioManifest;
-  report: Awaited<ReturnType<typeof getRuntimeStrategyDeskScenarioReportWorkflow>>["report"];
+  report: Awaited<
+    ReturnType<typeof getRuntimeStrategyDeskScenarioReportWorkflow>
+  >["report"];
   requestedBy: string;
   targetMode: StrategyDeskPrepareTargetMode;
   now: string;
@@ -476,7 +506,9 @@ function assertScenarioStateTransition(
   nextState: RuntimeStrategyDeskScenarioManifest["state"],
 ): void {
   if (scenario.state === nextState) return;
-  if (!canTransitionRuntimeStrategyDeskScenarioState(scenario.state, nextState)) {
+  if (
+    !canTransitionRuntimeStrategyDeskScenarioState(scenario.state, nextState)
+  ) {
     throw new Error(
       `runtime-strategy-desk-scenario-transition-invalid:${scenario.state}:${nextState}`,
     );
@@ -544,8 +576,7 @@ async function upsertPaperBoundBindingObjects(input: {
       input.binding.bindingId,
     );
     await writeStrategyDeskExecutionRecipe(input.env.WAITLIST_DB, {
-      recipeId:
-        existing?.recipeId ?? createDeskId("desk_recipe", undefined),
+      recipeId: existing?.recipeId ?? createDeskId("desk_recipe", undefined),
       scenarioId: input.scenario.scenarioId,
       handoffId: input.handoff.handoffId,
       bindingId: input.binding.bindingId,
@@ -716,8 +747,9 @@ function buildStrategyLabPromotionArtifacts(input: {
   now: string;
 }) {
   const deploymentId =
-    input.handoff.bindings.find((binding) => binding.bindingKind === "runtime_deployment")
-      ?.deploymentId ?? undefined;
+    input.handoff.bindings.find(
+      (binding) => binding.bindingKind === "runtime_deployment",
+    )?.deploymentId ?? undefined;
   const promotionId = createDeskId("promotion");
   const promotion = parseRuntimeStrategyLabPromotionRecord({
     schemaVersion: "v1",
@@ -860,7 +892,8 @@ export async function prepareRuntimeStrategyDeskPromotionHandoffWorkflow(
     handoffId: handoff.handoffId,
     eventType: "prepared",
     actor: input.requestedBy,
-    summary: "Prepared a bounded execution handoff draft from the current paper evidence.",
+    summary:
+      "Prepared a bounded execution handoff draft from the current paper evidence.",
     details: {
       targetMode,
       sourceReportId: report.reportId,
@@ -892,7 +925,10 @@ export async function upsertRuntimeStrategyDeskPromotionHandoffWorkflow(input: {
   if (existing) {
     assertHandoffStateTransition(existing, input.handoff.status);
   }
-  if (scenario.activeHandoffId && scenario.activeHandoffId !== input.handoff.handoffId) {
+  if (
+    scenario.activeHandoffId &&
+    scenario.activeHandoffId !== input.handoff.handoffId
+  ) {
     throw new Error(
       `runtime-strategy-desk-handoff-active-mismatch:${scenario.activeHandoffId}`,
     );
@@ -1028,7 +1064,8 @@ export async function transitionRuntimeStrategyDeskPromotionHandoffWorkflow(
       nextScenarioState = "paper_ready";
       nextActiveHandoffId = null;
       eventType = "rejected";
-      summary = "Rejected bounded execution handoff and returned scenario to paper readiness.";
+      summary =
+        "Rejected bounded execution handoff and returned scenario to paper readiness.";
       break;
     }
     case "apply": {
@@ -1037,6 +1074,7 @@ export async function transitionRuntimeStrategyDeskPromotionHandoffWorkflow(
           `runtime-strategy-desk-handoff-already-applied:${handoff.handoffId}`,
         );
       }
+      assertNoBlockedChecks(handoff);
       if (handoff.approvals.length === 0 && nextApprovals.length === 0) {
         throw new Error(
           "runtime-strategy-desk-handoff-human-approval-required",
@@ -1080,7 +1118,8 @@ export async function transitionRuntimeStrategyDeskPromotionHandoffWorkflow(
       await writeStrategyLabPromotion(input.env.WAITLIST_DB, promotion);
       await appendStrategyLabPromotionEvent(input.env.WAITLIST_DB, event);
       eventType = "applied";
-      summary = "Applied bounded execution handoff and materialized execution objects.";
+      summary =
+        "Applied bounded execution handoff and materialized execution objects.";
       break;
     }
     case "pause": {
@@ -1101,7 +1140,8 @@ export async function transitionRuntimeStrategyDeskPromotionHandoffWorkflow(
       nextScenarioState = "paused";
       nextActiveHandoffId = handoff.handoffId;
       eventType = "paused";
-      summary = "Paused bounded execution from the strategy desk operator boundary.";
+      summary =
+        "Paused bounded execution from the strategy desk operator boundary.";
       break;
     }
     case "kill": {
@@ -1122,7 +1162,8 @@ export async function transitionRuntimeStrategyDeskPromotionHandoffWorkflow(
       nextScenarioState = "paused";
       nextActiveHandoffId = handoff.handoffId;
       eventType = "killed";
-      summary = "Killed bounded execution from the strategy desk operator boundary.";
+      summary =
+        "Killed bounded execution from the strategy desk operator boundary.";
       break;
     }
     case "demote": {
@@ -1132,14 +1173,16 @@ export async function transitionRuntimeStrategyDeskPromotionHandoffWorkflow(
         );
       }
       assertScenarioStateTransition(scenario, "paper_ready");
-      await applyControlToMaterializedObjects({
-        env: input.env,
-        scenario,
-        handoff,
-        actor: input.actor,
-        now,
-        control: "demote",
-      });
+      if (handoff.status === "applied") {
+        await applyControlToMaterializedObjects({
+          env: input.env,
+          scenario,
+          handoff,
+          actor: input.actor,
+          now,
+          control: "demote",
+        });
+      }
       nextScenarioState = "paper_ready";
       nextActiveHandoffId = null;
       if (handoff.status === "approved" || handoff.status === "applied") {
@@ -1147,21 +1190,26 @@ export async function transitionRuntimeStrategyDeskPromotionHandoffWorkflow(
         nextStatus = "archived";
       }
       eventType = "demoted";
-      summary = "Demoted the scenario back to paper readiness and archived bounded execution bindings.";
+      summary =
+        "Demoted the scenario back to paper readiness and archived bounded execution bindings.";
       break;
     }
     case "archive": {
       assertHandoffStateTransition(handoff, "archived");
       nextStatus = "archived";
       nextActiveHandoffId =
-        scenario.activeHandoffId === handoff.handoffId ? null : scenario.activeHandoffId;
+        scenario.activeHandoffId === handoff.handoffId
+          ? null
+          : scenario.activeHandoffId;
       eventType = "archived";
       summary = "Archived the bounded execution handoff.";
       break;
     }
     default: {
       const exhaustiveCheck: never = input.action;
-      throw new Error(`runtime-strategy-desk-handoff-action-unknown:${exhaustiveCheck}`);
+      throw new Error(
+        `runtime-strategy-desk-handoff-action-unknown:${exhaustiveCheck}`,
+      );
     }
   }
 

--- a/apps/worker/src/runtime_strategy_desk_promotion.ts
+++ b/apps/worker/src/runtime_strategy_desk_promotion.ts
@@ -1,0 +1,1196 @@
+import {
+  canTransitionRuntimeStrategyDeskPromotionHandoffState,
+  canTransitionRuntimeStrategyDeskScenarioState,
+  parseRuntimeDeploymentRecord,
+  parseRuntimeStrategyDeskPromotionHandoff,
+  parseRuntimeStrategyLabPromotionEvent,
+  parseRuntimeStrategyLabPromotionRecord,
+} from "../../../src/runtime/contracts/autonomous_runtime.js";
+import {
+  appendStrategyLabPromotionEvent,
+  writeStrategyLabPromotion,
+} from "./strategy_lab_promotion_repository";
+import {
+  getStrategyLabSubjectControl,
+  writeStrategyLabSubjectControl,
+} from "./strategy_lab_readiness_repository";
+import {
+  applyRuntimeDeploymentControl,
+  upsertRuntimeDeployment,
+} from "./runtime_internal";
+import type {
+  RuntimeStrategyDeskPromotionHandoff,
+  RuntimeStrategyDeskScenarioLeg,
+  RuntimeStrategyDeskScenarioManifest,
+} from "./runtime_contracts";
+import {
+  getRuntimeStrategyDeskScenarioReportWorkflow,
+  getRuntimeStrategyDeskScenarioWorkflow,
+} from "./runtime_strategy_desk";
+import {
+  StrategyDeskExecutionRecipeRecord,
+  StrategyDeskPromotionHandoffEvent,
+  appendStrategyDeskPromotionHandoffEvent,
+  getStrategyDeskExecutionRecipeForBinding,
+  getStrategyDeskPromotionHandoff,
+  listStrategyDeskExecutionRecipes,
+  listStrategyDeskPromotionHandoffEvents,
+  listStrategyDeskPromotionHandoffs,
+  writeStrategyDeskExecutionRecipe,
+  writeStrategyDeskPromotionHandoff,
+} from "./strategy_desk_handoff_repository";
+import {
+  updateStrategyDeskScenarioReviewState,
+} from "./strategy_desk_repository";
+import type { Env } from "./types";
+
+type StrategyDeskPrepareTargetMode = "limited_live";
+
+type StrategyDeskPromotionAction =
+  | "submit"
+  | "approve"
+  | "reject"
+  | "apply"
+  | "pause"
+  | "kill"
+  | "demote"
+  | "archive";
+
+type StrategyDeskPromotionBinding =
+  RuntimeStrategyDeskPromotionHandoff["bindings"][number];
+
+type StrategyDeskPromotionResult = {
+  scenario: RuntimeStrategyDeskScenarioManifest;
+  handoff: RuntimeStrategyDeskPromotionHandoff;
+  events: StrategyDeskPromotionHandoffEvent[];
+  executionRecipes: StrategyDeskExecutionRecipeRecord[];
+};
+
+type PromotionDeps = {
+  now?: () => string;
+  createId?: (prefix: string) => string;
+};
+
+const DESK_PROMOTION_SUMMARY_MAX = 3;
+
+function nowIso(deps?: PromotionDeps): string {
+  return deps?.now ? deps.now() : new Date().toISOString();
+}
+
+function createDeskId(prefix: string, deps?: PromotionDeps): string {
+  if (deps?.createId) return deps.createId(prefix);
+  return `${prefix}_${crypto.randomUUID().replace(/-/g, "")}`;
+}
+
+function stringOrNull(value: unknown): string | null {
+  const parsed = String(value ?? "").trim();
+  return parsed ? parsed : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseDecimalToMicros(value: string): bigint {
+  const raw = String(value ?? "").trim();
+  const match = raw.match(/^([0-9]+)(?:\.([0-9]+))?$/);
+  if (!match) return 0n;
+  const whole = match[1] ?? "0";
+  const fraction = (match[2] ?? "").padEnd(6, "0").slice(0, 6);
+  return BigInt(whole) * 1_000_000n + BigInt(fraction || "0");
+}
+
+function formatMicros(value: bigint): string {
+  const whole = value / 1_000_000n;
+  const fraction = String(value % 1_000_000n).padStart(6, "0");
+  return fraction === "000000"
+    ? `${whole}`
+    : `${whole}.${fraction.replace(/0+$/, "")}`;
+}
+
+function addDecimalStrings(values: Array<string | null | undefined>): string {
+  const total = values.reduce(
+    (sum, value) => sum + parseDecimalToMicros(value ?? "0"),
+    0n,
+  );
+  return formatMicros(total);
+}
+
+function summarizeLabels(labels: string[]): string {
+  if (labels.length === 0) return "no live legs";
+  if (labels.length <= DESK_PROMOTION_SUMMARY_MAX) return labels.join(", ");
+  return `${labels.slice(0, DESK_PROMOTION_SUMMARY_MAX).join(", ")} +${labels.length - DESK_PROMOTION_SUMMARY_MAX}`;
+}
+
+function legAllowsLimitedLive(leg: RuntimeStrategyDeskScenarioLeg): boolean {
+  return leg.enabledModes.includes("live") || leg.enabledModes.includes("limited_live");
+}
+
+function buildBindingForLeg(
+  scenario: RuntimeStrategyDeskScenarioManifest,
+  leg: RuntimeStrategyDeskScenarioLeg,
+  targetMode: StrategyDeskPrepareTargetMode,
+): StrategyDeskPromotionBinding {
+  if (legAllowsLimitedLive(leg) && leg.intentFamily === "spot_swap" && leg.pair) {
+    return {
+      bindingId: `binding_${leg.legId}_runtime`,
+      bindingKind: "runtime_deployment",
+      legIds: [leg.legId],
+      venueKey: leg.venueKey,
+      pair: leg.pair,
+      targetMode,
+      deploymentId: `dep_${scenario.scenarioId}_${leg.legId}_${targetMode}`,
+      lane: "safe",
+      notes: "Primary spot leg is eligible for bounded live arming.",
+    };
+  }
+
+  if (leg.intentFamily === "prediction_order" || leg.marketType === "prediction") {
+    return {
+      bindingId: `binding_${leg.legId}_control`,
+      bindingKind: "subject_control",
+      legIds: [leg.legId],
+      venueKey: leg.venueKey,
+      ...(leg.instrumentId ? { instrumentId: leg.instrumentId } : {}),
+      targetMode: "paper",
+      notes: "Prediction overlay stays paper-bound during bounded live arming.",
+    };
+  }
+
+  return {
+    bindingId: `binding_${leg.legId}_recipe`,
+    bindingKind: "worker_execution_recipe",
+    legIds: [leg.legId],
+    venueKey: leg.venueKey,
+    ...(leg.pair ? { pair: leg.pair } : {}),
+    ...(leg.instrumentId ? { instrumentId: leg.instrumentId } : {}),
+    targetMode: "paper",
+    notes: "Non-spot execution remains desk-managed and paper-bound for the first live arming pass.",
+  };
+}
+
+function firstLegForBinding(
+  scenario: RuntimeStrategyDeskScenarioManifest,
+  binding: StrategyDeskPromotionBinding,
+): RuntimeStrategyDeskScenarioLeg {
+  const leg = scenario.legs.find((candidate) =>
+    binding.legIds.includes(candidate.legId),
+  );
+  if (!leg) {
+    throw new Error(
+      `runtime-strategy-desk-handoff-leg-missing:${binding.bindingId}`,
+    );
+  }
+  return leg;
+}
+
+function buildBudgetForBinding(
+  scenario: RuntimeStrategyDeskScenarioManifest,
+  binding: StrategyDeskPromotionBinding,
+): Record<string, unknown> {
+  const legs = scenario.legs.filter((leg) => binding.legIds.includes(leg.legId));
+  return {
+    targetNotionalUsd: addDecimalStrings(
+      legs.map((leg) => stringOrNull(leg.sizing.targetNotionalUsd)),
+    ),
+    maxNotionalUsd: addDecimalStrings(
+      legs.map((leg) => stringOrNull(leg.sizing.maxNotionalUsd)),
+    ),
+    reserveUsd: addDecimalStrings(
+      legs.map((leg) => stringOrNull(leg.sizing.reserveUsd)),
+    ),
+    legBudgets: legs.map((leg) => ({
+      legId: leg.legId,
+      targetNotionalUsd: stringOrNull(leg.sizing.targetNotionalUsd) ?? "0",
+      maxNotionalUsd: stringOrNull(leg.sizing.maxNotionalUsd) ?? "0",
+      reserveUsd: stringOrNull(leg.sizing.reserveUsd) ?? "0",
+    })),
+  };
+}
+
+function buildRuntimeDeploymentPayload(input: {
+  scenario: RuntimeStrategyDeskScenarioManifest;
+  binding: StrategyDeskPromotionBinding;
+  leg: RuntimeStrategyDeskScenarioLeg;
+  now: string;
+}) {
+  const budget = buildBudgetForBinding(input.scenario, input.binding);
+  const maxNotionalUsd = String(budget.maxNotionalUsd ?? "25");
+  const reserveUsd = String(budget.reserveUsd ?? maxNotionalUsd);
+  const allocatedUsd = addDecimalStrings([
+    reserveUsd,
+    String(input.scenario.riskLimits?.maxReservedCapitalUsd ?? "0"),
+  ]);
+  return parseRuntimeDeploymentRecord({
+    schemaVersion: "v1",
+    deploymentId: input.binding.deploymentId,
+    strategyKey: input.scenario.strategyKey,
+    sleeveId:
+      input.scenario.sleeveId ??
+      `desk_sleeve_${input.scenario.scenarioId}`,
+    ownerUserId: input.scenario.ownerUserId,
+    venueKey: input.binding.venueKey,
+    pair: input.binding.pair,
+    mode: "live",
+    state: "live",
+    lane: input.binding.lane ?? "safe",
+    createdAt: input.now,
+    updatedAt: input.now,
+    promotedAt: input.now,
+    policy: {
+      maxNotionalUsd,
+      dailyLossLimitUsd: String(
+        input.scenario.riskLimits?.maxDrawdownBps
+          ? Math.max(
+              1,
+              Math.round(Number(input.scenario.riskLimits.maxDrawdownBps) / 100),
+            )
+          : 10,
+      ),
+      maxSlippageBps: Number(input.leg.sizing.maxSlippageBps ?? 50),
+      maxConcurrentRuns: 1,
+      rebalanceToleranceBps: 125,
+    },
+    capital: {
+      allocatedUsd: allocatedUsd === "0" ? reserveUsd : allocatedUsd,
+      reservedUsd: reserveUsd,
+      availableUsd: reserveUsd,
+    },
+    tags: [
+      "strategy-desk",
+      "bounded-arming",
+      input.binding.bindingId,
+      input.binding.targetMode,
+    ],
+  });
+}
+
+function flattenEvidenceRefs(
+  report: Awaited<ReturnType<typeof getRuntimeStrategyDeskScenarioReportWorkflow>>["report"],
+): RuntimeStrategyDeskPromotionHandoff["evidenceRefs"] {
+  const refs: RuntimeStrategyDeskPromotionHandoff["evidenceRefs"] = [
+    {
+      kind: "strategy_desk_report",
+      ref: report.reportId,
+    },
+  ];
+  for (const bucket of report.evidence) {
+    const evidenceRefs = Array.isArray(bucket.evidenceRefs)
+      ? bucket.evidenceRefs
+      : [];
+    for (const entry of evidenceRefs) {
+      const kind = stringOrNull(isRecord(entry) ? entry.kind : null);
+      const ref = stringOrNull(isRecord(entry) ? entry.ref : null);
+      const notes = isRecord(entry) ? stringOrNull(entry.notes) : null;
+      if (kind && ref) {
+        refs.push({ kind, ref, ...(notes ? { notes } : {}) });
+      }
+    }
+  }
+
+  const seen = new Set<string>();
+  return refs.filter((entry) => {
+    const key = `${entry.kind}:${entry.ref}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function readImplementationReference(
+  scenario: RuntimeStrategyDeskScenarioManifest,
+): RuntimeStrategyDeskPromotionHandoff["implementationReference"] | undefined {
+  const candidate = scenario.implementationReferences[0];
+  if (!isRecord(candidate)) return undefined;
+  const kind = stringOrNull(candidate.kind);
+  const ref = stringOrNull(candidate.ref);
+  if (!kind || !ref) return undefined;
+  if (!["pull_request", "issue", "commit"].includes(kind)) return undefined;
+  return {
+    kind: kind as "pull_request" | "issue" | "commit",
+    ref,
+    ...(stringOrNull(candidate.mergedAt)
+      ? { mergedAt: String(candidate.mergedAt) }
+      : {}),
+    ...(stringOrNull(candidate.revision)
+      ? { revision: String(candidate.revision) }
+      : {}),
+    ...(stringOrNull(candidate.notes)
+      ? { notes: String(candidate.notes) }
+      : {}),
+  };
+}
+
+function buildChecks(input: {
+  scenario: RuntimeStrategyDeskScenarioManifest;
+  report: Awaited<ReturnType<typeof getRuntimeStrategyDeskScenarioReportWorkflow>>["report"];
+  bindings: StrategyDeskPromotionBinding[];
+}): RuntimeStrategyDeskPromotionHandoff["checks"] {
+  const liveBindings = input.bindings.filter(
+    (binding) => binding.bindingKind === "runtime_deployment",
+  );
+  return [
+    {
+      checkId: "paper-report-pass",
+      status:
+        input.report.stage === "paper" && input.report.status === "pass"
+          ? "pass"
+          : "blocked",
+      message:
+        input.report.stage === "paper" && input.report.status === "pass"
+          ? "Paper report is green and ready for operator review."
+          : "Bounded execution handoff requires a passing paper report.",
+    },
+    {
+      checkId: "bounded-live-live-leg",
+      status: liveBindings.length > 0 ? "pass" : "blocked",
+      observedValue: String(liveBindings.length),
+      thresholdValue: ">=1",
+      message:
+        liveBindings.length > 0
+          ? "At least one live-eligible leg is present for bounded execution."
+          : "No live-eligible leg is present for bounded execution.",
+    },
+    {
+      checkId: "limited-live-human-approval",
+      status: "requires_human_approval",
+      message:
+        "Limited-live promotion remains human-gated even when the desk report is green.",
+    },
+  ];
+}
+
+function buildActions(input: {
+  scenario: RuntimeStrategyDeskScenarioManifest;
+  bindings: StrategyDeskPromotionBinding[];
+  now: string;
+}): RuntimeStrategyDeskPromotionHandoff["actions"] {
+  const actions: RuntimeStrategyDeskPromotionHandoff["actions"] = [
+    {
+      actionId: "record-desk-state",
+      actionType: "record_state_transition",
+      summary: "Move the scenario into operator review before arming.",
+      required: true,
+      payload: {
+        scenarioId: input.scenario.scenarioId,
+        targetState: "operator_review",
+      },
+    },
+  ];
+
+  for (const binding of input.bindings) {
+    if (binding.bindingKind !== "runtime_deployment") continue;
+    const leg = firstLegForBinding(input.scenario, binding);
+    const deployment = buildRuntimeDeploymentPayload({
+      scenario: input.scenario,
+      binding,
+      leg,
+      now: input.now,
+    });
+    actions.push({
+      actionId: `upsert-${binding.bindingId}`,
+      actionType: "upsert_runtime_deployment",
+      summary: `Create or update the bounded deployment for ${leg.label}.`,
+      required: true,
+      payload: {
+        bindingId: binding.bindingId,
+        deployment,
+      },
+    });
+    actions.push({
+      actionId: `allowlist-${binding.bindingId}`,
+      actionType: "record_allowlist_change",
+      summary: `Record the bounded live allowlist change for ${leg.label}.`,
+      required: true,
+      payload: {
+        bindingId: binding.bindingId,
+        deploymentId: binding.deploymentId,
+        lane: binding.lane ?? "safe",
+        targetMode: binding.targetMode,
+        venueKey: binding.venueKey,
+      },
+    });
+  }
+
+  return actions;
+}
+
+function buildHandoffSummary(bindings: StrategyDeskPromotionBinding[]): string {
+  const liveLabels = bindings
+    .filter((binding) => binding.bindingKind === "runtime_deployment")
+    .map((binding) => binding.bindingId.replace(/^binding_/, ""));
+  const paperLabels = bindings
+    .filter((binding) => binding.bindingKind !== "runtime_deployment")
+    .map((binding) => binding.bindingId.replace(/^binding_/, ""));
+  return `Bound ${summarizeLabels(liveLabels)} to limited live while keeping ${summarizeLabels(paperLabels)} under paper-bound desk controls.`;
+}
+
+function buildDefaultHandoff(input: {
+  scenario: RuntimeStrategyDeskScenarioManifest;
+  report: Awaited<ReturnType<typeof getRuntimeStrategyDeskScenarioReportWorkflow>>["report"];
+  requestedBy: string;
+  targetMode: StrategyDeskPrepareTargetMode;
+  now: string;
+  deps?: PromotionDeps;
+}): RuntimeStrategyDeskPromotionHandoff {
+  const bindings = input.scenario.legs.map((leg) =>
+    buildBindingForLeg(input.scenario, leg, input.targetMode),
+  );
+  const checks = buildChecks({
+    scenario: input.scenario,
+    report: input.report,
+    bindings,
+  });
+  return parseRuntimeStrategyDeskPromotionHandoff({
+    schemaVersion: "v1",
+    handoffId: createDeskId("desk_handoff", input.deps),
+    scenarioId: input.scenario.scenarioId,
+    currentState: input.scenario.state,
+    targetMode: input.targetMode,
+    status: "draft",
+    summary: buildHandoffSummary(bindings),
+    requestedBy: input.requestedBy,
+    createdAt: input.now,
+    updatedAt: input.now,
+    ...(readImplementationReference(input.scenario)
+      ? { implementationReference: readImplementationReference(input.scenario) }
+      : {}),
+    evidenceRefs: flattenEvidenceRefs(input.report),
+    checks,
+    approvals: [],
+    bindings,
+    actions: buildActions({
+      scenario: input.scenario,
+      bindings,
+      now: input.now,
+    }),
+    metadata: {
+      sourceReportId: input.report.reportId,
+      generatedBy: "runtime_strategy_desk_promotion",
+    },
+  });
+}
+
+function assertScenarioStateTransition(
+  scenario: RuntimeStrategyDeskScenarioManifest,
+  nextState: RuntimeStrategyDeskScenarioManifest["state"],
+): void {
+  if (scenario.state === nextState) return;
+  if (!canTransitionRuntimeStrategyDeskScenarioState(scenario.state, nextState)) {
+    throw new Error(
+      `runtime-strategy-desk-scenario-transition-invalid:${scenario.state}:${nextState}`,
+    );
+  }
+}
+
+function assertHandoffStateTransition(
+  handoff: RuntimeStrategyDeskPromotionHandoff,
+  nextStatus: RuntimeStrategyDeskPromotionHandoff["status"],
+): void {
+  if (handoff.status === nextStatus) return;
+  if (
+    !canTransitionRuntimeStrategyDeskPromotionHandoffState(
+      handoff.status,
+      nextStatus,
+    )
+  ) {
+    throw new Error(
+      `runtime-strategy-desk-handoff-transition-invalid:${handoff.status}:${nextStatus}`,
+    );
+  }
+}
+
+function subjectControlKeyForBinding(
+  scenario: RuntimeStrategyDeskScenarioManifest,
+  binding: StrategyDeskPromotionBinding,
+): string {
+  return `${scenario.strategyKey}:${binding.bindingId}`;
+}
+
+async function upsertPaperBoundBindingObjects(input: {
+  env: Env;
+  scenario: RuntimeStrategyDeskScenarioManifest;
+  handoff: RuntimeStrategyDeskPromotionHandoff;
+  binding: StrategyDeskPromotionBinding;
+  actor: string;
+  now: string;
+}): Promise<void> {
+  if (input.binding.bindingKind === "subject_control") {
+    await writeStrategyLabSubjectControl(input.env.WAITLIST_DB, {
+      schemaVersion: "v1",
+      subjectKind: "strategy",
+      subjectKey: subjectControlKeyForBinding(input.scenario, input.binding),
+      liveAllowed: false,
+      killSwitchEnabled: false,
+      disabledReason: "paper-bound strategy desk control",
+      updatedAt: input.now,
+      updatedBy: input.actor,
+      metadata: {
+        source: "strategy_desk_handoff",
+        scenarioId: input.scenario.scenarioId,
+        handoffId: input.handoff.handoffId,
+        bindingId: input.binding.bindingId,
+        venueKey: input.binding.venueKey,
+        legIds: input.binding.legIds,
+      },
+    });
+    return;
+  }
+
+  if (input.binding.bindingKind === "worker_execution_recipe") {
+    const existing = await getStrategyDeskExecutionRecipeForBinding(
+      input.env.WAITLIST_DB,
+      input.handoff.handoffId,
+      input.binding.bindingId,
+    );
+    await writeStrategyDeskExecutionRecipe(input.env.WAITLIST_DB, {
+      recipeId:
+        existing?.recipeId ?? createDeskId("desk_recipe", undefined),
+      scenarioId: input.scenario.scenarioId,
+      handoffId: input.handoff.handoffId,
+      bindingId: input.binding.bindingId,
+      schemaVersion: existing?.schemaVersion ?? "v1",
+      status: "paper",
+      venueKey: input.binding.venueKey,
+      ...(input.binding.instrumentId
+        ? { instrumentId: input.binding.instrumentId }
+        : {}),
+      ...(input.binding.pair ? { pair: input.binding.pair } : {}),
+      targetMode: input.binding.targetMode,
+      ...(input.binding.lane ? { lane: input.binding.lane } : {}),
+      legIds: [...input.binding.legIds],
+      budget: buildBudgetForBinding(input.scenario, input.binding),
+      ...(input.binding.notes ? { notes: input.binding.notes } : {}),
+      metadata: {
+        source: "strategy_desk_handoff",
+        actor: input.actor,
+      },
+      createdAt: existing?.createdAt ?? input.now,
+      updatedAt: input.now,
+    });
+  }
+}
+
+async function applyRuntimeBindingActions(input: {
+  env: Env;
+  handoff: RuntimeStrategyDeskPromotionHandoff;
+}): Promise<void> {
+  for (const action of input.handoff.actions) {
+    if (!action.required) continue;
+    if (action.actionType === "record_state_transition") continue;
+    if (action.actionType === "record_allowlist_change") continue;
+
+    const payload =
+      isRecord(action.payload) && !Array.isArray(action.payload)
+        ? action.payload
+        : {};
+    if (action.actionType === "upsert_runtime_deployment") {
+      const deployment = parseRuntimeDeploymentRecord(payload.deployment);
+      const result = await upsertRuntimeDeployment(input.env, deployment);
+      if (!result.ok) {
+        throw new Error(
+          String(
+            result.payload.error ??
+              "runtime-strategy-desk-handoff-upsert-deployment-failed",
+          ),
+        );
+      }
+      continue;
+    }
+    if (action.actionType === "apply_runtime_control") {
+      const deploymentId = stringOrNull(payload.deploymentId);
+      const controlAction = stringOrNull(payload.action);
+      if (
+        !deploymentId ||
+        !controlAction ||
+        !["pause", "resume", "kill"].includes(controlAction)
+      ) {
+        throw new Error(
+          "runtime-strategy-desk-handoff-invalid-runtime-control-action",
+        );
+      }
+      const result = await applyRuntimeDeploymentControl({
+        env: input.env,
+        deploymentId,
+        action: controlAction as "pause" | "resume" | "kill",
+      });
+      if (!result.ok) {
+        throw new Error(
+          String(
+            result.payload.error ??
+              "runtime-strategy-desk-handoff-runtime-control-failed",
+          ),
+        );
+      }
+    }
+  }
+}
+
+async function applyControlToMaterializedObjects(input: {
+  env: Env;
+  scenario: RuntimeStrategyDeskScenarioManifest;
+  handoff: RuntimeStrategyDeskPromotionHandoff;
+  actor: string;
+  now: string;
+  control: "pause" | "kill" | "demote";
+}): Promise<void> {
+  for (const binding of input.handoff.bindings) {
+    if (binding.bindingKind === "runtime_deployment" && binding.deploymentId) {
+      const action = input.control === "kill" ? "kill" : "pause";
+      const result = await applyRuntimeDeploymentControl({
+        env: input.env,
+        deploymentId: binding.deploymentId,
+        action,
+      });
+      if (!result.ok) {
+        throw new Error(
+          String(
+            result.payload.error ??
+              "runtime-strategy-desk-handoff-control-runtime-deployment-failed",
+          ),
+        );
+      }
+      continue;
+    }
+
+    if (binding.bindingKind === "worker_execution_recipe") {
+      const existing = await getStrategyDeskExecutionRecipeForBinding(
+        input.env.WAITLIST_DB,
+        input.handoff.handoffId,
+        binding.bindingId,
+      );
+      if (!existing) continue;
+      await writeStrategyDeskExecutionRecipe(input.env.WAITLIST_DB, {
+        ...existing,
+        status:
+          input.control === "pause"
+            ? "paused"
+            : input.control === "kill"
+              ? "killed"
+              : "archived",
+        metadata: {
+          ...(existing.metadata ?? {}),
+          lastControl: input.control,
+          lastControlledBy: input.actor,
+        },
+        updatedAt: input.now,
+      });
+      continue;
+    }
+
+    const subjectKey = subjectControlKeyForBinding(input.scenario, binding);
+    const existingControl = await getStrategyLabSubjectControl(
+      input.env.WAITLIST_DB,
+      "strategy",
+      subjectKey,
+    );
+    await writeStrategyLabSubjectControl(input.env.WAITLIST_DB, {
+      schemaVersion: "v1",
+      subjectKind: "strategy",
+      subjectKey,
+      liveAllowed: false,
+      killSwitchEnabled:
+        input.control === "pause" ? true : input.control === "kill",
+      disabledReason:
+        input.control === "demote"
+          ? "demoted to paper"
+          : input.control === "kill"
+            ? "killed from strategy desk"
+            : "paused from strategy desk",
+      updatedAt: input.now,
+      updatedBy: input.actor,
+      metadata: {
+        ...(existingControl?.metadata ?? {}),
+        source: "strategy_desk_handoff",
+        handoffId: input.handoff.handoffId,
+        lastControl: input.control,
+      },
+    });
+  }
+}
+
+function buildStrategyLabPromotionArtifacts(input: {
+  scenario: RuntimeStrategyDeskScenarioManifest;
+  handoff: RuntimeStrategyDeskPromotionHandoff;
+  now: string;
+}) {
+  const deploymentId =
+    input.handoff.bindings.find((binding) => binding.bindingKind === "runtime_deployment")
+      ?.deploymentId ?? undefined;
+  const promotionId = createDeskId("promotion");
+  const promotion = parseRuntimeStrategyLabPromotionRecord({
+    schemaVersion: "v1",
+    promotionId,
+    subjectKind: "strategy",
+    subjectKey: input.scenario.strategyKey,
+    currentState: "paper",
+    targetState: "limited_live",
+    transitionType: "promote",
+    status: "applied",
+    summary: input.handoff.summary,
+    requestedBy: input.handoff.requestedBy,
+    createdAt: input.handoff.createdAt,
+    updatedAt: input.now,
+    appliedAt: input.now,
+    ...(deploymentId ? { deploymentId } : {}),
+    ...(input.handoff.implementationReference
+      ? { implementationReference: input.handoff.implementationReference }
+      : {}),
+    evidenceRefs: [
+      ...input.handoff.evidenceRefs,
+      {
+        kind: "strategy_desk_handoff",
+        ref: input.handoff.handoffId,
+      },
+    ],
+    checks: input.handoff.checks,
+    actions: input.handoff.actions,
+    approvals: input.handoff.approvals,
+    metadata: {
+      source: "strategy_desk_handoff",
+      scenarioId: input.scenario.scenarioId,
+      handoffId: input.handoff.handoffId,
+    },
+  });
+  const event = parseRuntimeStrategyLabPromotionEvent({
+    schemaVersion: "v1",
+    eventId: createDeskId("promoevt"),
+    promotionId,
+    eventType: "applied",
+    actor: input.handoff.requestedBy,
+    fromState: "paper",
+    toState: "limited_live",
+    summary: "Strategy desk bounded execution handoff applied.",
+    details: {
+      scenarioId: input.scenario.scenarioId,
+      handoffId: input.handoff.handoffId,
+      targetMode: input.handoff.targetMode,
+    },
+    createdAt: input.now,
+  });
+  return { promotion, event };
+}
+
+async function hydratePromotionResult(input: {
+  env: Env;
+  scenarioId: string;
+  handoffId: string;
+}): Promise<StrategyDeskPromotionResult> {
+  const scenario = (
+    await getRuntimeStrategyDeskScenarioWorkflow({
+      env: input.env,
+      scenarioId: input.scenarioId,
+    })
+  ).scenario;
+  const handoff = await getStrategyDeskPromotionHandoff(
+    input.env.WAITLIST_DB,
+    input.handoffId,
+  );
+  if (!handoff) {
+    throw new Error(
+      `runtime-strategy-desk-handoff-not-found:${input.handoffId}`,
+    );
+  }
+  return {
+    scenario,
+    handoff,
+    events: await listStrategyDeskPromotionHandoffEvents(
+      input.env.WAITLIST_DB,
+      handoff.handoffId,
+    ),
+    executionRecipes: await listStrategyDeskExecutionRecipes(
+      input.env.WAITLIST_DB,
+      { handoffId: handoff.handoffId, limit: 20 },
+    ),
+  };
+}
+
+export async function prepareRuntimeStrategyDeskPromotionHandoffWorkflow(
+  input: {
+    env: Env;
+    scenarioId: string;
+    requestedBy: string;
+    targetMode?: StrategyDeskPrepareTargetMode;
+  },
+  deps?: PromotionDeps,
+): Promise<StrategyDeskPromotionResult> {
+  const scenario = (
+    await getRuntimeStrategyDeskScenarioWorkflow({
+      env: input.env,
+      scenarioId: input.scenarioId,
+    })
+  ).scenario;
+  if (
+    scenario.state !== "paper_ready" &&
+    scenario.state !== "operator_review" &&
+    scenario.state !== "execution_ready" &&
+    scenario.state !== "execution_bound"
+  ) {
+    throw new Error(
+      `runtime-strategy-desk-handoff-scenario-not-ready:${scenario.state}`,
+    );
+  }
+  if (!scenario.latestReportId) {
+    throw new Error(
+      `runtime-strategy-desk-handoff-report-missing:${scenario.scenarioId}`,
+    );
+  }
+  const report = (
+    await getRuntimeStrategyDeskScenarioReportWorkflow({
+      env: input.env,
+      reportId: scenario.latestReportId,
+    })
+  ).report;
+  const now = nowIso(deps);
+  const targetMode = input.targetMode ?? "limited_live";
+  const handoff = buildDefaultHandoff({
+    scenario,
+    report,
+    requestedBy: input.requestedBy,
+    targetMode,
+    now,
+    deps,
+  });
+
+  await writeStrategyDeskPromotionHandoff(input.env.WAITLIST_DB, handoff);
+  await appendStrategyDeskPromotionHandoffEvent(input.env.WAITLIST_DB, {
+    eventId: createDeskId("desk_handoff_evt", deps),
+    handoffId: handoff.handoffId,
+    eventType: "prepared",
+    actor: input.requestedBy,
+    summary: "Prepared a bounded execution handoff draft from the current paper evidence.",
+    details: {
+      targetMode,
+      sourceReportId: report.reportId,
+    },
+    createdAt: now,
+  });
+
+  return hydratePromotionResult({
+    env: input.env,
+    scenarioId: scenario.scenarioId,
+    handoffId: handoff.handoffId,
+  });
+}
+
+export async function upsertRuntimeStrategyDeskPromotionHandoffWorkflow(input: {
+  env: Env;
+  handoff: RuntimeStrategyDeskPromotionHandoff;
+}): Promise<{ handoff: RuntimeStrategyDeskPromotionHandoff }> {
+  const scenario = (
+    await getRuntimeStrategyDeskScenarioWorkflow({
+      env: input.env,
+      scenarioId: input.handoff.scenarioId,
+    })
+  ).scenario;
+  const existing = await getStrategyDeskPromotionHandoff(
+    input.env.WAITLIST_DB,
+    input.handoff.handoffId,
+  );
+  if (existing) {
+    assertHandoffStateTransition(existing, input.handoff.status);
+  }
+  if (scenario.activeHandoffId && scenario.activeHandoffId !== input.handoff.handoffId) {
+    throw new Error(
+      `runtime-strategy-desk-handoff-active-mismatch:${scenario.activeHandoffId}`,
+    );
+  }
+  return {
+    handoff: await writeStrategyDeskPromotionHandoff(
+      input.env.WAITLIST_DB,
+      input.handoff,
+    ),
+  };
+}
+
+export async function getRuntimeStrategyDeskPromotionHandoffWorkflow(input: {
+  env: Env;
+  handoffId: string;
+}): Promise<{
+  handoff: RuntimeStrategyDeskPromotionHandoff;
+  events: StrategyDeskPromotionHandoffEvent[];
+  executionRecipes: StrategyDeskExecutionRecipeRecord[];
+}> {
+  const handoff = await getStrategyDeskPromotionHandoff(
+    input.env.WAITLIST_DB,
+    input.handoffId,
+  );
+  if (!handoff) {
+    throw new Error(
+      `runtime-strategy-desk-handoff-not-found:${input.handoffId}`,
+    );
+  }
+  return {
+    handoff,
+    events: await listStrategyDeskPromotionHandoffEvents(
+      input.env.WAITLIST_DB,
+      input.handoffId,
+    ),
+    executionRecipes: await listStrategyDeskExecutionRecipes(
+      input.env.WAITLIST_DB,
+      { handoffId: input.handoffId, limit: 20 },
+    ),
+  };
+}
+
+export async function listRuntimeStrategyDeskPromotionHandoffsWorkflow(input: {
+  env: Env;
+  handoffId?: string;
+  scenarioId?: string;
+  status?: string;
+  limit?: number;
+}): Promise<{
+  handoffs: RuntimeStrategyDeskPromotionHandoff[];
+}> {
+  return {
+    handoffs: await listStrategyDeskPromotionHandoffs(input.env.WAITLIST_DB, {
+      handoffId: input.handoffId,
+      scenarioId: input.scenarioId,
+      status: input.status,
+      limit: input.limit,
+    }),
+  };
+}
+
+export async function transitionRuntimeStrategyDeskPromotionHandoffWorkflow(
+  input: {
+    env: Env;
+    handoffId: string;
+    action: StrategyDeskPromotionAction;
+    actor: string;
+    notes?: string;
+  },
+  deps?: PromotionDeps,
+): Promise<StrategyDeskPromotionResult> {
+  const handoff = await getStrategyDeskPromotionHandoff(
+    input.env.WAITLIST_DB,
+    input.handoffId,
+  );
+  if (!handoff) {
+    throw new Error(
+      `runtime-strategy-desk-handoff-not-found:${input.handoffId}`,
+    );
+  }
+  const scenario = (
+    await getRuntimeStrategyDeskScenarioWorkflow({
+      env: input.env,
+      scenarioId: handoff.scenarioId,
+    })
+  ).scenario;
+  const now = nowIso(deps);
+
+  let nextStatus = handoff.status;
+  let nextScenarioState = scenario.state;
+  let nextActiveHandoffId: string | null | undefined = scenario.activeHandoffId;
+  let nextApprovals = [...handoff.approvals];
+  let nextAppliedAt = handoff.appliedAt;
+  let eventType: StrategyDeskPromotionHandoffEvent["eventType"];
+  let summary: string;
+
+  switch (input.action) {
+    case "submit": {
+      assertHandoffStateTransition(handoff, "awaiting_review");
+      assertScenarioStateTransition(scenario, "operator_review");
+      nextStatus = "awaiting_review";
+      nextScenarioState = "operator_review";
+      nextActiveHandoffId = handoff.handoffId;
+      eventType = "submitted";
+      summary = "Submitted bounded execution handoff for operator review.";
+      break;
+    }
+    case "approve": {
+      assertHandoffStateTransition(handoff, "approved");
+      assertScenarioStateTransition(scenario, "execution_ready");
+      nextStatus = "approved";
+      nextScenarioState = "execution_ready";
+      nextActiveHandoffId = handoff.handoffId;
+      nextApprovals = [
+        ...handoff.approvals.filter(
+          (approval) => approval.approvedBy !== input.actor,
+        ),
+        {
+          targetMode: handoff.targetMode,
+          approvedBy: input.actor,
+          approvedAt: now,
+          ...(input.notes ? { notes: input.notes } : {}),
+        },
+      ];
+      eventType = "approved";
+      summary = "Approved bounded execution handoff.";
+      break;
+    }
+    case "reject": {
+      assertHandoffStateTransition(handoff, "rejected");
+      assertScenarioStateTransition(scenario, "paper_ready");
+      nextStatus = "rejected";
+      nextScenarioState = "paper_ready";
+      nextActiveHandoffId = null;
+      eventType = "rejected";
+      summary = "Rejected bounded execution handoff and returned scenario to paper readiness.";
+      break;
+    }
+    case "apply": {
+      if (handoff.approvals.length === 0 && nextApprovals.length === 0) {
+        throw new Error(
+          "runtime-strategy-desk-handoff-human-approval-required",
+        );
+      }
+      assertHandoffStateTransition(handoff, "applied");
+      assertScenarioStateTransition(scenario, "execution_bound");
+      await applyRuntimeBindingActions({
+        env: input.env,
+        handoff,
+      });
+      for (const binding of handoff.bindings) {
+        if (binding.bindingKind === "runtime_deployment") {
+          continue;
+        }
+        await upsertPaperBoundBindingObjects({
+          env: input.env,
+          scenario,
+          handoff,
+          binding,
+          actor: input.actor,
+          now,
+        });
+      }
+      nextStatus = "applied";
+      nextScenarioState = "execution_bound";
+      nextActiveHandoffId = handoff.handoffId;
+      nextAppliedAt = now;
+      const { promotion, event } = buildStrategyLabPromotionArtifacts({
+        scenario,
+        handoff: {
+          ...handoff,
+          approvals:
+            nextApprovals.length > 0 ? nextApprovals : handoff.approvals,
+          status: "applied",
+          appliedAt: now,
+        },
+        now,
+      });
+      await writeStrategyLabPromotion(input.env.WAITLIST_DB, promotion);
+      await appendStrategyLabPromotionEvent(input.env.WAITLIST_DB, event);
+      eventType = "applied";
+      summary = "Applied bounded execution handoff and materialized execution objects.";
+      break;
+    }
+    case "pause": {
+      if (handoff.status !== "applied") {
+        throw new Error(
+          `runtime-strategy-desk-handoff-control-not-applied:${handoff.status}`,
+        );
+      }
+      assertScenarioStateTransition(scenario, "paused");
+      await applyControlToMaterializedObjects({
+        env: input.env,
+        scenario,
+        handoff,
+        actor: input.actor,
+        now,
+        control: "pause",
+      });
+      nextScenarioState = "paused";
+      nextActiveHandoffId = handoff.handoffId;
+      eventType = "paused";
+      summary = "Paused bounded execution from the strategy desk operator boundary.";
+      break;
+    }
+    case "kill": {
+      if (handoff.status !== "applied") {
+        throw new Error(
+          `runtime-strategy-desk-handoff-control-not-applied:${handoff.status}`,
+        );
+      }
+      assertScenarioStateTransition(scenario, "paused");
+      await applyControlToMaterializedObjects({
+        env: input.env,
+        scenario,
+        handoff,
+        actor: input.actor,
+        now,
+        control: "kill",
+      });
+      nextScenarioState = "paused";
+      nextActiveHandoffId = handoff.handoffId;
+      eventType = "killed";
+      summary = "Killed bounded execution from the strategy desk operator boundary.";
+      break;
+    }
+    case "demote": {
+      if (handoff.status !== "applied" && handoff.status !== "approved") {
+        throw new Error(
+          `runtime-strategy-desk-handoff-demote-not-ready:${handoff.status}`,
+        );
+      }
+      assertScenarioStateTransition(scenario, "paper_ready");
+      await applyControlToMaterializedObjects({
+        env: input.env,
+        scenario,
+        handoff,
+        actor: input.actor,
+        now,
+        control: "demote",
+      });
+      nextScenarioState = "paper_ready";
+      nextActiveHandoffId = null;
+      if (handoff.status === "approved" || handoff.status === "applied") {
+        assertHandoffStateTransition(handoff, "archived");
+        nextStatus = "archived";
+      }
+      eventType = "demoted";
+      summary = "Demoted the scenario back to paper readiness and archived bounded execution bindings.";
+      break;
+    }
+    case "archive": {
+      assertHandoffStateTransition(handoff, "archived");
+      nextStatus = "archived";
+      nextActiveHandoffId =
+        scenario.activeHandoffId === handoff.handoffId ? null : scenario.activeHandoffId;
+      eventType = "archived";
+      summary = "Archived the bounded execution handoff.";
+      break;
+    }
+    default: {
+      const exhaustiveCheck: never = input.action;
+      throw new Error(`runtime-strategy-desk-handoff-action-unknown:${exhaustiveCheck}`);
+    }
+  }
+
+  const nextHandoff = parseRuntimeStrategyDeskPromotionHandoff({
+    ...handoff,
+    status: nextStatus,
+    ...(nextApprovals.length > 0 ? { approvals: nextApprovals } : {}),
+    updatedAt: now,
+    ...(nextAppliedAt ? { appliedAt: nextAppliedAt } : {}),
+  });
+  await writeStrategyDeskPromotionHandoff(input.env.WAITLIST_DB, nextHandoff);
+  await updateStrategyDeskScenarioReviewState(input.env.WAITLIST_DB, {
+    scenarioId: scenario.scenarioId,
+    state: nextScenarioState,
+    activeHandoffId: nextActiveHandoffId,
+    reviewedAt: now,
+    updatedAt: now,
+  });
+  await appendStrategyDeskPromotionHandoffEvent(input.env.WAITLIST_DB, {
+    eventId: createDeskId("desk_handoff_evt", deps),
+    handoffId: handoff.handoffId,
+    eventType,
+    actor: input.actor,
+    ...(handoff.status !== nextStatus ? { fromStatus: handoff.status } : {}),
+    ...(handoff.status !== nextStatus ? { toStatus: nextStatus } : {}),
+    summary,
+    details: {
+      scenarioId: scenario.scenarioId,
+      nextScenarioState,
+      ...(input.notes ? { notes: input.notes } : {}),
+    },
+    createdAt: now,
+  });
+
+  return hydratePromotionResult({
+    env: input.env,
+    scenarioId: scenario.scenarioId,
+    handoffId: handoff.handoffId,
+  });
+}

--- a/apps/worker/src/strategy_desk_handoff_repository.ts
+++ b/apps/worker/src/strategy_desk_handoff_repository.ts
@@ -1,0 +1,548 @@
+import {
+  parseRuntimeStrategyDeskPromotionHandoff,
+  type RuntimeStrategyDeskPromotionHandoff,
+} from "../../../src/runtime/contracts/autonomous_runtime.js";
+
+export type StrategyDeskPromotionHandoffEvent = {
+  eventId: string;
+  handoffId: string;
+  eventType:
+    | "prepared"
+    | "submitted"
+    | "approved"
+    | "applied"
+    | "rejected"
+    | "paused"
+    | "killed"
+    | "demoted"
+    | "archived";
+  actor: string;
+  fromStatus?: string;
+  toStatus?: string;
+  summary: string;
+  details?: Record<string, unknown>;
+  createdAt: string;
+};
+
+export type StrategyDeskExecutionRecipeRecord = {
+  recipeId: string;
+  scenarioId: string;
+  handoffId: string;
+  bindingId: string;
+  schemaVersion: string;
+  status: "paper" | "armed" | "paused" | "killed" | "archived";
+  venueKey: string;
+  instrumentId?: string;
+  pair?: Record<string, unknown>;
+  targetMode: "shadow" | "paper" | "limited_live";
+  lane?: string;
+  legIds: string[];
+  budget?: Record<string, unknown>;
+  notes?: string;
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type StrategyDeskPromotionHandoffRow = Record<string, unknown>;
+type StrategyDeskPromotionHandoffEventRow = Record<string, unknown>;
+type StrategyDeskExecutionRecipeRow = Record<string, unknown>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string {
+  return String(value ?? "");
+}
+
+function stringOrNull(value: unknown): string | null {
+  const parsed = String(value ?? "").trim();
+  return parsed ? parsed : null;
+}
+
+function parseJsonValue(value: unknown): unknown {
+  if (typeof value !== "string" || !value.trim()) return undefined;
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function stringifyJson(value: unknown): string | null {
+  if (value === undefined) return null;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return null;
+  }
+}
+
+function mapHandoffRow(
+  row: StrategyDeskPromotionHandoffRow,
+): RuntimeStrategyDeskPromotionHandoff {
+  const implementationReference = parseJsonValue(row.implementationReference);
+  const evidenceRefs = parseJsonValue(row.evidenceRefs);
+  const checks = parseJsonValue(row.checks);
+  const approvals = parseJsonValue(row.approvals);
+  const bindings = parseJsonValue(row.bindings);
+  const actions = parseJsonValue(row.actions);
+  const metadata = parseJsonValue(row.metadata);
+  const appliedAt = stringOrNull(row.appliedAt);
+
+  return parseRuntimeStrategyDeskPromotionHandoff({
+    schemaVersion: stringValue(row.schemaVersion || "v1"),
+    handoffId: stringValue(row.handoffId),
+    scenarioId: stringValue(row.scenarioId),
+    currentState: stringValue(row.currentState),
+    targetMode: stringValue(row.targetMode),
+    status: stringValue(row.status),
+    summary: stringValue(row.summary),
+    requestedBy: stringValue(row.requestedBy),
+    createdAt: stringValue(row.createdAt),
+    updatedAt: stringValue(row.updatedAt),
+    ...(appliedAt ? { appliedAt } : {}),
+    ...(isRecord(implementationReference) ? { implementationReference } : {}),
+    evidenceRefs: Array.isArray(evidenceRefs) ? evidenceRefs : [],
+    checks: Array.isArray(checks) ? checks : [],
+    approvals: Array.isArray(approvals) ? approvals : [],
+    bindings: Array.isArray(bindings) ? bindings : [],
+    actions: Array.isArray(actions) ? actions : [],
+    ...(isRecord(metadata) ? { metadata } : {}),
+  });
+}
+
+function mapHandoffEventRow(
+  row: StrategyDeskPromotionHandoffEventRow,
+): StrategyDeskPromotionHandoffEvent {
+  const fromStatus = stringOrNull(row.fromStatus);
+  const toStatus = stringOrNull(row.toStatus);
+  const details = parseJsonValue(row.details);
+
+  return {
+    eventId: stringValue(row.eventId),
+    handoffId: stringValue(row.handoffId),
+    eventType: stringValue(
+      row.eventType,
+    ) as StrategyDeskPromotionHandoffEvent["eventType"],
+    actor: stringValue(row.actor),
+    ...(fromStatus ? { fromStatus } : {}),
+    ...(toStatus ? { toStatus } : {}),
+    summary: stringValue(row.summary),
+    ...(isRecord(details) ? { details } : {}),
+    createdAt: stringValue(row.createdAt),
+  };
+}
+
+function mapExecutionRecipeRow(
+  row: StrategyDeskExecutionRecipeRow,
+): StrategyDeskExecutionRecipeRecord {
+  const pair = parseJsonValue(row.pair);
+  const legIds = parseJsonValue(row.legIds);
+  const budget = parseJsonValue(row.budget);
+  const metadata = parseJsonValue(row.metadata);
+  const instrumentId = stringOrNull(row.instrumentId);
+  const lane = stringOrNull(row.lane);
+  const notes = stringOrNull(row.notes);
+
+  return {
+    recipeId: stringValue(row.recipeId),
+    scenarioId: stringValue(row.scenarioId),
+    handoffId: stringValue(row.handoffId),
+    bindingId: stringValue(row.bindingId),
+    schemaVersion: stringValue(row.schemaVersion || "v1"),
+    status: stringValue(
+      row.status,
+    ) as StrategyDeskExecutionRecipeRecord["status"],
+    venueKey: stringValue(row.venueKey),
+    ...(instrumentId ? { instrumentId } : {}),
+    ...(isRecord(pair) ? { pair } : {}),
+    targetMode: stringValue(
+      row.targetMode,
+    ) as StrategyDeskExecutionRecipeRecord["targetMode"],
+    ...(lane ? { lane } : {}),
+    legIds: Array.isArray(legIds)
+      ? legIds.filter((entry): entry is string => typeof entry === "string")
+      : [],
+    ...(isRecord(budget) ? { budget } : {}),
+    ...(notes ? { notes } : {}),
+    ...(isRecord(metadata) ? { metadata } : {}),
+    createdAt: stringValue(row.createdAt),
+    updatedAt: stringValue(row.updatedAt),
+  };
+}
+
+export async function writeStrategyDeskPromotionHandoff(
+  db: D1Database,
+  handoff: RuntimeStrategyDeskPromotionHandoff,
+): Promise<RuntimeStrategyDeskPromotionHandoff> {
+  await db
+    .prepare(
+      `
+      INSERT INTO strategy_desk_promotion_handoffs (
+        handoff_id,
+        scenario_id,
+        schema_version,
+        current_state,
+        target_mode,
+        status,
+        summary,
+        requested_by,
+        implementation_reference_json,
+        evidence_refs_json,
+        checks_json,
+        approvals_json,
+        bindings_json,
+        actions_json,
+        metadata_json,
+        created_at,
+        updated_at,
+        applied_at
+      ) VALUES (
+        ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18
+      )
+      ON CONFLICT(handoff_id) DO UPDATE SET
+        scenario_id = excluded.scenario_id,
+        schema_version = excluded.schema_version,
+        current_state = excluded.current_state,
+        target_mode = excluded.target_mode,
+        status = excluded.status,
+        summary = excluded.summary,
+        requested_by = excluded.requested_by,
+        implementation_reference_json = excluded.implementation_reference_json,
+        evidence_refs_json = excluded.evidence_refs_json,
+        checks_json = excluded.checks_json,
+        approvals_json = excluded.approvals_json,
+        bindings_json = excluded.bindings_json,
+        actions_json = excluded.actions_json,
+        metadata_json = excluded.metadata_json,
+        updated_at = excluded.updated_at,
+        applied_at = excluded.applied_at
+      `,
+    )
+    .bind(
+      handoff.handoffId,
+      handoff.scenarioId,
+      handoff.schemaVersion,
+      handoff.currentState,
+      handoff.targetMode,
+      handoff.status,
+      handoff.summary,
+      handoff.requestedBy,
+      stringifyJson(handoff.implementationReference),
+      stringifyJson(handoff.evidenceRefs) ?? "[]",
+      stringifyJson(handoff.checks) ?? "[]",
+      stringifyJson(handoff.approvals) ?? "[]",
+      stringifyJson(handoff.bindings) ?? "[]",
+      stringifyJson(handoff.actions) ?? "[]",
+      stringifyJson(handoff.metadata),
+      handoff.createdAt,
+      handoff.updatedAt,
+      handoff.appliedAt ?? null,
+    )
+    .run();
+  return handoff;
+}
+
+export async function getStrategyDeskPromotionHandoff(
+  db: D1Database,
+  handoffId: string,
+): Promise<RuntimeStrategyDeskPromotionHandoff | null> {
+  const row = (await db
+    .prepare(
+      `
+      SELECT
+        handoff_id AS handoffId,
+        scenario_id AS scenarioId,
+        schema_version AS schemaVersion,
+        current_state AS currentState,
+        target_mode AS targetMode,
+        status,
+        summary,
+        requested_by AS requestedBy,
+        implementation_reference_json AS implementationReference,
+        evidence_refs_json AS evidenceRefs,
+        checks_json AS checks,
+        approvals_json AS approvals,
+        bindings_json AS bindings,
+        actions_json AS actions,
+        metadata_json AS metadata,
+        created_at AS createdAt,
+        updated_at AS updatedAt,
+        applied_at AS appliedAt
+      FROM strategy_desk_promotion_handoffs
+      WHERE handoff_id = ?1
+      LIMIT 1
+      `,
+    )
+    .bind(handoffId)
+    .first()) as StrategyDeskPromotionHandoffRow | null;
+  return row ? mapHandoffRow(row) : null;
+}
+
+export async function listStrategyDeskPromotionHandoffs(
+  db: D1Database,
+  options?: {
+    handoffId?: string;
+    scenarioId?: string;
+    status?: string;
+    limit?: number;
+  },
+): Promise<RuntimeStrategyDeskPromotionHandoff[]> {
+  const limit = Math.max(1, Math.min(options?.limit ?? 20, 100));
+  const rows = (await db
+    .prepare(
+      `
+      SELECT
+        handoff_id AS handoffId,
+        scenario_id AS scenarioId,
+        schema_version AS schemaVersion,
+        current_state AS currentState,
+        target_mode AS targetMode,
+        status,
+        summary,
+        requested_by AS requestedBy,
+        implementation_reference_json AS implementationReference,
+        evidence_refs_json AS evidenceRefs,
+        checks_json AS checks,
+        approvals_json AS approvals,
+        bindings_json AS bindings,
+        actions_json AS actions,
+        metadata_json AS metadata,
+        created_at AS createdAt,
+        updated_at AS updatedAt,
+        applied_at AS appliedAt
+      FROM strategy_desk_promotion_handoffs
+      WHERE (?1 IS NULL OR handoff_id = ?1)
+        AND (?2 IS NULL OR scenario_id = ?2)
+        AND (?3 IS NULL OR status = ?3)
+      ORDER BY created_at DESC, handoff_id DESC
+      LIMIT ?4
+      `,
+    )
+    .bind(
+      options?.handoffId ?? null,
+      options?.scenarioId ?? null,
+      options?.status ?? null,
+      limit,
+    )
+    .all()) as { results?: StrategyDeskPromotionHandoffRow[] };
+  return (rows.results ?? []).map(mapHandoffRow);
+}
+
+export async function appendStrategyDeskPromotionHandoffEvent(
+  db: D1Database,
+  event: StrategyDeskPromotionHandoffEvent,
+): Promise<StrategyDeskPromotionHandoffEvent> {
+  await db
+    .prepare(
+      `
+      INSERT INTO strategy_desk_promotion_handoff_events (
+        event_id,
+        handoff_id,
+        event_type,
+        actor,
+        from_status,
+        to_status,
+        summary,
+        details_json,
+        created_at
+      ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+      `,
+    )
+    .bind(
+      event.eventId,
+      event.handoffId,
+      event.eventType,
+      event.actor,
+      event.fromStatus ?? null,
+      event.toStatus ?? null,
+      event.summary,
+      stringifyJson(event.details),
+      event.createdAt,
+    )
+    .run();
+  return event;
+}
+
+export async function listStrategyDeskPromotionHandoffEvents(
+  db: D1Database,
+  handoffId: string,
+): Promise<StrategyDeskPromotionHandoffEvent[]> {
+  const rows = (await db
+    .prepare(
+      `
+      SELECT
+        event_id AS eventId,
+        handoff_id AS handoffId,
+        event_type AS eventType,
+        actor,
+        from_status AS fromStatus,
+        to_status AS toStatus,
+        summary,
+        details_json AS details,
+        created_at AS createdAt
+      FROM strategy_desk_promotion_handoff_events
+      WHERE handoff_id = ?1
+      ORDER BY created_at ASC, rowid ASC
+      `,
+    )
+    .bind(handoffId)
+    .all()) as { results?: StrategyDeskPromotionHandoffEventRow[] };
+  return (rows.results ?? []).map(mapHandoffEventRow);
+}
+
+export async function writeStrategyDeskExecutionRecipe(
+  db: D1Database,
+  recipe: StrategyDeskExecutionRecipeRecord,
+): Promise<StrategyDeskExecutionRecipeRecord> {
+  await db
+    .prepare(
+      `
+      INSERT INTO strategy_desk_execution_recipes (
+        recipe_id,
+        scenario_id,
+        handoff_id,
+        binding_id,
+        schema_version,
+        status,
+        venue_key,
+        instrument_id,
+        pair_json,
+        target_mode,
+        lane,
+        leg_ids_json,
+        budget_json,
+        notes,
+        metadata_json,
+        created_at,
+        updated_at
+      ) VALUES (
+        ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17
+      )
+      ON CONFLICT(recipe_id) DO UPDATE SET
+        scenario_id = excluded.scenario_id,
+        handoff_id = excluded.handoff_id,
+        binding_id = excluded.binding_id,
+        schema_version = excluded.schema_version,
+        status = excluded.status,
+        venue_key = excluded.venue_key,
+        instrument_id = excluded.instrument_id,
+        pair_json = excluded.pair_json,
+        target_mode = excluded.target_mode,
+        lane = excluded.lane,
+        leg_ids_json = excluded.leg_ids_json,
+        budget_json = excluded.budget_json,
+        notes = excluded.notes,
+        metadata_json = excluded.metadata_json,
+        updated_at = excluded.updated_at
+      `,
+    )
+    .bind(
+      recipe.recipeId,
+      recipe.scenarioId,
+      recipe.handoffId,
+      recipe.bindingId,
+      recipe.schemaVersion,
+      recipe.status,
+      recipe.venueKey,
+      recipe.instrumentId ?? null,
+      stringifyJson(recipe.pair),
+      recipe.targetMode,
+      recipe.lane ?? null,
+      stringifyJson(recipe.legIds) ?? "[]",
+      stringifyJson(recipe.budget),
+      recipe.notes ?? null,
+      stringifyJson(recipe.metadata),
+      recipe.createdAt,
+      recipe.updatedAt,
+    )
+    .run();
+  return recipe;
+}
+
+export async function getStrategyDeskExecutionRecipeForBinding(
+  db: D1Database,
+  handoffId: string,
+  bindingId: string,
+): Promise<StrategyDeskExecutionRecipeRecord | null> {
+  const row = (await db
+    .prepare(
+      `
+      SELECT
+        recipe_id AS recipeId,
+        scenario_id AS scenarioId,
+        handoff_id AS handoffId,
+        binding_id AS bindingId,
+        schema_version AS schemaVersion,
+        status,
+        venue_key AS venueKey,
+        instrument_id AS instrumentId,
+        pair_json AS pair,
+        target_mode AS targetMode,
+        lane,
+        leg_ids_json AS legIds,
+        budget_json AS budget,
+        notes,
+        metadata_json AS metadata,
+        created_at AS createdAt,
+        updated_at AS updatedAt
+      FROM strategy_desk_execution_recipes
+      WHERE handoff_id = ?1 AND binding_id = ?2
+      LIMIT 1
+      `,
+    )
+    .bind(handoffId, bindingId)
+    .first()) as StrategyDeskExecutionRecipeRow | null;
+  return row ? mapExecutionRecipeRow(row) : null;
+}
+
+export async function listStrategyDeskExecutionRecipes(
+  db: D1Database,
+  options?: {
+    scenarioId?: string;
+    handoffId?: string;
+    status?: string;
+    limit?: number;
+  },
+): Promise<StrategyDeskExecutionRecipeRecord[]> {
+  const limit = Math.max(1, Math.min(options?.limit ?? 20, 100));
+  const rows = (await db
+    .prepare(
+      `
+      SELECT
+        recipe_id AS recipeId,
+        scenario_id AS scenarioId,
+        handoff_id AS handoffId,
+        binding_id AS bindingId,
+        schema_version AS schemaVersion,
+        status,
+        venue_key AS venueKey,
+        instrument_id AS instrumentId,
+        pair_json AS pair,
+        target_mode AS targetMode,
+        lane,
+        leg_ids_json AS legIds,
+        budget_json AS budget,
+        notes,
+        metadata_json AS metadata,
+        created_at AS createdAt,
+        updated_at AS updatedAt
+      FROM strategy_desk_execution_recipes
+      WHERE (?1 IS NULL OR scenario_id = ?1)
+        AND (?2 IS NULL OR handoff_id = ?2)
+        AND (?3 IS NULL OR status = ?3)
+      ORDER BY updated_at DESC, recipe_id DESC
+      LIMIT ?4
+      `,
+    )
+    .bind(
+      options?.scenarioId ?? null,
+      options?.handoffId ?? null,
+      options?.status ?? null,
+      limit,
+    )
+    .all()) as { results?: StrategyDeskExecutionRecipeRow[] };
+  return (rows.results ?? []).map(mapExecutionRecipeRow);
+}

--- a/apps/worker/src/strategy_desk_repository.ts
+++ b/apps/worker/src/strategy_desk_repository.ts
@@ -409,6 +409,37 @@ export async function updateStrategyDeskScenarioLatestReport(
     .run();
 }
 
+export async function updateStrategyDeskScenarioReviewState(
+  db: D1Database,
+  input: {
+    scenarioId: string;
+    state: RuntimeStrategyDeskScenarioManifest["state"];
+    updatedAt: string;
+    activeHandoffId?: string | null;
+    reviewedAt?: string | null;
+  },
+): Promise<void> {
+  await db
+    .prepare(
+      `
+      UPDATE strategy_desk_scenarios
+      SET state = ?2,
+          active_handoff_id = ?3,
+          reviewed_at = ?4,
+          updated_at = ?5
+      WHERE scenario_id = ?1
+      `,
+    )
+    .bind(
+      input.scenarioId,
+      input.state,
+      input.activeHandoffId ?? null,
+      input.reviewedAt ?? null,
+      input.updatedAt,
+    )
+    .run();
+}
+
 export async function getStrategyDeskScenarioManifest(
   db: D1Database,
   scenarioId: string,

--- a/src/runtime/contracts/autonomous_runtime.ts
+++ b/src/runtime/contracts/autonomous_runtime.ts
@@ -2405,7 +2405,7 @@ export const RUNTIME_STRATEGY_DESK_SCENARIO_STATE_TRANSITIONS = {
   shadow_ready: ["paper_ready", "paused", "archived"],
   paper_ready: ["operator_review", "paused", "archived"],
   operator_review: ["paper_ready", "execution_ready", "paused", "archived"],
-  execution_ready: ["execution_bound", "paused", "archived"],
+  execution_ready: ["paper_ready", "execution_bound", "paused", "archived"],
   execution_bound: ["operator_review", "paused", "archived"],
   paused: [
     "replay_ready",

--- a/tests/browser/harness-proof.spec.ts
+++ b/tests/browser/harness-proof.spec.ts
@@ -423,23 +423,23 @@ test("strategy desk proof covers author, run, inspect, and compare flows", async
   await captureCheckpoint(page, "strategy-desk-paper.png");
 
   await page.getByTestId("strategy-desk-prepare-handoff").click();
-  await expect(
-    page.getByTestId("strategy-desk-page"),
-  ).toContainText("operator review");
+  await expect(page.getByTestId("strategy-desk-page")).toContainText(
+    "operator review",
+  );
 
   await page.getByTestId("strategy-desk-submit-handoff").click();
   await page.getByTestId("strategy-desk-approve-handoff").click();
   await page.getByTestId("strategy-desk-apply-handoff").click();
-  await expect(
-    page.getByTestId("strategy-desk-page"),
-  ).toContainText("execution bound");
+  await expect(page.getByTestId("strategy-desk-page")).toContainText(
+    "execution bound",
+  );
   await expect(
     page.getByTestId("strategy-desk-handoff-bindings"),
   ).toContainText("binding_leg_spot_alpha_runtime");
   await captureCheckpoint(page, "strategy-desk-bounded-execution.png");
 
   await page.getByTestId("strategy-desk-demote-handoff").click();
-  await expect(
-    page.getByTestId("strategy-desk-page"),
-  ).toContainText("paper ready");
+  await expect(page.getByTestId("strategy-desk-page")).toContainText(
+    "paper ready",
+  );
 });

--- a/tests/browser/harness-proof.spec.ts
+++ b/tests/browser/harness-proof.spec.ts
@@ -421,4 +421,25 @@ test("strategy desk proof covers author, run, inspect, and compare flows", async
     "leg_spot_alpha",
   );
   await captureCheckpoint(page, "strategy-desk-paper.png");
+
+  await page.getByTestId("strategy-desk-prepare-handoff").click();
+  await expect(
+    page.getByTestId("strategy-desk-page"),
+  ).toContainText("operator review");
+
+  await page.getByTestId("strategy-desk-submit-handoff").click();
+  await page.getByTestId("strategy-desk-approve-handoff").click();
+  await page.getByTestId("strategy-desk-apply-handoff").click();
+  await expect(
+    page.getByTestId("strategy-desk-page"),
+  ).toContainText("execution bound");
+  await expect(
+    page.getByTestId("strategy-desk-handoff-bindings"),
+  ).toContainText("binding_leg_spot_alpha_runtime");
+  await captureCheckpoint(page, "strategy-desk-bounded-execution.png");
+
+  await page.getByTestId("strategy-desk-demote-handoff").click();
+  await expect(
+    page.getByTestId("strategy-desk-page"),
+  ).toContainText("paper ready");
 });

--- a/tests/unit/portal_runtime_strategy_desk_route.test.ts
+++ b/tests/unit/portal_runtime_strategy_desk_route.test.ts
@@ -109,7 +109,8 @@ function handoffFixture() {
     currentState: "operator_review",
     targetMode: "limited_live",
     status: "approved",
-    summary: "Bound the spot leg to limited live while keeping overlays paper-bound.",
+    summary:
+      "Bound the spot leg to limited live while keeping overlays paper-bound.",
     requestedBy: "operator_1",
     createdAt: FIXTURE_TIME,
     updatedAt: FIXTURE_TIME,

--- a/tests/unit/portal_runtime_strategy_desk_route.test.ts
+++ b/tests/unit/portal_runtime_strategy_desk_route.test.ts
@@ -101,6 +101,87 @@ function reportFixture() {
   };
 }
 
+function handoffFixture() {
+  return {
+    schemaVersion: "v1",
+    handoffId: "desk_handoff_sol_composite_live_1",
+    scenarioId: "desk_sol_composite_1",
+    currentState: "operator_review",
+    targetMode: "limited_live",
+    status: "approved",
+    summary: "Bound the spot leg to limited live while keeping overlays paper-bound.",
+    requestedBy: "operator_1",
+    createdAt: FIXTURE_TIME,
+    updatedAt: FIXTURE_TIME,
+    evidenceRefs: [
+      {
+        kind: "strategy_desk_report",
+        ref: "desk_report_sol_composite_paper_1",
+      },
+    ],
+    checks: [
+      {
+        checkId: "limited-live-human-approval",
+        status: "requires_human_approval",
+        message: "Human approval remains required.",
+      },
+    ],
+    approvals: [
+      {
+        targetMode: "limited_live",
+        approvedBy: "operator_1",
+        approvedAt: FIXTURE_TIME,
+      },
+    ],
+    bindings: [
+      {
+        bindingId: "binding_leg_spot_alpha_runtime",
+        bindingKind: "runtime_deployment",
+        legIds: ["leg_spot_alpha"],
+        venueKey: "jupiter",
+        targetMode: "limited_live",
+        deploymentId: "dep_desk_sol_live",
+        lane: "safe",
+      },
+    ],
+    actions: [
+      {
+        actionId: "record-desk-state",
+        actionType: "record_state_transition",
+        summary: "Move into operator review.",
+        required: true,
+      },
+    ],
+  };
+}
+
+function handoffEventFixture() {
+  return {
+    eventId: "desk_handoff_evt_1",
+    handoffId: "desk_handoff_sol_composite_live_1",
+    eventType: "approved",
+    actor: "operator_1",
+    summary: "Approved bounded execution handoff.",
+    createdAt: FIXTURE_TIME,
+  };
+}
+
+function executionRecipeFixture() {
+  return {
+    recipeId: "desk_recipe_perp_1",
+    scenarioId: "desk_sol_composite_1",
+    handoffId: "desk_handoff_sol_composite_live_1",
+    bindingId: "binding_leg_perp_hedge_recipe",
+    status: "paper",
+    venueKey: "drift",
+    instrumentId: "SOL-PERP",
+    targetMode: "paper",
+    legIds: ["leg_perp_hedge"],
+    createdAt: FIXTURE_TIME,
+    updatedAt: FIXTURE_TIME,
+  };
+}
+
 afterEach(() => {
   process.env.NEXT_PUBLIC_EDGE_API_BASE =
     ORIGINAL_ENV.NEXT_PUBLIC_EDGE_API_BASE;
@@ -249,6 +330,36 @@ describe("portal runtime strategy desk route", () => {
           },
         );
       }
+      if (url.includes("/api/admin/ops/runtime/strategy-desk/handoffs?")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            handoffs: [handoffFixture()],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (
+        url.endsWith(
+          "/api/admin/ops/runtime/strategy-desk/handoffs/desk_handoff_sol_composite_live_1",
+        )
+      ) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            handoff: handoffFixture(),
+            events: [handoffEventFixture()],
+            executionRecipes: [executionRecipeFixture()],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
       throw new Error(`unexpected fetch ${url}`);
     }) as typeof fetch;
 
@@ -280,6 +391,24 @@ describe("portal runtime strategy desk route", () => {
         reports: [
           {
             reportId: "desk_report_sol_composite_paper_1",
+          },
+        ],
+        handoffs: [
+          {
+            handoffId: "desk_handoff_sol_composite_live_1",
+          },
+        ],
+        latestHandoff: {
+          handoffId: "desk_handoff_sol_composite_live_1",
+        },
+        handoffEvents: [
+          {
+            eventId: "desk_handoff_evt_1",
+          },
+        ],
+        executionRecipes: [
+          {
+            recipeId: "desk_recipe_perp_1",
           },
         ],
       },
@@ -655,6 +784,176 @@ describe("portal runtime strategy desk route", () => {
       requestedBy: "operator_1",
       selectionMetric: "excess_vs_flat_cash_bps",
       variantIds: ["fast"],
+    });
+  });
+
+  test("forwards handoff preparation through the worker admin surface", async () => {
+    process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
+    process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";
+    process.env.RUNTIME_OPERATOR_USER_ALLOWLIST = "u_1";
+
+    let receivedPath = "";
+    let receivedBody: Record<string, unknown> | null = null;
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url = String(input);
+      if (url.endsWith("/api/me")) {
+        return new Response(JSON.stringify({ ok: true, user: { id: "u_1" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (
+        url.endsWith(
+          "/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/handoffs/prepare",
+        )
+      ) {
+        receivedPath = new URL(url).pathname;
+        receivedBody = JSON.parse(String(init?.body ?? "{}")) as Record<
+          string,
+          unknown
+        >;
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            scenario: scenarioFixture(),
+            handoff: handoffFixture(),
+            events: [handoffEventFixture()],
+            executionRecipes: [executionRecipeFixture()],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const response = await POST(
+      new Request("https://www.trader-ralph.com/api/runtime/strategy-desk", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer user-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          action: "prepare_handoff",
+          scenarioId: "desk_sol_composite_1",
+          requestedBy: "operator_1",
+          targetMode: "limited_live",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      handoff: {
+        handoffId: "desk_handoff_sol_composite_live_1",
+      },
+      executionRecipes: [
+        {
+          recipeId: "desk_recipe_perp_1",
+        },
+      ],
+    });
+    expect(receivedPath).toBe(
+      "/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/handoffs/prepare",
+    );
+    expect(receivedBody).toEqual({
+      requestedBy: "operator_1",
+      targetMode: "limited_live",
+    });
+  });
+
+  test("forwards handoff transitions through the worker admin surface", async () => {
+    process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
+    process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";
+    process.env.RUNTIME_OPERATOR_USER_ALLOWLIST = "u_1";
+
+    let receivedPath = "";
+    let receivedBody: Record<string, unknown> | null = null;
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url = String(input);
+      if (url.endsWith("/api/me")) {
+        return new Response(JSON.stringify({ ok: true, user: { id: "u_1" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (
+        url.endsWith(
+          "/api/admin/ops/runtime/strategy-desk/handoffs/desk_handoff_sol_composite_live_1/transition",
+        )
+      ) {
+        receivedPath = new URL(url).pathname;
+        receivedBody = JSON.parse(String(init?.body ?? "{}")) as Record<
+          string,
+          unknown
+        >;
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            scenario: {
+              ...scenarioFixture(),
+              state: "execution_bound",
+            },
+            handoff: {
+              ...handoffFixture(),
+              status: "applied",
+            },
+            events: [handoffEventFixture()],
+            executionRecipes: [executionRecipeFixture()],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const response = await POST(
+      new Request("https://www.trader-ralph.com/api/runtime/strategy-desk", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer user-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          action: "transition_handoff",
+          handoffId: "desk_handoff_sol_composite_live_1",
+          handoffAction: "apply",
+          actor: "operator_1",
+          notes: "arm bounded execution",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      scenario: {
+        state: "execution_bound",
+      },
+      handoff: {
+        status: "applied",
+      },
+    });
+    expect(receivedPath).toBe(
+      "/api/admin/ops/runtime/strategy-desk/handoffs/desk_handoff_sol_composite_live_1/transition",
+    );
+    expect(receivedBody).toEqual({
+      action: "apply",
+      actor: "operator_1",
+      notes: "arm bounded execution",
     });
   });
 });

--- a/tests/unit/portal_runtime_strategy_desk_route.test.ts
+++ b/tests/unit/portal_runtime_strategy_desk_route.test.ts
@@ -29,6 +29,7 @@ function scenarioFixture() {
     state: "paper_ready",
     createdAt: FIXTURE_TIME,
     updatedAt: FIXTURE_TIME,
+    activeHandoffId: "desk_handoff_sol_composite_live_1",
     legs: [
       {
         legId: "leg_spot_alpha",
@@ -399,6 +400,9 @@ describe("portal runtime strategy desk route", () => {
             handoffId: "desk_handoff_sol_composite_live_1",
           },
         ],
+        activeHandoff: {
+          handoffId: "desk_handoff_sol_composite_live_1",
+        },
         latestHandoff: {
           handoffId: "desk_handoff_sol_composite_live_1",
         },
@@ -416,6 +420,148 @@ describe("portal runtime strategy desk route", () => {
     });
     expect(seenAuthHeaders).toContain("Bearer user-token");
     expect(seenAuthHeaders).toContain("Bearer operator-admin");
+  });
+
+  test("loads detail from the active handoff even when a newer draft exists", async () => {
+    process.env.NEXT_PUBLIC_EDGE_API_BASE = "https://api.trader-ralph.com";
+    process.env.RUNTIME_OPERATOR_ADMIN_TOKEN = "operator-admin";
+    process.env.RUNTIME_OPERATOR_USER_ALLOWLIST = "u_1";
+
+    const latestDraft = {
+      ...handoffFixture(),
+      handoffId: "desk_handoff_sol_composite_draft_2",
+      status: "draft",
+      updatedAt: "2026-03-17T03:09:10Z",
+    };
+    let detailPath = "";
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/api/me")) {
+        return new Response(JSON.stringify({ ok: true, user: { id: "u_1" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.includes("/api/admin/ops/runtime/strategy-desk/scenarios?")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            scenarios: [scenarioFixture()],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (
+        url.endsWith(
+          "/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1",
+        )
+      ) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            scenario: scenarioFixture(),
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (url.includes("/api/admin/ops/runtime/strategy-desk/runs?")) {
+        return new Response(
+          JSON.stringify({ ok: true, runs: [runFixture()] }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (url.includes("/api/admin/ops/runtime/strategy-desk/reports?")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            reports: [reportFixture()],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (url.includes("/api/admin/ops/runtime/strategy-desk/handoffs?")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            handoffs: [handoffFixture(), latestDraft],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (
+        url.endsWith(
+          "/api/admin/ops/runtime/strategy-desk/handoffs/desk_handoff_sol_composite_live_1",
+        )
+      ) {
+        detailPath = new URL(url).pathname;
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            handoff: handoffFixture(),
+            events: [handoffEventFixture()],
+            executionRecipes: [executionRecipeFixture()],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const response = await GET(
+      new Request(
+        "https://www.trader-ralph.com/api/runtime/strategy-desk?scenarioId=desk_sol_composite_1",
+        {
+          headers: {
+            authorization: "Bearer user-token",
+          },
+        },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      snapshot: {
+        activeHandoff: {
+          handoffId: "desk_handoff_sol_composite_live_1",
+        },
+        latestHandoff: {
+          handoffId: "desk_handoff_sol_composite_draft_2",
+        },
+        handoffEvents: [
+          {
+            handoffId: "desk_handoff_sol_composite_live_1",
+          },
+        ],
+        executionRecipes: [
+          {
+            handoffId: "desk_handoff_sol_composite_live_1",
+          },
+        ],
+      },
+    });
+    expect(detailPath).toBe(
+      "/api/admin/ops/runtime/strategy-desk/handoffs/desk_handoff_sol_composite_live_1",
+    );
   });
 
   test("fails closed when the requested scenario cannot be loaded", async () => {

--- a/tests/unit/portal_strategy_desk_handoff_selection.test.ts
+++ b/tests/unit/portal_strategy_desk_handoff_selection.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type StrategyDeskApiPayload,
+  selectStrategyDeskFocusHandoff,
+  selectStrategyDeskHandoffForAction,
+} from "../../apps/portal/app/terminal/strategy-desk/types";
+import type { RuntimeStrategyDeskPromotionHandoff } from "../../apps/portal/lib/runtime-strategy-desk";
+
+const FIXTURE_TIME = "2026-03-17T03:08:10Z";
+
+function handoffFixture(
+  overrides?: Partial<RuntimeStrategyDeskPromotionHandoff>,
+): RuntimeStrategyDeskPromotionHandoff {
+  return {
+    schemaVersion: "v1",
+    handoffId: "desk_handoff_sol_composite_live_1",
+    scenarioId: "desk_sol_composite_1",
+    currentState: "operator_review",
+    targetMode: "limited_live",
+    status: "approved",
+    summary: "Bounded execution handoff.",
+    requestedBy: "operator_1",
+    createdAt: FIXTURE_TIME,
+    updatedAt: FIXTURE_TIME,
+    evidenceRefs: [],
+    checks: [],
+    approvals: [],
+    bindings: [],
+    actions: [],
+    ...overrides,
+  };
+}
+
+function snapshotFixture(
+  overrides?: Partial<StrategyDeskApiPayload["snapshot"]>,
+): StrategyDeskApiPayload["snapshot"] {
+  return {
+    scenarios: [],
+    selectedScenarioId: "desk_sol_composite_1",
+    selectedScenario: null,
+    runs: [],
+    reports: [],
+    handoffs: [],
+    activeHandoff: null,
+    latestHandoff: null,
+    handoffEvents: [],
+    executionRecipes: [],
+    latestRun: null,
+    latestReport: null,
+    ...overrides,
+  };
+}
+
+describe("strategy desk handoff selection", () => {
+  test("routes submit to the newest draft while keeping controls on the active applied handoff", () => {
+    const activeHandoff = handoffFixture({
+      handoffId: "desk_handoff_active",
+      status: "applied",
+    });
+    const latestDraft = handoffFixture({
+      handoffId: "desk_handoff_draft",
+      status: "draft",
+      updatedAt: "2026-03-17T03:09:10Z",
+    });
+    const snapshot = snapshotFixture({
+      activeHandoff,
+      latestHandoff: latestDraft,
+    });
+
+    expect(
+      selectStrategyDeskHandoffForAction(snapshot, "submit")?.handoffId,
+    ).toBe("desk_handoff_draft");
+    expect(
+      selectStrategyDeskHandoffForAction(snapshot, "pause")?.handoffId,
+    ).toBe("desk_handoff_active");
+    expect(selectStrategyDeskFocusHandoff(snapshot)?.handoffId).toBe(
+      "desk_handoff_active",
+    );
+  });
+
+  test("keeps apply and demote pinned to the active approved handoff when a newer draft exists", () => {
+    const activeApproved = handoffFixture({
+      handoffId: "desk_handoff_active",
+      status: "approved",
+    });
+    const latestDraft = handoffFixture({
+      handoffId: "desk_handoff_draft",
+      status: "draft",
+      updatedAt: "2026-03-17T03:09:10Z",
+    });
+    const snapshot = snapshotFixture({
+      activeHandoff: activeApproved,
+      latestHandoff: latestDraft,
+    });
+
+    expect(
+      selectStrategyDeskHandoffForAction(snapshot, "apply")?.handoffId,
+    ).toBe("desk_handoff_active");
+    expect(
+      selectStrategyDeskHandoffForAction(snapshot, "demote")?.handoffId,
+    ).toBe("desk_handoff_active");
+  });
+});

--- a/tests/unit/runtime_protocol_contracts.test.ts
+++ b/tests/unit/runtime_protocol_contracts.test.ts
@@ -1688,6 +1688,12 @@ describe("runtime protocol contracts", () => {
     ).toBe(true);
     expect(
       canTransitionRuntimeStrategyDeskScenarioState(
+        "execution_ready",
+        "paper_ready",
+      ),
+    ).toBe(true);
+    expect(
+      canTransitionRuntimeStrategyDeskScenarioState(
         "execution_bound",
         "paper_ready",
       ),

--- a/tests/unit/runtime_strategy_desk_runner.test.ts
+++ b/tests/unit/runtime_strategy_desk_runner.test.ts
@@ -65,6 +65,7 @@ function createOpsEnv(overrides?: Partial<Env>) {
     "0032_strategy_desk_leg_intent.sql",
     "0033_strategy_desk_scorecards.sql",
     "0034_strategy_desk_research_matrix.sql",
+    "0035_strategy_desk_promotion_handoffs.sql",
   ]) {
     const migrationPath = resolve(
       import.meta.dir,

--- a/tests/unit/runtime_strategy_desk_study.test.ts
+++ b/tests/unit/runtime_strategy_desk_study.test.ts
@@ -60,6 +60,7 @@ function createOpsEnv(overrides?: Partial<Env>) {
     "0032_strategy_desk_leg_intent.sql",
     "0033_strategy_desk_scorecards.sql",
     "0034_strategy_desk_research_matrix.sql",
+    "0035_strategy_desk_promotion_handoffs.sql",
   ]) {
     const migrationPath = resolve(
       import.meta.dir,

--- a/tests/unit/worker_execution_migrations.test.ts
+++ b/tests/unit/worker_execution_migrations.test.ts
@@ -18,6 +18,7 @@ function withExecutionSchema(run: (db: Database) => void): void {
       "0032_strategy_desk_leg_intent.sql",
       "0033_strategy_desk_scorecards.sql",
       "0034_strategy_desk_research_matrix.sql",
+      "0035_strategy_desk_promotion_handoffs.sql",
     ]) {
       const migrationPath = resolve(
         import.meta.dir,
@@ -119,7 +120,10 @@ describe("worker execution schema migration", () => {
               'strategy_desk_scenarios',
               'strategy_desk_scenario_legs',
               'strategy_desk_runs',
-              'strategy_desk_reports'
+              'strategy_desk_reports',
+              'strategy_desk_promotion_handoffs',
+              'strategy_desk_promotion_handoff_events',
+              'strategy_desk_execution_recipes'
             )
           ORDER BY name
           `,
@@ -135,6 +139,9 @@ describe("worker execution schema migration", () => {
         "execution_status_events",
         "runtime_canary_runs",
         "runtime_canary_state",
+        "strategy_desk_execution_recipes",
+        "strategy_desk_promotion_handoff_events",
+        "strategy_desk_promotion_handoffs",
         "strategy_desk_reports",
         "strategy_desk_runs",
         "strategy_desk_scenario_legs",

--- a/tests/unit/worker_runtime_strategy_desk_execute_route.test.ts
+++ b/tests/unit/worker_runtime_strategy_desk_execute_route.test.ts
@@ -146,6 +146,7 @@ function createOpsEnv(overrides?: Partial<Env>) {
     "0032_strategy_desk_leg_intent.sql",
     "0033_strategy_desk_scorecards.sql",
     "0034_strategy_desk_research_matrix.sql",
+    "0035_strategy_desk_promotion_handoffs.sql",
   ]) {
     const migrationPath = resolve(
       import.meta.dir,

--- a/tests/unit/worker_runtime_strategy_desk_route.test.ts
+++ b/tests/unit/worker_runtime_strategy_desk_route.test.ts
@@ -716,4 +716,139 @@ describe("worker runtime strategy desk routes", () => {
       sqlite.close();
     }
   });
+
+  test("applies bounded execution handoffs once and records the applying operator in promotion artifacts", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const scenario = readFixture(
+        "runtime.strategy_desk_scenario.valid.v1.json",
+      );
+      const run = readFixture("runtime.strategy_desk_run.valid.v1.json");
+      const report = readFixture("runtime.strategy_desk_report.valid.v1.json");
+
+      for (const [path, payload] of [
+        [
+          "http://localhost/api/admin/ops/runtime/strategy-desk/scenarios",
+          scenario,
+        ],
+        ["http://localhost/api/admin/ops/runtime/strategy-desk/runs", run],
+        [
+          "http://localhost/api/admin/ops/runtime/strategy-desk/reports",
+          report,
+        ],
+      ] as const) {
+        const response = await worker.fetch(
+          new Request(path, {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify(payload),
+          }),
+          env,
+          createExecutionContextStub(),
+        );
+        expect(response.status).toBe(200);
+      }
+
+      const prepareResponse = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/handoffs/prepare",
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              requestedBy: "requester_1",
+              targetMode: "limited_live",
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(prepareResponse.status).toBe(200);
+      const preparePayload = (await prepareResponse.json()) as {
+        handoff: { handoffId: string };
+      };
+      const handoffId = preparePayload.handoff.handoffId;
+
+      for (const [action, actor] of [
+        ["submit", "requester_1"],
+        ["approve", "approver_2"],
+        ["apply", "approver_2"],
+      ] as const) {
+        const response = await worker.fetch(
+          new Request(
+            `http://localhost/api/admin/ops/runtime/strategy-desk/handoffs/${handoffId}/transition`,
+            {
+              method: "POST",
+              headers: {
+                authorization: "Bearer admin-secret",
+                "content-type": "application/json",
+              },
+              body: JSON.stringify({
+                action,
+                actor,
+              }),
+            },
+          ),
+          env,
+          createExecutionContextStub(),
+        );
+        expect(response.status).toBe(200);
+      }
+
+      const promotionRow = sqlite
+        .query(
+          "SELECT requested_by AS requestedBy, metadata_json AS metadataJson FROM strategy_lab_promotions LIMIT 1",
+        )
+        .get() as { requestedBy: string; metadataJson: string };
+      const appliedEventRow = sqlite
+        .query(
+          "SELECT actor FROM strategy_lab_promotion_events WHERE event_type = 'applied' LIMIT 1",
+        )
+        .get() as { actor: string };
+
+      expect(promotionRow.requestedBy).toBe("approver_2");
+      expect(JSON.parse(promotionRow.metadataJson)).toMatchObject({
+        handoffRequestedBy: "requester_1",
+      });
+      expect(appliedEventRow.actor).toBe("approver_2");
+
+      const secondApplyResponse = await worker.fetch(
+        new Request(
+          `http://localhost/api/admin/ops/runtime/strategy-desk/handoffs/${handoffId}/transition`,
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              action: "apply",
+              actor: "approver_2",
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(secondApplyResponse.status).toBe(400);
+      await expect(secondApplyResponse.json()).resolves.toMatchObject({
+        ok: false,
+        error: `runtime-strategy-desk-handoff-already-applied:${handoffId}`,
+      });
+
+      const promotionCount = sqlite
+        .query("SELECT COUNT(*) AS count FROM strategy_lab_promotions")
+        .get() as { count: number };
+      expect(promotionCount.count).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
 });

--- a/tests/unit/worker_runtime_strategy_desk_route.test.ts
+++ b/tests/unit/worker_runtime_strategy_desk_route.test.ts
@@ -982,6 +982,159 @@ describe("worker runtime strategy desk routes", () => {
     }
   });
 
+  test("blocks apply when a newer active handoff supersedes an older approved handoff", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const scenario = readFixture(
+        "runtime.strategy_desk_scenario.valid.v1.json",
+      );
+      const run = readFixture("runtime.strategy_desk_run.valid.v1.json");
+      const report = {
+        ...readFixture("runtime.strategy_desk_report.valid.v1.json"),
+        status: "pass",
+      };
+
+      for (const [path, payload] of [
+        [
+          "http://localhost/api/admin/ops/runtime/strategy-desk/scenarios",
+          scenario,
+        ],
+        ["http://localhost/api/admin/ops/runtime/strategy-desk/runs", run],
+        [
+          "http://localhost/api/admin/ops/runtime/strategy-desk/reports",
+          report,
+        ],
+      ] as const) {
+        const response = await worker.fetch(
+          new Request(path, {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify(payload),
+          }),
+          env,
+          createExecutionContextStub(),
+        );
+        expect(response.status).toBe(200);
+      }
+
+      async function prepareApproveHandoff(requestedBy: string) {
+        const prepareResponse = await worker.fetch(
+          new Request(
+            "http://localhost/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/handoffs/prepare",
+            {
+              method: "POST",
+              headers: {
+                authorization: "Bearer admin-secret",
+                "content-type": "application/json",
+              },
+              body: JSON.stringify({
+                requestedBy,
+                targetMode: "limited_live",
+              }),
+            },
+          ),
+          env,
+          createExecutionContextStub(),
+        );
+        expect(prepareResponse.status).toBe(200);
+        const preparePayload = (await prepareResponse.json()) as {
+          handoff: { handoffId: string };
+        };
+        const handoffId = preparePayload.handoff.handoffId;
+
+        for (const action of ["submit", "approve"] as const) {
+          const response = await worker.fetch(
+            new Request(
+              `http://localhost/api/admin/ops/runtime/strategy-desk/handoffs/${handoffId}/transition`,
+              {
+                method: "POST",
+                headers: {
+                  authorization: "Bearer admin-secret",
+                  "content-type": "application/json",
+                },
+                body: JSON.stringify({
+                  action,
+                  actor: requestedBy,
+                }),
+              },
+            ),
+            env,
+            createExecutionContextStub(),
+          );
+          expect(response.status).toBe(200);
+        }
+
+        return handoffId;
+      }
+
+      const staleApprovedHandoffId = await prepareApproveHandoff("operator_1");
+      const prepareNewerDraftResponse = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/handoffs/prepare",
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              requestedBy: "operator_2",
+              targetMode: "limited_live",
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(prepareNewerDraftResponse.status).toBe(200);
+      const prepareNewerDraftPayload =
+        (await prepareNewerDraftResponse.json()) as {
+          handoff: { handoffId: string };
+        };
+      const activeApprovedHandoffId =
+        prepareNewerDraftPayload.handoff.handoffId;
+
+      sqlite
+        .query(
+          "UPDATE strategy_desk_scenarios SET active_handoff_id = ?1, updated_at = ?2 WHERE scenario_id = ?3",
+        )
+        .run(
+          activeApprovedHandoffId,
+          "2026-03-17T03:10:00Z",
+          "desk_sol_composite_1",
+        );
+
+      const applyResponse = await worker.fetch(
+        new Request(
+          `http://localhost/api/admin/ops/runtime/strategy-desk/handoffs/${staleApprovedHandoffId}/transition`,
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              action: "apply",
+              actor: "operator_1",
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(applyResponse.status).toBe(400);
+      await expect(applyResponse.json()).resolves.toMatchObject({
+        ok: false,
+        error: `runtime-strategy-desk-handoff-not-active:apply:${activeApprovedHandoffId}`,
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
   test("demotes approved handoffs without requiring materialized deployment controls", async () => {
     const { env, sqlite } = createOpsEnv();
     try {

--- a/tests/unit/worker_runtime_strategy_desk_route.test.ts
+++ b/tests/unit/worker_runtime_strategy_desk_route.test.ts
@@ -68,6 +68,7 @@ function createOpsEnv(overrides?: Partial<Env>) {
     "0032_strategy_desk_leg_intent.sql",
     "0033_strategy_desk_scorecards.sql",
     "0034_strategy_desk_research_matrix.sql",
+    "0035_strategy_desk_promotion_handoffs.sql",
   ]) {
     const migrationPath = resolve(
       import.meta.dir,
@@ -528,6 +529,189 @@ describe("worker runtime strategy desk routes", () => {
       expect(scenarioCount.count).toBe(1);
       expect(runCount.count).toBe(1);
       expect(reportCount.count).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("prepares, applies, and rolls back bounded execution handoffs", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const scenario = readFixture(
+        "runtime.strategy_desk_scenario.valid.v1.json",
+      );
+      const run = readFixture("runtime.strategy_desk_run.valid.v1.json");
+      const report = readFixture("runtime.strategy_desk_report.valid.v1.json");
+
+      for (const [path, payload] of [
+        [
+          "http://localhost/api/admin/ops/runtime/strategy-desk/scenarios",
+          scenario,
+        ],
+        ["http://localhost/api/admin/ops/runtime/strategy-desk/runs", run],
+        [
+          "http://localhost/api/admin/ops/runtime/strategy-desk/reports",
+          report,
+        ],
+      ] as const) {
+        const response = await worker.fetch(
+          new Request(path, {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify(payload),
+          }),
+          env,
+          createExecutionContextStub(),
+        );
+        expect(response.status).toBe(200);
+      }
+
+      const prepareResponse = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/handoffs/prepare",
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              requestedBy: "operator_1",
+              targetMode: "limited_live",
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(prepareResponse.status).toBe(200);
+      const preparePayload = (await prepareResponse.json()) as {
+        ok: boolean;
+        handoff: { handoffId: string; status: string; bindings: unknown[] };
+        events: Array<{ eventType: string }>;
+      };
+      expect(preparePayload.ok).toBe(true);
+      expect(preparePayload.handoff.status).toBe("draft");
+      expect(preparePayload.handoff.bindings.length).toBeGreaterThan(0);
+      expect(preparePayload.events.map((event) => event.eventType)).toEqual([
+        "prepared",
+      ]);
+
+      const handoffId = preparePayload.handoff.handoffId;
+
+      for (const action of ["submit", "approve", "apply"] as const) {
+        const response = await worker.fetch(
+          new Request(
+            `http://localhost/api/admin/ops/runtime/strategy-desk/handoffs/${handoffId}/transition`,
+            {
+              method: "POST",
+              headers: {
+                authorization: "Bearer admin-secret",
+                "content-type": "application/json",
+              },
+              body: JSON.stringify({
+                action,
+                actor: "operator_1",
+              }),
+            },
+          ),
+          env,
+          createExecutionContextStub(),
+        );
+        expect(response.status).toBe(200);
+      }
+
+      const appliedDetailResponse = await worker.fetch(
+        new Request(
+          `http://localhost/api/admin/ops/runtime/strategy-desk/handoffs/${handoffId}`,
+          {
+            headers: {
+              authorization: "Bearer admin-secret",
+            },
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(appliedDetailResponse.status).toBe(200);
+      const appliedDetailPayload = (await appliedDetailResponse.json()) as {
+        ok: boolean;
+        handoff: { status: string };
+        events: Array<{ eventType: string }>;
+        executionRecipes: Array<{ recipeId: string }>;
+      };
+      expect(appliedDetailPayload.ok).toBe(true);
+      expect(appliedDetailPayload.handoff.status).toBe("applied");
+      expect(
+        appliedDetailPayload.events.map((event) => event.eventType),
+      ).toEqual(["prepared", "submitted", "approved", "applied"]);
+      expect(appliedDetailPayload.executionRecipes.length).toBeGreaterThan(0);
+
+      const promotionCount = sqlite
+        .query("SELECT COUNT(*) AS count FROM strategy_lab_promotions")
+        .get() as { count: number };
+      const recipeCount = sqlite
+        .query("SELECT COUNT(*) AS count FROM strategy_desk_execution_recipes")
+        .get() as { count: number };
+      expect(promotionCount.count).toBe(1);
+      expect(recipeCount.count).toBeGreaterThan(0);
+
+      const pauseResponse = await worker.fetch(
+        new Request(
+          `http://localhost/api/admin/ops/runtime/strategy-desk/handoffs/${handoffId}/transition`,
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              action: "pause",
+              actor: "operator_1",
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(pauseResponse.status).toBe(200);
+      const pausePayload = (await pauseResponse.json()) as {
+        ok: boolean;
+        scenario: { state: string };
+      };
+      expect(pausePayload.ok).toBe(true);
+      expect(pausePayload.scenario.state).toBe("paused");
+
+      const demoteResponse = await worker.fetch(
+        new Request(
+          `http://localhost/api/admin/ops/runtime/strategy-desk/handoffs/${handoffId}/transition`,
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              action: "demote",
+              actor: "operator_1",
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(demoteResponse.status).toBe(200);
+      const demotePayload = (await demoteResponse.json()) as {
+        ok: boolean;
+        scenario: { state: string };
+        handoff: { status: string };
+      };
+      expect(demotePayload.ok).toBe(true);
+      expect(demotePayload.scenario.state).toBe("paper_ready");
+      expect(demotePayload.handoff.status).toBe("archived");
     } finally {
       sqlite.close();
     }

--- a/tests/unit/worker_runtime_strategy_desk_route.test.ts
+++ b/tests/unit/worker_runtime_strategy_desk_route.test.ts
@@ -305,7 +305,10 @@ describe("worker runtime strategy desk routes", () => {
         "runtime.strategy_desk_scenario.valid.v1.json",
       );
       const run = readFixture("runtime.strategy_desk_run.valid.v1.json");
-      const report = readFixture("runtime.strategy_desk_report.valid.v1.json");
+      const report = {
+        ...readFixture("runtime.strategy_desk_report.valid.v1.json"),
+        status: "pass",
+      };
 
       for (const payload of [scenario]) {
         const response = await worker.fetch(
@@ -541,7 +544,10 @@ describe("worker runtime strategy desk routes", () => {
         "runtime.strategy_desk_scenario.valid.v1.json",
       );
       const run = readFixture("runtime.strategy_desk_run.valid.v1.json");
-      const report = readFixture("runtime.strategy_desk_report.valid.v1.json");
+      const report = {
+        ...readFixture("runtime.strategy_desk_report.valid.v1.json"),
+        status: "pass",
+      };
 
       for (const [path, payload] of [
         [
@@ -724,7 +730,10 @@ describe("worker runtime strategy desk routes", () => {
         "runtime.strategy_desk_scenario.valid.v1.json",
       );
       const run = readFixture("runtime.strategy_desk_run.valid.v1.json");
-      const report = readFixture("runtime.strategy_desk_report.valid.v1.json");
+      const report = {
+        ...readFixture("runtime.strategy_desk_report.valid.v1.json"),
+        status: "pass",
+      };
 
       for (const [path, payload] of [
         [
@@ -847,6 +856,248 @@ describe("worker runtime strategy desk routes", () => {
         .query("SELECT COUNT(*) AS count FROM strategy_lab_promotions")
         .get() as { count: number };
       expect(promotionCount.count).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("blocks apply when the prepared handoff still has blocked checks", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const scenario = readFixture(
+        "runtime.strategy_desk_scenario.valid.v1.json",
+      );
+      const run = readFixture("runtime.strategy_desk_run.valid.v1.json");
+      const report = {
+        ...readFixture("runtime.strategy_desk_report.valid.v1.json"),
+        status: "blocked",
+      };
+
+      for (const [path, payload] of [
+        [
+          "http://localhost/api/admin/ops/runtime/strategy-desk/scenarios",
+          scenario,
+        ],
+        ["http://localhost/api/admin/ops/runtime/strategy-desk/runs", run],
+        [
+          "http://localhost/api/admin/ops/runtime/strategy-desk/reports",
+          report,
+        ],
+      ] as const) {
+        const response = await worker.fetch(
+          new Request(path, {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify(payload),
+          }),
+          env,
+          createExecutionContextStub(),
+        );
+        expect(response.status).toBe(200);
+      }
+
+      const prepareResponse = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/handoffs/prepare",
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              requestedBy: "operator_1",
+              targetMode: "limited_live",
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(prepareResponse.status).toBe(200);
+      const preparePayload = (await prepareResponse.json()) as {
+        handoff: { handoffId: string; checks: Array<{ status: string }> };
+      };
+      const handoffId = preparePayload.handoff.handoffId;
+      expect(
+        preparePayload.handoff.checks.some(
+          (check) => check.status === "blocked",
+        ),
+      ).toBe(true);
+
+      for (const action of ["submit", "approve"] as const) {
+        const response = await worker.fetch(
+          new Request(
+            `http://localhost/api/admin/ops/runtime/strategy-desk/handoffs/${handoffId}/transition`,
+            {
+              method: "POST",
+              headers: {
+                authorization: "Bearer admin-secret",
+                "content-type": "application/json",
+              },
+              body: JSON.stringify({
+                action,
+                actor: "operator_1",
+              }),
+            },
+          ),
+          env,
+          createExecutionContextStub(),
+        );
+        expect(response.status).toBe(200);
+      }
+
+      const applyResponse = await worker.fetch(
+        new Request(
+          `http://localhost/api/admin/ops/runtime/strategy-desk/handoffs/${handoffId}/transition`,
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              action: "apply",
+              actor: "operator_1",
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(applyResponse.status).toBe(400);
+      const applyPayload = (await applyResponse.json()) as {
+        ok: boolean;
+        error: string;
+      };
+      expect(applyPayload.ok).toBe(false);
+      expect(applyPayload.error).toContain(
+        `runtime-strategy-desk-handoff-checks-blocked:${handoffId}:paper-report-pass`,
+      );
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("demotes approved handoffs without requiring materialized deployment controls", async () => {
+    const { env, sqlite } = createOpsEnv();
+    try {
+      const scenario = readFixture(
+        "runtime.strategy_desk_scenario.valid.v1.json",
+      );
+      const run = readFixture("runtime.strategy_desk_run.valid.v1.json");
+      const report = {
+        ...readFixture("runtime.strategy_desk_report.valid.v1.json"),
+        status: "pass",
+      };
+
+      for (const [path, payload] of [
+        [
+          "http://localhost/api/admin/ops/runtime/strategy-desk/scenarios",
+          scenario,
+        ],
+        ["http://localhost/api/admin/ops/runtime/strategy-desk/runs", run],
+        [
+          "http://localhost/api/admin/ops/runtime/strategy-desk/reports",
+          report,
+        ],
+      ] as const) {
+        const response = await worker.fetch(
+          new Request(path, {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify(payload),
+          }),
+          env,
+          createExecutionContextStub(),
+        );
+        expect(response.status).toBe(200);
+      }
+
+      const prepareResponse = await worker.fetch(
+        new Request(
+          "http://localhost/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/handoffs/prepare",
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              requestedBy: "operator_1",
+              targetMode: "limited_live",
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(prepareResponse.status).toBe(200);
+      const preparePayload = (await prepareResponse.json()) as {
+        handoff: { handoffId: string };
+      };
+      const handoffId = preparePayload.handoff.handoffId;
+
+      for (const action of ["submit", "approve"] as const) {
+        const response = await worker.fetch(
+          new Request(
+            `http://localhost/api/admin/ops/runtime/strategy-desk/handoffs/${handoffId}/transition`,
+            {
+              method: "POST",
+              headers: {
+                authorization: "Bearer admin-secret",
+                "content-type": "application/json",
+              },
+              body: JSON.stringify({
+                action,
+                actor: "operator_1",
+              }),
+            },
+          ),
+          env,
+          createExecutionContextStub(),
+        );
+        expect(response.status).toBe(200);
+      }
+
+      const demoteResponse = await worker.fetch(
+        new Request(
+          `http://localhost/api/admin/ops/runtime/strategy-desk/handoffs/${handoffId}/transition`,
+          {
+            method: "POST",
+            headers: {
+              authorization: "Bearer admin-secret",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              action: "demote",
+              actor: "operator_1",
+            }),
+          },
+        ),
+        env,
+        createExecutionContextStub(),
+      );
+      expect(demoteResponse.status).toBe(200);
+      const demotePayload = (await demoteResponse.json()) as {
+        ok: boolean;
+        scenario: { state: string };
+        handoff: { status: string };
+      };
+      expect(demotePayload.ok).toBe(true);
+      expect(demotePayload.scenario.state).toBe("paper_ready");
+      expect(demotePayload.handoff.status).toBe("archived");
+
+      const promotionCount = sqlite
+        .query("SELECT COUNT(*) AS count FROM strategy_lab_promotions")
+        .get() as { count: number };
+      expect(promotionCount.count).toBe(0);
     } finally {
       sqlite.close();
     }

--- a/tests/unit/worker_runtime_strategy_desk_study_route.test.ts
+++ b/tests/unit/worker_runtime_strategy_desk_study_route.test.ts
@@ -240,6 +240,7 @@ function createOpsEnv(overrides?: Partial<Env>) {
     "0032_strategy_desk_leg_intent.sql",
     "0033_strategy_desk_scorecards.sql",
     "0034_strategy_desk_research_matrix.sql",
+    "0035_strategy_desk_promotion_handoffs.sql",
   ]) {
     const migrationPath = resolve(
       import.meta.dir,


### PR DESCRIPTION
## Summary
- add strategy-desk promotion handoff persistence, transitions, and bounded execution materialization in the worker
- expose handoff preparation and transition flows through the portal strategy desk and proof surface
- cover the new handoff lifecycle with worker, portal, migration, and browser-proof tests

## Testing
- bun test tests/unit/worker_runtime_strategy_desk_route.test.ts tests/unit/portal_runtime_strategy_desk_route.test.ts tests/unit/worker_execution_migrations.test.ts
- bun test tests/unit/runtime_strategy_desk_runner.test.ts tests/unit/runtime_strategy_desk_study.test.ts
- bun run harness:proof --output-dir .tmp/browser-proof-sd6