### PR TITLE
Persisted Svelte store for Phoenix trader state

### DIFF
--- a/apps/portal/src/lib/persisted.ts
+++ b/apps/portal/src/lib/persisted.ts
@@ -1,0 +1,40 @@
+// Writable Svelte store persisted to localStorage: hydrates synchronously at
+// creation (module scope → survives client-side navigation), writes through
+// on every set, and syncs across tabs via the storage event — a deposit made
+// in one tab updates every other tab's state.
+
+import { type Writable, writable } from "svelte/store";
+
+export function persisted<T>(key: string, initial: T): Writable<T> {
+  let start = initial;
+  if (typeof window !== "undefined") {
+    try {
+      const raw = window.localStorage.getItem(key);
+      if (raw !== null) start = JSON.parse(raw) as T;
+    } catch {
+      // corrupted or unavailable storage — fall back to the initial value
+    }
+  }
+  const store = writable<T>(start);
+  if (typeof window !== "undefined") {
+    let writingSelf = false;
+    store.subscribe((value) => {
+      writingSelf = true;
+      try {
+        window.localStorage.setItem(key, JSON.stringify(value));
+      } catch {
+        // storage full/unavailable — the in-memory store still works
+      }
+      writingSelf = false;
+    });
+    window.addEventListener("storage", (event) => {
+      if (writingSelf || event.key !== key || event.newValue === null) return;
+      try {
+        store.set(JSON.parse(event.newValue) as T);
+      } catch {
+        // another tab wrote something unparseable — ignore
+      }
+    });
+  }
+  return store;
+}

--- a/apps/portal/src/lib/phoenix-cache.ts
+++ b/apps/portal/src/lib/phoenix-cache.ts
@@ -1,0 +1,44 @@
+// Per-wallet Phoenix trader snapshots, persisted on device. The store is the
+// single source of truth for account state: the terminal derives its view
+// from here, the live refresh writes back here, and localStorage + the
+// cross-tab storage event keep every tab and every page load instant.
+
+import { persisted } from "./persisted";
+import type { PhoenixTraderState } from "./phoenix-trade";
+
+export type TraderSnapshot = { at: number; state: PhoenixTraderState };
+
+const SNAPSHOT_TTL_MS = 24 * 3_600_000;
+const MAX_WALLETS = 4;
+
+export const traderSnapshots = persisted<Record<string, TraderSnapshot>>(
+  "trader-ralph-phoenix-snapshots",
+  {},
+);
+
+/** Snapshot for a wallet, or null when absent/expired. */
+export function freshSnapshot(
+  snapshots: Record<string, TraderSnapshot>,
+  authority: string,
+): PhoenixTraderState | null {
+  const entry = snapshots[authority];
+  if (!entry || typeof entry.at !== "number" || !entry.state) return null;
+  if (Date.now() - entry.at > SNAPSHOT_TTL_MS) return null;
+  return entry.state;
+}
+
+/** Record a fresh snapshot, pruning to the most recent wallets. */
+export function recordSnapshot(
+  authority: string,
+  state: PhoenixTraderState,
+): void {
+  traderSnapshots.update((snapshots) => {
+    const next: Record<string, TraderSnapshot> = {
+      ...snapshots,
+      [authority]: { at: Date.now(), state },
+    };
+    const keys = Object.keys(next).sort((a, b) => next[b].at - next[a].at);
+    for (const key of keys.slice(MAX_WALLETS)) delete next[key];
+    return next;
+  });
+}

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -14,6 +14,11 @@
     type AiRead,
   } from "$lib/ai";
   import {
+    freshSnapshot,
+    recordSnapshot,
+    traderSnapshots,
+  } from "$lib/phoenix-cache";
+  import {
     fetchNews,
     fetchOilPanel,
     fetchRatesPanel,
@@ -257,7 +262,12 @@
   let onboardedAddress = "";
 
   // Phoenix venue (live trading) state.
-  let phoenixTrader: PhoenixTraderState | null = null;
+  // Derived from the persisted per-wallet store: instant on load (device
+  // snapshot), corrected by the live refresh, synced across tabs. Loading
+  // is null — the ticket never claims "Deposit first" for it.
+  $: phoenixTrader = phoenixAuthority
+    ? freshSnapshot($traderSnapshots, phoenixAuthority)
+    : null;
   let phoenixBusy = false;
   let phoenixActionError = "";
   let lastTradeSignature = "";
@@ -446,52 +456,14 @@
     void screenWallet(normalizedWalletAddress);
   }
   $: phoenixAuthority = $privyAuth.authenticated ? normalizedWalletAddress : "";
