### PR TITLE
[Phase VP1] Promote venue lineage to first-class Loop A/B/C contracts and storage

### DIFF
--- a/apps/worker/src/loop_a/mark_engine.ts
+++ b/apps/worker/src/loop_a/mark_engine.ts
@@ -176,6 +176,8 @@ function buildMarkFromSwap(input: {
   const px = ratioAsDecimalString(outAtomic * inScale, inAtomic * outScale, 18);
   if (px === "0") return null;
 
+  const pools = extractPools(input.event);
+  const venue = input.event.venue ?? input.event.protocol;
   const evidenceInput = `${loopAEventBatchR2Key(input.commitment, input.event.slot)}#sig=${input.event.sig}`;
   return {
     schemaVersion: LOOP_A_SCHEMA_VERSION,
@@ -190,12 +192,18 @@ function buildMarkFromSwap(input: {
       hasUnitSize: inAtomic >= inScale && outAtomic >= outScale,
       hasLargeSize:
         inAtomic >= 1_000n * inScale && outAtomic >= 1_000n * outScale,
-      venue: input.event.venue,
+      venue,
     }),
-    venue: input.event.venue ?? input.event.protocol,
+    venue,
+    lineage: {
+      protocol: input.event.protocol,
+      venue,
+      marketType: "spot",
+      ...(pools?.[0] ? { pool: pools[0] } : {}),
+    },
     evidence: {
       sigs: [input.event.sig],
-      pools: extractPools(input.event),
+      pools,
       inputs: [evidenceInput],
     },
     version: LOOP_A_SCHEMA_VERSION,

--- a/apps/worker/src/loop_b/minute_accumulator.ts
+++ b/apps/worker/src/loop_b/minute_accumulator.ts
@@ -25,6 +25,21 @@ export const LOOP_B_HEALTH_KEY = "loopB:v1:health";
 
 type MinuteId = `${string}T${string}:00Z`;
 
+export type LoopVenueMarketType = NonNullable<Mark["lineage"]>["marketType"];
+
+export type LoopBVenueLineageRow = {
+  protocol: string;
+  venue: string;
+  marketType: LoopVenueMarketType;
+  markCount: number;
+  confidenceAvg: number;
+  firstSlot: number;
+  lastSlot: number;
+  lastTs: string;
+  inputRefs: string[];
+  pools: string[];
+};
+
 type PairAggregate = {
   pairId: string;
   baseMint: string;
@@ -39,6 +54,9 @@ type PairAggregate = {
   lastSlot: number;
   lastTs: string;
   inputRefs: string[];
+  sourceProtocols: string[];
+  sourceVenues: string[];
+  venueLineage: LoopBVenueLineageRow[];
   revision: number;
   explain: string[];
 };
@@ -56,6 +74,9 @@ export type LoopBFeatureRow = {
   volatilityPct: number;
   confidenceAvg: number;
   markCount: number;
+  sourceProtocols: string[];
+  sourceVenues: string[];
+  venueLineage: LoopBVenueLineageRow[];
   slotRange: {
     fromSlot: number;
     toSlot: number;
@@ -126,6 +147,9 @@ export type LoopBScoreRow = {
   finalScore: number;
   contributions: LoopBScoreContributions;
   featuresRef: string;
+  sourceProtocols: string[];
+  sourceVenues: string[];
+  venueLineage: LoopBVenueLineageRow[];
   revision: number;
   explain: string[];
 };
@@ -219,6 +243,122 @@ function markEventId(mark: Mark): string {
 function asFiniteNumber(value: string): number | null {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeStringList(values: Iterable<string>): string[] {
+  const items = new Set<string>();
+  for (const value of values) {
+    const normalized = value.trim();
+    if (normalized.length > 0) items.add(normalized);
+  }
+  return [...items].sort();
+}
+
+function markProtocol(mark: Mark): string {
+  const normalized = mark.lineage?.protocol?.trim();
+  return normalized && normalized.length > 0 ? normalized : mark.venue;
+}
+
+function markVenue(mark: Mark): string {
+  const normalized = mark.lineage?.venue?.trim();
+  return normalized && normalized.length > 0 ? normalized : mark.venue;
+}
+
+function markMarketType(mark: Mark): LoopVenueMarketType {
+  return mark.lineage?.marketType ?? "unknown";
+}
+
+function summarizeVenueLineage(marks: Mark[]): {
+  sourceProtocols: string[];
+  sourceVenues: string[];
+  venueLineage: LoopBVenueLineageRow[];
+} {
+  const byVenue = new Map<
+    string,
+    Omit<LoopBVenueLineageRow, "confidenceAvg" | "inputRefs" | "pools"> & {
+      confidenceSum: number;
+      inputRefs: Set<string>;
+      pools: Set<string>;
+    }
+  >();
+
+  for (const mark of marks) {
+    const protocol = markProtocol(mark);
+    const venue = markVenue(mark);
+    const marketType = markMarketType(mark);
+    const key = `${marketType}:${protocol}:${venue}`;
+    const current = byVenue.get(key);
+    if (current) {
+      current.markCount += 1;
+      current.confidenceSum += mark.confidence;
+      current.firstSlot = Math.min(current.firstSlot, mark.slot);
+      current.lastSlot = Math.max(current.lastSlot, mark.slot);
+      if (mark.ts > current.lastTs) current.lastTs = mark.ts;
+      for (const inputRef of mark.evidence?.inputs ?? []) {
+        if (inputRef) current.inputRefs.add(inputRef);
+      }
+      if (mark.lineage?.pool) current.pools.add(mark.lineage.pool);
+      for (const pool of mark.evidence?.pools ?? []) {
+        if (pool) current.pools.add(pool);
+      }
+      continue;
+    }
+
+    byVenue.set(key, {
+      protocol,
+      venue,
+      marketType,
+      markCount: 1,
+      confidenceSum: mark.confidence,
+      firstSlot: mark.slot,
+      lastSlot: mark.slot,
+      lastTs: mark.ts,
+      inputRefs: new Set(
+        (mark.evidence?.inputs ?? []).filter(
+          (inputRef): inputRef is string => inputRef.length > 0,
+        ),
+      ),
+      pools: new Set(
+        [
+          ...(mark.lineage?.pool ? [mark.lineage.pool] : []),
+          ...(mark.evidence?.pools ?? []),
+        ].filter((pool): pool is string => pool.length > 0),
+      ),
+    });
+  }
+
+  const venueLineage = [...byVenue.values()]
+    .map((entry) => ({
+      protocol: entry.protocol,
+      venue: entry.venue,
+      marketType: entry.marketType,
+      markCount: entry.markCount,
+      confidenceAvg: round(
+        entry.confidenceSum / Math.max(1, entry.markCount),
+        8,
+      ),
+      firstSlot: entry.firstSlot,
+      lastSlot: entry.lastSlot,
+      lastTs: entry.lastTs,
+      inputRefs: [...entry.inputRefs].sort(),
+      pools: [...entry.pools].sort(),
+    }))
+    .sort((a, b) => {
+      if (a.venue !== b.venue) return a.venue < b.venue ? -1 : 1;
+      if (a.protocol !== b.protocol) return a.protocol < b.protocol ? -1 : 1;
+      if (a.marketType !== b.marketType) {
+        return a.marketType < b.marketType ? -1 : 1;
+      }
+      return a.firstSlot - b.firstSlot;
+    });
+
+  return {
+    sourceProtocols: normalizeStringList(
+      venueLineage.map((entry) => entry.protocol),
+    ),
+    sourceVenues: normalizeStringList(venueLineage.map((entry) => entry.venue)),
+    venueLineage,
+  };
 }
 
 function loadState(input: unknown): MinuteAccumulatorState {
@@ -391,6 +531,7 @@ function aggregateMinutePairs(minuteRecord: MinuteRecord): PairAggregate[] {
     const pctChange = ((lastPx - firstPx) / firstPx) * 100;
     const volatility = ((maxPx - minPx) / firstPx) * 100;
     const avgConfidence = confidenceSum / marks.length;
+    const lineage = summarizeVenueLineage(marks);
 
     pairs.push({
       pairId: pairId(first),
@@ -406,6 +547,9 @@ function aggregateMinutePairs(minuteRecord: MinuteRecord): PairAggregate[] {
       lastSlot: last.slot,
       lastTs: last.ts,
       inputRefs: [...inputRefs].sort(),
+      sourceProtocols: lineage.sourceProtocols,
+      sourceVenues: lineage.sourceVenues,
+      venueLineage: lineage.venueLineage,
       revision: minuteRecord.revision,
       explain: [
         `minute=${minuteRecord.minute}`,
@@ -532,6 +676,9 @@ function buildFeatureSet(input: {
       volatilityPct: pair.volatility,
       confidenceAvg: pair.avgConfidence,
       markCount: pair.markCount,
+      sourceProtocols: pair.sourceProtocols,
+      sourceVenues: pair.sourceVenues,
+      venueLineage: pair.venueLineage,
       slotRange: {
         fromSlot: pair.firstSlot,
         toSlot: pair.lastSlot,
@@ -580,6 +727,9 @@ function buildScoreSet(input: { featureSet: LoopBFeatureSet }): LoopBScoreSet {
           activity: round(activity, 8),
         },
         featuresRef: `${LOOP_B_FEATURES_LATEST_KEY}:pair:${row.pairId}`,
+        sourceProtocols: row.sourceProtocols,
+        sourceVenues: row.sourceVenues,
+        venueLineage: row.venueLineage,
         revision: row.revision,
         explain: [
           `score=momentum+confidence+activity-stability`,

--- a/apps/worker/src/loop_c/candidate_pool.ts
+++ b/apps/worker/src/loop_c/candidate_pool.ts
@@ -1,11 +1,12 @@
-import type { LoopBScoreRow } from "../loop_b/minute_accumulator";
+import type {
+  LoopBScoreRow,
+  LoopBVenueLineageRow,
+} from "../loop_b/minute_accumulator";
 
 export const LOOP_C_SCHEMA_VERSION = "v1" as const;
 export const LOOP_C_CANDIDATE_POOL_LATEST_KEY = "loopC:v1:candidates:latest";
 export const LOOP_C_CANDIDATE_POOL_DEFAULT_LIMIT = 24;
 export const LOOP_C_CANDIDATE_POOL_MAX_LIMIT = 200;
-
-const KNOWN_PROTOCOLS = ["jupiter", "raydium", "orca", "meteora"] as const;
 
 export type LoopCCandidateFeatureHints = {
   markCount: number;
@@ -31,6 +32,8 @@ export type LoopCCandidateRow = {
   scoreRef: string;
   evidenceRefs: string[];
   sourceProtocols: string[];
+  sourceVenues: string[];
+  venueLineage: LoopBVenueLineageRow[];
   freshnessMs: number;
   liquidityScore: number;
   markCount: number;
@@ -90,12 +93,34 @@ function acceptancePriorFromScore(finalScore: number): number {
   return clamp01(1 / (1 + Math.exp(-scaled)));
 }
 
-function inferProtocolsFromEvidenceRefs(input: string[]): string[] {
-  const lower = input.join(" ").toLowerCase();
-  const protocols = KNOWN_PROTOCOLS.filter((protocol) =>
-    lower.includes(protocol),
-  );
-  return protocols.length > 0 ? [...protocols] : [];
+function normalizeVenueLineage(
+  input: LoopBVenueLineageRow[] | undefined,
+): LoopBVenueLineageRow[] {
+  return [...(input ?? [])]
+    .filter(
+      (entry) =>
+        entry.protocol.trim().length > 0 && entry.venue.trim().length > 0,
+    )
+    .map((entry) => ({
+      protocol: entry.protocol.trim(),
+      venue: entry.venue.trim(),
+      marketType: entry.marketType,
+      markCount: Math.max(0, Math.floor(entry.markCount)),
+      confidenceAvg: clamp01(entry.confidenceAvg),
+      firstSlot: Math.max(0, Math.floor(entry.firstSlot)),
+      lastSlot: Math.max(0, Math.floor(entry.lastSlot)),
+      lastTs: entry.lastTs,
+      inputRefs: normalizeStringList(entry.inputRefs),
+      pools: normalizeStringList(entry.pools),
+    }))
+    .sort((a, b) => {
+      if (a.venue !== b.venue) return a.venue < b.venue ? -1 : 1;
+      if (a.protocol !== b.protocol) return a.protocol < b.protocol ? -1 : 1;
+      if (a.marketType !== b.marketType) {
+        return a.marketType < b.marketType ? -1 : 1;
+      }
+      return a.firstSlot - b.firstSlot;
+    });
 }
 
 function parseFeatureHints(input: LoopCCandidateFeatureHints | undefined): {
@@ -180,8 +205,10 @@ export function buildLoopCCandidatePool(input: {
     const evidenceRefs = normalizeEvidenceRefs(
       input.evidenceRefsByPair.get(row.pairId),
     );
-    const sourceProtocols = inferProtocolsFromEvidenceRefs(evidenceRefs);
     const hints = parseFeatureHints(input.featureHintsByPair.get(row.pairId));
+    const sourceProtocols = normalizeStringList(row.sourceProtocols);
+    const sourceVenues = normalizeStringList(row.sourceVenues);
+    const venueLineage = normalizeVenueLineage(row.venueLineage);
 
     const curiosity =
       Math.abs(row.contributions.momentum) + row.contributions.activity * 0.2;
@@ -209,6 +236,8 @@ export function buildLoopCCandidatePool(input: {
       scoreRef: `loopB:v1:scores:latest:pair:${row.pairId}`,
       evidenceRefs,
       sourceProtocols,
+      sourceVenues,
+      venueLineage,
       freshnessMs,
       liquidityScore: round(liquidityScore),
       markCount: hints.markCount,
@@ -221,6 +250,8 @@ export function buildLoopCCandidatePool(input: {
         `source=loopB`,
         `score_ref=loopB:v1:scores:latest:pair:${row.pairId}`,
         `evidence_refs=${evidenceRefs.length}`,
+        `source_protocols=${sourceProtocols.join("|") || "none"}`,
+        `source_venues=${sourceVenues.join("|") || "none"}`,
         `risk_tags=${riskTags.join("|") || "none"}`,
         `stability_tags=${stabilityTags.join("|") || "none"}`,
       ],
@@ -288,6 +319,58 @@ function parseLoopCCandidateRow(raw: unknown): LoopCCandidateRow | null {
           row.sourceProtocols.filter(
             (entry): entry is string => typeof entry === "string",
           ),
+        )
+      : [],
+    sourceVenues: Array.isArray(row.sourceVenues)
+      ? normalizeStringList(
+          row.sourceVenues.filter(
+            (entry): entry is string => typeof entry === "string",
+          ),
+        )
+      : [],
+    venueLineage: Array.isArray(row.venueLineage)
+      ? normalizeVenueLineage(
+          row.venueLineage.flatMap((entry) => {
+            const parsed = asRecord(entry);
+            if (!parsed) return [];
+            if (
+              typeof parsed.protocol !== "string" ||
+              typeof parsed.venue !== "string" ||
+              typeof parsed.marketType !== "string" ||
+              typeof parsed.lastTs !== "string"
+            ) {
+              return [];
+            }
+            return [
+              {
+                protocol: parsed.protocol,
+                venue: parsed.venue,
+                marketType:
+                  parsed.marketType as LoopBVenueLineageRow["marketType"],
+                markCount:
+                  typeof parsed.markCount === "number" ? parsed.markCount : 0,
+                confidenceAvg:
+                  typeof parsed.confidenceAvg === "number"
+                    ? parsed.confidenceAvg
+                    : 0,
+                firstSlot:
+                  typeof parsed.firstSlot === "number" ? parsed.firstSlot : 0,
+                lastSlot:
+                  typeof parsed.lastSlot === "number" ? parsed.lastSlot : 0,
+                lastTs: parsed.lastTs,
+                inputRefs: Array.isArray(parsed.inputRefs)
+                  ? parsed.inputRefs.filter(
+                      (item): item is string => typeof item === "string",
+                    )
+                  : [],
+                pools: Array.isArray(parsed.pools)
+                  ? parsed.pools.filter(
+                      (item): item is string => typeof item === "string",
+                    )
+                  : [],
+              },
+            ];
+          }),
         )
       : [],
     freshnessMs:

--- a/apps/worker/src/loop_c/recommender.ts
+++ b/apps/worker/src/loop_c/recommender.ts
@@ -1,6 +1,7 @@
 import {
   LOOP_B_SCORES_LATEST_KEY,
   type LoopBScoreRow,
+  type LoopBVenueLineageRow,
 } from "../loop_b/minute_accumulator";
 import type { Env } from "../types";
 import {
@@ -37,6 +38,9 @@ export type RecommendationRow = {
   personaBoost: number;
   acceptProb: number;
   acceptBoost: number;
+  sourceProtocols: string[];
+  sourceVenues: string[];
+  venueLineage: LoopBVenueLineageRow[];
   modelVersion: typeof LOOP_C_SCHEMA_VERSION;
   explain: string[];
 };
@@ -105,6 +109,8 @@ type RecommendationInputRow = {
   riskPenalty: number;
   stabilityBonus: number;
   sourceProtocols: string[];
+  sourceVenues: string[];
+  venueLineage: LoopBVenueLineageRow[];
   freshnessMs: number;
   liquidityScore: number;
   riskTags: string[];
@@ -156,6 +162,42 @@ function priorFromBaseSignal(baseSignal: number): number {
 function normalizePrior(input: number): number {
   if (!Number.isFinite(input)) return 0.5;
   return clamp01(input);
+}
+
+function normalizeStringArray(input: string[] | undefined): string[] {
+  return [
+    ...new Set((input ?? []).map((item) => item.trim()).filter(Boolean)),
+  ].sort();
+}
+
+function normalizeVenueLineageRows(
+  input: LoopBVenueLineageRow[] | undefined,
+): LoopBVenueLineageRow[] {
+  return [...(input ?? [])]
+    .filter(
+      (entry) =>
+        entry.protocol.trim().length > 0 && entry.venue.trim().length > 0,
+    )
+    .map((entry) => ({
+      protocol: entry.protocol.trim(),
+      venue: entry.venue.trim(),
+      marketType: entry.marketType,
+      markCount: Math.max(0, Math.floor(entry.markCount)),
+      confidenceAvg: clamp01(entry.confidenceAvg),
+      firstSlot: Math.max(0, Math.floor(entry.firstSlot)),
+      lastSlot: Math.max(0, Math.floor(entry.lastSlot)),
+      lastTs: entry.lastTs,
+      inputRefs: normalizeStringArray(entry.inputRefs),
+      pools: normalizeStringArray(entry.pools),
+    }))
+    .sort((a, b) => {
+      if (a.venue !== b.venue) return a.venue < b.venue ? -1 : 1;
+      if (a.protocol !== b.protocol) return a.protocol < b.protocol ? -1 : 1;
+      if (a.marketType !== b.marketType) {
+        return a.marketType < b.marketType ? -1 : 1;
+      }
+      return a.firstSlot - b.firstSlot;
+    });
 }
 
 function parseDefaultLimit(raw: string | undefined): number {
@@ -230,6 +272,65 @@ function parseScoreRow(raw: unknown): LoopBScoreRow | null {
       activity: contributions.activity,
     },
     featuresRef: typeof row.featuresRef === "string" ? row.featuresRef : "",
+    sourceProtocols: Array.isArray(row.sourceProtocols)
+      ? normalizeStringArray(
+          row.sourceProtocols.filter(
+            (item): item is string => typeof item === "string",
+          ),
+        )
+      : [],
+    sourceVenues: Array.isArray(row.sourceVenues)
+      ? normalizeStringArray(
+          row.sourceVenues.filter(
+            (item): item is string => typeof item === "string",
+          ),
+        )
+      : [],
+    venueLineage: Array.isArray(row.venueLineage)
+      ? normalizeVenueLineageRows(
+          row.venueLineage.flatMap((entry) => {
+            const parsed = asRecord(entry);
+            if (!parsed) return [];
+            if (
+              typeof parsed.protocol !== "string" ||
+              typeof parsed.venue !== "string" ||
+              typeof parsed.marketType !== "string" ||
+              typeof parsed.lastTs !== "string"
+            ) {
+              return [];
+            }
+            return [
+              {
+                protocol: parsed.protocol,
+                venue: parsed.venue,
+                marketType:
+                  parsed.marketType as LoopBVenueLineageRow["marketType"],
+                markCount:
+                  typeof parsed.markCount === "number" ? parsed.markCount : 0,
+                confidenceAvg:
+                  typeof parsed.confidenceAvg === "number"
+                    ? parsed.confidenceAvg
+                    : 0,
+                firstSlot:
+                  typeof parsed.firstSlot === "number" ? parsed.firstSlot : 0,
+                lastSlot:
+                  typeof parsed.lastSlot === "number" ? parsed.lastSlot : 0,
+                lastTs: parsed.lastTs,
+                inputRefs: Array.isArray(parsed.inputRefs)
+                  ? parsed.inputRefs.filter(
+                      (item): item is string => typeof item === "string",
+                    )
+                  : [],
+                pools: Array.isArray(parsed.pools)
+                  ? parsed.pools.filter(
+                      (item): item is string => typeof item === "string",
+                    )
+                  : [],
+              },
+            ];
+          }),
+        )
+      : [],
     revision:
       typeof row.revision === "number" && Number.isInteger(row.revision)
         ? row.revision
@@ -264,7 +365,9 @@ function fromScoreRows(rows: LoopBScoreRow[]): RecommendationInputRow[] {
     baseSignal: row.finalScore,
     riskPenalty: row.contributions.stabilityPenalty,
     stabilityBonus: row.contributions.confidence,
-    sourceProtocols: [],
+    sourceProtocols: row.sourceProtocols,
+    sourceVenues: row.sourceVenues,
+    venueLineage: row.venueLineage,
     freshnessMs: Math.max(
       0,
       Date.parse(row.generatedAt) - Date.parse(row.minute),
@@ -286,6 +389,8 @@ function fromCandidatePoolRows(raw: string | null): RecommendationInputRow[] {
     riskPenalty: row.riskPenalty,
     stabilityBonus: row.stabilityBonus,
     sourceProtocols: row.sourceProtocols,
+    sourceVenues: row.sourceVenues,
+    venueLineage: row.venueLineage,
     freshnessMs: row.freshnessMs,
     liquidityScore: row.liquidityScore,
     riskTags: row.riskTags,
@@ -661,6 +766,9 @@ function buildRecommendations(input: {
       personaBoost: round(personaBoost),
       acceptProb,
       acceptBoost,
+      sourceProtocols: row.sourceProtocols,
+      sourceVenues: row.sourceVenues,
+      venueLineage: row.venueLineage,
       modelVersion: LOOP_C_SCHEMA_VERSION,
       explain: [
         `base_signal=${row.baseSignal.toFixed(4)}`,
@@ -669,6 +777,8 @@ function buildRecommendations(input: {
         `persona_boost=${personaBoost.toFixed(4)}`,
         `stability_boost=${stabilityBoost.toFixed(4)}`,
         `risk_penalty=${riskPenalty.toFixed(4)}`,
+        `source_protocols=${row.sourceProtocols.join("|") || "none"}`,
+        `source_venues=${row.sourceVenues.join("|") || "none"}`,
         `risk_tags=${row.riskTags.join("|") || "none"}`,
         `stability_tags=${row.stabilityTags.join("|") || "none"}`,
         ...row.explain.slice(0, 2),
@@ -752,6 +862,69 @@ function parseState(input: unknown): RecommenderState {
             ? normalizePrior(row.acceptProb)
             : 0.5,
         acceptBoost: typeof row.acceptBoost === "number" ? row.acceptBoost : 0,
+        sourceProtocols: Array.isArray(row.sourceProtocols)
+          ? normalizeStringArray(
+              row.sourceProtocols.filter(
+                (entry): entry is string => typeof entry === "string",
+              ),
+            )
+          : [],
+        sourceVenues: Array.isArray(row.sourceVenues)
+          ? normalizeStringArray(
+              row.sourceVenues.filter(
+                (entry): entry is string => typeof entry === "string",
+              ),
+            )
+          : [],
+        venueLineage: Array.isArray(row.venueLineage)
+          ? normalizeVenueLineageRows(
+              row.venueLineage.flatMap((entry) => {
+                const parsed = asRecord(entry);
+                if (!parsed) return [];
+                if (
+                  typeof parsed.protocol !== "string" ||
+                  typeof parsed.venue !== "string" ||
+                  typeof parsed.marketType !== "string" ||
+                  typeof parsed.lastTs !== "string"
+                ) {
+                  return [];
+                }
+                return [
+                  {
+                    protocol: parsed.protocol,
+                    venue: parsed.venue,
+                    marketType:
+                      parsed.marketType as LoopBVenueLineageRow["marketType"],
+                    markCount:
+                      typeof parsed.markCount === "number"
+                        ? parsed.markCount
+                        : 0,
+                    confidenceAvg:
+                      typeof parsed.confidenceAvg === "number"
+                        ? parsed.confidenceAvg
+                        : 0,
+                    firstSlot:
+                      typeof parsed.firstSlot === "number"
+                        ? parsed.firstSlot
+                        : 0,
+                    lastSlot:
+                      typeof parsed.lastSlot === "number" ? parsed.lastSlot : 0,
+                    lastTs: parsed.lastTs,
+                    inputRefs: Array.isArray(parsed.inputRefs)
+                      ? parsed.inputRefs.filter(
+                          (entry): entry is string => typeof entry === "string",
+                        )
+                      : [],
+                    pools: Array.isArray(parsed.pools)
+                      ? parsed.pools.filter(
+                          (entry): entry is string => typeof entry === "string",
+                        )
+                      : [],
+                  },
+                ];
+              }),
+            )
+          : [],
         modelVersion:
           row.modelVersion === LOOP_C_SCHEMA_VERSION
             ? LOOP_C_SCHEMA_VERSION

--- a/docs/strategy-lab/venue-lineage-contracts.md
+++ b/docs/strategy-lab/venue-lineage-contracts.md
@@ -1,0 +1,62 @@
+# Venue Lineage Contracts
+
+This note defines the VP1 compatibility contract for venue lineage across Loop
+A, Loop B, and Loop C.
+
+## Goals
+
+- Keep pair-level artifacts stable for existing readers.
+- Add structured venue provenance so downstream consumers stop inferring source
+  venues from evidence-ref strings.
+- Preserve a clear substrate for later venue-parity work without widening any
+  live execution path.
+
+## Contract Shape
+
+- Loop A marks keep their existing pair-level identity and `venue` field.
+- Loop A marks now optionally carry `lineage`, which records `protocol`,
+  `venue`, `marketType`, and an optional `pool`.
+- Loop B feature and score rows remain pair-level rows keyed by the same
+  `pairId`, `baseMint`, and `quoteMint`.
+- Loop B now carries additive provenance fields:
+  - `sourceProtocols`
+  - `sourceVenues`
+  - `venueLineage`
+- Loop C candidate and recommendation rows remain pair-level outputs.
+- Loop C now carries the same additive provenance fields so fallback reads from
+  Loop B stay structured.
+
+## Coexistence Rule
+
+Pair identity stays pair-scoped in VP1. `venueLineage` is provenance attached
+to a pair row, not a new row key.
+
+That means:
+
+- readers that only care about pair ranking can keep reading the existing
+  pair-level row identity;
+- readers that need venue-aware provenance must read `sourceVenues` and
+  `venueLineage` instead of reconstructing venue origin from evidence refs;
+- VP2 through VP7 can add venue-native ingestion and ranking behavior without
+  breaking the existing pair-level view.
+
+## Compatibility Strategy
+
+- No storage keys change in VP1.
+- The new provenance fields are additive.
+- Loop A `lineage` is optional so pre-VP1 marks remain parseable.
+- Loop B and Loop C parsers default missing provenance fields to empty arrays.
+- Existing KV and R2 readers that ignore unknown JSON properties remain
+  compatible without migration.
+- Existing readers that want venue-aware behavior must opt in to the new
+  fields; they must not keep using evidence-ref substring scans once structured
+  provenance is available.
+
+## Reader Guidance
+
+- Treat `sourceProtocols` and `sourceVenues` as convenience summaries.
+- Treat `venueLineage` as the authoritative structured provenance slice for a
+  pair row.
+- Do not assume a pair row maps to only one venue.
+- Do not create venue-specific ranking behavior in VP1 by rewriting pair keys;
+  that belongs to later venue-parity phases built on this substrate.

--- a/docs/strategy-lab/venue-readiness-matrix.md
+++ b/docs/strategy-lab/venue-readiness-matrix.md
@@ -7,6 +7,9 @@ It exists to keep venue onboarding, terminal rollout, and later real-TX smoke
 proofs on one explicit path instead of scattering readiness assumptions across
 issue bodies and PR notes.
 
+The Loop A/B/C provenance substrate for this program is defined in
+`docs/strategy-lab/venue-lineage-contracts.md`.
+
 ## How To Use It
 
 - Treat venue readiness as separate from strategy readiness.

--- a/src/loops/contracts/json/loop_a.mark.v1.schema.json
+++ b/src/loops/contracts/json/loop_a.mark.v1.schema.json
@@ -57,6 +57,30 @@
       "type": "string",
       "pattern": "^\\d+(?:\\.\\d+)?$"
     },
+    "lineage": {
+      "type": "object",
+      "properties": {
+        "protocol": {
+          "type": "string",
+          "minLength": 1
+        },
+        "venue": {
+          "type": "string",
+          "minLength": 1
+        },
+        "marketType": {
+          "type": "string",
+          "enum": ["spot", "clob", "perp", "prediction", "flash", "unknown"]
+        },
+        "pool": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 64
+        }
+      },
+      "required": ["protocol", "venue", "marketType"],
+      "additionalProperties": false
+    },
     "evidence": {
       "type": "object",
       "properties": {

--- a/src/loops/contracts/loop_a.ts
+++ b/src/loops/contracts/loop_a.ts
@@ -12,6 +12,14 @@ const DECIMAL_STRING_SCHEMA = z
 const NUMERIC_STRING_SCHEMA = z
   .string()
   .regex(/^-?\d+(?:\.\d+)?$/, "invalid-numeric-string");
+const MARKET_TYPE_SCHEMA = z.enum([
+  "spot",
+  "clob",
+  "perp",
+  "prediction",
+  "flash",
+  "unknown",
+]);
 
 export const ArtifactMetaSchema = z
   .object({
@@ -110,6 +118,15 @@ export const ProtocolEventSchema = z.discriminatedUnion("kind", [
   UnknownProtocolEventSchema,
 ]);
 
+export const MarkLineageSchema = z
+  .object({
+    protocol: NON_EMPTY_STRING_SCHEMA,
+    venue: NON_EMPTY_STRING_SCHEMA,
+    marketType: MARKET_TYPE_SCHEMA,
+    pool: PUBKEY_SCHEMA.optional(),
+  })
+  .strict();
+
 export const MarkSchema = ArtifactMetaSchema.extend({
   slot: z.number().int().nonnegative(),
   ts: ISO_DATETIME_SCHEMA,
@@ -121,6 +138,7 @@ export const MarkSchema = ArtifactMetaSchema.extend({
   confidence: z.number().min(0).max(1),
   venue: NON_EMPTY_STRING_SCHEMA,
   liquidityUsd: DECIMAL_STRING_SCHEMA.optional(),
+  lineage: MarkLineageSchema.optional(),
   evidence: z
     .object({
       sigs: z.array(NON_EMPTY_STRING_SCHEMA).optional(),
@@ -183,6 +201,7 @@ export const HealthSchema = ArtifactMetaSchema.extend({
 
 export type ArtifactMeta = z.infer<typeof ArtifactMetaSchema>;
 export type ProtocolEvent = z.infer<typeof ProtocolEventSchema>;
+export type MarkLineage = z.infer<typeof MarkLineageSchema>;
 export type Mark = z.infer<typeof MarkSchema>;
 export type StateSnapshot = z.infer<typeof StateSnapshotSchema>;
 export type Health = z.infer<typeof HealthSchema>;

--- a/tests/unit/loop_a_contracts.test.ts
+++ b/tests/unit/loop_a_contracts.test.ts
@@ -80,6 +80,12 @@ describe("loop A contracts", () => {
       px: "192.44",
       confidence: 0.78,
       venue: "orca",
+      lineage: {
+        protocol: "orca",
+        venue: "orca",
+        marketType: "spot",
+        pool: POOL,
+      },
       version: "v1",
       evidence: {
         sigs: [SIG],
@@ -88,6 +94,28 @@ describe("loop A contracts", () => {
     });
 
     expect(mark.confidence).toBe(0.78);
+    expect(mark.lineage?.protocol).toBe("orca");
+    expect(mark.lineage?.pool).toBe(POOL);
+  });
+
+  test("rejects mark lineage without protocol", () => {
+    const result = safeParseMark({
+      ...META,
+      slot: 200,
+      ts: "2026-02-21T00:01:00Z",
+      baseMint: SOL_MINT,
+      quoteMint: USDC_MINT,
+      px: "192.44",
+      confidence: 0.78,
+      venue: "orca",
+      lineage: {
+        venue: "orca",
+        marketType: "spot",
+      },
+      version: "v1",
+    });
+
+    expect(result.success).toBe(false);
   });
 
   test("rejects mark when confidence is out of range", () => {

--- a/tests/unit/worker_loop_a_mark_engine.test.ts
+++ b/tests/unit/worker_loop_a_mark_engine.test.ts
@@ -165,6 +165,11 @@ describe("worker loop A mark engine", () => {
     expect(mark.baseMint).toBe("So11111111111111111111111111111111111111112");
     expect(mark.quoteMint).toBe("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
     expect(mark.px).toBe("4");
+    expect(mark.lineage).toEqual({
+      protocol: "jupiter",
+      venue: "jupiter",
+      marketType: "spot",
+    });
     expect(mark.evidence?.sigs).toEqual(["sig-100"]);
 
     const pairKey =

--- a/tests/unit/worker_loop_b_minute_accumulator.test.ts
+++ b/tests/unit/worker_loop_b_minute_accumulator.test.ts
@@ -108,6 +108,11 @@ function createMark(input: {
     px: input.px,
     confidence: input.confidence ?? 0.8,
     venue: "jupiter",
+    lineage: {
+      protocol: "jupiter",
+      venue: "jupiter",
+      marketType: "spot",
+    },
     evidence: {
       sigs: [input.sig],
       inputs: [input.inputRef ?? `loopA/v1/events/slot=${input.slot}`],
@@ -217,6 +222,13 @@ describe("worker loop B minute accumulator", () => {
     ) as {
       rows: Array<{
         pairId: string;
+        sourceProtocols: string[];
+        sourceVenues: string[];
+        venueLineage: Array<{
+          protocol: string;
+          venue: string;
+          marketType: string;
+        }>;
         slotRange: { fromSlot: number; toSlot: number };
         inputRefs: string[];
       }>;
@@ -232,6 +244,13 @@ describe("worker loop B minute accumulator", () => {
       fromSlot: 700,
       toSlot: 701,
     });
+    expect(solUsdc?.sourceProtocols).toEqual(["jupiter"]);
+    expect(solUsdc?.sourceVenues).toEqual(["jupiter"]);
+    expect(solUsdc?.venueLineage[0]).toMatchObject({
+      protocol: "jupiter",
+      venue: "jupiter",
+      marketType: "spot",
+    });
     expect(solUsdc?.inputRefs).toEqual([
       "loopA/v1/events/slot=700",
       "loopA/v1/events/slot=701",
@@ -242,6 +261,8 @@ describe("worker loop B minute accumulator", () => {
       rows: Array<{
         pairId: string;
         finalScore: number;
+        sourceProtocols: string[];
+        sourceVenues: string[];
         contributions: {
           momentum: number;
           confidence: number;
@@ -254,6 +275,8 @@ describe("worker loop B minute accumulator", () => {
     expect(scoreSet.rows.length).toBe(2);
     expect(scoreSet.rows[0]?.finalScore).toBeGreaterThan(0);
     expect(scoreSet.rows[0]?.contributions.confidence).toBeGreaterThan(0);
+    expect(scoreSet.rows[0]?.sourceProtocols).toEqual(["jupiter"]);
+    expect(scoreSet.rows[0]?.sourceVenues).toEqual(["jupiter"]);
     expect(scoreSet.rows[0]?.explain[0]).toContain("score=momentum");
     const candidatePool = JSON.parse(
       kvStore.get(LOOP_C_CANDIDATE_POOL_LATEST_KEY) ?? "{}",
@@ -264,6 +287,8 @@ describe("worker loop B minute accumulator", () => {
         featuresRef: string;
         scoreRef: string;
         sourceProtocols: string[];
+        sourceVenues: string[];
+        venueLineage: Array<{ protocol: string; venue: string }>;
         freshnessMs: number;
         liquidityScore: number;
         riskTags: string[];
@@ -276,7 +301,12 @@ describe("worker loop B minute accumulator", () => {
     expect(candidatePool.rows[0]?.scoreRef).toContain("loopB:v1:scores");
     expect(candidatePool.rows[0]?.freshnessMs).toBe(60000);
     expect(candidatePool.rows[0]?.liquidityScore).toBeGreaterThanOrEqual(0);
-    expect(candidatePool.rows[0]?.sourceProtocols).toEqual([]);
+    expect(candidatePool.rows[0]?.sourceProtocols).toEqual(["jupiter"]);
+    expect(candidatePool.rows[0]?.sourceVenues).toEqual(["jupiter"]);
+    expect(candidatePool.rows[0]?.venueLineage[0]).toMatchObject({
+      protocol: "jupiter",
+      venue: "jupiter",
+    });
     expect(candidatePool.rows[0]?.riskTags.length).toBeGreaterThanOrEqual(0);
     expect(candidatePool.rows[0]?.stabilityTags.length).toBeGreaterThanOrEqual(
       0,

--- a/tests/unit/worker_loop_c_recommender.test.ts
+++ b/tests/unit/worker_loop_c_recommender.test.ts
@@ -154,6 +154,59 @@ function setScores(store: Map<string, string>, rowFinalScore: number): void {
   );
 }
 
+function setScoresWithLineage(
+  store: Map<string, string>,
+  rowFinalScore: number,
+): void {
+  store.set(
+    LOOP_B_SCORES_LATEST_KEY,
+    JSON.stringify({
+      schemaVersion: "v1",
+      generatedAt: "2026-02-21T20:00:00.000Z",
+      minute: "2026-02-21T20:00:00.000Z",
+      count: 1,
+      rows: [
+        {
+          schemaVersion: "v1",
+          generatedAt: "2026-02-21T20:00:00.000Z",
+          minute: "2026-02-21T20:00:00.000Z",
+          pairId:
+            "So11111111111111111111111111111111111111112:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          baseMint: "So11111111111111111111111111111111111111112",
+          quoteMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          finalScore: rowFinalScore,
+          contributions: {
+            momentum: 2.1,
+            confidence: 10.1,
+            stabilityPenalty: 1.3,
+            activity: 1.2,
+          },
+          featuresRef:
+            "loopB:v1:features:latest:pair:So11111111111111111111111111111111111111112:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          sourceProtocols: ["jupiter"],
+          sourceVenues: ["jupiter"],
+          venueLineage: [
+            {
+              protocol: "jupiter",
+              venue: "jupiter",
+              marketType: "spot",
+              markCount: 3,
+              confidenceAvg: 0.9,
+              firstSlot: 700,
+              lastSlot: 702,
+              lastTs: "2026-02-21T20:00:00.000Z",
+              inputRefs: ["loopA/v1/events/slot=700"],
+              pools: [],
+            },
+          ],
+          revision: 1,
+          explain: ["score=momentum+confidence+activity-stability"],
+        },
+      ],
+    }),
+  );
+}
+
 function setCandidatePool(store: Map<string, string>, pairId: string): void {
   const [baseMint, quoteMint] = pairId.split(":");
   store.set(
@@ -184,6 +237,21 @@ function setCandidatePool(store: Map<string, string>, pairId: string): void {
           scoreRef: `loopB:v1:scores:latest:pair:${pairId}`,
           evidenceRefs: ["loopA/v1/events/slot=123"],
           sourceProtocols: ["jupiter"],
+          sourceVenues: ["jupiter"],
+          venueLineage: [
+            {
+              protocol: "jupiter",
+              venue: "jupiter",
+              marketType: "spot",
+              markCount: 3,
+              confidenceAvg: 0.9,
+              firstSlot: 120,
+              lastSlot: 123,
+              lastTs: "2026-02-21T20:00:00.000Z",
+              inputRefs: ["loopA/v1/events/slot=123"],
+              pools: [],
+            },
+          ],
           freshnessMs: 60000,
           liquidityScore: 2.7,
           markCount: 3,
@@ -448,7 +516,12 @@ describe("worker loop C recommender durable object", () => {
       ok: boolean;
       cacheHit: boolean;
       view: {
-        recommendations: Array<{ pairId: string; finalScore: number }>;
+        recommendations: Array<{
+          pairId: string;
+          finalScore: number;
+          sourceProtocols: string[];
+          sourceVenues: string[];
+        }>;
       };
     };
 
@@ -459,6 +532,55 @@ describe("worker loop C recommender durable object", () => {
       "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN:So11111111111111111111111111111111111111112",
     );
     expect(payload.view.recommendations[0]?.finalScore).toBeGreaterThan(7.5);
+    expect(payload.view.recommendations[0]?.sourceProtocols).toEqual([
+      "jupiter",
+    ]);
+    expect(payload.view.recommendations[0]?.sourceVenues).toEqual(["jupiter"]);
+  });
+
+  test("fallback score rows preserve structured venue lineage", async () => {
+    const { env, kvStore } = createEnv();
+    setScoresWithLineage(kvStore, 7.5);
+
+    const mock = createMockDoState();
+    const recommender = new Recommender(mock.state, env, {
+      now: () => "2026-02-21T20:15:00.000Z",
+    });
+
+    const response = await recommender.fetch(
+      new Request("https://internal/loop-c/recommend", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          userId: "user-lineage",
+          wallet: "wallet-lineage",
+          observedAt: "2026-02-21T20:15:00.000Z",
+          limit: 1,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as {
+      ok: boolean;
+      view: {
+        recommendations: Array<{
+          sourceProtocols: string[];
+          sourceVenues: string[];
+          venueLineage: Array<{ protocol: string; venue: string }>;
+        }>;
+      };
+    };
+
+    expect(payload.ok).toBe(true);
+    expect(payload.view.recommendations[0]?.sourceProtocols).toEqual([
+      "jupiter",
+    ]);
+    expect(payload.view.recommendations[0]?.sourceVenues).toEqual(["jupiter"]);
+    expect(payload.view.recommendations[0]?.venueLineage[0]).toMatchObject({
+      protocol: "jupiter",
+      venue: "jupiter",
+    });
   });
 
   test("feedback yes/no updates acceptance probability predictably", async () => {


### PR DESCRIPTION
## Summary
- add structured venue lineage to Loop A marks and generated JSON schema artifacts
- preserve provenance through Loop B feature/score artifacts and into Loop C candidates/recommendations
- document the VP1 coexistence and compatibility rules for existing KV and R2 readers

## Before / After Artifacts
Before Loop A mark:
```json
{
  "venue": "jupiter"
}
```

After Loop A mark:
```json
{
  "venue": "jupiter",
  "lineage": {
    "protocol": "jupiter",
    "venue": "jupiter",
    "marketType": "spot",
    "pool": "<optional pool pubkey>"
  }
}
```

Before Loop C fallback recommendation provenance:
```json
{
  "pairId": "<base>:<quote>",
  "sourceProtocols": []
}
```

After Loop C fallback recommendation provenance:
```json
{
  "pairId": "<base>:<quote>",
  "sourceProtocols": ["jupiter"],
  "sourceVenues": ["jupiter"],
  "venueLineage": [
    {
      "protocol": "jupiter",
      "venue": "jupiter",
      "marketType": "spot",
      "markCount": 3,
      "confidenceAvg": 0.9,
      "firstSlot": 700,
      "lastSlot": 702,
      "lastTs": "2026-02-21T20:00:00.000Z",
      "inputRefs": ["loopA/v1/events/slot=700"],
      "pools": []
    }
  ]
}
```

## Compatibility
- no storage keys changed in VP1
- Loop A `lineage` is optional, so pre-VP1 marks remain parseable
- Loop B and Loop C parsers default missing provenance fields to empty arrays
- pair-level artifact identity remains unchanged; venue-specific provenance is additive via `sourceVenues` and `venueLineage`
- repo note added at `docs/strategy-lab/venue-lineage-contracts.md`

## Validation
- `bun run contracts:loop-a:schemas`
- `bun run lint`
- `bun run typecheck`
- `bun test tests/unit/loop_a_contracts.test.ts tests/unit/worker_loop_a_mark_engine.test.ts tests/unit/worker_loop_b_minute_accumulator.test.ts tests/unit/worker_loop_c_recommender.test.ts tests/unit/runtime_protocol_contracts.test.ts`

Fixes #455
