### PR TITLE
Deposit gate: chain-verified + debounced, no more flashes

### DIFF
--- a/apps/portal/src/lib/phoenix-trade.ts
+++ b/apps/portal/src/lib/phoenix-trade.ts
@@ -73,6 +73,9 @@ export type PhoenixOpenOrder = {
 
 export type PhoenixTraderState = {
   registered: boolean;
+  /** True when collateralUsd came from a this-session trader-PDA read —
+   * the only source allowed to trigger the "Deposit first" gate. */
+  chainVerified?: boolean;
   /** Indexer snapshot slot — compared against the chain tip for sync lag. */
   apiSlot: number | null;
   /** Free cross collateral in the parent subaccount — gates new orders. */

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -544,11 +544,27 @@
   $: requiredMarginUsd = tradePreview ? tradePreview.notionalUsd / tradeLeverage : 0;
   $: phoenixCollateral = phoenixTrader?.collateralUsd ?? 0;
   $: phoenixStateKnown = phoenixTrader !== null;
-  $: needsPhoenixFunding =
+  // "Deposit first" is a strong claim: it may only come from a
+  // this-session on-chain read of free collateral (never the lagging
+  // indexer, never a device snapshot), and the shortfall must hold for a
+  // beat — transitional refreshes while funds move between subaccounts
+  // can never flash it.
+  $: fundingShortfallRaw =
     Boolean(phoenixAuthority) &&
     phoenixStateKnown &&
+    phoenixTrader?.chainVerified === true &&
     requiredMarginUsd > 0 &&
     phoenixCollateral + 0.01 < requiredMarginUsd;
+  let fundingShortfallSince: number | null = null;
+  $: if (!fundingShortfallRaw) {
+    fundingShortfallSince = null;
+  } else if (fundingShortfallSince === null) {
+    fundingShortfallSince = Date.now();
+  }
+  $: needsPhoenixFunding =
+    fundingShortfallRaw &&
+    fundingShortfallSince !== null &&
+    nowMs - fundingShortfallSince >= 1_200;
 
   // ── Ambient risk (Bloomberg posture) ───────────────────────────────
   // The trader API stopped shipping uPnL/liq per position; reconstruct
@@ -2261,6 +2277,9 @@
       if (chainCollateralUsd !== null) {
         state.registered = true;
         state.collateralUsd = chainCollateralUsd;
+        state.chainVerified = true;
+      } else {
+        state.chainVerified = false;
       }
       // Store is keyed per wallet, so a mid-flight switch cannot
       // cross-pollinate — record under the authority we fetched for.


### PR DESCRIPTION
## Problem

"Deposit first · $12.50" could still flash briefly: the gate accepted collateral figures from the lagging Phoenix indexer, which reads low mid-transition (e.g., right after a close while margin moves between subaccounts).

## Fix — the claim now needs proof

- `PhoenixTraderState.chainVerified`: set only when the collateral figure came from a **this-session trader-PDA read**; indexer-only refreshes and device snapshots can never trigger the gate
- **1.2s hold**: the shortfall must persist across refreshes before the button flips — transitional dips are structurally incapable of flashing it
- Fallback stays safe: without chain verification the ticket shows the normal Long/Short action, and a genuinely underfunded order is caught by the simulation gate with the friendly shortfall message

## Proof

typecheck 0/0 · build clean · lint 0 · 16/16 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)