-  // Cold-start honesty: hydrate the last-known trader snapshot for this
-  // wallet instantly (localStorage), then let the live refresh correct it.
-  // Without this, page load reads null state as "collateral 0" and flashes
-  // "Deposit first" at funded users for seconds.
-  const TRADER_CACHE_PREFIX = "trader-ralph-phoenix-state:";
-  const TRADER_CACHE_TTL_MS = 24 * 3_600_000;
-  let hydratedAuthority: string | null = null;
-
-  function loadTraderCache(authority: string): PhoenixTraderState | null {
-    if (typeof window === "undefined") return null;
-    try {
-      const raw = window.localStorage.getItem(TRADER_CACHE_PREFIX + authority);
-      if (!raw) return null;
-      const parsed = JSON.parse(raw) as {
-        at: number;
-        state: PhoenixTraderState;
-      };
-      if (!parsed || typeof parsed.at !== "number" || !parsed.state) {
-        return null;
-      }
-      if (Date.now() - parsed.at > TRADER_CACHE_TTL_MS) return null;
-      return parsed.state;
-    } catch {
-      return null;
-    }
-  }
-
-  function saveTraderCache(authority: string, state: PhoenixTraderState): void {
-    try {
-      window.localStorage.setItem(
-        TRADER_CACHE_PREFIX + authority,
-        JSON.stringify({ at: Date.now(), state }),
-      );
-    } catch {
-      // storage unavailable — non-fatal, next load just fetches
-    }
-  }
-
-  $: if (phoenixAuthority && hydratedAuthority !== phoenixAuthority) {
-    hydratedAuthority = phoenixAuthority;
-    phoenixTrader = loadTraderCache(phoenixAuthority);
+  // Wallet appears (login, restore, or switch): refresh from the network;
+  // the derived view above already shows the device snapshot meanwhile.
+  let refreshedAuthority: string | null = null;
+  $: if (phoenixAuthority && refreshedAuthority !== phoenixAuthority) {
+    refreshedAuthority = phoenixAuthority;
     void refreshPhoenixTrader();
-  } else if (!phoenixAuthority && hydratedAuthority !== null) {
-    // Logout / wallet teardown: never show one wallet's state for another.
-    hydratedAuthority = null;
-    phoenixTrader = null;
+  } else if (!phoenixAuthority) {
+    refreshedAuthority = null;
   }
   $: if (phoenixAuthority) void ensurePhoenixOnboarding(phoenixAuthority);
   $: if (phoenixAuthority) void refreshTokenBalances(phoenixAuthority);
@@ -2290,10 +2262,9 @@
         state.registered = true;
         state.collateralUsd = chainCollateralUsd;
       }
-      // Wallet may have switched while we fetched — never cross-pollinate.
-      if (authority !== phoenixAuthority) return;
-      phoenixTrader = state;
-      saveTraderCache(authority, state);
+      // Store is keyed per wallet, so a mid-flight switch cannot
+      // cross-pollinate — record under the authority we fetched for.
+      recordSnapshot(authority, state);
     } catch {
       // transient API hiccup — keep last state
     }


### PR DESCRIPTION
## What

Promotes #471's ad-hoc cache to the right architecture, per review:

- **`persisted<T>(key, initial)`** (`$lib/persisted.ts`): writable Svelte store hydrated synchronously at module scope, write-through to localStorage, **cross-tab sync** via the `storage` event
- **`$lib/phoenix-cache.ts`**: per-wallet trader snapshots (24h TTL, pruned to 4 wallets) with `freshSnapshot`/`recordSnapshot`
- Terminal: `phoenixTrader` is now **derived** from the store (single source of truth); the live refresh writes back through the store; the component-local cache/hydration block from #471 is deleted

## Why it's better than #471

- Survives client-side navigation without re-parsing storage (module scope)
- **Deposit in one tab → the other tab's button updates** (storage event)
- Mutable component state → derived value; the store is testable in isolation and reusable for the next persisted state

## Proof

typecheck 0/0 · build clean · unused-CSS 0 · lint 0 (74 files incl. the two new libs) · 16/16 tests · SSR-safe (module-scope init behind window guards; /terminal 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)