### PR TITLE
Live price in the tab title

### DIFF
--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -523,6 +523,16 @@
   $: fundingPercent =
     marketStats?.funding != null ? marketStats.funding * 100 : null;
   $: priceLoading = chartPrice === null;
+  $: docTitle = (() => {
+    if (tradeMode === "spot" && spotAsset) {
+      return spotAsset.price !== null
+        ? `${formatPrice(spotAsset.price)} ${spotAsset.symbol} · Trader Ralph`
+        : `${spotAsset.symbol} · Trader Ralph`;
+    }
+    return latestPrice !== null
+      ? `${formatPrice(latestPrice)} ${selectedSymbol}-PERP · Trader Ralph`
+      : "Trader Ralph";
+  })();
   $: statsLoading = marketStats === null;
   $: bookLoading = asks.length === 0 || bids.length === 0;
   $: updatedLoading = lastMarketUpdate === null;
@@ -3958,7 +3968,7 @@
 </script>
 
 <svelte:head>
-  <title>Trader Ralph</title>
+  <title>{docTitle}</title>
   <meta
     name="description"
     content="Frontend-only Trader Ralph SvelteKit terminal."


### PR DESCRIPTION
The document title becomes a ticker for the selected market: `81.31 SOL-PERP · Trader Ralph` (price first — that's what you scan a tab strip for). Tracks venue switches; plain app name while loading/SSR.

Verified live via the spot REST path: title rendered `81.26 SOL · Trader Ralph`. typecheck 0/0 · build clean · lint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)