### PR TITLE
[codex] add terminal open beta banner

### DIFF
--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -76,7 +76,7 @@
     getJupiterSwapTransaction,
     type JupiterQuote,
   } from "$lib/funding";
-  import { BrandMark } from "@trader-ralph/ui";
+  import { BrandMark, OpenBetaBanner } from "@trader-ralph/ui";
   import { colors } from "@trader-ralph/ui/tokens";
   import {
     clearJournal,
@@ -411,6 +411,8 @@
   const PREFS_STORAGE_KEY = "trader-ralph-terminal/prefs/v1";
   const ALERTS_STORAGE_KEY = "trader-ralph-terminal/alerts/v1";
   const LAYOUT_STORAGE_KEY = "trader-ralph-terminal/layout/v1";
+  const OPEN_BETA_BANNER_STORAGE_KEY =
+    "trader-ralph-terminal/open-beta-banner/v1";
   // Stale-while-revalidate widget caches (instant paint on reload).
   const CACHE_PANELS = "trader-ralph-terminal/cache/panels/v1";
   const CACHE_NEWS = "trader-ralph-terminal/cache/news/v1";
@@ -418,6 +420,7 @@
   const CACHE_READS = "trader-ralph-terminal/cache/reads/v1";
   const CACHE_MAX_AGE = 30 * 60_000;
   const MARKETS_MAX_AGE = 24 * 60 * 60_000;
+  let showOpenBetaBanner = false;
 
   $: selectedMarket = markets.find((market) => market.symbol === selectedSymbol) ?? null;
   // Funds = everything the user considers theirs: wallet USDC + ALL Phoenix
@@ -847,6 +850,7 @@
     );
 
   onMount(() => {
+    loadOpenBetaBanner();
     loadPrefs();
     applyDeepLink(); // ?asset=&venue=&side=… — overrides restored prefs
     loadAlerts();
@@ -3751,6 +3755,30 @@
     }
   }
 
+  function loadOpenBetaBanner(): void {
+    if (typeof window === "undefined") return;
+    try {
+      showOpenBetaBanner =
+        window.localStorage.getItem(OPEN_BETA_BANNER_STORAGE_KEY) !==
+        "dismissed";
+    } catch {
+      showOpenBetaBanner = true;
+    }
+  }
+
+  function dismissOpenBetaBanner(): void {
+    showOpenBetaBanner = false;
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(
+        OPEN_BETA_BANNER_STORAGE_KEY,
+        "dismissed",
+      );
+    } catch {
+      // storage unavailable — banner is still hidden for this session
+    }
+  }
+
   function persistPrefs(
     _symbol: string,
     _timeframe: PhoenixTimeframe,
@@ -4217,6 +4245,12 @@
       {/if}
     </div>
   </header>
+
+  {#if showOpenBetaBanner}
+    <div class="terminal-notice">
+      <OpenBetaBanner ondismiss={dismissOpenBetaBanner} />
+    </div>
+  {/if}
 
   <div class="market-rail">
   <div class="ticker" role="status" aria-live="polite">
@@ -6451,6 +6485,12 @@
     min-height: 1.7rem;
     padding: 0.25rem 0.45rem;
     font-size: 0.75rem;
+  }
+
+  .terminal-notice {
+    padding: 0.6rem clamp(0.75rem, 2vw, 1.25rem);
+    border-bottom: 1px solid var(--line-soft);
+    background: rgba(8, 10, 13, 0.86);
   }
 
   /* ── Privy auth: topbar + account menu ───────────────────────────── */

--- a/packages/ui/src/components/OpenBetaBanner.svelte
+++ b/packages/ui/src/components/OpenBetaBanner.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+  let {
+    title = "Trader Ralph Terminal is in open beta",
+    body = "Market data, account access, and trading tools may change while we harden the experience.",
+    dismissLabel = "Dismiss open beta banner",
+    ondismiss,
+  }: {
+    title?: string;
+    body?: string;
+    dismissLabel?: string;
+    ondismiss?: () => void;
+  } = $props();
+</script>
+
+<section class="open-beta-banner" aria-label="Open beta notice">
+  <div class="copy">
+    <span>Open beta</span>
+    <div>
+      <strong>{title}</strong>
+      <p>{body}</p>
+    </div>
+  </div>
+
+  {#if ondismiss}
+    <button class="dismiss" type="button" aria-label={dismissLabel} onclick={ondismiss}>
+      <span aria-hidden="true">x</span>
+    </button>
+  {/if}
+</section>
+
+<style>
+  .open-beta-banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    border: 1px solid var(--line);
+    border-left: 3px solid var(--accent);
+    border-radius: var(--radius);
+    background:
+      linear-gradient(180deg, rgba(255, 255, 255, 0.035), transparent),
+      var(--surface);
+    color: var(--ink);
+    padding: 0.65rem 0.75rem;
+  }
+
+  .copy {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    min-width: 0;
+  }
+
+  .copy span {
+    flex: 0 0 auto;
+    color: var(--accent);
+    font-size: 0.66rem;
+    font-weight: 800;
+    text-transform: uppercase;
+  }
+
+  .copy div {
+    display: grid;
+    gap: 0.12rem;
+    min-width: 0;
+  }
+
+  .copy strong {
+    font-size: 0.84rem;
+  }
+
+  .copy p {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.74rem;
+    line-height: 1.35;
+  }
+
+  .dismiss {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    background: transparent;
+    color: var(--muted);
+    font: inherit;
+    font-weight: 800;
+    cursor: pointer;
+  }
+
+  .dismiss:hover {
+    border-color: var(--accent);
+    color: var(--ink);
+  }
+
+  @media (max-width: 720px) {
+    .open-beta-banner,
+    .copy {
+      align-items: flex-start;
+    }
+
+    .copy {
+      flex-direction: column;
+      gap: 0.35rem;
+    }
+  }
+</style>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -5,6 +5,7 @@ export { default as AssetTable } from "./components/AssetTable.svelte";
 export { default as BrandMark } from "./components/BrandMark.svelte";
 export { default as Button } from "./components/Button.svelte";
 export { default as NewsItem } from "./components/NewsItem.svelte";
+export { default as OpenBetaBanner } from "./components/OpenBetaBanner.svelte";
 export { default as SiteFooter } from "./components/SiteFooter.svelte";
 export { default as SiteNav } from "./components/SiteNav.svelte";
 export { default as StatCard } from "./components/StatCard.svelte";


### PR DESCRIPTION
## What changed

- Added a reusable `OpenBetaBanner` component to `@trader-ralph/ui`.
- Rendered the banner on `/terminal` for all users until they dismiss it.
- Persisted dismissal in localStorage with a terminal-scoped key.

## Why

The terminal is in open beta and should say so clearly without blocking the trading surface.

## Validation

- `bun run typecheck`
- `bun run build`
- `bun run lint`
- Browser smoke at `http://localhost:3001/terminal` because port 3000 was already in use: desktop and mobile banner visible, dismiss works, reload keeps it hidden.