### PR TITLE
[Phase SD7] Add strategy desk proof runbooks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -149,7 +149,7 @@
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
-    "@drift-labs/sdk": ["@drift-labs/sdk@2.159.0-beta.2", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/anchor-30": "npm:@coral-xyz/anchor@0.30.1", "@ellipsis-labs/phoenix-sdk": "1.4.5", "@grpc/grpc-js": "1.14.0", "@msgpack/msgpack": "^3.1.2", "@openbook-dex/openbook-v2": "0.2.10", "@project-serum/serum": "0.13.65", "@pythnetwork/client": "2.5.3", "@pythnetwork/price-service-sdk": "1.7.1", "@pythnetwork/pyth-lazer-sdk": "5.2.1", "@solana/spl-token": "0.4.13", "@solana/web3.js": "1.98.0", "@switchboard-xyz/common": "3.0.14", "@switchboard-xyz/on-demand": "2.4.1", "@triton-one/yellowstone-grpc": "5.0.2", "anchor-bankrun": "0.3.0", "gill": "^0.10.2", "nanoid": "3.3.4", "node-cache": "5.1.2", "solana-bankrun": "0.3.1", "strict-event-emitter-types": "2.0.0", "tweetnacl": "1.0.3", "tweetnacl-util": "0.15.1", "uuid": "8.3.2", "yargs": "17.7.2", "zod": "4.0.17", "zstddec": "0.1.0" }, "optionalDependencies": { "helius-laserstream": "0.1.8" } }, "sha512-WkDFgb6aSCeAeVuwN2B+kupc4FyrXN8paWUczfEYk80Bsk0ArPD6teL6Z41NTb6H+saSzUqHUHxxd+3bxgNImQ=="],
+    "@drift-labs/sdk": ["@drift-labs/sdk@2.159.0-beta.2", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/anchor-30": "npm:@coral-xyz/anchor@0.30.1", "@ellipsis-labs/phoenix-sdk": "1.4.5", "@grpc/grpc-js": "1.14.0", "@msgpack/msgpack": "^3.1.2", "@noble/hashes": "^1.8.0", "@openbook-dex/openbook-v2": "0.2.10", "@project-serum/serum": "0.13.65", "@pythnetwork/client": "2.5.3", "@pythnetwork/price-service-sdk": "1.7.1", "@pythnetwork/pyth-lazer-sdk": "5.2.1", "@solana/spl-token": "0.4.13", "@solana/web3.js": "1.98.0", "@switchboard-xyz/common": "3.0.14", "@switchboard-xyz/on-demand": "2.4.1", "@triton-one/yellowstone-grpc": "5.0.2", "anchor-bankrun": "0.3.0", "gill": "^0.10.2", "nanoid": "3.3.4", "node-cache": "5.1.2", "solana-bankrun": "0.3.1", "strict-event-emitter-types": "2.0.0", "tweetnacl": "1.0.3", "tweetnacl-util": "0.15.1", "uuid": "8.3.2", "yargs": "17.7.2", "zod": "4.0.17", "zstddec": "0.1.0" }, "optionalDependencies": { "helius-laserstream": "0.1.8" } }, "sha512-WkDFgb6aSCeAeVuwN2B+kupc4FyrXN8paWUczfEYk80Bsk0ArPD6teL6Z41NTb6H+saSzUqHUHxxd+3bxgNImQ=="],
 
     "@ecies/ciphers": ["@ecies/ciphers@0.2.5", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A=="],
 
@@ -389,9 +389,11 @@
 
     "@openbook-dex/openbook-v2": ["@openbook-dex/openbook-v2@0.2.10", "", { "dependencies": { "@coral-xyz/anchor": "^0.29.0", "@solana/spl-token": "^0.4.0", "@solana/web3.js": "^1.77.3", "big.js": "^6.2.1" } }, "sha512-JOroVQHeia+RbghpluDJB5psUIhdhYRPLu0zWoG0h5vgDU4SjXwlcC+LJiIa2HVPasvZjWuCtlKWFyrOS75lOA=="],
 
+    "@orca-so/common-sdk/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
-    "@orca-so/common-sdk": ["@orca-so/common-sdk@0.7.0", "", { "dependencies": { "decimal.js": "^10.5.0", "tiny-invariant": "^1.3.1" }, "peerDependencies": { "@solana/spl-token": "^0.4.14", "@solana/web3.js": "^1.98.4" } }, "sha512-YJHmVvj+1EYbHnnGAyMoRKij6qkVFeecp0mIPt4xLKO7ZaAylqLCi6j4jxFY1fZCgHVhlgLNukFxXEln4skxbA=="],
+    "@orca-so/common-sdk": ["@orca-so/common-sdk@0.7.0", "", { "dependencies": { "@noble/hashes": "^1.8.0", "decimal.js": "^10.5.0", "tiny-invariant": "^1.3.1" }, "peerDependencies": { "@solana/spl-token": "^0.4.14", "@solana/web3.js": "^1.98.4" } }, "sha512-YJHmVvj+1EYbHnnGAyMoRKij6qkVFeecp0mIPt4xLKO7ZaAylqLCi6j4jxFY1fZCgHVhlgLNukFxXEln4skxbA=="],
 
     "@orca-so/whirlpools-sdk": ["@orca-so/whirlpools-sdk@0.20.0", "", { "dependencies": { "@orca-so/common-sdk": "0.7.0", "decimal.js": "^10.5.0", "tiny-invariant": "^1.3.1" }, "peerDependencies": { "@coral-xyz/anchor": "~0.32.1", "@solana/spl-token": "^0.4.14", "@solana/web3.js": "^1.98.4" } }, "sha512-7i8VG7KKIC3/opB+qeLHuHIbJVsJyN3d47ENHcD45tXy0m+7dTx2opQVEXMQFmCX7VNCg+T7G/18MI1T8ABc+Q=="],
 
@@ -1640,6 +1642,8 @@
     "@coral-xyz/anchor-31/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "@drift-labs/sdk/@coral-xyz/anchor": ["@coral-xyz/anchor@0.29.0", "", { "dependencies": { "@coral-xyz/borsh": "^0.29.0", "@noble/hashes": "^1.3.1", "@solana/web3.js": "^1.68.0", "bn.js": "^5.1.2", "bs58": "^4.0.1", "buffer-layout": "^1.2.2", "camelcase": "^6.3.0", "cross-fetch": "^3.1.5", "crypto-hash": "^1.3.0", "eventemitter3": "^4.0.7", "pako": "^2.0.3", "snake-case": "^3.0.4", "superstruct": "^0.15.4", "toml": "^3.0.0" } }, "sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA=="],
+
+    "@drift-labs/sdk/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@drift-labs/sdk/@ellipsis-labs/phoenix-sdk": ["@ellipsis-labs/phoenix-sdk@1.4.5", "", { "dependencies": { "@metaplex-foundation/beet": "^0.7.1", "@metaplex-foundation/rustbin": "^0.3.1", "@metaplex-foundation/solita": "^0.12.2", "@solana/spl-token": "^0.3.7", "@types/node": "^18.11.13", "bn.js": "^5.2.1", "borsh": "^0.7.0", "bs58": "^5.0.0" } }, "sha512-vEYgMXuV5/mpnpEi+VK4HO8f6SheHtVLdHHlULBiDN1eECYmL67gq+/cRV7Ar6jAQ7rJZL7xBxhbUW5kugMl6A=="],
 

--- a/docs/reliability/strategy-desk-ops-runbook.md
+++ b/docs/reliability/strategy-desk-ops-runbook.md
@@ -1,0 +1,268 @@
+# Strategy Desk Ops Runbook
+
+## Purpose
+
+This runbook defines how operators should author, test, arm, pause, kill, and
+demote harness-native strategy-desk scenarios without pretending they are
+first-class runtime deployments.
+
+Use this alongside the existing strategy-lab and autonomous-runtime runbooks:
+
+- strategy and venue promotion policy still lives in
+  `docs/reliability/strategy-lab-ops-runbook.md`
+- bounded runtime deployment controls still live in
+  `docs/reliability/autonomous-runtime-ops-runbook.md`
+
+## Operating model
+
+- A strategy-desk scenario is a composite harness object, not a runtime
+  deployment.
+- Scenario state, scenario-run state, and promotion-handoff state are all
+  separate and must stay auditable.
+- Replay and backtest evidence determine whether a composite scenario should
+  enter shadow or paper.
+- Shadow and paper runs are still non-monetary.
+- Limited-live arming only happens through a promotion handoff.
+- A handoff may materialize one or more bounded objects:
+  - a runtime deployment when a leg fits the existing runtime model
+  - a Worker execution recipe when a leg must remain harness-owned
+  - a subject control when a leg must stay paper-bound or disabled
+- Human review remains mandatory before any limited-live arming.
+
+## Desk states and required operator posture
+
+| Stage | Scenario state | Required evidence | Immediate rollback path |
+| --- | --- | --- | --- |
+| Replay and backtest | `replay_ready` | scenario manifest, study matrix, reproducibility refs, selected-variant summary | keep in `draft` or return to `replay_ready` |
+| Shadow | `shadow_ready` | latest replay or backtest report, shadow run, leg receipts, failure overlay review | pause scenario or demote to `replay_ready` |
+| Paper | `paper_ready` | shadow evidence, paper run, scorecard, risk overlays, browser proof if UI changed | pause scenario or demote to `shadow_ready` |
+| Review | `operator_review` or `execution_ready` | green paper bundle, explicit leg bindings, human approval note, drill references | reject handoff, archive handoff, keep scenario paper-bound |
+| Bounded execution | `execution_bound` | applied handoff, bound deployment or recipes, canary note, rollback drill | pause, kill, or demote the handoff and scenario |
+
+## Required controls before bounded execution arming
+
+- scenario latest report is `paper` or `shadow` evidence suitable for operator
+  review
+- handoff status is `approved` before `apply`
+- every live-eligible binding is explicit about venue, target mode, and lane
+- all non-live legs are explicitly left as paper-bound recipes or controls
+- rollback path is chosen before applying the handoff
+
+## Routine operator actions
+
+Set a local base URL before running the command matrix:
+
+```bash
+export DESK_BASE_URL="${DESK_BASE_URL:-http://127.0.0.1:8888}"
+export ADMIN_TOKEN="${ADMIN_TOKEN:?set ADMIN_TOKEN first}"
+```
+
+### Upsert or review a scenario
+
+Use the checked-in manifest template:
+
+```bash
+bun run strategy-desk:registry \
+  --resource scenario \
+  --action upsert \
+  --base-url "${DESK_BASE_URL}" \
+  --admin-token "${ADMIN_TOKEN}" \
+  --request-file docs/strategy-desk/request-templates/desk-sol-composite/scenario.upsert.json \
+  --output-dir .tmp/strategy-desk-proof/desk_sol_composite_1/01-scenario
+```
+
+Expected effect:
+
+- the scenario manifest is persisted through the Worker admin surface
+- the scenario remains auditable as a desk object instead of a runtime
+  deployment
+
+### Run replay or backtest study
+
+Use the study request template:
+
+```bash
+bun run strategy-desk:registry \
+  --resource scenario \
+  --action study \
+  --base-url "${DESK_BASE_URL}" \
+  --admin-token "${ADMIN_TOKEN}" \
+  --request-file docs/strategy-desk/request-templates/desk-sol-composite/study.backtest.request.json \
+  --output-dir .tmp/strategy-desk-proof/desk_sol_composite_1/02-study
+```
+
+Expected effect:
+
+- a study matrix is attached to the scenario
+- selected-variant and holdout summaries are persisted as first-class evidence
+
+### Run a shadow validation
+
+```bash
+bun run strategy-desk:registry \
+  --resource scenario \
+  --action execute \
+  --base-url "${DESK_BASE_URL}" \
+  --admin-token "${ADMIN_TOKEN}" \
+  --request-file docs/strategy-desk/request-templates/desk-sol-composite/execute.shadow.request.json \
+  --output-dir .tmp/strategy-desk-proof/desk_sol_composite_1/03-shadow
+```
+
+Expected effect:
+
+- a composite shadow run is persisted
+- leg receipts and overlays become reviewable without mutating live capital
+
+### Run a paper validation
+
+```bash
+bun run strategy-desk:registry \
+  --resource scenario \
+  --action execute \
+  --base-url "${DESK_BASE_URL}" \
+  --admin-token "${ADMIN_TOKEN}" \
+  --request-file docs/strategy-desk/request-templates/desk-sol-composite/execute.paper.request.json \
+  --output-dir .tmp/strategy-desk-proof/desk_sol_composite_1/04-paper
+```
+
+Expected effect:
+
+- the desk paper run becomes the canonical pre-arming evidence
+- portfolio summary, scorecard, and leg outcomes are pinned to one report
+
+### Prepare a bounded execution handoff
+
+```bash
+curl -fsS \
+  "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/handoffs/prepare" \
+  -X POST \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "content-type: application/json" \
+  --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.prepare.request.json \
+  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/01-prepare.json
+```
+
+Expected effect:
+
+- a draft handoff is created from the latest scenario report
+- proposed bindings, checks, and actions are materialized for review
+
+### Submit, approve, and apply a handoff
+
+Set the handoff id from the prepare response:
+
+```bash
+export HANDOFF_ID="${HANDOFF_ID:?set HANDOFF_ID from prepare output}"
+```
+
+Submit:
+
+```bash
+curl -fsS \
+  "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}/transition" \
+  -X POST \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "content-type: application/json" \
+  --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.submit.request.json \
+  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/02-submit.json
+```
+
+Approve:
+
+```bash
+curl -fsS \
+  "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}/transition" \
+  -X POST \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "content-type: application/json" \
+  --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.approve.request.json \
+  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/03-approve.json
+```
+
+Apply:
+
+```bash
+curl -fsS \
+  "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}/transition" \
+  -X POST \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "content-type: application/json" \
+  --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.apply.request.json \
+  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/04-apply.json
+```
+
+Read back the handoff detail and materialized recipes:
+
+```bash
+curl -fsS \
+  "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}" \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/05-detail.json
+```
+
+Expected effect:
+
+- scenario state moves into bounded execution only after explicit approval
+- runtime deployments, execution recipes, and paper-only controls remain
+  inspectable as one composite handoff
+
+### Pause, kill, or demote a handoff
+
+Pause:
+
+```bash
+curl -fsS \
+  "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}/transition" \
+  -X POST \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "content-type: application/json" \
+  --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.pause.request.json \
+  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/pause.json
+```
+
+Kill:
+
+```bash
+curl -fsS \
+  "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}/transition" \
+  -X POST \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "content-type: application/json" \
+  --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.kill.request.json \
+  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/kill.json
+```
+
+Demote:
+
+```bash
+curl -fsS \
+  "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}/transition" \
+  -X POST \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "content-type: application/json" \
+  --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.demote.request.json \
+  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/demote.json
+```
+
+## Rollback order of operations
+
+1. Pause or kill the active handoff.
+2. Confirm the detail route shows the scenario as no longer execution-bound.
+3. Demote the handoff so the scenario returns to a paper-safe state.
+4. Preserve the handoff detail, event log, and recipe list in the proof bundle.
+5. If the incident is venue-specific, tighten the corresponding strategy-lab
+   readiness or subject control before resuming desk activity.
+
+## Required drills
+
+- one canary arm drill from `prepare` through `apply`
+- one rollback drill from `applied` through `pause` or `kill`, then `demote`
+- one venue-disable or paper-only leg isolation drill for a non-live binding
+- one proof reconstruction drill from stored scenario, run, report, handoff,
+  and browser-proof artifacts
+
+See:
+
+- `docs/strategy-desk/drills/desk-sol-composite.canary-drill.md`
+- `docs/strategy-desk/drills/desk-sol-composite.rollback-drill.md`
+- `docs/strategy-desk/proof-bundles.md`

--- a/docs/reliability/strategy-desk-ops-runbook.md
+++ b/docs/reliability/strategy-desk-ops-runbook.md
@@ -133,13 +133,19 @@ Expected effect:
 ### Prepare a bounded execution handoff
 
 ```bash
+mkdir -p \
+  .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff \
+  .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills
+
 curl -fsS \
   "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/handoffs/prepare" \
   -X POST \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
   -H "content-type: application/json" \
   --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.prepare.request.json \
-  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/01-prepare.json
+  --output .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/01-prepare.json
+
+cat .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/01-prepare.json
 ```
 
 Expected effect:
@@ -152,7 +158,8 @@ Expected effect:
 Set the handoff id from the prepare response:
 
 ```bash
-export HANDOFF_ID="${HANDOFF_ID:?set HANDOFF_ID from prepare output}"
+export HANDOFF_ID="$(jq -r '.handoff.handoffId' .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/01-prepare.json)"
+test -n "${HANDOFF_ID}" && test "${HANDOFF_ID}" != "null"
 ```
 
 Submit:
@@ -164,7 +171,9 @@ curl -fsS \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
   -H "content-type: application/json" \
   --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.submit.request.json \
-  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/02-submit.json
+  --output .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/02-submit.json
+
+cat .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/02-submit.json
 ```
 
 Approve:
@@ -176,7 +185,9 @@ curl -fsS \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
   -H "content-type: application/json" \
   --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.approve.request.json \
-  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/03-approve.json
+  --output .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/03-approve.json
+
+cat .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/03-approve.json
 ```
 
 Apply:
@@ -188,7 +199,9 @@ curl -fsS \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
   -H "content-type: application/json" \
   --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.apply.request.json \
-  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/04-apply.json
+  --output .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/04-apply.json
+
+cat .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/04-apply.json
 ```
 
 Read back the handoff detail and materialized recipes:
@@ -197,7 +210,9 @@ Read back the handoff detail and materialized recipes:
 curl -fsS \
   "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}" \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
-  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/05-detail.json
+  --output .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/05-detail.json
+
+cat .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/05-detail.json
 ```
 
 Expected effect:
@@ -217,7 +232,9 @@ curl -fsS \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
   -H "content-type: application/json" \
   --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.pause.request.json \
-  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/pause.json
+  --output .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/pause.json
+
+cat .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/pause.json
 ```
 
 Kill:
@@ -229,7 +246,9 @@ curl -fsS \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
   -H "content-type: application/json" \
   --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.kill.request.json \
-  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/kill.json
+  --output .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/kill.json
+
+cat .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/kill.json
 ```
 
 Demote:
@@ -241,7 +260,9 @@ curl -fsS \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
   -H "content-type: application/json" \
   --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.demote.request.json \
-  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/demote.json
+  --output .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/demote.json
+
+cat .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/demote.json
 ```
 
 ## Rollback order of operations

--- a/docs/reliability/strategy-lab-ops-runbook.md
+++ b/docs/reliability/strategy-lab-ops-runbook.md
@@ -5,6 +5,10 @@
 This runbook defines how operators should control candidate strategies, venues,
 and assets as they move from research to bounded real-money validation.
 
+For composite harness-native desk scenarios, use
+`docs/reliability/strategy-desk-ops-runbook.md` as the desk-specific extension
+to this runbook.
+
 ## Operating model
 
 - The Worker remains the public edge and the operator control surface.

--- a/docs/repository-verification-index.md
+++ b/docs/repository-verification-index.md
@@ -13,6 +13,7 @@ how to verify or roll back the main operating paths.
 | Runtime control plane | Bun CLI, agent runtime, tools, policies, and journals | `src` |
 | Autonomous runtime | Rust hot path for always-on automation, reconciliation, and portfolio state | `services/runtime-rs`, `docs/product-specs/autonomous-runtime-prd.md`, `docs/design-docs/autonomous-runtime-architecture.md` |
 | Strategy lab | Research-to-production workflow for new strategies, venues, and assets | `docs/product-specs/strategy-lab-prd.md`, `docs/exec-plans/active/strategy-lab-rollout.md` |
+| Strategy desk | Harness-native composite scenario authoring, study, paper validation, and bounded execution handoffs | `apps/portal/app/terminal/strategy-desk`, `apps/worker/src/runtime_strategy_desk*.ts`, `docs/strategy-desk` |
 | Tests | Unit, integration, and terminal execution suites | `tests` |
 | Public contracts | Execution docs, schemas, fixtures, and runbooks | `docs/execution` |
 | Agent registry | Lane metadata and operator runbook | `docs/agent-registry` |
@@ -66,6 +67,9 @@ Autonomous runtime planning surfaces:
 - Strategy-lab product spec: `docs/product-specs/strategy-lab-prd.md`
 - Strategy-lab rollout plan: `docs/exec-plans/active/strategy-lab-rollout.md`
 - Strategy-lab ops runbook: `docs/reliability/strategy-lab-ops-runbook.md`
+- Strategy-desk overview: `docs/strategy-desk/README.md`
+- Strategy-desk ops runbook: `docs/reliability/strategy-desk-ops-runbook.md`
+- Strategy-desk proof bundles: `docs/strategy-desk/proof-bundles.md`
 
 The runtime service is deployed on Fly and verified independently from the
 portal and Worker lanes.
@@ -594,6 +598,31 @@ curl -fsS -X POST \
   "$API_BASE/api/admin/execution/canary/reset"
 ```
 
+### 7a. Strategy-desk verification
+
+For composite scenario authoring, study, paper validation, bounded execution
+handoffs, and drill documentation:
+
+```bash
+bun run lint
+bun test tests/unit/runtime_strategy_desk_runner.test.ts tests/unit/runtime_strategy_desk_study.test.ts
+bun test tests/unit/worker_runtime_strategy_desk_route.test.ts tests/unit/worker_runtime_strategy_desk_execute_route.test.ts tests/unit/worker_runtime_strategy_desk_study_route.test.ts
+bun test tests/unit/portal_runtime_strategy_desk_route.test.ts tests/unit/worker_execution_migrations.test.ts
+bun run harness:proof --output-dir .tmp/strategy-desk-proof/desk_sol_composite_1/07-browser-proof
+```
+
+Verify:
+
+- the strategy-desk runbook, proof-bundle spec, and drill docs agree on the
+  same scenario id, command matrix, and rollback posture,
+- request templates exist for scenario upsert, study, shadow, paper, prepare,
+  approve, apply, pause, kill, and demote flows,
+- the browser proof includes the bounded execution desk state,
+- the proof bundle layout is explicit enough for a future issue runner to
+  reproduce the same desk flow without inventing new files,
+- bounded execution remains human-gated and auditable through the handoff
+  object instead of bypassing the Worker admin boundary.
+
 ## Rollback Steps
 
 ### Code rollback
@@ -665,4 +694,8 @@ and can comment on a PR when `pr_number` is supplied.
 - Autonomous runtime architecture: `docs/design-docs/autonomous-runtime-architecture.md`
 - Autonomous runtime runbook: `docs/reliability/autonomous-runtime-ops-runbook.md`
 - Autonomous runtime rollout plan: `docs/exec-plans/active/autonomous-runtime-rollout.md`
+- Strategy-desk overview: `docs/strategy-desk/README.md`
+- Strategy-desk runbook: `docs/reliability/strategy-desk-ops-runbook.md`
+- Strategy-desk proof bundles: `docs/strategy-desk/proof-bundles.md`
+- Strategy-desk drills: `docs/strategy-desk/drills/`
 - Long-form pipeline architecture: `loop-a-loop-b-architecture.md`

--- a/docs/strategy-desk/README.md
+++ b/docs/strategy-desk/README.md
@@ -1,0 +1,28 @@
+# Strategy Desk
+
+This folder contains the operator-facing documentation for the harness-native
+strategy desk.
+
+Use it when you need to:
+
+- author or update a composite scenario
+- capture replay, backtest, shadow, and paper evidence
+- prepare or arm a bounded execution handoff
+- run canary or rollback drills against the desk surface
+- assemble a proof bundle for review or future issue runners
+
+Primary docs:
+
+- ops runbook:
+  `docs/reliability/strategy-desk-ops-runbook.md`
+- proof bundle spec:
+  `docs/strategy-desk/proof-bundles.md`
+- canary drill:
+  `docs/strategy-desk/drills/desk-sol-composite.canary-drill.md`
+- rollback drill:
+  `docs/strategy-desk/drills/desk-sol-composite.rollback-drill.md`
+- request templates:
+  `docs/strategy-desk/request-templates/desk-sol-composite/`
+
+The strategy desk extends the current strategy-lab and autonomous-runtime
+surfaces. It does not replace their policy boundaries.

--- a/docs/strategy-desk/drills/desk-sol-composite.canary-drill.md
+++ b/docs/strategy-desk/drills/desk-sol-composite.canary-drill.md
@@ -28,12 +28,15 @@ export ADMIN_TOKEN="${ADMIN_TOKEN:?set ADMIN_TOKEN first}"
 ```bash
 mkdir -p .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills
 
+rm -f .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.prepare.json
+
 curl -fsS \
   "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/handoffs/prepare" \
   -X POST \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
   -H "content-type: application/json" \
   --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.prepare.request.json \
+  --remove-on-error \
   --output .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.prepare.json
 
 cat .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.prepare.json
@@ -54,15 +57,20 @@ Expected:
 ### 2. Submit and approve
 
 ```bash
+rm -f .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.submit.json
+
 curl -fsS \
   "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}/transition" \
   -X POST \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
   -H "content-type: application/json" \
   --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.submit.request.json \
+  --remove-on-error \
   --output .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.submit.json
 
 cat .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.submit.json
+
+rm -f .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.approve.json
 
 curl -fsS \
   "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}/transition" \
@@ -70,6 +78,7 @@ curl -fsS \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
   -H "content-type: application/json" \
   --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.approve.request.json \
+  --remove-on-error \
   --output .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.approve.json
 
 cat .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.approve.json
@@ -83,19 +92,25 @@ Expected:
 ### 3. Apply and inspect
 
 ```bash
+rm -f .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.apply.json
+
 curl -fsS \
   "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}/transition" \
   -X POST \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
   -H "content-type: application/json" \
   --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.apply.request.json \
+  --remove-on-error \
   --output .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.apply.json
 
 cat .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.apply.json
 
+rm -f .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.detail.json
+
 curl -fsS \
   "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}" \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  --remove-on-error \
   --output .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.detail.json
 
 cat .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.detail.json

--- a/docs/strategy-desk/drills/desk-sol-composite.canary-drill.md
+++ b/docs/strategy-desk/drills/desk-sol-composite.canary-drill.md
@@ -26,19 +26,24 @@ export ADMIN_TOKEN="${ADMIN_TOKEN:?set ADMIN_TOKEN first}"
 ### 1. Prepare the handoff
 
 ```bash
+mkdir -p .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills
+
 curl -fsS \
   "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/handoffs/prepare" \
   -X POST \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
   -H "content-type: application/json" \
   --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.prepare.request.json \
-  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.prepare.json
+  --output .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.prepare.json
+
+cat .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.prepare.json
 ```
 
 Extract the created handoff id:
 
 ```bash
 export HANDOFF_ID="$(jq -r '.handoff.handoffId' .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.prepare.json)"
+test -n "${HANDOFF_ID}" && test "${HANDOFF_ID}" != "null"
 ```
 
 Expected:
@@ -55,7 +60,9 @@ curl -fsS \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
   -H "content-type: application/json" \
   --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.submit.request.json \
-  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.submit.json
+  --output .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.submit.json
+
+cat .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.submit.json
 
 curl -fsS \
   "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}/transition" \
@@ -63,7 +70,9 @@ curl -fsS \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
   -H "content-type: application/json" \
   --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.approve.request.json \
-  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.approve.json
+  --output .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.approve.json
+
+cat .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.approve.json
 ```
 
 Expected:
@@ -80,12 +89,16 @@ curl -fsS \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
   -H "content-type: application/json" \
   --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.apply.request.json \
-  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.apply.json
+  --output .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.apply.json
+
+cat .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.apply.json
 
 curl -fsS \
   "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}" \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
-  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.detail.json
+  --output .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.detail.json
+
+cat .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.detail.json
 ```
 
 Expected:

--- a/docs/strategy-desk/drills/desk-sol-composite.canary-drill.md
+++ b/docs/strategy-desk/drills/desk-sol-composite.canary-drill.md
@@ -1,0 +1,103 @@
+# Desk SOL Composite Canary Drill
+
+## Goal
+
+Prove that a paper-ready composite scenario can move through bounded execution
+review without skipping human approval and while preserving a single auditable
+handoff trail.
+
+## Preconditions
+
+- local or remote Worker admin surface is healthy
+- the desk scenario is already persisted from
+  `docs/strategy-desk/request-templates/desk-sol-composite/scenario.upsert.json`
+- the paper report exists for `desk_sol_composite_1`
+- `ADMIN_TOKEN` is set
+
+Set:
+
+```bash
+export DESK_BASE_URL="${DESK_BASE_URL:-http://127.0.0.1:8888}"
+export ADMIN_TOKEN="${ADMIN_TOKEN:?set ADMIN_TOKEN first}"
+```
+
+## Drill steps
+
+### 1. Prepare the handoff
+
+```bash
+curl -fsS \
+  "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/handoffs/prepare" \
+  -X POST \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "content-type: application/json" \
+  --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.prepare.request.json \
+  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.prepare.json
+```
+
+Extract the created handoff id:
+
+```bash
+export HANDOFF_ID="$(jq -r '.handoff.handoffId' .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.prepare.json)"
+```
+
+Expected:
+
+- handoff status is `draft`
+- at least one binding is present
+
+### 2. Submit and approve
+
+```bash
+curl -fsS \
+  "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}/transition" \
+  -X POST \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "content-type: application/json" \
+  --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.submit.request.json \
+  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.submit.json
+
+curl -fsS \
+  "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}/transition" \
+  -X POST \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "content-type: application/json" \
+  --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.approve.request.json \
+  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.approve.json
+```
+
+Expected:
+
+- handoff status reaches `approved`
+- human approval is visible in the handoff payload
+
+### 3. Apply and inspect
+
+```bash
+curl -fsS \
+  "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}/transition" \
+  -X POST \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "content-type: application/json" \
+  --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.apply.request.json \
+  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.apply.json
+
+curl -fsS \
+  "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}" \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/canary.detail.json
+```
+
+Expected:
+
+- scenario state is `execution_bound`
+- handoff status is `applied`
+- event list includes `prepared`, `submitted`, `approved`, and `applied`
+- execution recipes or controls are materialized for non-live legs
+
+## Pass criteria
+
+- every transition response is `ok=true`
+- no transition bypasses `approved`
+- final detail output contains the full event trail
+- the canary outputs are saved in the proof bundle directory

--- a/docs/strategy-desk/drills/desk-sol-composite.rollback-drill.md
+++ b/docs/strategy-desk/drills/desk-sol-composite.rollback-drill.md
@@ -36,7 +36,8 @@ curl -fsS \
 Expected:
 
 - scenario state is `paused`
-- handoff status moves to `rejected` or equivalent paused state trail
+- handoff status remains `applied` until an explicit demotion archives it
+- the event trail records a `paused` transition
 
 ### 2. Optional venue-disable style kill
 
@@ -79,7 +80,7 @@ Expected:
 
 - scenario state is `paper_ready`
 - handoff status is `archived`
-- event list includes `pause` or `kill`, then `demote` or `archive`
+- event list includes `paused` or `killed`, then `demoted`
 - no leg remains silently armed after demotion
 
 ## Pass criteria

--- a/docs/strategy-desk/drills/desk-sol-composite.rollback-drill.md
+++ b/docs/strategy-desk/drills/desk-sol-composite.rollback-drill.md
@@ -1,0 +1,89 @@
+# Desk SOL Composite Rollback Drill
+
+## Goal
+
+Prove that an applied bounded-execution handoff can be paused or killed and
+then demoted back to a paper-safe scenario without losing the audit trail.
+
+## Preconditions
+
+- the canary drill has already produced an applied handoff
+- `HANDOFF_ID` points at an applied desk handoff
+- `ADMIN_TOKEN` is set
+
+Set:
+
+```bash
+export DESK_BASE_URL="${DESK_BASE_URL:-http://127.0.0.1:8888}"
+export ADMIN_TOKEN="${ADMIN_TOKEN:?set ADMIN_TOKEN first}"
+export HANDOFF_ID="${HANDOFF_ID:?set HANDOFF_ID first}"
+```
+
+## Drill steps
+
+### 1. Pause the active handoff
+
+```bash
+curl -fsS \
+  "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}/transition" \
+  -X POST \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "content-type: application/json" \
+  --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.pause.request.json \
+  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/rollback.pause.json
+```
+
+Expected:
+
+- scenario state is `paused`
+- handoff status moves to `rejected` or equivalent paused state trail
+
+### 2. Optional venue-disable style kill
+
+Use this if the triggering condition is a venue failure or a non-live binding
+misbehaving:
+
+```bash
+curl -fsS \
+  "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}/transition" \
+  -X POST \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "content-type: application/json" \
+  --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.kill.request.json \
+  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/rollback.kill.json
+```
+
+Expected:
+
+- active execution is fail-closed immediately
+- the event trail records a `killed` transition
+
+### 3. Demote back to paper
+
+```bash
+curl -fsS \
+  "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}/transition" \
+  -X POST \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "content-type: application/json" \
+  --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.demote.request.json \
+  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/rollback.demote.json
+
+curl -fsS \
+  "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}" \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills/rollback.detail.json
+```
+
+Expected:
+
+- scenario state is `paper_ready`
+- handoff status is `archived`
+- event list includes `pause` or `kill`, then `demote` or `archive`
+- no leg remains silently armed after demotion
+
+## Pass criteria
+
+- the desk can return to a paper-safe state without deleting the handoff
+- the final detail output still contains the full event history
+- rollback outputs are captured in the proof bundle directory

--- a/docs/strategy-desk/proof-bundles.md
+++ b/docs/strategy-desk/proof-bundles.md
@@ -52,7 +52,6 @@ Set:
 ```bash
 export DESK_BASE_URL="${DESK_BASE_URL:-http://127.0.0.1:8888}"
 export ADMIN_TOKEN="${ADMIN_TOKEN:?set ADMIN_TOKEN first}"
-export HANDOFF_ID="${HANDOFF_ID:-desk_handoff_sol_composite_live_1}"
 ```
 
 ### 1. Scenario manifest
@@ -111,6 +110,9 @@ curl -fsS \
   -H "content-type: application/json" \
   --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.prepare.request.json \
   | tee .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/01-prepare.json
+
+export HANDOFF_ID="${HANDOFF_ID:-$(jq -r '.handoff.handoffId' .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/01-prepare.json)}"
+test -n "${HANDOFF_ID}" && test "${HANDOFF_ID}" != "null"
 ```
 
 Approve and apply:

--- a/docs/strategy-desk/proof-bundles.md
+++ b/docs/strategy-desk/proof-bundles.md
@@ -103,6 +103,11 @@ bun run strategy-desk:registry \
 Prepare:
 
 ```bash
+mkdir -p \
+  .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff \
+  .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills \
+  .tmp/strategy-desk-proof/desk_sol_composite_1/07-browser-proof
+
 curl -fsS \
   "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/handoffs/prepare" \
   -X POST \
@@ -111,7 +116,7 @@ curl -fsS \
   --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.prepare.request.json \
   | tee .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/01-prepare.json
 
-export HANDOFF_ID="${HANDOFF_ID:-$(jq -r '.handoff.handoffId' .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/01-prepare.json)}"
+export HANDOFF_ID="$(jq -r '.handoff.handoffId' .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/01-prepare.json)"
 test -n "${HANDOFF_ID}" && test "${HANDOFF_ID}" != "null"
 ```
 

--- a/docs/strategy-desk/proof-bundles.md
+++ b/docs/strategy-desk/proof-bundles.md
@@ -1,0 +1,170 @@
+# Strategy Desk Proof Bundles
+
+## Purpose
+
+A strategy-desk proof bundle is the minimum auditable artifact set required to
+justify moving a composite scenario from study through shadow, paper, and
+bounded execution review.
+
+The bundle is scenario-scoped. Do not mix outputs from different scenario ids,
+commits, or request templates inside one bundle.
+
+## Recommended bundle layout
+
+Store desk proofs under:
+
+```text
+.tmp/strategy-desk-proof/<scenario-id>/
+```
+
+Recommended layout:
+
+```text
+.tmp/strategy-desk-proof/desk_sol_composite_1/
+  01-scenario/
+  02-study/
+  03-shadow/
+  04-paper/
+  05-handoff/
+  06-drills/
+  07-browser-proof/
+```
+
+## Minimum artifacts by stage
+
+| Stage | Required artifacts | Minimum pass condition |
+| --- | --- | --- |
+| Replay and backtest | scenario upsert output, study output, selected-variant summary, reproducibility refs | study matrix exists, selected variant exists, holdout coverage is explicit |
+| Shadow | shadow run output, shadow report, leg receipts or failures, overlay status | no unexpected fail-open behavior, scenario remains non-monetary |
+| Paper | paper run output, paper report, scorecard, portfolio summary, overlay status | paper evidence is stable enough for operator review |
+| Arming review | prepare output, handoff detail, check list, binding list, approval record | all live-eligible bindings are explicit and human review is recorded |
+| Applied bounded execution | apply output, handoff detail after apply, event timeline, execution recipes | scenario is `execution_bound`, handoff is `applied`, rollback path is documented |
+| Drill evidence | pause or kill output, demote output, drill notes, browser proof summary | rollback is reversible and evidence reconstruction is possible |
+
+## Exact command matrix
+
+The request templates under
+`docs/strategy-desk/request-templates/desk-sol-composite/` are the canonical
+command inputs for the sample composite desk scenario.
+
+Set:
+
+```bash
+export DESK_BASE_URL="${DESK_BASE_URL:-http://127.0.0.1:8888}"
+export ADMIN_TOKEN="${ADMIN_TOKEN:?set ADMIN_TOKEN first}"
+export HANDOFF_ID="${HANDOFF_ID:-desk_handoff_sol_composite_live_1}"
+```
+
+### 1. Scenario manifest
+
+```bash
+bun run strategy-desk:registry \
+  --resource scenario \
+  --action upsert \
+  --base-url "${DESK_BASE_URL}" \
+  --admin-token "${ADMIN_TOKEN}" \
+  --request-file docs/strategy-desk/request-templates/desk-sol-composite/scenario.upsert.json \
+  --output-dir .tmp/strategy-desk-proof/desk_sol_composite_1/01-scenario
+```
+
+### 2. Study evidence
+
+```bash
+bun run strategy-desk:registry \
+  --resource scenario \
+  --action study \
+  --base-url "${DESK_BASE_URL}" \
+  --admin-token "${ADMIN_TOKEN}" \
+  --request-file docs/strategy-desk/request-templates/desk-sol-composite/study.backtest.request.json \
+  --output-dir .tmp/strategy-desk-proof/desk_sol_composite_1/02-study
+```
+
+### 3. Shadow and paper evidence
+
+```bash
+bun run strategy-desk:registry \
+  --resource scenario \
+  --action execute \
+  --base-url "${DESK_BASE_URL}" \
+  --admin-token "${ADMIN_TOKEN}" \
+  --request-file docs/strategy-desk/request-templates/desk-sol-composite/execute.shadow.request.json \
+  --output-dir .tmp/strategy-desk-proof/desk_sol_composite_1/03-shadow
+
+bun run strategy-desk:registry \
+  --resource scenario \
+  --action execute \
+  --base-url "${DESK_BASE_URL}" \
+  --admin-token "${ADMIN_TOKEN}" \
+  --request-file docs/strategy-desk/request-templates/desk-sol-composite/execute.paper.request.json \
+  --output-dir .tmp/strategy-desk-proof/desk_sol_composite_1/04-paper
+```
+
+### 4. Handoff and bounded execution evidence
+
+Prepare:
+
+```bash
+curl -fsS \
+  "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/handoffs/prepare" \
+  -X POST \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "content-type: application/json" \
+  --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.prepare.request.json \
+  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/01-prepare.json
+```
+
+Approve and apply:
+
+```bash
+curl -fsS \
+  "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}/transition" \
+  -X POST \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "content-type: application/json" \
+  --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.submit.request.json \
+  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/02-submit.json
+
+curl -fsS \
+  "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}/transition" \
+  -X POST \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "content-type: application/json" \
+  --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.approve.request.json \
+  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/03-approve.json
+
+curl -fsS \
+  "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}/transition" \
+  -X POST \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "content-type: application/json" \
+  --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.apply.request.json \
+  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/04-apply.json
+
+curl -fsS \
+  "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}" \
+  -H "authorization: Bearer ${ADMIN_TOKEN}" \
+  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/05-detail.json
+```
+
+### 5. Browser proof
+
+```bash
+bun run harness:proof \
+  --output-dir .tmp/strategy-desk-proof/desk_sol_composite_1/07-browser-proof
+```
+
+Required desk screenshot:
+
+- `strategy-desk-bounded-execution.png`
+
+## Review checklist
+
+Before calling the bundle complete, confirm all of the following:
+
+- scenario id is consistent across every artifact
+- study, shadow, paper, and handoff outputs are all present
+- the handoff detail shows the final status you intend to claim
+- the event timeline includes the transitions you executed
+- recipe or binding materialization is explicit for every non-live leg
+- browser-proof summary exists if the operator surface changed
+- canary or rollback drill outputs are attached for bounded execution claims

--- a/docs/strategy-desk/proof-bundles.md
+++ b/docs/strategy-desk/proof-bundles.md
@@ -108,13 +108,18 @@ mkdir -p \
   .tmp/strategy-desk-proof/desk_sol_composite_1/06-drills \
   .tmp/strategy-desk-proof/desk_sol_composite_1/07-browser-proof
 
+rm -f .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/01-prepare.json
+
 curl -fsS \
   "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/scenarios/desk_sol_composite_1/handoffs/prepare" \
   -X POST \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
   -H "content-type: application/json" \
   --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.prepare.request.json \
-  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/01-prepare.json
+  --remove-on-error \
+  --output .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/01-prepare.json
+
+cat .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/01-prepare.json
 
 export HANDOFF_ID="$(jq -r '.handoff.handoffId' .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/01-prepare.json)"
 test -n "${HANDOFF_ID}" && test "${HANDOFF_ID}" != "null"

--- a/docs/strategy-desk/proof-bundles.md
+++ b/docs/strategy-desk/proof-bundles.md
@@ -123,13 +123,20 @@ test -n "${HANDOFF_ID}" && test "${HANDOFF_ID}" != "null"
 Approve and apply:
 
 ```bash
+rm -f .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/02-submit.json
+
 curl -fsS \
   "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}/transition" \
   -X POST \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
   -H "content-type: application/json" \
   --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.submit.request.json \
-  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/02-submit.json
+  --remove-on-error \
+  --output .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/02-submit.json
+
+cat .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/02-submit.json
+
+rm -f .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/03-approve.json
 
 curl -fsS \
   "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}/transition" \
@@ -137,7 +144,12 @@ curl -fsS \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
   -H "content-type: application/json" \
   --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.approve.request.json \
-  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/03-approve.json
+  --remove-on-error \
+  --output .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/03-approve.json
+
+cat .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/03-approve.json
+
+rm -f .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/04-apply.json
 
 curl -fsS \
   "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}/transition" \
@@ -145,12 +157,20 @@ curl -fsS \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
   -H "content-type: application/json" \
   --data @docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.apply.request.json \
-  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/04-apply.json
+  --remove-on-error \
+  --output .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/04-apply.json
+
+cat .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/04-apply.json
+
+rm -f .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/05-detail.json
 
 curl -fsS \
   "${DESK_BASE_URL}/api/admin/ops/runtime/strategy-desk/handoffs/${HANDOFF_ID}" \
   -H "authorization: Bearer ${ADMIN_TOKEN}" \
-  | tee .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/05-detail.json
+  --remove-on-error \
+  --output .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/05-detail.json
+
+cat .tmp/strategy-desk-proof/desk_sol_composite_1/05-handoff/05-detail.json
 ```
 
 ### 5. Browser proof

--- a/docs/strategy-desk/request-templates/desk-sol-composite/README.md
+++ b/docs/strategy-desk/request-templates/desk-sol-composite/README.md
@@ -1,0 +1,18 @@
+# Desk SOL Composite Request Templates
+
+These files are the checked-in inputs for the sample strategy-desk proof bundle
+and drill flows.
+
+Use them with:
+
+- `bun run strategy-desk:registry` for scenario upsert, study, shadow, and
+  paper runs
+- direct `curl` calls to the Worker admin surface for handoff preparation,
+  transitions, and detail reads
+
+The handoff transition files do not contain the handoff id because the route
+uses the path parameter:
+
+```text
+/api/admin/ops/runtime/strategy-desk/handoffs/<handoff-id>/transition
+```

--- a/docs/strategy-desk/request-templates/desk-sol-composite/execute.paper.request.json
+++ b/docs/strategy-desk/request-templates/desk-sol-composite/execute.paper.request.json
@@ -1,0 +1,10 @@
+{
+  "scenarioId": "desk_sol_composite_1",
+  "runKind": "paper",
+  "requestedBy": "operator_1",
+  "walletAddress": "11111111111111111111111111111111",
+  "maxRetriesPerLeg": 1,
+  "trigger": {
+    "reason": "desk-paper-proof"
+  }
+}

--- a/docs/strategy-desk/request-templates/desk-sol-composite/execute.shadow.request.json
+++ b/docs/strategy-desk/request-templates/desk-sol-composite/execute.shadow.request.json
@@ -1,0 +1,10 @@
+{
+  "scenarioId": "desk_sol_composite_1",
+  "runKind": "shadow",
+  "requestedBy": "operator_1",
+  "walletAddress": "11111111111111111111111111111111",
+  "maxRetriesPerLeg": 1,
+  "trigger": {
+    "reason": "desk-shadow-proof"
+  }
+}

--- a/docs/strategy-desk/request-templates/desk-sol-composite/handoff.prepare.request.json
+++ b/docs/strategy-desk/request-templates/desk-sol-composite/handoff.prepare.request.json
@@ -1,0 +1,4 @@
+{
+  "requestedBy": "operator_1",
+  "targetMode": "limited_live"
+}

--- a/docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.apply.request.json
+++ b/docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.apply.request.json
@@ -1,0 +1,5 @@
+{
+  "action": "apply",
+  "actor": "operator_1",
+  "notes": "arm bounded execution"
+}

--- a/docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.approve.request.json
+++ b/docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.approve.request.json
@@ -1,0 +1,5 @@
+{
+  "action": "approve",
+  "actor": "operator_1",
+  "notes": "approve bounded execution review"
+}

--- a/docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.demote.request.json
+++ b/docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.demote.request.json
@@ -1,0 +1,5 @@
+{
+  "action": "demote",
+  "actor": "operator_1",
+  "notes": "return scenario to paper after rollback drill"
+}

--- a/docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.kill.request.json
+++ b/docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.kill.request.json
@@ -1,0 +1,5 @@
+{
+  "action": "kill",
+  "actor": "operator_1",
+  "notes": "kill bounded execution during venue-disable drill"
+}

--- a/docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.pause.request.json
+++ b/docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.pause.request.json
@@ -1,0 +1,5 @@
+{
+  "action": "pause",
+  "actor": "operator_1",
+  "notes": "pause bounded execution during rollback drill"
+}

--- a/docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.submit.request.json
+++ b/docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.submit.request.json
@@ -1,0 +1,5 @@
+{
+  "action": "submit",
+  "actor": "operator_1",
+  "notes": "submit bounded execution review"
+}

--- a/docs/strategy-desk/request-templates/desk-sol-composite/scenario.upsert.json
+++ b/docs/strategy-desk/request-templates/desk-sol-composite/scenario.upsert.json
@@ -1,0 +1,243 @@
+{
+  "schemaVersion": "v1",
+  "scenarioId": "desk_sol_composite_1",
+  "title": "SOL composite desk scenario",
+  "summary": "Composite spot, perp, prediction, and flash scenario staged through the harness.",
+  "ownerUserId": "user_1",
+  "strategyKey": "strategy_desk::sol_composite",
+  "thesis": "Pair trend spot exposure with bounded perp hedge, event overlay, and flash rebalancing.",
+  "sleeveId": "sleeve_1",
+  "state": "paper_ready",
+  "createdAt": "2026-03-17T03:00:00Z",
+  "updatedAt": "2026-03-17T03:05:00Z",
+  "reviewedAt": "2026-03-17T03:06:00Z",
+  "latestReportId": "desk_report_sol_composite_paper_1",
+  "riskLimits": {
+    "maxReservedCapitalUsd": "1600",
+    "maxGrossExposureUsd": "3500",
+    "maxNetExposureUsd": "1500",
+    "maxLegConcentrationBps": 7000,
+    "maxVenueFamilyConcentrationBps": 9000,
+    "maxDrawdownBps": 750
+  },
+  "researchMatrix": {
+    "selectionMetric": "excess_vs_flat_cash_bps",
+    "backtestLegs": [
+      {
+        "legId": "leg_spot_alpha",
+        "experimentId": "exp_sol_spot",
+        "replayCorpusId": "replay_sol_usdc",
+        "venueKey": "jupiter",
+        "pairSymbol": "SOL/USDC",
+        "marketType": "spot",
+        "windowMode": "rolling",
+        "trainingWindowObservations": 8,
+        "testingWindowObservations": 4,
+        "stepObservations": 4,
+        "purgeObservations": 1,
+        "baselineStrategies": ["flat_cash", "buy_and_hold"]
+      },
+      {
+        "legId": "leg_perp_hedge",
+        "experimentId": "exp_sol_perp",
+        "replayCorpusId": "replay_sol_perp",
+        "venueKey": "drift",
+        "pairSymbol": "SOL-PERP",
+        "marketType": "perp",
+        "windowMode": "rolling",
+        "trainingWindowObservations": 8,
+        "testingWindowObservations": 4,
+        "stepObservations": 4,
+        "purgeObservations": 1,
+        "baselineStrategies": ["flat_cash", "buy_and_hold"]
+      }
+    ],
+    "windows": [
+      {
+        "windowId": "selection_week_1",
+        "label": "Selection week 1",
+        "cohort": "selection",
+        "windowMode": "rolling",
+        "trainingWindowObservations": 8,
+        "testingWindowObservations": 4,
+        "stepObservations": 4,
+        "purgeObservations": 1
+      },
+      {
+        "windowId": "holdout_week_1",
+        "label": "Holdout week 1",
+        "cohort": "holdout",
+        "windowMode": "rolling",
+        "trainingWindowObservations": 8,
+        "testingWindowObservations": 4,
+        "stepObservations": 4,
+        "purgeObservations": 1
+      }
+    ],
+    "variants": [
+      {
+        "variantId": "fast",
+        "label": "Fast",
+        "parameterManifest": {
+          "threshold": "fast"
+        }
+      },
+      {
+        "variantId": "slow",
+        "label": "Slow",
+        "parameterManifest": {
+          "threshold": "slow"
+        }
+      }
+    ]
+  },
+  "legs": [
+    {
+      "legId": "leg_spot_alpha",
+      "label": "Spot alpha",
+      "role": "primary_alpha",
+      "venueKey": "jupiter",
+      "intentFamily": "spot_swap",
+      "marketType": "spot",
+      "pair": {
+        "symbol": "SOL/USDC",
+        "baseMint": "So11111111111111111111111111111111111111112",
+        "quoteMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        "marketType": "spot"
+      },
+      "assetKeys": ["SOL", "USDC"],
+      "enabledModes": ["shadow", "paper", "live"],
+      "sizing": {
+        "targetNotionalUsd": "1000",
+        "maxNotionalUsd": "2500",
+        "reserveUsd": "1000",
+        "maxSlippageBps": 50
+      },
+      "intent": {
+        "side": "buy"
+      },
+      "thesis": "Primary directional spot leg.",
+      "tags": ["alpha", "spot"]
+    },
+    {
+      "legId": "leg_perp_hedge",
+      "label": "Perp hedge",
+      "role": "hedge",
+      "venueKey": "drift",
+      "intentFamily": "perp_order",
+      "marketType": "perp",
+      "pair": {
+        "symbol": "SOL-PERP",
+        "baseMint": "So11111111111111111111111111111111111111112",
+        "quoteMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        "marketType": "perp"
+      },
+      "instrumentId": "SOL-PERP",
+      "assetKeys": ["SOL", "USDC"],
+      "enabledModes": ["shadow", "paper"],
+      "sizing": {
+        "targetNotionalUsd": "500",
+        "maxNotionalUsd": "750",
+        "reserveUsd": "250",
+        "maxSlippageBps": 30
+      },
+      "intent": {
+        "side": "short",
+        "quantityAtomic": "3521126760"
+      },
+      "thesis": "Hedge spot beta when momentum weakens.",
+      "dependencies": ["leg_spot_alpha"],
+      "tags": ["hedge", "perp"]
+    },
+    {
+      "legId": "leg_prediction_overlay",
+      "label": "Prediction overlay",
+      "role": "prediction",
+      "venueKey": "dflow",
+      "intentFamily": "prediction_order",
+      "marketType": "prediction",
+      "instrumentId": "macro-fed-cut-jun-2026",
+      "assetKeys": ["SOL", "USDC"],
+      "enabledModes": ["shadow", "paper"],
+      "sizing": {
+        "targetNotionalUsd": "150",
+        "maxNotionalUsd": "250",
+        "reserveUsd": "100",
+        "maxSlippageBps": 100
+      },
+      "intent": {
+        "side": "buy_yes",
+        "outcomeId": "yes"
+      },
+      "thesis": "Event hedge for macro-sensitive weeks.",
+      "tags": ["overlay", "prediction"]
+    },
+    {
+      "legId": "leg_flash_rebalance",
+      "label": "Flash rebalance",
+      "role": "flash_rebalance",
+      "venueKey": "flash_liquidity",
+      "intentFamily": "flash_atomic",
+      "marketType": "spot",
+      "pair": {
+        "symbol": "SOL/USDC",
+        "baseMint": "So11111111111111111111111111111111111111112",
+        "quoteMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        "marketType": "spot"
+      },
+      "assetKeys": ["SOL", "USDC"],
+      "enabledModes": ["shadow", "paper"],
+      "sizing": {
+        "targetNotionalUsd": "250",
+        "maxNotionalUsd": "500",
+        "reserveUsd": "125",
+        "maxSlippageBps": 35
+      },
+      "intent": {
+        "referenceId": "flash_rebalance_sol_usdc",
+        "settlementMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        "borrowLegs": [
+          {
+            "provider": "marginfi",
+            "mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amountAtomic": "250000000"
+          }
+        ]
+      },
+      "thesis": "Atomic rebalance path for bounded inventory clean-up.",
+      "dependencies": ["leg_spot_alpha", "leg_perp_hedge"],
+      "tags": ["flash", "rebalance"]
+    }
+  ],
+  "evidence": [
+    {
+      "stage": "backtest",
+      "summary": "Walk-forward backtest bundle for the composite thesis.",
+      "evidenceRefs": [
+        {
+          "kind": "backtest_report",
+          "ref": "backtest_alloc_dca_report"
+        }
+      ]
+    },
+    {
+      "stage": "paper",
+      "summary": "Composite paper report and leg receipts.",
+      "evidenceRefs": [
+        {
+          "kind": "strategy_desk_report",
+          "ref": "desk_report_sol_composite_paper_1"
+        }
+      ],
+      "latestReportId": "desk_report_sol_composite_paper_1"
+    }
+  ],
+  "implementationReferences": [
+    {
+      "kind": "issue",
+      "ref": "#436",
+      "notes": "Contract-first strategy desk rollout."
+    }
+  ],
+  "tags": ["strategy-desk", "composite"]
+}

--- a/docs/strategy-desk/request-templates/desk-sol-composite/study.backtest.request.json
+++ b/docs/strategy-desk/request-templates/desk-sol-composite/study.backtest.request.json
@@ -1,0 +1,6 @@
+{
+  "scenarioId": "desk_sol_composite_1",
+  "runKind": "backtest",
+  "requestedBy": "operator_1",
+  "selectionMetric": "excess_vs_flat_cash_bps"
+}

--- a/patches/@drift-labs%2Fsdk@2.159.0-beta.2.patch
+++ b/patches/@drift-labs%2Fsdk@2.159.0-beta.2.patch
@@ -7,7 +7,7 @@ index 41a66da1474c34ab67a9deb220993c9df3fb63eb..924b6544e89e04601289615d3ce73b2a
  const oracleId_1 = require("./oracles/oracleId");
  // BN is already imported globally in this file via other imports
 -const sha256_1 = require("@noble/hashes/sha256");
-+const sha256_1 = require("@noble/hashes/sha2.js");
++const sha256_1 = require("@noble/hashes/sha2");
  const utils_3 = require("./oracles/utils");
  const orders_1 = require("./math/orders");
  const builder_1 = require("./math/builder");
@@ -20,7 +20,7 @@ index 4fb011d4758a8f19e611addf38dd0fee44d48fbb..c45c1c7f7ed62363ea95a3320316d1bc
  const tweetnacl_util_1 = require("tweetnacl-util");
  const ws_1 = __importDefault(require("ws"));
 -const sha256_1 = require("@noble/hashes/sha256");
-+const sha256_1 = require("@noble/hashes/sha2.js");
++const sha256_1 = require("@noble/hashes/sha2");
  class SwiftOrderSubscriber {
      constructor(config) {
          this.config = config;
@@ -33,7 +33,7 @@ index 41a66da1474c34ab67a9deb220993c9df3fb63eb..924b6544e89e04601289615d3ce73b2a
  const oracleId_1 = require("./oracles/oracleId");
  // BN is already imported globally in this file via other imports
 -const sha256_1 = require("@noble/hashes/sha256");
-+const sha256_1 = require("@noble/hashes/sha2.js");
++const sha256_1 = require("@noble/hashes/sha2");
  const utils_3 = require("./oracles/utils");
  const orders_1 = require("./math/orders");
  const builder_1 = require("./math/builder");
@@ -46,7 +46,7 @@ index 4fb011d4758a8f19e611addf38dd0fee44d48fbb..c45c1c7f7ed62363ea95a3320316d1bc
  const tweetnacl_util_1 = require("tweetnacl-util");
  const ws_1 = __importDefault(require("ws"));
 -const sha256_1 = require("@noble/hashes/sha256");
-+const sha256_1 = require("@noble/hashes/sha2.js");
++const sha256_1 = require("@noble/hashes/sha2");
  class SwiftOrderSubscriber {
      constructor(config) {
          this.config = config;

--- a/patches/@drift-labs%2Fsdk@2.159.0-beta.2.patch
+++ b/patches/@drift-labs%2Fsdk@2.159.0-beta.2.patch
@@ -1,3 +1,9 @@
+diff --git a/package.json b/package.json
+index 7bf472fd43c63d42dd67e14cb916ad1a328376fc..f19b2d9c147aa64537df1ed8c97a927cb83160cf 100644
+--- a/package.json
++++ b/package.json
+@@ -46,0 +47 @@
++		"@noble/hashes": "^1.8.0",
 diff --git a/lib/browser/driftClient.js b/lib/browser/driftClient.js
 index 41a66da1474c34ab67a9deb220993c9df3fb63eb..924b6544e89e04601289615d3ce73b2a56fe025d 100644
 --- a/lib/browser/driftClient.js

--- a/patches/@orca-so%2Fcommon-sdk@0.7.0.patch
+++ b/patches/@orca-so%2Fcommon-sdk@0.7.0.patch
@@ -1,6 +1,12 @@
 diff --git a/node_modules/@orca-so/common-sdk/.bun-tag-d1b7d85cd245eea2 b/.bun-tag-d1b7d85cd245eea2
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/package.json b/package.json
+index eef31f07ac5b3947c75a44589fdcdcf40dd429f0..38df3ad5a714400558fdf5d7c915c7f4450985b8 100644
+--- a/package.json
++++ b/package.json
+@@ -15,0 +16 @@
++    "@noble/hashes": "^1.8.0",
 diff --git a/dist/web3/token-util.js b/dist/web3/token-util.js
 index a1915973084b9f5c69ddad9922b8b5c8c63b46bf..e634274d137a19cb9028afa139bb36d3228b730e 100644
 --- a/dist/web3/token-util.js

--- a/patches/@orca-so%2Fcommon-sdk@0.7.0.patch
+++ b/patches/@orca-so%2Fcommon-sdk@0.7.0.patch
@@ -10,7 +10,7 @@ index a1915973084b9f5c69ddad9922b8b5c8c63b46bf..e634274d137a19cb9028afa139bb36d3
  const spl_token_1 = require("@solana/spl-token");
  const web3_js_1 = require("@solana/web3.js");
 -const sha256_1 = require("@noble/hashes/sha256");
-+const sha256_1 = require("@noble/hashes/sha2.js");
++const sha256_1 = require("@noble/hashes/sha2");
  const tiny_invariant_1 = __importDefault(require("tiny-invariant"));
  const math_1 = require("../math");
  const web3_1 = require("../web3");


### PR DESCRIPTION
## Summary
- add a strategy-desk ops runbook, proof-bundle spec, and end-to-end canary and rollback drills
- check in desk-sol-composite request templates for scenario, study, execute, and handoff flows
- wire the new desk workflow docs into the repository verification index and strategy-lab runbook

## Testing
- bun run lint (blocked locally by existing Biome CLI/config version mismatch)
- bunx @biomejs/biome@2.3.15 check docs/reliability/strategy-desk-ops-runbook.md docs/reliability/strategy-lab-ops-runbook.md docs/strategy-desk/README.md docs/strategy-desk/proof-bundles.md docs/strategy-desk/drills/desk-sol-composite.canary-drill.md docs/strategy-desk/drills/desk-sol-composite.rollback-drill.md docs/strategy-desk/request-templates/desk-sol-composite/README.md docs/strategy-desk/request-templates/desk-sol-composite/scenario.upsert.json docs/strategy-desk/request-templates/desk-sol-composite/study.backtest.request.json docs/strategy-desk/request-templates/desk-sol-composite/execute.shadow.request.json docs/strategy-desk/request-templates/desk-sol-composite/execute.paper.request.json docs/strategy-desk/request-templates/desk-sol-composite/handoff.prepare.request.json docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.submit.request.json docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.approve.request.json docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.apply.request.json docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.pause.request.json docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.kill.request.json docs/strategy-desk/request-templates/desk-sol-composite/handoff.transition.demote.request.json docs/repository-verification-index.md