### PR TITLE
[Phase VP4] Publish venue-aware Loop B artifacts and parity views

### DIFF
--- a/apps/worker/src/loop_b/minute_accumulator.ts
+++ b/apps/worker/src/loop_b/minute_accumulator.ts
@@ -2,6 +2,8 @@ import {
   type Mark,
   safeParseMark,
 } from "../../../../src/loops/contracts/loop_a";
+import { listRuntimeVenueCapabilities } from "../../../../src/runtime/venues/catalog";
+import { listLoopAVenueParityStatuses } from "../loop_a/venue_bridge";
 import {
   buildLoopCCandidatePool,
   LOOP_C_CANDIDATE_POOL_LATEST_KEY,
@@ -21,6 +23,10 @@ export const LOOP_B_LIQUIDITY_STRESS_KEY =
 export const LOOP_B_ANOMALY_FEED_KEY = "loopB:v1:views:anomaly_feed:latest";
 export const LOOP_B_FEATURES_LATEST_KEY = "loopB:v1:features:latest";
 export const LOOP_B_SCORES_LATEST_KEY = "loopB:v1:scores:latest";
+export const LOOP_B_VENUE_FEATURES_LATEST_KEY =
+  "loopB:v1:features:by_venue:latest";
+export const LOOP_B_VENUE_SCORES_LATEST_KEY = "loopB:v1:scores:by_venue:latest";
+export const LOOP_B_PARITY_VIEW_KEY = "loopB:v1:views:pair_venue_parity:latest";
 export const LOOP_B_HEALTH_KEY = "loopB:v1:health";
 
 type MinuteId = `${string}T${string}:00Z`;
@@ -62,6 +68,44 @@ type PairAggregate = {
   venueLineage: LoopBVenueLineageRow[];
   revision: number;
   explain: string[];
+};
+
+export type LoopBVenueFeatureRow = {
+  schemaVersion: typeof LOOP_B_SCHEMA_VERSION;
+  generatedAt: string;
+  minute: MinuteId;
+  venueRowId: string;
+  pairId: string;
+  baseMint: string;
+  quoteMint: string;
+  protocol: string;
+  venue: string;
+  marketType: LoopVenueMarketType;
+  openPx: string;
+  closePx: string;
+  returnPct: number;
+  volatilityPct: number;
+  confidenceAvg: number;
+  markCount: number;
+  slotRange: {
+    fromSlot: number;
+    toSlot: number;
+  };
+  inputRefs: string[];
+  pools: string[];
+  markets: string[];
+  positionAccounts: string[];
+  settlementMints: string[];
+  revision: number;
+  explain: string[];
+};
+
+type LoopBVenueFeatureSet = {
+  schemaVersion: typeof LOOP_B_SCHEMA_VERSION;
+  generatedAt: string;
+  minute: MinuteId;
+  count: number;
+  rows: LoopBVenueFeatureRow[];
 };
 
 export type LoopBFeatureRow = {
@@ -157,12 +201,80 @@ export type LoopBScoreRow = {
   explain: string[];
 };
 
+export type LoopBVenueScoreRow = {
+  schemaVersion: typeof LOOP_B_SCHEMA_VERSION;
+  generatedAt: string;
+  minute: MinuteId;
+  venueRowId: string;
+  pairId: string;
+  baseMint: string;
+  quoteMint: string;
+  protocol: string;
+  venue: string;
+  marketType: LoopVenueMarketType;
+  finalScore: number;
+  contributions: LoopBScoreContributions;
+  featuresRef: string;
+  inputRefs: string[];
+  pools: string[];
+  markets: string[];
+  positionAccounts: string[];
+  settlementMints: string[];
+  revision: number;
+  explain: string[];
+};
+
 type LoopBScoreSet = {
   schemaVersion: typeof LOOP_B_SCHEMA_VERSION;
   generatedAt: string;
   minute: MinuteId;
   count: number;
   rows: LoopBScoreRow[];
+};
+
+type LoopBVenueScoreSet = {
+  schemaVersion: typeof LOOP_B_SCHEMA_VERSION;
+  generatedAt: string;
+  minute: MinuteId;
+  count: number;
+  rows: LoopBVenueScoreRow[];
+};
+
+export type LoopBParityVenueStatusRow = {
+  protocol: string;
+  venue: string;
+  marketType: LoopVenueMarketType;
+  status: "available" | "unavailable";
+  reasonCode: string;
+  reasonDetail?: string;
+  artifactRef?: string;
+  markCount: number;
+  confidenceAvg: number;
+  featureRef?: string;
+  scoreRef?: string;
+  pools: string[];
+  markets: string[];
+  positionAccounts: string[];
+  settlementMints: string[];
+};
+
+export type LoopBParityRow = {
+  pairId: string;
+  baseMint: string;
+  quoteMint: string;
+  marketTypes: LoopVenueMarketType[];
+  availableVenues: string[];
+  unavailableVenues: string[];
+  venues: LoopBParityVenueStatusRow[];
+  explain: string[];
+};
+
+type LoopBParityView = {
+  schemaVersion: typeof LOOP_B_SCHEMA_VERSION;
+  generatedAt: string;
+  minute: MinuteId;
+  count: number;
+  rows: LoopBParityRow[];
 };
 
 type LoopBHealth = {
@@ -253,6 +365,15 @@ function markVenueIdentity(mark: Mark): string {
 function markEventId(mark: Mark): string {
   const sig = mark.evidence?.sigs?.[0] ?? "no_sig";
   return `${pairId(mark)}:${mark.slot}:${sig}:${markVenueIdentity(mark)}`;
+}
+
+function venueAggregateKey(mark: Mark): string {
+  return [
+    pairId(mark),
+    markMarketType(mark),
+    markProtocol(mark),
+    markVenue(mark),
+  ].join(":");
 }
 
 function asFiniteNumber(value: string): number | null {
@@ -642,6 +763,396 @@ function aggregateMinutePairs(minuteRecord: MinuteRecord): PairAggregate[] {
   return pairs;
 }
 
+function venueRowId(input: {
+  pairId: string;
+  marketType: LoopVenueMarketType;
+  protocol: string;
+  venue: string;
+}): string {
+  return `${input.pairId}:${input.marketType}:${input.protocol}:${input.venue}`;
+}
+
+function aggregateMinuteVenueFeatures(
+  minuteRecord: MinuteRecord,
+  generatedAt: string,
+): LoopBVenueFeatureRow[] {
+  const marksSorted = Object.values(minuteRecord.marksById).sort((a, b) => {
+    const venueA = venueAggregateKey(a);
+    const venueB = venueAggregateKey(b);
+    if (venueA !== venueB) return venueA < venueB ? -1 : 1;
+    if (a.slot !== b.slot) return a.slot - b.slot;
+    if (a.ts < b.ts) return -1;
+    if (a.ts > b.ts) return 1;
+    return 0;
+  });
+
+  const grouped = new Map<string, Mark[]>();
+  for (const mark of marksSorted) {
+    const key = venueAggregateKey(mark);
+    const existing = grouped.get(key);
+    if (existing) {
+      existing.push(mark);
+    } else {
+      grouped.set(key, [mark]);
+    }
+  }
+
+  const rows: LoopBVenueFeatureRow[] = [];
+  for (const marks of grouped.values()) {
+    if (marks.length === 0) continue;
+    marks.sort((a, b) => {
+      if (a.slot !== b.slot) return a.slot - b.slot;
+      if (a.ts < b.ts) return -1;
+      if (a.ts > b.ts) return 1;
+      return 0;
+    });
+
+    const first = marks[0];
+    const last = marks[marks.length - 1];
+    if (!first || !last) continue;
+
+    const firstPx = asFiniteNumber(first.px);
+    const lastPx = asFiniteNumber(last.px);
+    if (firstPx === null || lastPx === null || firstPx <= 0) continue;
+
+    let minPx = firstPx;
+    let maxPx = firstPx;
+    let confidenceSum = 0;
+    const inputRefs = new Set<string>();
+    for (const mark of marks) {
+      const px = asFiniteNumber(mark.px);
+      if (px !== null) {
+        if (px < minPx) minPx = px;
+        if (px > maxPx) maxPx = px;
+      }
+      confidenceSum += mark.confidence;
+      for (const inputRef of mark.evidence?.inputs ?? []) {
+        if (inputRef) inputRefs.add(inputRef);
+      }
+    }
+
+    const marketType = markMarketType(first);
+    const protocol = markProtocol(first);
+    const venue = markVenue(first);
+    const lineage = summarizeVenueLineage(marks).venueLineage[0];
+    if (!lineage) continue;
+
+    const pairIdValue = pairId(first);
+    rows.push({
+      schemaVersion: LOOP_B_SCHEMA_VERSION,
+      generatedAt,
+      minute: minuteRecord.minute,
+      venueRowId: venueRowId({
+        pairId: pairIdValue,
+        marketType,
+        protocol,
+        venue,
+      }),
+      pairId: pairIdValue,
+      baseMint: first.baseMint,
+      quoteMint: first.quoteMint,
+      protocol,
+      venue,
+      marketType,
+      openPx: first.px,
+      closePx: last.px,
+      returnPct: ((lastPx - firstPx) / firstPx) * 100,
+      volatilityPct: ((maxPx - minPx) / firstPx) * 100,
+      confidenceAvg: confidenceSum / marks.length,
+      markCount: marks.length,
+      slotRange: {
+        fromSlot: first.slot,
+        toSlot: last.slot,
+      },
+      inputRefs: [...inputRefs].sort(),
+      pools: lineage.pools,
+      markets: lineage.markets,
+      positionAccounts: lineage.positionAccounts,
+      settlementMints: lineage.settlementMints,
+      revision: minuteRecord.revision,
+      explain: [
+        `minute=${minuteRecord.minute}`,
+        `venue=${venue}`,
+        `protocol=${protocol}`,
+        `mark_count=${marks.length}`,
+      ],
+    });
+  }
+
+  rows.sort((a, b) => {
+    if (a.pairId !== b.pairId) return a.pairId < b.pairId ? -1 : 1;
+    if (a.marketType !== b.marketType) {
+      return a.marketType < b.marketType ? -1 : 1;
+    }
+    if (a.venue !== b.venue) return a.venue < b.venue ? -1 : 1;
+    if (a.protocol !== b.protocol) return a.protocol < b.protocol ? -1 : 1;
+    return 0;
+  });
+
+  return rows;
+}
+
+function buildVenueFeatureSet(input: {
+  minute: MinuteId;
+  generatedAt: string;
+  rows: LoopBVenueFeatureRow[];
+}): LoopBVenueFeatureSet {
+  return {
+    schemaVersion: LOOP_B_SCHEMA_VERSION,
+    generatedAt: input.generatedAt,
+    minute: input.minute,
+    count: input.rows.length,
+    rows: input.rows,
+  };
+}
+
+function venueFeatureRowKey(venueRowIdValue: string): string {
+  return `${LOOP_B_VENUE_FEATURES_LATEST_KEY}:row:${venueRowIdValue}`;
+}
+
+function venueScoreRowKey(venueRowIdValue: string): string {
+  return `${LOOP_B_VENUE_SCORES_LATEST_KEY}:row:${venueRowIdValue}`;
+}
+
+function buildVenueScoreSet(input: {
+  featureSet: LoopBVenueFeatureSet;
+}): LoopBVenueScoreSet {
+  const rows = input.featureSet.rows
+    .map((row) => {
+      const momentum = row.returnPct * 0.55;
+      const confidence = row.confidenceAvg * 100 * 0.25;
+      const stabilityPenalty = row.volatilityPct * 0.2;
+      const activity = Math.log10(row.markCount + 1) * 2.5;
+      const finalScore = momentum + confidence + activity - stabilityPenalty;
+
+      const scoreRow: LoopBVenueScoreRow = {
+        schemaVersion: LOOP_B_SCHEMA_VERSION,
+        generatedAt: row.generatedAt,
+        minute: row.minute,
+        venueRowId: row.venueRowId,
+        pairId: row.pairId,
+        baseMint: row.baseMint,
+        quoteMint: row.quoteMint,
+        protocol: row.protocol,
+        venue: row.venue,
+        marketType: row.marketType,
+        finalScore: round(finalScore, 8),
+        contributions: {
+          momentum: round(momentum, 8),
+          confidence: round(confidence, 8),
+          stabilityPenalty: round(stabilityPenalty, 8),
+          activity: round(activity, 8),
+        },
+        featuresRef: venueFeatureRowKey(row.venueRowId),
+        inputRefs: row.inputRefs,
+        pools: row.pools,
+        markets: row.markets,
+        positionAccounts: row.positionAccounts,
+        settlementMints: row.settlementMints,
+        revision: row.revision,
+        explain: [
+          `score=momentum+confidence+activity-stability`,
+          `venue=${row.venue}`,
+          `market_type=${row.marketType}`,
+        ],
+      };
+      return scoreRow;
+    })
+    .sort((a, b) => {
+      if (a.finalScore !== b.finalScore) return b.finalScore - a.finalScore;
+      if (a.pairId !== b.pairId) return a.pairId < b.pairId ? -1 : 1;
+      if (a.venue !== b.venue) return a.venue < b.venue ? -1 : 1;
+      return a.protocol < b.protocol ? -1 : a.protocol > b.protocol ? 1 : 0;
+    });
+
+  return {
+    schemaVersion: LOOP_B_SCHEMA_VERSION,
+    generatedAt: input.featureSet.generatedAt,
+    minute: input.featureSet.minute,
+    count: rows.length,
+    rows,
+  };
+}
+
+function expectedVenueCandidates(marketTypes: LoopVenueMarketType[]): Array<{
+  protocol: string;
+  venue: string;
+  marketType: LoopVenueMarketType;
+  reasonCode: string;
+  reasonDetail?: string;
+  artifactRef?: string;
+}> {
+  const expectedTypes = new Set(marketTypes);
+  const parityIndex = new Map(
+    listLoopAVenueParityStatuses().map((status) => [
+      `${status.venueKey}:${status.marketType}`,
+      status,
+    ]),
+  );
+  const candidates = new Map<
+    string,
+    {
+      protocol: string;
+      venue: string;
+      marketType: LoopVenueMarketType;
+      reasonCode: string;
+      reasonDetail?: string;
+      artifactRef?: string;
+    }
+  >();
+
+  for (const capability of listRuntimeVenueCapabilities()) {
+    for (const rawMarketType of capability.marketTypes) {
+      const marketType = rawMarketType as LoopVenueMarketType;
+      if (!expectedTypes.has(marketType)) continue;
+      const parity = parityIndex.get(`${capability.venueKey}:${marketType}`);
+      const reasonCode =
+        parity?.mode === "blocked"
+          ? "blocked_in_loop_a"
+          : "no_mark_for_pair_in_minute";
+      const key = `${marketType}:${capability.venueKey}:${capability.venueKey}`;
+      candidates.set(key, {
+        protocol: capability.venueKey,
+        venue: capability.venueKey,
+        marketType,
+        reasonCode,
+        ...(parity ? { reasonDetail: parity.summary } : {}),
+        ...(parity?.artifactRef ? { artifactRef: parity.artifactRef } : {}),
+      });
+    }
+  }
+
+  return [...candidates.values()].sort((a, b) => {
+    if (a.marketType !== b.marketType) {
+      return a.marketType < b.marketType ? -1 : 1;
+    }
+    if (a.venue !== b.venue) return a.venue < b.venue ? -1 : 1;
+    if (a.protocol !== b.protocol) return a.protocol < b.protocol ? -1 : 1;
+    return 0;
+  });
+}
+
+function buildParityView(input: {
+  generatedAt: string;
+  pairs: PairAggregate[];
+  venueFeatureSet: LoopBVenueFeatureSet;
+  venueScoreSet: LoopBVenueScoreSet;
+}): LoopBParityView {
+  const featuresByPair = new Map<string, LoopBVenueFeatureRow[]>();
+  for (const row of input.venueFeatureSet.rows) {
+    const existing = featuresByPair.get(row.pairId);
+    if (existing) {
+      existing.push(row);
+    } else {
+      featuresByPair.set(row.pairId, [row]);
+    }
+  }
+  const scoreByVenueRowId = new Map(
+    input.venueScoreSet.rows.map((row) => [row.venueRowId, row] as const),
+  );
+
+  const rows: LoopBParityRow[] = input.pairs.map((pair) => {
+    const venueFeatures = featuresByPair.get(pair.pairId) ?? [];
+    const marketTypes = [
+      ...new Set(venueFeatures.map((row) => row.marketType)),
+    ].sort() as LoopVenueMarketType[];
+    const availableByKey = new Map(
+      venueFeatures.map((row) => [
+        `${row.marketType}:${row.protocol}:${row.venue}`,
+        row,
+      ]),
+    );
+    const venues: LoopBParityVenueStatusRow[] = venueFeatures.map((row) => {
+      const scoreRow = scoreByVenueRowId.get(row.venueRowId) ?? null;
+      return {
+        protocol: row.protocol,
+        venue: row.venue,
+        marketType: row.marketType,
+        status: "available",
+        reasonCode: "observed_marks",
+        markCount: row.markCount,
+        confidenceAvg: row.confidenceAvg,
+        featureRef: venueFeatureRowKey(row.venueRowId),
+        ...(scoreRow
+          ? { scoreRef: venueScoreRowKey(scoreRow.venueRowId) }
+          : {}),
+        pools: row.pools,
+        markets: row.markets,
+        positionAccounts: row.positionAccounts,
+        settlementMints: row.settlementMints,
+      };
+    });
+
+    for (const candidate of expectedVenueCandidates(marketTypes)) {
+      const existing = availableByKey.get(
+        `${candidate.marketType}:${candidate.protocol}:${candidate.venue}`,
+      );
+      if (existing) continue;
+      venues.push({
+        protocol: candidate.protocol,
+        venue: candidate.venue,
+        marketType: candidate.marketType,
+        status: "unavailable",
+        reasonCode: candidate.reasonCode,
+        ...(candidate.reasonDetail
+          ? { reasonDetail: candidate.reasonDetail }
+          : {}),
+        ...(candidate.artifactRef
+          ? { artifactRef: candidate.artifactRef }
+          : {}),
+        markCount: 0,
+        confidenceAvg: 0,
+        pools: [],
+        markets: [],
+        positionAccounts: [],
+        settlementMints: [],
+      });
+    }
+
+    venues.sort((a, b) => {
+      if (a.status !== b.status) return a.status === "available" ? -1 : 1;
+      if (a.marketType !== b.marketType) {
+        return a.marketType < b.marketType ? -1 : 1;
+      }
+      if (a.venue !== b.venue) return a.venue < b.venue ? -1 : 1;
+      if (a.protocol !== b.protocol) return a.protocol < b.protocol ? -1 : 1;
+      return 0;
+    });
+
+    return {
+      pairId: pair.pairId,
+      baseMint: pair.baseMint,
+      quoteMint: pair.quoteMint,
+      marketTypes,
+      availableVenues: normalizeStringList(
+        venues
+          .filter((row) => row.status === "available")
+          .map((row) => row.venue),
+      ),
+      unavailableVenues: normalizeStringList(
+        venues
+          .filter((row) => row.status === "unavailable")
+          .map((row) => row.venue),
+      ),
+      venues,
+      explain: [
+        `available=${venues.filter((row) => row.status === "available").length}`,
+        `unavailable=${venues.filter((row) => row.status === "unavailable").length}`,
+      ],
+    };
+  });
+
+  rows.sort((a, b) => (a.pairId < b.pairId ? -1 : a.pairId > b.pairId ? 1 : 0));
+
+  return {
+    schemaVersion: LOOP_B_SCHEMA_VERSION,
+    generatedAt: input.generatedAt,
+    minute: input.venueFeatureSet.minute,
+    count: rows.length,
+    rows,
+  };
+}
+
 function buildTopMoversView(input: {
   minute: MinuteId;
   generatedAt: string;
@@ -895,6 +1406,36 @@ function scoreSnapshotR2Key(input: {
   return `loopB/${LOOP_B_SCHEMA_VERSION}/scores/date=${yyyy}-${mm}-${dd}/hour=${hh}/minute=${yyyy}-${mm}-${dd}T${hh}:${minute}:00Z/revision=${input.revision}/at=${token}.json`;
 }
 
+function venueFeatureSnapshotR2Key(input: {
+  minute: MinuteId;
+  generatedAt: string;
+  revision: number;
+}): string {
+  const date = new Date(input.minute);
+  const yyyy = date.getUTCFullYear().toString().padStart(4, "0");
+  const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(date.getUTCDate()).padStart(2, "0");
+  const hh = String(date.getUTCHours()).padStart(2, "0");
+  const minute = String(date.getUTCMinutes()).padStart(2, "0");
+  const token = input.generatedAt.replaceAll(":", "-");
+  return `loopB/${LOOP_B_SCHEMA_VERSION}/features_by_venue/date=${yyyy}-${mm}-${dd}/hour=${hh}/minute=${yyyy}-${mm}-${dd}T${hh}:${minute}:00Z/revision=${input.revision}/at=${token}.json`;
+}
+
+function venueScoreSnapshotR2Key(input: {
+  minute: MinuteId;
+  generatedAt: string;
+  revision: number;
+}): string {
+  const date = new Date(input.minute);
+  const yyyy = date.getUTCFullYear().toString().padStart(4, "0");
+  const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(date.getUTCDate()).padStart(2, "0");
+  const hh = String(date.getUTCHours()).padStart(2, "0");
+  const minute = String(date.getUTCMinutes()).padStart(2, "0");
+  const token = input.generatedAt.replaceAll(":", "-");
+  return `loopB/${LOOP_B_SCHEMA_VERSION}/scores_by_venue/date=${yyyy}-${mm}-${dd}/hour=${hh}/minute=${yyyy}-${mm}-${dd}T${hh}:${minute}:00Z/revision=${input.revision}/at=${token}.json`;
+}
+
 function viewSnapshotR2Key(input: {
   minute: MinuteId;
   generatedAt: string;
@@ -908,6 +1449,21 @@ function viewSnapshotR2Key(input: {
   const minute = String(date.getUTCMinutes()).padStart(2, "0");
   const token = input.generatedAt.replaceAll(":", "-");
   return `loopB/${LOOP_B_SCHEMA_VERSION}/views/date=${yyyy}-${mm}-${dd}/hour=${hh}/minute=${yyyy}-${mm}-${dd}T${hh}:${minute}:00Z/revision=${input.revision}/at=${token}.json`;
+}
+
+function paritySnapshotR2Key(input: {
+  minute: MinuteId;
+  generatedAt: string;
+  revision: number;
+}): string {
+  const date = new Date(input.minute);
+  const yyyy = date.getUTCFullYear().toString().padStart(4, "0");
+  const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(date.getUTCDate()).padStart(2, "0");
+  const hh = String(date.getUTCHours()).padStart(2, "0");
+  const minute = String(date.getUTCMinutes()).padStart(2, "0");
+  const token = input.generatedAt.replaceAll(":", "-");
+  return `loopB/${LOOP_B_SCHEMA_VERSION}/parity/date=${yyyy}-${mm}-${dd}/hour=${hh}/minute=${yyyy}-${mm}-${dd}T${hh}:${minute}:00Z/revision=${input.revision}/at=${token}.json`;
 }
 
 function candidateSnapshotR2Key(input: {
@@ -951,6 +1507,14 @@ async function publishFinalizedMinute(input: {
   candidateLimit: number;
 }): Promise<void> {
   const pairs = aggregateMinutePairs(input.minuteRecord);
+  const venueFeatureSet = buildVenueFeatureSet({
+    minute: input.minute,
+    generatedAt: input.generatedAt,
+    rows: aggregateMinuteVenueFeatures(input.minuteRecord, input.generatedAt),
+  });
+  const venueScoreSet = buildVenueScoreSet({
+    featureSet: venueFeatureSet,
+  });
   const featureSet = buildFeatureSet({
     minute: input.minute,
     generatedAt: input.generatedAt,
@@ -974,6 +1538,12 @@ async function publishFinalizedMinute(input: {
     generatedAt: input.generatedAt,
     pairs,
     limit: input.topLimit,
+  });
+  const parityView = buildParityView({
+    generatedAt: input.generatedAt,
+    pairs,
+    venueFeatureSet,
+    venueScoreSet,
   });
   const evidenceRefsByPair = new Map(
     featureSet.rows.map((row) => [row.pairId, row.inputRefs] as const),
@@ -1005,12 +1575,21 @@ async function publishFinalizedMinute(input: {
   await putKvJson(input.env, LOOP_B_ANOMALY_FEED_KEY, anomalyFeed);
   await putKvJson(input.env, LOOP_B_FEATURES_LATEST_KEY, featureSet);
   await putKvJson(input.env, LOOP_B_SCORES_LATEST_KEY, scoreSet);
+  await putKvJson(input.env, LOOP_B_VENUE_FEATURES_LATEST_KEY, venueFeatureSet);
+  await putKvJson(input.env, LOOP_B_VENUE_SCORES_LATEST_KEY, venueScoreSet);
+  await putKvJson(input.env, LOOP_B_PARITY_VIEW_KEY, parityView);
   await putKvJson(input.env, LOOP_C_CANDIDATE_POOL_LATEST_KEY, candidatePool);
   const featureRowsByPair = new Map(
     featureSet.rows.map((row) => [row.pairId, row] as const),
   );
   const scoreRowsByPair = new Map(
     scoreSet.rows.map((row) => [row.pairId, row] as const),
+  );
+  const venueFeatureRowsById = new Map(
+    venueFeatureSet.rows.map((row) => [row.venueRowId, row] as const),
+  );
+  const venueScoreRowsById = new Map(
+    venueScoreSet.rows.map((row) => [row.venueRowId, row] as const),
   );
 
   for (const pair of pairs) {
@@ -1021,6 +1600,21 @@ async function publishFinalizedMinute(input: {
     const featureRow = featureRowsByPair.get(pair.pairId) ?? null;
     if (featureRow) {
       await putKvJson(input.env, featureRowKey(pair.pairId), featureRow);
+    }
+  }
+
+  for (const row of venueFeatureSet.rows) {
+    const featureRow = venueFeatureRowsById.get(row.venueRowId) ?? null;
+    if (featureRow) {
+      await putKvJson(
+        input.env,
+        venueFeatureRowKey(row.venueRowId),
+        featureRow,
+      );
+    }
+    const scoreRow = venueScoreRowsById.get(row.venueRowId) ?? null;
+    if (scoreRow) {
+      await putKvJson(input.env, venueScoreRowKey(row.venueRowId), scoreRow);
     }
   }
 
@@ -1050,12 +1644,28 @@ async function publishFinalizedMinute(input: {
         JSON.stringify(featureSet),
       ),
       input.env.LOGS_BUCKET.put(
+        venueFeatureSnapshotR2Key({
+          minute: input.minute,
+          generatedAt: input.generatedAt,
+          revision: input.minuteRecord.revision,
+        }),
+        JSON.stringify(venueFeatureSet),
+      ),
+      input.env.LOGS_BUCKET.put(
         scoreSnapshotR2Key({
           minute: input.minute,
           generatedAt: input.generatedAt,
           revision: input.minuteRecord.revision,
         }),
         JSON.stringify(scoreSet),
+      ),
+      input.env.LOGS_BUCKET.put(
+        venueScoreSnapshotR2Key({
+          minute: input.minute,
+          generatedAt: input.generatedAt,
+          revision: input.minuteRecord.revision,
+        }),
+        JSON.stringify(venueScoreSet),
       ),
       input.env.LOGS_BUCKET.put(
         viewSnapshotR2Key({
@@ -1072,9 +1682,18 @@ async function publishFinalizedMinute(input: {
             topMovers,
             liquidityStress,
             anomalyFeed,
+            parityView,
             candidatePool,
           },
         }),
+      ),
+      input.env.LOGS_BUCKET.put(
+        paritySnapshotR2Key({
+          minute: input.minute,
+          generatedAt: input.generatedAt,
+          revision: input.minuteRecord.revision,
+        }),
+        JSON.stringify(parityView),
       ),
       input.env.LOGS_BUCKET.put(
         candidateSnapshotR2Key({

--- a/apps/worker/src/loop_b/minute_accumulator.ts
+++ b/apps/worker/src/loop_b/minute_accumulator.ts
@@ -277,6 +277,13 @@ type LoopBParityView = {
   rows: LoopBParityRow[];
 };
 
+type LoopBParityStatusOverride = {
+  venueKey: string;
+  marketType: LoopVenueMarketType;
+  reasonDetail: string;
+  artifactRef: string;
+};
+
 type LoopBHealth = {
   schemaVersion: typeof LOOP_B_SCHEMA_VERSION;
   generatedAt: string;
@@ -293,6 +300,7 @@ type MinuteRecord = {
   revision: number;
   finalizedRevision: number;
   marksById: Record<string, Mark>;
+  publishedVenueRowIds: string[];
   updatedAt: string;
 };
 
@@ -303,6 +311,23 @@ type MinuteAccumulatorState = {
   lastFinalizedMinute: MinuteId | null;
   minutes: Record<string, MinuteRecord>;
 };
+
+const LOOP_A_BLOCKED_PARITY_OVERRIDES: LoopBParityStatusOverride[] = [
+  {
+    venueKey: "magicblock",
+    marketType: "spot",
+    reasonDetail:
+      "MagicBlock stays fail-closed for direct Loop A marks because the repo path is an ephemeral rollup execution adapter, not a deterministic L1 event feed.",
+    artifactRef: "docs/strategy-lab/loop-a-spot-venue-parity.md",
+  },
+  {
+    venueKey: "flash_liquidity",
+    marketType: "spot",
+    reasonDetail:
+      "Flash Liquidity stays fail-closed for direct Loop A marks because the current repo path is an atomic flash substrate, not a venue-native quote or fill stream.",
+    artifactRef: "docs/strategy-lab/loop-a-spot-venue-parity.md",
+  },
+];
 
 type IngestRequest = {
   marks: unknown[];
@@ -602,6 +627,14 @@ function loadState(input: unknown): MinuteAccumulatorState {
         revision,
         finalizedRevision,
         marksById,
+        publishedVenueRowIds: Array.isArray(rawRecord.publishedVenueRowIds)
+          ? normalizeStringList(
+              rawRecord.publishedVenueRowIds.filter(
+                (value): value is string =>
+                  typeof value === "string" && value.trim().length > 0,
+              ),
+            )
+          : [],
         updatedAt:
           typeof rawRecord.updatedAt === "string"
             ? rawRecord.updatedAt
@@ -637,6 +670,7 @@ function createMinuteRecord(
     revision: 0,
     finalizedRevision: 0,
     marksById: {},
+    publishedVenueRowIds: [],
     updatedAt: observedAt,
   };
 }
@@ -984,10 +1018,22 @@ function expectedVenueCandidates(marketTypes: LoopVenueMarketType[]): Array<{
 }> {
   const expectedTypes = new Set(marketTypes);
   const parityIndex = new Map(
-    listLoopAVenueParityStatuses().map((status) => [
-      `${status.venueKey}:${status.marketType}`,
-      status,
-    ]),
+    [
+      ...listLoopAVenueParityStatuses().map((status) => ({
+        venueKey: status.venueKey,
+        marketType: status.marketType,
+        mode: status.mode,
+        summary: status.summary,
+        artifactRef: status.artifactRef,
+      })),
+      ...LOOP_A_BLOCKED_PARITY_OVERRIDES.map((status) => ({
+        venueKey: status.venueKey,
+        marketType: status.marketType,
+        mode: "blocked" as const,
+        summary: status.reasonDetail,
+        artifactRef: status.artifactRef,
+      })),
+    ].map((status) => [`${status.venueKey}:${status.marketType}`, status]),
   );
   const candidates = new Map<
     string,
@@ -1490,6 +1536,11 @@ async function putKvJson(
   await env.CONFIG_KV.put(key, JSON.stringify(payload));
 }
 
+async function deleteKvKey(env: Env, key: string): Promise<void> {
+  if (!env.CONFIG_KV) return;
+  await env.CONFIG_KV.delete(key);
+}
+
 function pairScoreKey(pairIdValue: string): string {
   return `loopB:v1:scores:latest:pair:${pairIdValue}`;
 }
@@ -1591,6 +1642,23 @@ async function publishFinalizedMinute(input: {
   const venueScoreRowsById = new Map(
     venueScoreSet.rows.map((row) => [row.venueRowId, row] as const),
   );
+  const currentVenueRowIds = normalizeStringList(
+    venueFeatureSet.rows.map((row) => row.venueRowId),
+  );
+  const previousVenueRowIds = normalizeStringList(
+    input.minuteRecord.publishedVenueRowIds,
+  );
+  const currentVenueRowIdSet = new Set(currentVenueRowIds);
+  const staleVenueRowIds = previousVenueRowIds.filter(
+    (venueRowId) => !currentVenueRowIdSet.has(venueRowId),
+  );
+
+  await Promise.all(
+    staleVenueRowIds.flatMap((venueRowId) => [
+      deleteKvKey(input.env, venueFeatureRowKey(venueRowId)),
+      deleteKvKey(input.env, venueScoreRowKey(venueRowId)),
+    ]),
+  );
 
   for (const pair of pairs) {
     const scoreRow = scoreRowsByPair.get(pair.pairId) ?? null;
@@ -1617,6 +1685,8 @@ async function publishFinalizedMinute(input: {
       await putKvJson(input.env, venueScoreRowKey(row.venueRowId), scoreRow);
     }
   }
+
+  input.minuteRecord.publishedVenueRowIds = currentVenueRowIds;
 
   if (input.env.LOGS_BUCKET) {
     await Promise.all([

--- a/apps/worker/src/loop_b/minute_accumulator.ts
+++ b/apps/worker/src/loop_b/minute_accumulator.ts
@@ -300,7 +300,6 @@ type MinuteRecord = {
   revision: number;
   finalizedRevision: number;
   marksById: Record<string, Mark>;
-  publishedVenueRowIds: string[];
   updatedAt: string;
 };
 
@@ -309,6 +308,7 @@ type MinuteAccumulatorState = {
   updatedAt: string;
   currentMinute: MinuteId | null;
   lastFinalizedMinute: MinuteId | null;
+  lastPublishedVenueRowIds: string[];
   minutes: Record<string, MinuteRecord>;
 };
 
@@ -588,6 +588,7 @@ function loadState(input: unknown): MinuteAccumulatorState {
       updatedAt: new Date().toISOString(),
       currentMinute: null,
       lastFinalizedMinute: null,
+      lastPublishedVenueRowIds: [],
       minutes: {},
     };
   }
@@ -627,14 +628,6 @@ function loadState(input: unknown): MinuteAccumulatorState {
         revision,
         finalizedRevision,
         marksById,
-        publishedVenueRowIds: Array.isArray(rawRecord.publishedVenueRowIds)
-          ? normalizeStringList(
-              rawRecord.publishedVenueRowIds.filter(
-                (value): value is string =>
-                  typeof value === "string" && value.trim().length > 0,
-              ),
-            )
-          : [],
         updatedAt:
           typeof rawRecord.updatedAt === "string"
             ? rawRecord.updatedAt
@@ -657,6 +650,14 @@ function loadState(input: unknown): MinuteAccumulatorState {
       typeof record.lastFinalizedMinute === "string"
         ? (toMinuteId(record.lastFinalizedMinute) ?? null)
         : null,
+    lastPublishedVenueRowIds: Array.isArray(record.lastPublishedVenueRowIds)
+      ? normalizeStringList(
+          record.lastPublishedVenueRowIds.filter(
+            (value): value is string =>
+              typeof value === "string" && value.trim().length > 0,
+          ),
+        )
+      : [],
     minutes: outMinutes,
   };
 }
@@ -670,7 +671,6 @@ function createMinuteRecord(
     revision: 0,
     finalizedRevision: 0,
     marksById: {},
-    publishedVenueRowIds: [],
     updatedAt: observedAt,
   };
 }
@@ -1096,97 +1096,116 @@ function buildParityView(input: {
   const scoreByVenueRowId = new Map(
     input.venueScoreSet.rows.map((row) => [row.venueRowId, row] as const),
   );
+  const pairsById = new Map(
+    input.pairs.map((pair) => [pair.pairId, pair] as const),
+  );
+  const pairIds = normalizeStringList([
+    ...input.pairs.map((pair) => pair.pairId),
+    ...input.venueFeatureSet.rows.map((row) => row.pairId),
+  ]);
 
-  const rows: LoopBParityRow[] = input.pairs.map((pair) => {
-    const venueFeatures = featuresByPair.get(pair.pairId) ?? [];
-    const marketTypes = [
-      ...new Set(venueFeatures.map((row) => row.marketType)),
-    ].sort() as LoopVenueMarketType[];
-    const availableByKey = new Map(
-      venueFeatures.map((row) => [
-        `${row.marketType}:${row.protocol}:${row.venue}`,
-        row,
-      ]),
-    );
-    const venues: LoopBParityVenueStatusRow[] = venueFeatures.map((row) => {
-      const scoreRow = scoreByVenueRowId.get(row.venueRowId) ?? null;
-      return {
-        protocol: row.protocol,
-        venue: row.venue,
-        marketType: row.marketType,
-        status: "available",
-        reasonCode: "observed_marks",
-        markCount: row.markCount,
-        confidenceAvg: row.confidenceAvg,
-        featureRef: venueFeatureRowKey(row.venueRowId),
-        ...(scoreRow
-          ? { scoreRef: venueScoreRowKey(scoreRow.venueRowId) }
-          : {}),
-        pools: row.pools,
-        markets: row.markets,
-        positionAccounts: row.positionAccounts,
-        settlementMints: row.settlementMints,
-      };
-    });
+  const rows: LoopBParityRow[] = pairIds
+    .map((pairId) => {
+      const pair = pairsById.get(pairId) ?? null;
+      const venueFeatures = featuresByPair.get(pairId) ?? [];
+      const exemplar = venueFeatures[0] ?? null;
+      if (!pair && !exemplar) return null;
 
-    for (const candidate of expectedVenueCandidates(marketTypes)) {
-      const existing = availableByKey.get(
-        `${candidate.marketType}:${candidate.protocol}:${candidate.venue}`,
+      const marketTypes = normalizeStringList([
+        ...venueFeatures.map((row) => row.marketType),
+        ...((pair?.venueLineage ?? []).map(
+          (row) => row.marketType,
+        ) as string[]),
+      ]) as LoopVenueMarketType[];
+      const availableByKey = new Map(
+        venueFeatures.map((row) => [
+          `${row.marketType}:${row.protocol}:${row.venue}`,
+          row,
+        ]),
       );
-      if (existing) continue;
-      venues.push({
-        protocol: candidate.protocol,
-        venue: candidate.venue,
-        marketType: candidate.marketType,
-        status: "unavailable",
-        reasonCode: candidate.reasonCode,
-        ...(candidate.reasonDetail
-          ? { reasonDetail: candidate.reasonDetail }
-          : {}),
-        ...(candidate.artifactRef
-          ? { artifactRef: candidate.artifactRef }
-          : {}),
-        markCount: 0,
-        confidenceAvg: 0,
-        pools: [],
-        markets: [],
-        positionAccounts: [],
-        settlementMints: [],
+      const venues: LoopBParityVenueStatusRow[] = venueFeatures.map((row) => {
+        const scoreRow = scoreByVenueRowId.get(row.venueRowId) ?? null;
+        return {
+          protocol: row.protocol,
+          venue: row.venue,
+          marketType: row.marketType,
+          status: "available",
+          reasonCode: "observed_marks",
+          markCount: row.markCount,
+          confidenceAvg: row.confidenceAvg,
+          featureRef: venueFeatureRowKey(row.venueRowId),
+          ...(scoreRow
+            ? { scoreRef: venueScoreRowKey(scoreRow.venueRowId) }
+            : {}),
+          pools: row.pools,
+          markets: row.markets,
+          positionAccounts: row.positionAccounts,
+          settlementMints: row.settlementMints,
+        };
       });
-    }
 
-    venues.sort((a, b) => {
-      if (a.status !== b.status) return a.status === "available" ? -1 : 1;
-      if (a.marketType !== b.marketType) {
-        return a.marketType < b.marketType ? -1 : 1;
+      for (const candidate of expectedVenueCandidates(marketTypes)) {
+        const existing = availableByKey.get(
+          `${candidate.marketType}:${candidate.protocol}:${candidate.venue}`,
+        );
+        if (existing) continue;
+        venues.push({
+          protocol: candidate.protocol,
+          venue: candidate.venue,
+          marketType: candidate.marketType,
+          status: "unavailable",
+          reasonCode: candidate.reasonCode,
+          ...(candidate.reasonDetail
+            ? { reasonDetail: candidate.reasonDetail }
+            : {}),
+          ...(candidate.artifactRef
+            ? { artifactRef: candidate.artifactRef }
+            : {}),
+          markCount: 0,
+          confidenceAvg: 0,
+          pools: [],
+          markets: [],
+          positionAccounts: [],
+          settlementMints: [],
+        });
       }
-      if (a.venue !== b.venue) return a.venue < b.venue ? -1 : 1;
-      if (a.protocol !== b.protocol) return a.protocol < b.protocol ? -1 : 1;
-      return 0;
-    });
 
-    return {
-      pairId: pair.pairId,
-      baseMint: pair.baseMint,
-      quoteMint: pair.quoteMint,
-      marketTypes,
-      availableVenues: normalizeStringList(
-        venues
-          .filter((row) => row.status === "available")
-          .map((row) => row.venue),
-      ),
-      unavailableVenues: normalizeStringList(
-        venues
-          .filter((row) => row.status === "unavailable")
-          .map((row) => row.venue),
-      ),
-      venues,
-      explain: [
-        `available=${venues.filter((row) => row.status === "available").length}`,
-        `unavailable=${venues.filter((row) => row.status === "unavailable").length}`,
-      ],
-    };
-  });
+      venues.sort((a, b) => {
+        if (a.status !== b.status) return a.status === "available" ? -1 : 1;
+        if (a.marketType !== b.marketType) {
+          return a.marketType < b.marketType ? -1 : 1;
+        }
+        if (a.venue !== b.venue) return a.venue < b.venue ? -1 : 1;
+        if (a.protocol !== b.protocol) return a.protocol < b.protocol ? -1 : 1;
+        return 0;
+      });
+
+      return {
+        pairId,
+        baseMint:
+          pair?.baseMint ?? exemplar?.baseMint ?? pairId.split(":")[0] ?? "",
+        quoteMint:
+          pair?.quoteMint ?? exemplar?.quoteMint ?? pairId.split(":")[1] ?? "",
+        marketTypes,
+        availableVenues: normalizeStringList(
+          venues
+            .filter((row) => row.status === "available")
+            .map((row) => row.venue),
+        ),
+        unavailableVenues: normalizeStringList(
+          venues
+            .filter((row) => row.status === "unavailable")
+            .map((row) => row.venue),
+        ),
+        venues,
+        explain: [
+          `available=${venues.filter((row) => row.status === "available").length}`,
+          `unavailable=${venues.filter((row) => row.status === "unavailable").length}`,
+          `source_pair_aggregate=${pair ? "present" : "missing"}`,
+        ],
+      };
+    })
+    .filter((row): row is LoopBParityRow => row !== null);
 
   rows.sort((a, b) => (a.pairId < b.pairId ? -1 : a.pairId > b.pairId ? 1 : 0));
 
@@ -1556,7 +1575,8 @@ async function publishFinalizedMinute(input: {
   generatedAt: string;
   topLimit: number;
   candidateLimit: number;
-}): Promise<void> {
+  previousVenueRowIds: string[];
+}): Promise<string[]> {
   const pairs = aggregateMinutePairs(input.minuteRecord);
   const venueFeatureSet = buildVenueFeatureSet({
     minute: input.minute,
@@ -1645,9 +1665,7 @@ async function publishFinalizedMinute(input: {
   const currentVenueRowIds = normalizeStringList(
     venueFeatureSet.rows.map((row) => row.venueRowId),
   );
-  const previousVenueRowIds = normalizeStringList(
-    input.minuteRecord.publishedVenueRowIds,
-  );
+  const previousVenueRowIds = normalizeStringList(input.previousVenueRowIds);
   const currentVenueRowIdSet = new Set(currentVenueRowIds);
   const staleVenueRowIds = previousVenueRowIds.filter(
     (venueRowId) => !currentVenueRowIdSet.has(venueRowId),
@@ -1685,8 +1703,6 @@ async function publishFinalizedMinute(input: {
       await putKvJson(input.env, venueScoreRowKey(row.venueRowId), scoreRow);
     }
   }
-
-  input.minuteRecord.publishedVenueRowIds = currentVenueRowIds;
 
   if (input.env.LOGS_BUCKET) {
     await Promise.all([
@@ -1775,6 +1791,8 @@ async function publishFinalizedMinute(input: {
       ),
     ]);
   }
+
+  return currentVenueRowIds;
 }
 
 function parseTopLimit(raw: string | undefined): number {
@@ -1871,14 +1889,16 @@ export class MinuteAccumulator {
       if (!minuteRecord) continue;
       if (minuteRecord.revision === minuteRecord.finalizedRevision) continue;
 
-      await publishFinalizedMinute({
+      const publishedVenueRowIds = await publishFinalizedMinute({
         env: this.env,
         minute: minuteId,
         minuteRecord,
         generatedAt: input.observedAt,
         topLimit,
         candidateLimit,
+        previousVenueRowIds: input.state.lastPublishedVenueRowIds,
       });
+      input.state.lastPublishedVenueRowIds = publishedVenueRowIds;
       minuteRecord.finalizedRevision = minuteRecord.revision;
       minuteRecord.updatedAt = input.observedAt;
       finalizedMinutes += 1;

--- a/docs/strategy-lab/loop-b-venue-parity-artifacts.md
+++ b/docs/strategy-lab/loop-b-venue-parity-artifacts.md
@@ -1,0 +1,69 @@
+# Loop B Venue Parity Artifacts
+
+This note records the VP4 outcome for Loop B venue parity.
+
+It sits on top of the VP1 lineage contract in
+`docs/strategy-lab/venue-lineage-contracts.md`, the VP2 spot parity note in
+`docs/strategy-lab/loop-a-spot-venue-parity.md`, and the VP3 perp and
+prediction parity note in
+`docs/strategy-lab/loop-a-perp-prediction-venue-parity.md`.
+
+## Outcome
+
+- Loop B keeps the existing pair-level feature and score rows for legacy
+  readers.
+- Loop B now also publishes venue-native feature rows and score rows keyed by
+  `pairId`, `marketType`, `protocol`, and `venue`.
+- Loop B now publishes a pair-and-venue parity view that marks each venue as
+  either `available` or `unavailable` for the finalized minute.
+- Unavailable venues now carry structured reasons such as
+  `no_mark_for_pair_in_minute` or `blocked_in_loop_a` instead of disappearing
+  silently.
+
+## Artifact Surface
+
+| Artifact | Key | Purpose |
+| --- | --- | --- |
+| Pair features | `loopB:v1:features:latest` | Existing pair-level minute features for compatibility readers. |
+| Pair scores | `loopB:v1:scores:latest` | Existing pair-level minute scores for compatibility readers and Loop C fallback. |
+| Venue features | `loopB:v1:features:by_venue:latest` | Venue-native minute features for each observed pair-plus-venue row. |
+| Venue scores | `loopB:v1:scores:by_venue:latest` | Venue-native minute scores derived from venue feature rows. |
+| Pair/venue parity view | `loopB:v1:views:pair_venue_parity:latest` | Operator-facing availability view that names present and absent venues per pair. |
+
+Loop B also writes row-level compatibility keys for each published venue row:
+
+- `loopB:v1:features:by_venue:latest:row:<venueRowId>`
+- `loopB:v1:scores:by_venue:latest:row:<venueRowId>`
+
+## Determinism Rules
+
+- Venue rows sort by `pairId`, then `marketType`, then `venue`, then
+  `protocol`.
+- Venue score rows sort by descending `finalScore`, then `pairId`, then
+  `venue`, then `protocol`.
+- Parity rows sort by `pairId`.
+- Within a parity row, available venues sort ahead of unavailable venues, then
+  by `marketType`, `venue`, and `protocol`.
+
+These rules keep R2 snapshots stable across replays and late minute
+corrections.
+
+## Availability Semantics
+
+- `observed_marks` means the finalized minute produced venue-native Loop B
+  features from Loop A marks.
+- `no_mark_for_pair_in_minute` means the venue exists in the runtime venue
+  catalog for the pair's market type, but Loop B did not receive a mark for
+  that pair and venue in the finalized minute.
+- `blocked_in_loop_a` means Loop A parity status says the venue remains
+  fail-closed, and the parity row should expose the checked-in summary and
+  optional artifact reference instead of pretending the venue is simply quiet.
+
+## Reader Guidance
+
+- Existing pair-level readers can stay on the pair keys without migration.
+- New venue-aware readers should use the venue keys when they need
+  venue-specific scoring, and the parity view when they need to distinguish
+  "present" from "absent but expected".
+- VP5 should consume the venue-level rows and parity view directly instead of
+  collapsing back to pair-only inputs before recommendation ranking.

--- a/docs/strategy-lab/venue-lineage-contracts.md
+++ b/docs/strategy-lab/venue-lineage-contracts.md
@@ -1,7 +1,7 @@
 # Venue Lineage Contracts
 
-This note defines the VP1 compatibility contract for venue lineage across Loop
-A, Loop B, and Loop C.
+This note defines the lineage compatibility contract introduced in VP1 and
+extended through VP4 across Loop A, Loop B, and Loop C.
 
 ## Goals
 
@@ -17,20 +17,25 @@ A, Loop B, and Loop C.
 - Loop A marks now optionally carry `lineage`, which records `protocol`,
   `venue`, `marketType`, and optional `pool`, `market`, `positionAccount`, or
   `settlementMint` identifiers.
-- Loop B feature and score rows remain pair-level rows keyed by the same
-  `pairId`, `baseMint`, and `quoteMint`.
-- Loop B now carries additive provenance fields:
+- Loop B pair-level feature and score rows remain keyed by the same `pairId`,
+  `baseMint`, and `quoteMint`.
+- Loop B pair-level rows carry additive provenance fields:
   - `sourceProtocols`
   - `sourceVenues`
   - `venueLineage`
+- Loop B also publishes venue-native feature and score rows keyed by
+  `pairId`, `marketType`, `protocol`, and `venue`.
+- Loop B also publishes a pair-and-venue parity view with explicit
+  availability or unavailability reasons per venue.
 - Loop C candidate and recommendation rows remain pair-level outputs.
 - Loop C now carries the same additive provenance fields so fallback reads from
   Loop B stay structured.
 
 ## Coexistence Rule
 
-Pair identity stays pair-scoped in VP1. `venueLineage` is provenance attached
-to a pair row, not a new row key.
+Pair identity stays pair-scoped for existing readers. `venueLineage` remains
+provenance attached to a pair row, while VP4 adds separate venue-native Loop B
+artifacts for readers that need venue-specific scoring and availability.
 
 That means:
 
@@ -38,20 +43,22 @@ That means:
   pair-level row identity;
 - readers that need venue-aware provenance must read `sourceVenues` and
   `venueLineage` instead of reconstructing venue origin from evidence refs;
+- readers that need venue-native Loop B artifacts should read the VP4
+  venue-level keys and parity view instead of overloading pair rows;
 - VP2 through VP7 can add venue-native ingestion and ranking behavior without
   breaking the existing pair-level view.
 
 ## Compatibility Strategy
 
-- No storage keys change in VP1.
-- The new provenance fields are additive.
+- No existing pair-level storage keys change.
+- New provenance fields and venue-level artifacts are additive.
 - Loop A `lineage` is optional so pre-VP1 marks remain parseable.
 - Loop B and Loop C parsers default missing provenance fields to empty arrays.
 - Existing KV and R2 readers that ignore unknown JSON properties remain
   compatible without migration.
 - Existing readers that want venue-aware behavior must opt in to the new
-  fields; they must not keep using evidence-ref substring scans once structured
-  provenance is available.
+  fields and new venue-level artifacts; they must not keep using evidence-ref
+  substring scans once structured provenance is available.
 
 ## Reader Guidance
 
@@ -60,5 +67,7 @@ That means:
   pair row, including pool, market, position-account, and settlement lineage
   when they are available.
 - Do not assume a pair row maps to only one venue.
-- Do not create venue-specific ranking behavior in VP1 by rewriting pair keys;
-  that belongs to later venue-parity phases built on this substrate.
+- Treat Loop B venue-level rows as the authoritative venue-native score and
+  feature surface once VP4 artifacts are available.
+- Treat the Loop B parity view as the authoritative source for expected but
+  absent venues in a finalized minute.

--- a/docs/strategy-lab/venue-readiness-matrix.md
+++ b/docs/strategy-lab/venue-readiness-matrix.md
@@ -13,6 +13,8 @@ Loop A spot-family venue parity status for VP2 is recorded in
 `docs/strategy-lab/loop-a-spot-venue-parity.md`.
 Loop A perp and prediction venue parity status for VP3 is recorded in
 `docs/strategy-lab/loop-a-perp-prediction-venue-parity.md`.
+Loop B venue-aware artifact posture for VP4 is recorded in
+`docs/strategy-lab/loop-b-venue-parity-artifacts.md`.
 
 ## How To Use It
 

--- a/tests/unit/worker_loop_b_minute_accumulator.test.ts
+++ b/tests/unit/worker_loop_b_minute_accumulator.test.ts
@@ -5,8 +5,11 @@ import {
   LOOP_B_HEALTH_KEY,
   LOOP_B_LIQUIDITY_STRESS_KEY,
   LOOP_B_MINUTE_ACCUMULATOR_NAME,
+  LOOP_B_PARITY_VIEW_KEY,
   LOOP_B_SCORES_LATEST_KEY,
   LOOP_B_TOP_MOVERS_KEY,
+  LOOP_B_VENUE_FEATURES_LATEST_KEY,
+  LOOP_B_VENUE_SCORES_LATEST_KEY,
   MinuteAccumulator,
   publishMarksToMinuteAccumulator,
 } from "../../apps/worker/src/loop_b/minute_accumulator";
@@ -225,6 +228,9 @@ describe("worker loop B minute accumulator", () => {
     expect(kvStore.has(LOOP_B_ANOMALY_FEED_KEY)).toBe(true);
     expect(kvStore.has(LOOP_B_FEATURES_LATEST_KEY)).toBe(true);
     expect(kvStore.has(LOOP_B_SCORES_LATEST_KEY)).toBe(true);
+    expect(kvStore.has(LOOP_B_VENUE_FEATURES_LATEST_KEY)).toBe(true);
+    expect(kvStore.has(LOOP_B_VENUE_SCORES_LATEST_KEY)).toBe(true);
+    expect(kvStore.has(LOOP_B_PARITY_VIEW_KEY)).toBe(true);
     expect(kvStore.has(LOOP_B_HEALTH_KEY)).toBe(true);
     expect(kvStore.has(LOOP_C_CANDIDATE_POOL_LATEST_KEY)).toBe(true);
     expect(
@@ -441,6 +447,115 @@ describe("worker loop B minute accumulator", () => {
     });
   });
 
+  test("publishes venue-aware feature, score, and parity artifacts", async () => {
+    const { env, kvStore } = createEnv({ withR2: false });
+    const mock = createMockDoState();
+    const accumulator = new MinuteAccumulator(mock.state, env, {
+      now: () => "2026-02-21T18:05:00.000Z",
+    });
+
+    await accumulator.fetch(
+      new Request("https://internal/loop-b/ingest", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          observedAt: "2026-02-21T18:05:00.000Z",
+          marks: [
+            createMark({
+              slot: 710,
+              ts: "2026-02-21T18:04:10.000Z",
+              px: "5.1",
+              sig: "sig-raydium-710",
+              protocol: "raydium",
+              venue: "raydium",
+              pool: "Czfq3xZZD7f7mUXGQ95M5x7TQYtjY1fM6bMpiKFF9s8s",
+            }),
+            createMark({
+              slot: 711,
+              ts: "2026-02-21T18:04:25.000Z",
+              px: "5.15",
+              sig: "sig-openbook-711",
+              protocol: "openbook",
+              venue: "openbook",
+              marketType: "clob",
+              market: "7YttLkHDoNzpkAd3gg4MM3VQRSJ5ZK7VMBdb6Yf2mP6P",
+            }),
+          ],
+        }),
+      }),
+    );
+
+    const venueFeatureSet = JSON.parse(
+      kvStore.get(LOOP_B_VENUE_FEATURES_LATEST_KEY) ?? "{}",
+    ) as {
+      rows: Array<{
+        venue: string;
+        marketType: string;
+        pools: string[];
+        markets: string[];
+      }>;
+    };
+    expect(venueFeatureSet.rows.map((row) => row.venue).sort()).toEqual([
+      "openbook",
+      "raydium",
+    ]);
+    expect(
+      venueFeatureSet.rows.find((row) => row.venue === "raydium"),
+    ).toMatchObject({
+      marketType: "spot",
+      pools: ["Czfq3xZZD7f7mUXGQ95M5x7TQYtjY1fM6bMpiKFF9s8s"],
+    });
+    expect(
+      venueFeatureSet.rows.find((row) => row.venue === "openbook"),
+    ).toMatchObject({
+      marketType: "clob",
+      markets: ["7YttLkHDoNzpkAd3gg4MM3VQRSJ5ZK7VMBdb6Yf2mP6P"],
+    });
+
+    const venueScoreSet = JSON.parse(
+      kvStore.get(LOOP_B_VENUE_SCORES_LATEST_KEY) ?? "{}",
+    ) as {
+      rows: Array<{
+        venue: string;
+        marketType: string;
+        featuresRef: string;
+      }>;
+    };
+    expect(venueScoreSet.rows.map((row) => row.venue).sort()).toEqual([
+      "openbook",
+      "raydium",
+    ]);
+    expect(
+      venueScoreSet.rows.find((row) => row.venue === "openbook")?.featuresRef,
+    ).toContain("loopB:v1:features:by_venue:latest:row:");
+
+    const parityView = JSON.parse(
+      kvStore.get(LOOP_B_PARITY_VIEW_KEY) ?? "{}",
+    ) as {
+      rows: Array<{
+        pairId: string;
+        availableVenues: string[];
+        unavailableVenues: string[];
+        venues: Array<{
+          venue: string;
+          status: string;
+          reasonCode: string;
+        }>;
+      }>;
+    };
+    const solUsdc = parityView.rows.find((row) =>
+      row.pairId.startsWith("So11111111111111111111111111111111111111112:"),
+    );
+    expect(solUsdc?.availableVenues).toEqual(["openbook", "raydium"]);
+    expect(solUsdc?.unavailableVenues).toContain("jupiter");
+    expect(
+      solUsdc?.venues.find((row) => row.venue === "jupiter"),
+    ).toMatchObject({
+      status: "unavailable",
+      reasonCode: "no_mark_for_pair_in_minute",
+    });
+  });
+
   test("keeps same-signature multi-venue marks distinct", async () => {
     const { env, kvStore } = createEnv({ withR2: false });
     const mock = createMockDoState();
@@ -556,6 +671,81 @@ describe("worker loop B minute accumulator", () => {
       positionAccounts: ["drift-user-account"],
       settlementMints: ["EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"],
     });
+
+    const parityView = JSON.parse(
+      kvStore.get(LOOP_B_PARITY_VIEW_KEY) ?? "{}",
+    ) as {
+      rows: Array<{
+        venues: Array<{
+          venue: string;
+          status: string;
+          reasonCode: string;
+          artifactRef?: string;
+        }>;
+      }>;
+    };
+
+    expect(
+      parityView.rows[0]?.venues.find((row) => row.venue === "drift"),
+    ).toMatchObject({
+      status: "available",
+      reasonCode: "observed_marks",
+    });
+    expect(
+      parityView.rows[0]?.venues.find((row) => row.venue === "jupiter_perps"),
+    ).toMatchObject({
+      status: "unavailable",
+      reasonCode: "blocked_in_loop_a",
+      artifactRef: "docs/strategy-lab/pilots/jupiter-perps-readiness/README.md",
+    });
+  });
+
+  test("keeps finalized minute on empty venue-aware artifacts", async () => {
+    const { env, kvStore } = createEnv({ withR2: false });
+    const mock = createMockDoState();
+    const accumulator = new MinuteAccumulator(mock.state, env, {
+      now: () => "2026-02-21T18:08:00.000Z",
+    });
+
+    await accumulator.fetch(
+      new Request("https://internal/loop-b/ingest", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          observedAt: "2026-02-21T18:08:00.000Z",
+          marks: [
+            createMark({
+              slot: 740,
+              ts: "2026-02-21T18:07:10.000Z",
+              px: "0",
+              sig: "sig-zero-740",
+            }),
+          ],
+        }),
+      }),
+    );
+
+    const venueFeatureSet = JSON.parse(
+      kvStore.get(LOOP_B_VENUE_FEATURES_LATEST_KEY) ?? "{}",
+    ) as {
+      minute: string;
+      count: number;
+      rows: unknown[];
+    };
+    const parityView = JSON.parse(
+      kvStore.get(LOOP_B_PARITY_VIEW_KEY) ?? "{}",
+    ) as {
+      minute: string;
+      count: number;
+      rows: unknown[];
+    };
+
+    expect(venueFeatureSet.minute).toBe("2026-02-21T18:07:00.000Z");
+    expect(venueFeatureSet.count).toBe(0);
+    expect(venueFeatureSet.rows).toEqual([]);
+    expect(parityView.minute).toBe("2026-02-21T18:07:00.000Z");
+    expect(parityView.count).toBe(0);
+    expect(parityView.rows).toEqual([]);
   });
 
   test("late correction re-finalizes the minute with updated scores", async () => {

--- a/tests/unit/worker_loop_b_minute_accumulator.test.ts
+++ b/tests/unit/worker_loop_b_minute_accumulator.test.ts
@@ -764,6 +764,60 @@ describe("worker loop B minute accumulator", () => {
     expect(parityView.rows).toEqual([]);
   });
 
+  test("builds parity rows from venue features even when pair aggregates drop the pair", async () => {
+    const { env, kvStore } = createEnv({ withR2: false });
+    const mock = createMockDoState();
+    const accumulator = new MinuteAccumulator(mock.state, env, {
+      now: () => "2026-02-21T18:11:00.000Z",
+    });
+
+    await accumulator.fetch(
+      new Request("https://internal/loop-b/ingest", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          observedAt: "2026-02-21T18:11:00.000Z",
+          marks: [
+            createMark({
+              slot: 760,
+              ts: "2026-02-21T18:10:05.000Z",
+              px: "0",
+              sig: "sig-raydium-760",
+              protocol: "raydium",
+              venue: "raydium",
+            }),
+            createMark({
+              slot: 761,
+              ts: "2026-02-21T18:10:20.000Z",
+              px: "5.2",
+              sig: "sig-openbook-761",
+              protocol: "openbook",
+              venue: "openbook",
+              marketType: "clob",
+              market: "7YttLkHDoNzpkAd3gg4MM3VQRSJ5ZK7VMBdb6Yf2mP6P",
+            }),
+          ],
+        }),
+      }),
+    );
+
+    const parityView = JSON.parse(
+      kvStore.get(LOOP_B_PARITY_VIEW_KEY) ?? "{}",
+    ) as {
+      rows: Array<{
+        pairId: string;
+        availableVenues: string[];
+        explain: string[];
+      }>;
+    };
+
+    const solUsdc = parityView.rows.find((row) =>
+      row.pairId.startsWith("So11111111111111111111111111111111111111112:"),
+    );
+    expect(solUsdc?.availableVenues).toEqual(["openbook"]);
+    expect(solUsdc?.explain).toContain("source_pair_aggregate=missing");
+  });
+
   test("removes stale venue row keys when a late correction drops a venue row", async () => {
     const { env, kvStore } = createEnv({ withR2: false });
     const mock = createMockDoState();
@@ -821,6 +875,66 @@ describe("worker loop B minute accumulator", () => {
 
     expect(kvStore.has(initialVenueFeatureKey)).toBe(false);
     expect(kvStore.has(initialVenueScoreKey)).toBe(false);
+  });
+
+  test("removes stale venue row keys when the latest minute rolls over to a new venue set", async () => {
+    const { env, kvStore } = createEnv({ withR2: false });
+    const mock = createMockDoState();
+    const accumulator = new MinuteAccumulator(mock.state, env, {
+      now: () => "2026-02-21T18:10:00.000Z",
+    });
+
+    await accumulator.fetch(
+      new Request("https://internal/loop-b/ingest", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          observedAt: "2026-02-21T18:10:00.000Z",
+          marks: [
+            createMark({
+              slot: 770,
+              ts: "2026-02-21T18:09:10.000Z",
+              px: "5.1",
+              sig: "sig-raydium-770",
+              protocol: "raydium",
+              venue: "raydium",
+            }),
+          ],
+        }),
+      }),
+    );
+
+    const raydiumVenueFeatureKey =
+      "loopB:v1:features:by_venue:latest:row:So11111111111111111111111111111111111111112:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v:spot:raydium:raydium";
+    const openbookVenueFeatureKey =
+      "loopB:v1:features:by_venue:latest:row:So11111111111111111111111111111111111111112:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v:clob:openbook:openbook";
+
+    expect(kvStore.has(raydiumVenueFeatureKey)).toBe(true);
+
+    await accumulator.fetch(
+      new Request("https://internal/loop-b/ingest", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          observedAt: "2026-02-21T18:11:00.000Z",
+          marks: [
+            createMark({
+              slot: 771,
+              ts: "2026-02-21T18:10:15.000Z",
+              px: "5.2",
+              sig: "sig-openbook-771",
+              protocol: "openbook",
+              venue: "openbook",
+              marketType: "clob",
+              market: "7YttLkHDoNzpkAd3gg4MM3VQRSJ5ZK7VMBdb6Yf2mP6P",
+            }),
+          ],
+        }),
+      }),
+    );
+
+    expect(kvStore.has(raydiumVenueFeatureKey)).toBe(false);
+    expect(kvStore.has(openbookVenueFeatureKey)).toBe(true);
   });
 
   test("late correction re-finalizes the minute with updated scores", async () => {

--- a/tests/unit/worker_loop_b_minute_accumulator.test.ts
+++ b/tests/unit/worker_loop_b_minute_accumulator.test.ts
@@ -548,11 +548,27 @@ describe("worker loop B minute accumulator", () => {
     );
     expect(solUsdc?.availableVenues).toEqual(["openbook", "raydium"]);
     expect(solUsdc?.unavailableVenues).toContain("jupiter");
+    expect(solUsdc?.unavailableVenues).toContain("magicblock");
+    expect(solUsdc?.unavailableVenues).toContain("flash_liquidity");
     expect(
       solUsdc?.venues.find((row) => row.venue === "jupiter"),
     ).toMatchObject({
       status: "unavailable",
       reasonCode: "no_mark_for_pair_in_minute",
+    });
+    expect(
+      solUsdc?.venues.find((row) => row.venue === "magicblock"),
+    ).toMatchObject({
+      status: "unavailable",
+      reasonCode: "blocked_in_loop_a",
+      artifactRef: "docs/strategy-lab/loop-a-spot-venue-parity.md",
+    });
+    expect(
+      solUsdc?.venues.find((row) => row.venue === "flash_liquidity"),
+    ).toMatchObject({
+      status: "unavailable",
+      reasonCode: "blocked_in_loop_a",
+      artifactRef: "docs/strategy-lab/loop-a-spot-venue-parity.md",
     });
   });
 
@@ -746,6 +762,65 @@ describe("worker loop B minute accumulator", () => {
     expect(parityView.minute).toBe("2026-02-21T18:07:00.000Z");
     expect(parityView.count).toBe(0);
     expect(parityView.rows).toEqual([]);
+  });
+
+  test("removes stale venue row keys when a late correction drops a venue row", async () => {
+    const { env, kvStore } = createEnv({ withR2: false });
+    const mock = createMockDoState();
+    const accumulator = new MinuteAccumulator(mock.state, env, {
+      now: () => "2026-02-21T18:09:00.000Z",
+    });
+
+    await accumulator.fetch(
+      new Request("https://internal/loop-b/ingest", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          observedAt: "2026-02-21T18:09:00.000Z",
+          marks: [
+            createMark({
+              slot: 750,
+              ts: "2026-02-21T18:08:10.000Z",
+              px: "5.1",
+              sig: "sig-raydium-750",
+              protocol: "raydium",
+              venue: "raydium",
+            }),
+          ],
+        }),
+      }),
+    );
+
+    const initialVenueFeatureKey =
+      "loopB:v1:features:by_venue:latest:row:So11111111111111111111111111111111111111112:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v:spot:raydium:raydium";
+    const initialVenueScoreKey =
+      "loopB:v1:scores:by_venue:latest:row:So11111111111111111111111111111111111111112:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v:spot:raydium:raydium";
+
+    expect(kvStore.has(initialVenueFeatureKey)).toBe(true);
+    expect(kvStore.has(initialVenueScoreKey)).toBe(true);
+
+    await accumulator.fetch(
+      new Request("https://internal/loop-b/ingest", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          observedAt: "2026-02-21T18:10:00.000Z",
+          marks: [
+            createMark({
+              slot: 750,
+              ts: "2026-02-21T18:08:10.000Z",
+              px: "0",
+              sig: "sig-raydium-750",
+              protocol: "raydium",
+              venue: "raydium",
+            }),
+          ],
+        }),
+      }),
+    );
+
+    expect(kvStore.has(initialVenueFeatureKey)).toBe(false);
+    expect(kvStore.has(initialVenueScoreKey)).toBe(false);
   });
 
   test("late correction re-finalizes the minute with updated scores", async () => {


### PR DESCRIPTION
## Summary
- add venue-native Loop B feature and score artifacts alongside existing pair-level rows
- publish pair/venue parity views with explicit unavailable reasons from runtime capabilities and Loop A parity status
- document the VP4 artifact surface and cover empty-minute plus multi-venue regression cases

## Validation
- bun run lint
- bun run typecheck
- bun test tests/unit/worker_loop_b_minute_accumulator.test.ts tests/unit/worker_loop_a_mark_engine.test.ts tests/unit/worker_loop_c_recommender.test.ts

Closes #458