### PR TITLE
Terminal split batch 1: 12 pure-logic modules extracted with 150 unit tests

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "start": "vite preview --host localhost --port 3000",
     "typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-    "lint": "biome check ."
+    "lint": "biome check .",
+    "test": "bun test"
   },
   "dependencies": {
     "@ellipsis-labs/rise": "^0.4.60",
@@ -28,6 +29,7 @@
     "@sveltejs/adapter-vercel": "^6.3.3",
     "@sveltejs/kit": "^2.48.0",
     "@types/qrcode": "^1.5.6",
+    "bun-types": "^1.3.14",
     "svelte": "^5.43.0",
     "svelte-check": "^4.3.0",
     "typescript": "^5.9.3",

--- a/apps/portal/src/lib/solana-rpc.test.ts
+++ b/apps/portal/src/lib/solana-rpc.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { parseLamportsResponse } from "./solana-rpc";
+
+describe("parseLamportsResponse", () => {
+  test("http failure → coded error with status", () => {
+    expect(() => parseLamportsResponse(null, false, 429)).toThrow(
+      "solana-rpc-http-429",
+    );
+  });
+
+  test("non-record payload → invalid-response", () => {
+    expect(() => parseLamportsResponse(null, true, 200)).toThrow(
+      "solana-rpc-invalid-response",
+    );
+    expect(() => parseLamportsResponse("x", true, 200)).toThrow(
+      "solana-rpc-invalid-response",
+    );
+  });
+
+  test("rpc error object surfaces its message", () => {
+    expect(() =>
+      parseLamportsResponse({ error: { message: "boom" } }, true, 200),
+    ).toThrow("boom");
+    expect(() => parseLamportsResponse({ error: {} }, true, 200)).toThrow(
+      "solana-rpc-error",
+    );
+  });
+
+  test("numeric value truncates and floors at 0", () => {
+    expect(
+      parseLamportsResponse({ result: { value: 1234.9 } }, true, 200),
+    ).toBe("1234");
+    expect(parseLamportsResponse({ result: { value: -5 } }, true, 200)).toBe(
+      "0",
+    );
+  });
+
+  test("digit-string value passes through; non-digits rejected", () => {
+    expect(
+      parseLamportsResponse({ result: { value: "98765" } }, true, 200),
+    ).toBe("98765");
+    expect(() =>
+      parseLamportsResponse({ result: { value: "12x" } }, true, 200),
+    ).toThrow("solana-balance-missing");
+  });
+
+  test("missing value → balance-missing", () => {
+    expect(() => parseLamportsResponse({ result: {} }, true, 200)).toThrow(
+      "solana-balance-missing",
+    );
+  });
+});

--- a/apps/portal/src/lib/solana-rpc.ts
+++ b/apps/portal/src/lib/solana-rpc.ts
@@ -1,0 +1,64 @@
+// Solana RPC URL resolution + the lightweight balance fetch used by wallet
+// displays. Deliberately free of @solana/web3.js so importing this module
+// never pulls the heavy SDK into a bundle — raw JSON-RPC over fetch is all
+// the balance path needs.
+
+import { isRecord } from "$lib/utils";
+
+export const SOLANA_MAINNET_RPC = "https://api.mainnet-beta.solana.com";
+
+export function solanaRpcUrl(): string {
+  const env = import.meta.env as Record<string, string | undefined>;
+  const configured = String(
+    env.PUBLIC_SOLANA_RPC_URL ??
+      env.VITE_SOLANA_RPC_URL ??
+      env.NEXT_PUBLIC_SOLANA_RPC_URL ??
+      "",
+  )
+    .trim()
+    .replace(/^"+|"+$/g, "")
+    .replace(/\\n$/, "");
+  return configured || SOLANA_MAINNET_RPC;
+}
+
+/**
+ * Pure core of the balance fetch: validate a getBalance JSON-RPC payload
+ * into a lamports string. Split from the fetch so every branch is testable.
+ * `ok`/`status` mirror the HTTP response the payload arrived with.
+ */
+export function parseLamportsResponse(
+  payload: unknown,
+  ok: boolean,
+  status: number,
+): string {
+  if (!ok) throw new Error(`solana-rpc-http-${status}`);
+  if (!isRecord(payload)) throw new Error("solana-rpc-invalid-response");
+  if (isRecord(payload.error)) {
+    throw new Error(String(payload.error.message ?? "solana-rpc-error"));
+  }
+  const result = isRecord(payload.result) ? payload.result : null;
+  const value = result?.value;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(0, Math.trunc(value)).toString();
+  }
+  if (typeof value === "string" && /^\d+$/.test(value)) return value;
+  throw new Error("solana-balance-missing");
+}
+
+export async function fetchSolanaLamports(address: string): Promise<string> {
+  const response = await fetch(solanaRpcUrl(), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: "trader-ralph-wallet-balance",
+      method: "getBalance",
+      // "processed" over the default "finalized": received SOL shows in
+      // about a slot instead of ~12s. Display-only, so the tiny rollback
+      // window is acceptable.
+      params: [address, { commitment: "processed" }],
+    }),
+  });
+  const payload = (await response.json().catch(() => null)) as unknown;
+  return parseLamportsResponse(payload, response.ok, response.status);
+}

--- a/apps/portal/src/lib/spot.triggerOrderView.test.ts
+++ b/apps/portal/src/lib/spot.triggerOrderView.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type SpotAsset,
+  type TriggerOrder,
+  triggerOrderView,
+  USDC_MINT,
+} from "./spot";
+
+const SOL = "So11111111111111111111111111111111111111112";
+
+function asset(overrides: Partial<SpotAsset> = {}): SpotAsset {
+  return {
+    symbol: "SOL",
+    name: "Solana",
+    mint: SOL,
+    decimals: 9,
+    hub: "crypto",
+    price: 100,
+    change24hPct: null,
+    volume24hUsd: null,
+    marketCap: null,
+    ...overrides,
+  } as SpotAsset;
+}
+
+function order(overrides: Partial<TriggerOrder> = {}): TriggerOrder {
+  return {
+    orderKey: "k",
+    inputMint: USDC_MINT,
+    outputMint: SOL,
+    makingAmountAtoms: 250_000_000, // 250 USDC
+    takingAmountAtoms: 2_000_000_000, // 2 SOL
+    ...overrides,
+  } as TriggerOrder;
+}
+
+describe("triggerOrderView", () => {
+  test("USDC input → buy; notional from USDC atoms; implied limit", () => {
+    const view = triggerOrderView(order(), [asset()]);
+    expect(view?.side).toBe("buy");
+    expect(view?.symbol).toBe("SOL");
+    expect(view?.notionalUsd).toBe(250);
+    expect(view?.limitPrice).toBe(125); // 250 USDC / 2 SOL
+  });
+
+  test("token input → sell with mint orientation flipped", () => {
+    const view = triggerOrderView(
+      order({
+        inputMint: SOL,
+        outputMint: USDC_MINT,
+        makingAmountAtoms: 2_000_000_000, // 2 SOL out
+        takingAmountAtoms: 300_000_000, // 300 USDC in
+      }),
+      [asset()],
+    );
+    expect(view?.side).toBe("sell");
+    expect(view?.notionalUsd).toBe(300);
+    expect(view?.limitPrice).toBe(150);
+  });
+
+  test("non-9-decimal tokens use asset decimals for quantity", () => {
+    const view = triggerOrderView(
+      order({
+        outputMint: "mint6",
+        takingAmountAtoms: 5_000_000, // 5 tokens at 6 decimals
+      }),
+      [asset({ mint: "mint6", decimals: 6, symbol: "USDT" })],
+    );
+    expect(view?.limitPrice).toBe(50); // 250 / 5
+  });
+
+  test("unknown mint → null", () => {
+    expect(
+      triggerOrderView(order({ outputMint: "ghost" }), [asset()]),
+    ).toBeNull();
+  });
+
+  test("zero/absent amounts guard to null fields", () => {
+    const view = triggerOrderView(
+      order({ makingAmountAtoms: 0, takingAmountAtoms: 0 }),
+      [asset()],
+    );
+    expect(view?.notionalUsd).toBeNull();
+    expect(view?.limitPrice).toBeNull();
+  });
+});

--- a/apps/portal/src/lib/spot.ts
+++ b/apps/portal/src/lib/spot.ts
@@ -366,4 +366,34 @@ export async function fetchAllTokenBalances(
   return balances;
 }
 
+/**
+ * Human view of a resting trigger (limit) order: side/symbol from the mint
+ * orientation (USDC in = buy), notional from the USDC atoms, implied limit
+ * price from the atoms ratio. Null when the token isn't in the catalog.
+ */
+export function triggerOrderView(
+  order: TriggerOrder,
+  assets: SpotAsset[],
+): {
+  side: "buy" | "sell";
+  symbol: string;
+  notionalUsd: number | null;
+  limitPrice: number | null;
+} | null {
+  const isBuy = order.inputMint === USDC_MINT;
+  const tokenMint = isBuy ? order.outputMint : order.inputMint;
+  const asset = assets.find((candidate) => candidate.mint === tokenMint);
+  if (!asset) return null;
+  const usdAtoms = isBuy ? order.makingAmountAtoms : order.takingAmountAtoms;
+  const tokenAtoms = isBuy ? order.takingAmountAtoms : order.makingAmountAtoms;
+  const usd = usdAtoms / 1e6;
+  const qty = tokenAtoms / 10 ** asset.decimals;
+  return {
+    side: isBuy ? "buy" : "sell",
+    symbol: asset.symbol,
+    notionalUsd: Number.isFinite(usd) && usd > 0 ? usd : null,
+    limitPrice: qty > 0 && usd > 0 ? usd / qty : null,
+  };
+}
+
 export { SOL_MINT, USDC_MINT };

--- a/apps/portal/src/lib/terminal/account-format.test.ts
+++ b/apps/portal/src/lib/terminal/account-format.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import {
+  aiErr,
+  humanizeBalanceError,
+  humanizePrivyError,
+  shortAddress,
+  shortEmail,
+  walletStatusText,
+} from "./account-format";
+
+describe("shortAddress", () => {
+  test("empty/null → --", () => {
+    expect(shortAddress(null)).toBe("--");
+    expect(shortAddress("  ")).toBe("--");
+  });
+
+  test("short addresses pass through", () => {
+    expect(shortAddress("abc123")).toBe("abc123");
+  });
+
+  test("long addresses truncate 6...4", () => {
+    expect(shortAddress("3jU1fEpb6KJSkML59eYhAF32ZrdrazA9cen9BZxnNEzu")).toBe(
+      "3jU1fE...NEzu",
+    );
+  });
+});
+
+describe("shortEmail", () => {
+  test("short emails pass through", () => {
+    expect(shortEmail("gui@solana.org")).toBe("gui@solana.org");
+  });
+
+  test("long local part truncates with ellipsis, domain kept", () => {
+    expect(shortEmail("gui.bibeau.the.trader@solana.org")).toBe(
+      "gui.bibea…@solana.org",
+    );
+  });
+
+  test("long string without @ hard-truncates at 19 + ellipsis", () => {
+    const raw = "x".repeat(30);
+    expect(shortEmail(raw)).toBe(`${"x".repeat(19)}…`);
+  });
+});
+
+describe("walletStatusText", () => {
+  test("all four states", () => {
+    expect(walletStatusText("ready")).toBe("Wallet ready");
+    expect(walletStatusText("creating")).toBe("Creating wallet…");
+    expect(walletStatusText("error")).toBe("Wallet error");
+    expect(walletStatusText("missing")).toBe("No wallet");
+  });
+});
+
+describe("humanizePrivyError", () => {
+  test("known code table", () => {
+    expect(humanizePrivyError("email-required")).toBe(
+      "Enter a valid email address.",
+    );
+    expect(humanizePrivyError("privy-login-failed")).toBe(
+      "That code didn't work. Request a new one and retry.",
+    );
+  });
+
+  test("unknown kebab-case codes get tidied", () => {
+    expect(humanizePrivyError("some-new-code")).toBe("Some new code");
+  });
+
+  test("non-kebab messages pass through verbatim", () => {
+    expect(humanizePrivyError("Something Went Wrong!")).toBe(
+      "Something Went Wrong!",
+    );
+  });
+
+  test("empty → empty string", () => {
+    expect(humanizePrivyError(null)).toBe("");
+    expect(humanizePrivyError("  ")).toBe("");
+  });
+});
+
+describe("humanizeBalanceError", () => {
+  test("401/403/forbidden → blocked guidance", () => {
+    expect(humanizeBalanceError("solana-rpc-http-403")).toContain("blocked");
+    expect(humanizeBalanceError("Forbidden by policy")).toContain("blocked");
+  });
+
+  test("429 → rate-limit guidance", () => {
+    expect(humanizeBalanceError("solana-rpc-http-429")).toContain(
+      "rate-limited",
+    );
+  });
+
+  test("other http codes → generic RPC guidance", () => {
+    expect(humanizeBalanceError("solana-rpc-http-500")).toContain(
+      "PUBLIC_SOLANA_RPC_URL",
+    );
+  });
+
+  test("unrecognized strings pass through", () => {
+    expect(humanizeBalanceError("weird")).toBe("weird");
+  });
+});
+
+describe("aiErr", () => {
+  test("proxy-unavailable gets dev copy", () => {
+    expect(aiErr(new Error("ai-proxy-unavailable"))).toBe(
+      "AI offline (dev proxy only)",
+    );
+  });
+
+  test("other errors pass message through; non-Errors coerce", () => {
+    expect(aiErr(new Error("boom"))).toBe("boom");
+    expect(aiErr("nope")).toBe("ai-error");
+  });
+});

--- a/apps/portal/src/lib/terminal/account-format.ts
+++ b/apps/portal/src/lib/terminal/account-format.ts
@@ -1,0 +1,93 @@
+// Pure account/auth display helpers for the terminal page — address/email
+// truncation, wallet status copy, and the error humanizers. All close over
+// no component state; moved verbatim from the page.
+
+import type { PrivyAuthState } from "$lib/privy-auth";
+
+export function shortAddress(value: string | null): string {
+  const trimmed = String(value ?? "").trim();
+  if (!trimmed) return "--";
+  if (trimmed.length <= 14) return trimmed;
+  return `${trimmed.slice(0, 6)}...${trimmed.slice(-4)}`;
+}
+
+export function shortEmail(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= 22) return trimmed;
+  const [name, domain] = trimmed.split("@");
+  if (!domain) return `${trimmed.slice(0, 19)}…`;
+  const head = name.length > 10 ? `${name.slice(0, 9)}…` : name;
+  return `${head}@${domain}`;
+}
+
+export function walletStatusText(
+  status: "missing" | "creating" | "ready" | "error",
+): string {
+  switch (status) {
+    case "ready":
+      return "Wallet ready";
+    case "creating":
+      return "Creating wallet…";
+    case "error":
+      return "Wallet error";
+    default:
+      return "No wallet";
+  }
+}
+
+export function walletFundsLabel(
+  auth: PrivyAuthState,
+  balanceStatus: "idle" | "loading" | "ready" | "error",
+  fundsText: string,
+): string {
+  if (!auth.authenticated) {
+    if (!auth.configured) return "Auth unconfigured";
+    if (!auth.ready) return "Privy loading";
+    return "Account not connected";
+  }
+  if (auth.walletStatus === "creating") return "Creating wallet";
+  if (auth.walletStatus === "error") return "Wallet unavailable";
+  if (!auth.walletAddress) return "Wallet pending";
+  if (balanceStatus === "loading") return "Loading funds";
+  if (balanceStatus === "error") return "Balance unavailable";
+  return fundsText;
+}
+
+export function humanizePrivyError(value: string | null | undefined): string {
+  const raw = String(value ?? "").trim();
+  if (!raw) return "";
+  const known: Record<string, string> = {
+    "email-required": "Enter a valid email address.",
+    "code-required": "Enter the 6-digit code we emailed you.",
+    "privy-app-id-missing": "Auth is not configured for this environment.",
+    "privy-not-configured": "Auth is not configured for this environment.",
+    "privy-code-send-failed":
+      "Couldn't send the code. Check the email and try again.",
+    "privy-login-failed": "That code didn't work. Request a new one and retry.",
+    "privy-logout-failed": "Couldn't log out cleanly. Try again.",
+    "Code sent.": "Code sent — check your inbox.",
+  };
+  if (known[raw]) return known[raw];
+  // Surface Privy SDK messages verbatim; tidy our internal kebab-case codes.
+  if (/^[a-z0-9-]+$/.test(raw)) {
+    return raw.replace(/-/g, " ").replace(/^\w/, (c) => c.toUpperCase());
+  }
+  return raw;
+}
+
+export function humanizeBalanceError(raw: string): string {
+  if (/-40[13]$/.test(raw) || /forbidden/i.test(raw)) {
+    return "RPC blocked the request. Set PUBLIC_SOLANA_RPC_URL to a browser-accessible endpoint.";
+  }
+  if (/-429$/.test(raw))
+    return "RPC rate-limited. Set a dedicated PUBLIC_SOLANA_RPC_URL.";
+  if (/^solana-rpc-http-/.test(raw))
+    return "RPC request failed. Check PUBLIC_SOLANA_RPC_URL.";
+  return raw;
+}
+
+export function aiErr(error: unknown): string {
+  const message = error instanceof Error ? error.message : "ai-error";
+  if (message === "ai-proxy-unavailable") return "AI offline (dev proxy only)";
+  return message;
+}

--- a/apps/portal/src/lib/terminal/alerts.test.ts
+++ b/apps/portal/src/lib/terminal/alerts.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { type Alert, headlineMatches, matchAlerts } from "./alerts";
+
+function alert(overrides: Partial<Alert> = {}): Alert {
+  return {
+    id: "a1",
+    symbol: "SOL",
+    op: "above",
+    price: 150,
+    tier: "PRIORITY",
+    triggered: false,
+    ...overrides,
+  };
+}
+
+describe("matchAlerts", () => {
+  test("above fires at >= threshold; below at <=", () => {
+    expect(matchAlerts([alert()], 150, "SOL")?.length).toBe(1);
+    expect(matchAlerts([alert()], 149.99, "SOL")).toBeNull();
+    expect(
+      matchAlerts([alert({ op: "below", price: 100 })], 100, "SOL")?.length,
+    ).toBe(1);
+    expect(
+      matchAlerts([alert({ op: "below", price: 100 })], 100.01, "SOL"),
+    ).toBeNull();
+  });
+
+  test("already-triggered alerts never refire", () => {
+    expect(matchAlerts([alert({ triggered: true })], 200, "SOL")).toBeNull();
+  });
+
+  test("symbol scoping: other markets' alerts are ignored", () => {
+    expect(matchAlerts([alert({ symbol: "BTC" })], 200, "SOL")).toBeNull();
+  });
+
+  test("no-hit path is allocation-free (returns null, not [])", () => {
+    expect(matchAlerts([], 100, "SOL")).toBeNull();
+    expect(matchAlerts([alert()], 1, "SOL")).toBeNull();
+  });
+
+  test("multiple hits return in alert order", () => {
+    const hits = matchAlerts(
+      [alert({ id: "x", price: 100 }), alert({ id: "y", price: 120 })],
+      150,
+      "SOL",
+    );
+    expect(hits?.map((a) => a.id)).toEqual(["x", "y"]);
+  });
+});
+
+describe("headlineMatches", () => {
+  test("case-insensitive substring", () => {
+    expect(headlineMatches("Solana rallies as SOL breaks out", "sol")).toBe(
+      true,
+    );
+    expect(headlineMatches("Bitcoin ETF flows", "SOL")).toBe(false);
+  });
+});

--- a/apps/portal/src/lib/terminal/alerts.ts
+++ b/apps/portal/src/lib/terminal/alerts.ts
@@ -1,0 +1,39 @@
+// Pure alert-matching layer. matchAlerts runs on every price tick, so the
+// no-hit path is allocation-free — it returns null rather than a fresh
+// empty array. Mutation + fireAlert side effects stay in the page.
+
+export type Alert = {
+  id: string;
+  symbol: string;
+  op: "above" | "below";
+  price: number;
+  tier: "FLASH" | "PRIORITY" | "ROUTINE";
+  triggered: boolean;
+};
+
+/**
+ * Untriggered alerts for `symbol` whose threshold the price has crossed —
+ * `above` fires at price >= threshold, `below` at price <= threshold.
+ * Returns null when nothing fired (reference-stable for the hot path).
+ */
+export function matchAlerts(
+  alerts: Alert[],
+  price: number,
+  symbol: string,
+): Alert[] | null {
+  let hits: Alert[] | null = null;
+  for (const alert of alerts) {
+    if (alert.triggered || alert.symbol !== symbol) continue;
+    const hit =
+      alert.op === "above" ? price >= alert.price : price <= alert.price;
+    if (hit) {
+      if (!hits) hits = [];
+      hits.push(alert);
+    }
+  }
+  return hits;
+}
+
+export function headlineMatches(title: string, symbol: string): boolean {
+  return title.toUpperCase().includes(symbol.toUpperCase());
+}

--- a/apps/portal/src/lib/terminal/book.test.ts
+++ b/apps/portal/src/lib/terminal/book.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import type { DepthLevel } from "$lib/phoenix-market-data";
+import {
+  bookLevelNotional,
+  bookLevelTotalNotional,
+  depthWidth,
+  formatBookPrice,
+  maxBookNotional,
+} from "./book";
+
+function level(price: number, size: number, cum: number): DepthLevel {
+  return { price, size, cum };
+}
+
+describe("bookLevelNotional", () => {
+  test("price × size", () => {
+    expect(bookLevelNotional(level(100, 2.5, 0))).toBe(250);
+  });
+
+  test("null level → null", () => {
+    expect(bookLevelNotional(null)).toBeNull();
+    expect(bookLevelNotional(undefined)).toBeNull();
+  });
+});
+
+describe("bookLevelTotalNotional", () => {
+  test("uses cumulative size, not level size", () => {
+    expect(bookLevelTotalNotional(level(100, 2, 7))).toBe(700);
+  });
+
+  test("null level → 0", () => {
+    expect(bookLevelTotalNotional(null)).toBe(0);
+  });
+});
+
+describe("maxBookNotional", () => {
+  test("max cumulative notional across both sides", () => {
+    const asks = [level(101, 1, 1), level(102, 2, 3)];
+    const bids = [level(99, 5, 5), level(98, 1, 6)];
+    // deepest bid: 98 × 6 = 588 vs deepest ask: 102 × 3 = 306
+    expect(maxBookNotional(asks, bids)).toBe(588);
+  });
+
+  test("floors at 1 so depthWidth never divides by zero", () => {
+    expect(maxBookNotional([], [])).toBe(1);
+  });
+});
+
+describe("depthWidth", () => {
+  test("proportional width against the passed max", () => {
+    expect(depthWidth(level(100, 1, 5), 1000)).toBe(50);
+  });
+
+  test("clamps small levels up to 2%", () => {
+    expect(depthWidth(level(1, 1, 0.001), 1000)).toBe(2);
+  });
+
+  test("clamps at 100%", () => {
+    expect(depthWidth(level(100, 1, 50), 1000)).toBe(100);
+  });
+});
+
+describe("formatBookPrice", () => {
+  test("≥1000 → 0 decimal places", () => {
+    expect(formatBookPrice(98123.4)).toBe(
+      (98123.4).toLocaleString(undefined, {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+      }),
+    );
+  });
+
+  test("≥1 → 2 decimal places", () => {
+    expect(formatBookPrice(150.2)).toBe(
+      (150.2).toLocaleString(undefined, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }),
+    );
+  });
+
+  test("<1 → 4 decimal places", () => {
+    expect(formatBookPrice(0.1234567)).toBe(
+      (0.1234567).toLocaleString(undefined, {
+        minimumFractionDigits: 4,
+        maximumFractionDigits: 4,
+      }),
+    );
+  });
+
+  test('non-finite and nullish guard → "--"', () => {
+    expect(formatBookPrice(null)).toBe("--");
+    expect(formatBookPrice(undefined)).toBe("--");
+    expect(formatBookPrice(Number.NaN)).toBe("--");
+    expect(formatBookPrice(Number.POSITIVE_INFINITY)).toBe("--");
+  });
+});

--- a/apps/portal/src/lib/terminal/book.ts
+++ b/apps/portal/src/lib/terminal/book.ts
@@ -1,0 +1,54 @@
+// Pure order-book ladder helpers for the terminal page — level notionals,
+// the depth-bar width math, and the book price formatter. No component
+// state; the ladder max is passed in explicitly.
+
+import type { DepthLevel } from "$lib/phoenix-market-data";
+
+export const BOOK_LADDER_LEVELS = 10;
+// Stacked desktop shares the panel with the ticket — cap the ladder so
+// both stay readable; the narrow-viewport tabs keep the full depth.
+export const BOOK_LADDER_LEVELS_STACKED = 8;
+
+export function bookLevelNotional(
+  level: DepthLevel | null | undefined,
+): number | null {
+  if (!level) return null;
+  return level.price * level.size;
+}
+
+export function bookLevelTotalNotional(
+  level: DepthLevel | null | undefined,
+): number {
+  if (!level) return 0;
+  return level.price * level.cum;
+}
+
+export function maxBookNotional(
+  askLevels: DepthLevel[],
+  bidLevels: DepthLevel[],
+): number {
+  return Math.max(
+    1,
+    ...askLevels.map(bookLevelTotalNotional),
+    ...bidLevels.map(bookLevelTotalNotional),
+  );
+}
+
+export function depthWidth(level: DepthLevel, maxNotional: number): number {
+  return Math.min(
+    100,
+    Math.max(2, (bookLevelTotalNotional(level) / maxNotional) * 100),
+  );
+}
+
+export function formatBookPrice(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return "--";
+  }
+  const abs = Math.abs(value);
+  const digits = abs >= 1_000 ? 0 : abs >= 1 ? 2 : 4;
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  });
+}

--- a/apps/portal/src/lib/terminal/chart-format.test.ts
+++ b/apps/portal/src/lib/terminal/chart-format.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, test } from "bun:test";
+import type { UTCTimestamp } from "lightweight-charts";
+import type {
+  MarketPoint,
+  PhoenixMarketConfig,
+  PhoenixTimeframe,
+} from "$lib/phoenix-market-data";
+import {
+  computeMarketChange,
+  DEFAULT_VISIBLE_CANDLES,
+  formatCandleCountdown,
+  formatChartRange,
+  MAX_VISIBLE_CANDLES,
+  sessionNote,
+  timeframeMs,
+  toCandle,
+  toVolume,
+} from "./chart-format";
+
+function point(overrides: Partial<MarketPoint> = {}): MarketPoint {
+  return {
+    ts: 1_700_000_000_000,
+    price: 100,
+    open: 99,
+    high: 101,
+    low: 98,
+    close: 100,
+    ...overrides,
+  };
+}
+
+function market(
+  overrides: Partial<PhoenixMarketConfig> = {},
+): PhoenixMarketConfig {
+  return {
+    symbol: "SOL",
+    marketStatus: "active",
+    isolatedOnly: true,
+    makerFee: null,
+    takerFee: null,
+    maxLeverage: 20,
+    commodity: false,
+    nextTransitionUtc: null,
+    ...overrides,
+  };
+}
+
+const stats = {
+  symbol: "SOL",
+  dayNtlVlm: null,
+  prevDayPx: 100,
+  markPx: null,
+  midPx: null,
+  funding: null,
+  openInterest: null,
+  oraclePx: null,
+};
+
+describe("toCandle", () => {
+  const mixed = point({
+    markOpen: 99.5,
+    markHigh: null,
+    markLow: 98.5,
+    markClose: undefined,
+  });
+
+  test("last mode always uses trade OHLC", () => {
+    const candle = toCandle(mixed, "last");
+    expect(candle).toEqual({
+      time: Math.floor(mixed.ts / 1000) as UTCTimestamp,
+      open: 99,
+      high: 101,
+      low: 98,
+      close: 100,
+    });
+  });
+
+  test("mark mode falls back per field (markX ?? x)", () => {
+    const candle = toCandle(mixed, "mark");
+    expect(candle.open).toBe(99.5);
+    expect(candle.high).toBe(101);
+    expect(candle.low).toBe(98.5);
+    expect(candle.close).toBe(100);
+  });
+});
+
+describe("toVolume", () => {
+  test("colors up candles green and down candles red", () => {
+    expect(toVolume(point({ open: 99, close: 100 })).color).toBe(
+      "rgba(44, 233, 127, 0.45)",
+    );
+    expect(toVolume(point({ open: 100, close: 99 })).color).toBe(
+      "rgba(255, 90, 106, 0.45)",
+    );
+  });
+
+  test("value prefers quote volume, then base volume, then 0", () => {
+    expect(toVolume(point({ volumeQuote: 5, volume: 3 })).value).toBe(5);
+    expect(toVolume(point({ volumeQuote: null, volume: 3 })).value).toBe(3);
+    expect(toVolume(point()).value).toBe(0);
+  });
+});
+
+describe("timeframeMs", () => {
+  test("parses minute and hour suffixes", () => {
+    expect(timeframeMs("1m")).toBe(60_000);
+    expect(timeframeMs("15m")).toBe(15 * 60_000);
+    expect(timeframeMs("1h")).toBe(3_600_000);
+    expect(timeframeMs("4h")).toBe(4 * 3_600_000);
+  });
+
+  test("defaults to one minute on unknown suffix", () => {
+    expect(timeframeMs("1d" as PhoenixTimeframe)).toBe(60_000);
+  });
+});
+
+describe("formatCandleCountdown", () => {
+  test("-- without a candle", () => {
+    expect(formatCandleCountdown(null, "5m", Date.now())).toBe("--");
+  });
+
+  test("mm:ss with zero padding", () => {
+    const candle = point({ ts: 0 });
+    expect(formatCandleCountdown(candle, "5m", 60_000)).toBe("04:00");
+    expect(formatCandleCountdown(candle, "5m", 1_000)).toBe("04:59");
+    expect(formatCandleCountdown(candle, "1h", 3_540_500)).toBe("00:59");
+  });
+
+  test("clamps at 00:00 once the bar has closed", () => {
+    const candle = point({ ts: 0 });
+    expect(formatCandleCountdown(candle, "5m", 10 * 60_000)).toBe("00:00");
+  });
+});
+
+describe("computeMarketChange", () => {
+  test("prefers the prevDayPx path", () => {
+    expect(computeMarketChange(110, stats, [])).toBeCloseTo(10, 10);
+  });
+
+  test("falls back to the 80-candle anchor without stats", () => {
+    const points: MarketPoint[] = [];
+    for (let index = 0; index < 100; index += 1) {
+      points.push(point({ ts: index, price: index === 21 ? 50 : 60 }));
+    }
+    points.push(point({ ts: 100, price: 75 }));
+    // 101 points: points.at(-80) is the index-21 sample (price 50); latest is 75.
+    expect(computeMarketChange(null, null, points)).toBeCloseTo(50, 10);
+  });
+
+  test("short history anchors at the first point", () => {
+    const points = [point({ ts: 0, price: 50 }), point({ ts: 1, price: 55 })];
+    expect(computeMarketChange(null, null, points)).toBeCloseTo(10, 10);
+  });
+
+  test("null when no usable anchor", () => {
+    expect(computeMarketChange(null, null, [])).toBeNull();
+    expect(computeMarketChange(null, null, [point({ price: 0 })])).toBeNull();
+  });
+});
+
+describe("formatChartRange", () => {
+  test("-- when either endpoint is missing", () => {
+    expect(formatChartRange([])).toBe("--");
+  });
+
+  test("locks the `first - last` Intl format byte-for-byte", () => {
+    const first = point({ ts: Date.UTC(2026, 0, 5, 14, 30) });
+    const last = point({ ts: Date.UTC(2026, 0, 6, 9, 15) });
+    const formatter = new Intl.DateTimeFormat(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+      month: "short",
+      day: "numeric",
+    });
+    expect(formatChartRange([first, last])).toBe(
+      `${formatter.format(first.ts)} - ${formatter.format(last.ts)}`,
+    );
+  });
+});
+
+describe("sessionNote", () => {
+  const now = Date.UTC(2026, 6, 3, 12, 0, 0);
+
+  test("spot mode is always 24/7 Jupiter", () => {
+    expect(sessionNote("spot", null, now)).toBe("24/7 · Jupiter");
+  });
+
+  test("24/7 without a market, calendar, or parseable transition", () => {
+    expect(sessionNote("perps", null, now)).toBe("24/7");
+    expect(sessionNote("perps", market(), now)).toBe("24/7");
+    expect(
+      sessionNote("perps", market({ nextTransitionUtc: "not-a-date" }), now),
+    ).toBe("24/7");
+  });
+
+  test("active market counts down to close; inactive to open", () => {
+    const next = new Date(now + 90 * 60_000).toISOString();
+    expect(sessionNote("perps", market({ nextTransitionUtc: next }), now)).toBe(
+      "closes 1h 30m",
+    );
+    expect(
+      sessionNote(
+        "perps",
+        market({ nextTransitionUtc: next, marketStatus: "closed" }),
+        now,
+      ),
+    ).toBe("opens 1h 30m");
+  });
+
+  test("sub-hour spans drop the hours segment", () => {
+    const next = new Date(now + 45 * 60_000).toISOString();
+    expect(sessionNote("perps", market({ nextTransitionUtc: next }), now)).toBe(
+      "closes 45m",
+    );
+  });
+
+  test("transition due at and past the boundary", () => {
+    const at = new Date(now).toISOString();
+    expect(sessionNote("perps", market({ nextTransitionUtc: at }), now)).toBe(
+      "session transition due",
+    );
+    const past = new Date(now - 60_000).toISOString();
+    expect(sessionNote("perps", market({ nextTransitionUtc: past }), now)).toBe(
+      "session transition due",
+    );
+  });
+});
+
+describe("visible candle presets", () => {
+  test("hold the shipped defaults", () => {
+    expect(DEFAULT_VISIBLE_CANDLES).toBe(150);
+    expect(MAX_VISIBLE_CANDLES).toBe(180);
+  });
+});

--- a/apps/portal/src/lib/terminal/chart-format.ts
+++ b/apps/portal/src/lib/terminal/chart-format.ts
@@ -1,0 +1,105 @@
+// Pure chart data/format helpers for the terminal page — candle/volume
+// mapping, timeframe math, and the derived header strings. No chart
+// handles, no component state.
+
+import type { CandlestickData, UTCTimestamp } from "lightweight-charts";
+import type {
+  MarketPoint,
+  PhoenixMarketConfig,
+  PhoenixMarketStats,
+  PhoenixTimeframe,
+} from "$lib/phoenix-market-data";
+
+export const DEFAULT_VISIBLE_CANDLES = 150;
+export const MAX_VISIBLE_CANDLES = 180;
+
+export function toCandle(
+  point: MarketPoint,
+  mode: "last" | "mark",
+): CandlestickData<UTCTimestamp> {
+  // Mark mode renders the mark-price OHLC series (the smoother series that
+  // drives funding/liquidations); falls back to last-trade when absent.
+  const useMark = mode === "mark";
+  return {
+    time: Math.floor(point.ts / 1000) as UTCTimestamp,
+    open: useMark ? (point.markOpen ?? point.open) : point.open,
+    high: useMark ? (point.markHigh ?? point.high) : point.high,
+    low: useMark ? (point.markLow ?? point.low) : point.low,
+    close: useMark ? (point.markClose ?? point.close) : point.close,
+  };
+}
+
+export function toVolume(point: MarketPoint) {
+  const up = point.close >= point.open;
+  return {
+    time: Math.floor(point.ts / 1000) as UTCTimestamp,
+    value: point.volumeQuote ?? point.volume ?? 0,
+    color: up ? "rgba(44, 233, 127, 0.45)" : "rgba(255, 90, 106, 0.45)",
+  };
+}
+
+export function timeframeMs(timeframe: PhoenixTimeframe): number {
+  if (timeframe.endsWith("m")) return Number(timeframe.slice(0, -1)) * 60_000;
+  if (timeframe.endsWith("h")) {
+    return Number(timeframe.slice(0, -1)) * 60 * 60_000;
+  }
+  return 60_000;
+}
+
+export function formatCandleCountdown(
+  point: MarketPoint | null,
+  timeframe: PhoenixTimeframe,
+  currentTime: number,
+): string {
+  if (!point) return "--";
+  const duration = timeframeMs(timeframe);
+  const remaining = Math.max(0, point.ts + duration - currentTime);
+  const minutes = Math.floor(remaining / 60_000);
+  const seconds = Math.floor((remaining % 60_000) / 1_000);
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+export function computeMarketChange(
+  price: number | null,
+  stats: PhoenixMarketStats | null,
+  points: MarketPoint[],
+): number | null {
+  if (price && stats?.prevDayPx && stats.prevDayPx > 0) {
+    return ((price - stats.prevDayPx) / stats.prevDayPx) * 100;
+  }
+  const latest = points.at(-1);
+  const anchor = points.at(-80) ?? points.at(0);
+  if (!latest || !anchor || anchor.price <= 0) return null;
+  return ((latest.price - anchor.price) / anchor.price) * 100;
+}
+
+export function formatChartRange(points: MarketPoint[]): string {
+  const first = points.at(0);
+  const last = points.at(-1);
+  if (!first || !last) return "--";
+  const formatter = new Intl.DateTimeFormat(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    month: "short",
+    day: "numeric",
+  });
+  return `${formatter.format(first.ts)} - ${formatter.format(last.ts)}`;
+}
+
+// Session state for the selected market from its exchange calendar.
+export function sessionNote(
+  mode: "perps" | "spot",
+  market: PhoenixMarketConfig | null,
+  nowMs: number,
+): string {
+  if (mode === "spot") return "24/7 · Jupiter";
+  const next = market?.nextTransitionUtc;
+  if (!next) return "24/7";
+  const ms = Date.parse(next) - nowMs;
+  if (!Number.isFinite(ms)) return "24/7";
+  const hours = Math.floor(Math.abs(ms) / 3_600_000);
+  const minutes = Math.floor((Math.abs(ms) % 3_600_000) / 60_000);
+  const span = hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+  if (ms <= 0) return "session transition due";
+  return market?.marketStatus === "active" ? `closes ${span}` : `opens ${span}`;
+}

--- a/apps/portal/src/lib/terminal/chart-lines.test.ts
+++ b/apps/portal/src/lib/terminal/chart-lines.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "bun:test";
+import { colors } from "@trader-ralph/ui/tokens";
+import type { PhoenixOpenOrder, PhoenixPosition } from "$lib/phoenix-trade";
+import type { Alert } from "./alerts";
+import { buildChartLineSpecs } from "./chart-lines";
+
+const PREFS_ALL = { pos: true, tpsl: true, orders: true, alerts: true };
+
+function position(overrides: Partial<PhoenixPosition> = {}): PhoenixPosition {
+  return {
+    symbol: "SOL",
+    size: 2,
+    entryPrice: 100,
+    liquidationPrice: 80,
+    unrealizedPnl: 12.345,
+    positionValue: 200,
+    takeProfitPrice: 130,
+    stopLossPrice: 90,
+    ...overrides,
+  } as PhoenixPosition;
+}
+
+function order(overrides: Partial<PhoenixOpenOrder> = {}): PhoenixOpenOrder {
+  return {
+    symbol: "SOL",
+    side: "bid",
+    price: 95,
+    remaining: 1.5,
+    orderSequenceNumber: "1",
+    isStopLoss: false,
+    ...overrides,
+  } as PhoenixOpenOrder;
+}
+
+function alert(overrides: Partial<Alert> = {}): Alert {
+  return {
+    id: "a",
+    symbol: "SOL",
+    op: "above",
+    price: 150,
+    tier: "PRIORITY",
+    triggered: false,
+    ...overrides,
+  };
+}
+
+describe("buildChartLineSpecs", () => {
+  test("spot mode → no lines at all", () => {
+    expect(
+      buildChartLineSpecs(
+        [position()],
+        [order()],
+        [alert()],
+        PREFS_ALL,
+        "SOL",
+        "spot",
+      ),
+    ).toEqual([]);
+  });
+
+  test("full long position renders entry/LIQ/TP/SL with exact fields", () => {
+    const specs = buildChartLineSpecs(
+      [position()],
+      [],
+      [],
+      PREFS_ALL,
+      "SOL",
+      "perps",
+    );
+    expect(specs).toHaveLength(4);
+    const [entry, liq, tp, sl] = specs;
+    expect(entry.price).toBe(100);
+    expect(entry.color).toBe(colors.up);
+    expect(entry.lineWidth).toBe(2);
+    expect(entry.lineStyle).toBe(0);
+    expect(entry.title).toContain("LONG");
+    expect(entry.title).toContain("+$12.35"); // signed uPnL in the label
+    expect(liq.title).toBe("LIQ est");
+    expect(liq.lineStyle).toBe(2);
+    expect(tp.title).toBe("TP · +$60.00"); // |130-100| × 2
+    expect(tp.color).toBe(colors.up);
+    expect(sl.title).toBe("SL · -$20.00"); // |90-100| × 2
+    expect(sl.color).toBe(colors.down);
+  });
+
+  test("short position gets down-colored solid entry with SHORT label", () => {
+    const specs = buildChartLineSpecs(
+      [
+        position({
+          size: -2,
+          takeProfitPrice: null,
+          stopLossPrice: null,
+          liquidationPrice: null,
+        }),
+      ],
+      [],
+      [],
+      PREFS_ALL,
+      "SOL",
+      "perps",
+    );
+    expect(specs).toHaveLength(1);
+    expect(specs[0].color).toBe(colors.down);
+    expect(specs[0].title).toContain("SHORT");
+  });
+
+  test("pref groups gate independently", () => {
+    const posOnly = buildChartLineSpecs(
+      [position()],
+      [order()],
+      [alert()],
+      { pos: true, tpsl: false, orders: false, alerts: false },
+      "SOL",
+      "perps",
+    );
+    expect(posOnly.map((s) => s.title)).toEqual([
+      expect.stringContaining("LONG"),
+      "LIQ est",
+    ]);
+    const ordersOnly = buildChartLineSpecs(
+      [position()],
+      [order()],
+      [alert()],
+      { pos: false, tpsl: false, orders: true, alerts: false },
+      "SOL",
+      "perps",
+    );
+    expect(ordersOnly).toHaveLength(1);
+    expect(ordersOnly[0].color).toBe(colors.amber);
+    expect(ordersOnly[0].lineStyle).toBe(1);
+    expect(ordersOnly[0].title).toBe("BID 1.5000");
+  });
+
+  test("symbol filtering applies to positions, orders, and alerts", () => {
+    const specs = buildChartLineSpecs(
+      [position({ symbol: "BTC" })],
+      [order({ symbol: "BTC" })],
+      [alert({ symbol: "BTC" })],
+      PREFS_ALL,
+      "SOL",
+      "perps",
+    );
+    expect(specs).toEqual([]);
+  });
+
+  test("triggered alerts are excluded; arrow follows op", () => {
+    const specs = buildChartLineSpecs(
+      [],
+      [],
+      [alert(), alert({ id: "b", op: "below", triggered: true })],
+      PREFS_ALL,
+      "SOL",
+      "perps",
+    );
+    expect(specs).toHaveLength(1);
+    expect(specs[0].title).toBe("ALERT ↑");
+    expect(specs[0].color).toBe(colors.accent);
+  });
+
+  test("ask order with null remaining renders bare ASK label", () => {
+    const specs = buildChartLineSpecs(
+      [],
+      [order({ side: "ask", remaining: null })],
+      [],
+      PREFS_ALL,
+      "SOL",
+      "perps",
+    );
+    expect(specs[0].title).toBe("ASK");
+  });
+});

--- a/apps/portal/src/lib/terminal/chart-lines.ts
+++ b/apps/portal/src/lib/terminal/chart-lines.ts
@@ -1,0 +1,124 @@
+// Chart price-line specs — the pure half of refreshChartLines. Builds the
+// exact option objects the page feeds to lightweight-charts'
+// createPriceLine (field-for-field identical to the previous inline
+// literals); the page keeps a ~10-line applier that clears and re-adds.
+// This split is the prerequisite for memoizing line churn off the tick path.
+
+import { colors } from "@trader-ralph/ui/tokens";
+import type { ChartLinePrefs } from "$lib/phoenix-cache";
+import type { PhoenixOpenOrder, PhoenixPosition } from "$lib/phoenix-trade";
+import { formatNumber, formatPrice } from "$lib/utils";
+import type { Alert } from "./alerts";
+
+export type PriceLineSpec = {
+  price: number;
+  color: string;
+  lineWidth: 1 | 2;
+  lineStyle: 0 | 1 | 2; // lightweight-charts: 0 solid · 1 dotted · 2 dashed
+  axisLabelVisible: boolean;
+  title: string;
+};
+
+export function buildChartLineSpecs(
+  positions: PhoenixPosition[],
+  orders: PhoenixOpenOrder[],
+  armed: Alert[],
+  prefs: ChartLinePrefs,
+  symbol: string,
+  mode: "perps" | "spot",
+): PriceLineSpec[] {
+  if (mode !== "perps") return [];
+  const specs: PriceLineSpec[] = [];
+
+  for (const position of positions) {
+    if (position.symbol !== symbol) continue;
+    const side = position.size > 0 ? "LONG" : "SHORT";
+    const sideColor = position.size > 0 ? colors.up : colors.down;
+    if (prefs.pos && position.entryPrice !== null) {
+      const upnl =
+        position.unrealizedPnl !== null
+          ? ` · ${position.unrealizedPnl >= 0 ? "+" : "-"}$${formatNumber(Math.abs(position.unrealizedPnl), 2)}`
+          : "";
+      specs.push({
+        price: position.entryPrice,
+        color: sideColor,
+        lineWidth: 2,
+        lineStyle: 0, // solid
+        axisLabelVisible: true,
+        title: `${side} ${formatNumber(Math.abs(position.size), 4)} @ ${formatPrice(position.entryPrice)}${upnl}`,
+      });
+    }
+    if (prefs.pos && position.liquidationPrice !== null) {
+      specs.push({
+        price: position.liquidationPrice,
+        color: colors.down,
+        lineWidth: 1,
+        lineStyle: 2, // dashed
+        axisLabelVisible: true,
+        title: "LIQ est",
+      });
+    }
+    if (
+      prefs.tpsl &&
+      position.takeProfitPrice !== null &&
+      position.entryPrice !== null
+    ) {
+      const gain =
+        Math.abs(position.takeProfitPrice - position.entryPrice) *
+        Math.abs(position.size);
+      specs.push({
+        price: position.takeProfitPrice,
+        color: colors.up,
+        lineWidth: 1,
+        lineStyle: 2,
+        axisLabelVisible: true,
+        title: `TP · +$${formatNumber(gain, 2)}`,
+      });
+    }
+    if (
+      prefs.tpsl &&
+      position.stopLossPrice !== null &&
+      position.entryPrice !== null
+    ) {
+      const loss =
+        Math.abs(position.stopLossPrice - position.entryPrice) *
+        Math.abs(position.size);
+      specs.push({
+        price: position.stopLossPrice,
+        color: colors.down,
+        lineWidth: 1,
+        lineStyle: 2,
+        axisLabelVisible: true,
+        title: `SL · -$${formatNumber(loss, 2)}`,
+      });
+    }
+  }
+  if (prefs.orders) {
+    for (const order of orders) {
+      if (order.symbol !== symbol || order.price === null) continue;
+      specs.push({
+        price: order.price,
+        color: colors.amber,
+        lineWidth: 1,
+        lineStyle: 1, // dotted
+        axisLabelVisible: true,
+        title:
+          `${order.side === "bid" ? "BID" : "ASK"} ${order.remaining !== null ? formatNumber(order.remaining, 4) : ""}`.trim(),
+      });
+    }
+  }
+  if (prefs.alerts) {
+    for (const alert of armed) {
+      if (alert.symbol !== symbol || alert.triggered) continue;
+      specs.push({
+        price: alert.price,
+        color: colors.accent,
+        lineWidth: 1,
+        lineStyle: 1,
+        axisLabelVisible: true,
+        title: `ALERT ${alert.op === "above" ? "↑" : "↓"}`,
+      });
+    }
+  }
+  return specs;
+}

--- a/apps/portal/src/lib/terminal/deep-link.test.ts
+++ b/apps/portal/src/lib/terminal/deep-link.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+import { parseTerminalDeepLink, snapLeverage } from "./deep-link";
+
+describe("snapLeverage", () => {
+  test("snaps to nearest allowed option", () => {
+    const allowed = [1, 2, 5, 10, 20];
+    expect(snapLeverage(3, allowed)).toBe(2); // ties keep the earlier option
+    expect(snapLeverage(4, allowed)).toBe(5);
+    expect(snapLeverage(100, allowed)).toBe(20);
+    expect(snapLeverage(1, allowed)).toBe(1);
+  });
+});
+
+describe("parseTerminalDeepLink", () => {
+  test("null when no KNOWN param present (replaceState no-op)", () => {
+    expect(parseTerminalDeepLink("")).toBeNull();
+    expect(parseTerminalDeepLink("?utm_source=x&ref=abc")).toBeNull();
+  });
+
+  test("perp venue: symbol uppercased, -PERP stripped, side/size/leverage", () => {
+    const intent = parseTerminalDeepLink(
+      "?venue=perps&asset=sol-perp&side=short&size=500&leverage=8",
+    );
+    expect(intent?.venue).toBe("perp");
+    expect(intent?.symbol).toBe("SOL");
+    expect(intent?.side).toBe("sell");
+    expect(intent?.sizeUsd).toBe(500);
+    expect(intent?.leverage).toBe(10); // 8 snaps to 10
+    expect(intent?.bookTab).toBe("trade");
+  });
+
+  test("default venue is spot; asset id lowercased", () => {
+    const intent = parseTerminalDeepLink("?asset=SOL&side=sell&size=25");
+    expect(intent?.venue).toBe("spot");
+    expect(intent?.spotAssetId).toBe("sol");
+    expect(intent?.side).toBe("sell");
+    expect(intent?.sizeUsd).toBe(25);
+  });
+
+  test("tf-only link touches neither venue nor bookTab", () => {
+    const intent = parseTerminalDeepLink("?tf=1h");
+    expect(intent?.venue).toBeNull();
+    expect(intent?.bookTab).toBeNull();
+    expect(intent?.timeframe).toBe("1h");
+  });
+
+  test("price implies limit type and beats explicit type param", () => {
+    const priced = parseTerminalDeepLink("?venue=perp&price=150.5&type=market");
+    expect(priced?.orderType).toBe("limit");
+    expect(priced?.limitPrice).toBe(150.5);
+    const typed = parseTerminalDeepLink("?venue=perp&type=limit");
+    expect(typed?.orderType).toBe("limit");
+    expect(typed?.limitPrice).toBeNull();
+  });
+
+  test("bounds rejection: zero, negative, huge, NaN", () => {
+    const intent = parseTerminalDeepLink(
+      "?venue=perp&size=0&price=-5&tp=200000001&sl=abc&leverage=101",
+    );
+    expect(intent?.sizeUsd).toBeNull();
+    expect(intent?.limitPrice).toBeNull();
+    expect(intent?.takeProfit).toBeNull();
+    expect(intent?.stopLoss).toBeNull();
+    expect(intent?.leverage).toBeNull();
+  });
+
+  test("tp/sl within bounds pass through", () => {
+    const intent = parseTerminalDeepLink("?venue=perp&tp=180&sl=140");
+    expect(intent?.takeProfit).toBe(180);
+    expect(intent?.stopLoss).toBe(140);
+  });
+
+  test("tab overrides branch default; cmd overrides tab", () => {
+    expect(parseTerminalDeepLink("?venue=perp&tab=book")?.bookTab).toBe("book");
+    expect(parseTerminalDeepLink("?asset=sol&tab=book")?.bookTab).toBe("book");
+    expect(
+      parseTerminalDeepLink("?venue=perp&tab=book&cmd=buy%20sol")?.bookTab,
+    ).toBe("trade");
+  });
+
+  test("watch tokens: trim, uppercase, charset rule, keeps order", () => {
+    const intent = parseTerminalDeepLink(
+      "?watch=sol,%20btc%20,toolongsymbol123,we$rd",
+    );
+    expect(intent?.watchSymbols).toEqual(["SOL", "BTC"]);
+  });
+
+  test("overlay precedence: funds > ticket > alerts", () => {
+    const funds = parseTerminalDeepLink(
+      "?venue=perp&fund=convert&ticket=1&alerts=1",
+    );
+    expect(funds?.overlay).toEqual({ kind: "funds", tab: "convert" });
+    const ticket = parseTerminalDeepLink("?venue=perp&ticket=1&alerts=1");
+    expect(ticket?.overlay).toEqual({ kind: "ticket" });
+    const alerts = parseTerminalDeepLink("?ticket=1&alerts=1");
+    // ticket flag only opens the ticket on the perp venue
+    expect(alerts?.overlay).toEqual({ kind: "alerts" });
+  });
+
+  test("fund opens on ANY value (even 0/false); unknown tab → null tab", () => {
+    expect(parseTerminalDeepLink("?fund=0")?.overlay).toEqual({
+      kind: "funds",
+      tab: null,
+    });
+    expect(parseTerminalDeepLink("?fund=phoenix")?.overlay).toEqual({
+      kind: "funds",
+      tab: "phoenix",
+    });
+  });
+
+  test("ticket/alerts flags reject 0 and false", () => {
+    expect(
+      parseTerminalDeepLink("?venue=perp&ticket=false")?.overlay,
+    ).toBeNull();
+    expect(parseTerminalDeepLink("?alerts=0")?.overlay).toBeNull();
+  });
+
+  test("mode param whitelists last/mark", () => {
+    expect(parseTerminalDeepLink("?mode=mark")?.priceMode).toBe("mark");
+    expect(parseTerminalDeepLink("?mode=oracle")?.priceMode).toBeNull();
+  });
+});

--- a/apps/portal/src/lib/terminal/deep-link.ts
+++ b/apps/portal/src/lib/terminal/deep-link.ts
@@ -1,0 +1,194 @@
+// Terminal deep-link parsing — the ?asset=&venue=&side=… query contract is
+// an external distribution surface (share links, OG cards, partner embeds),
+// so its semantics are locked here as a pure parser with tests. The page
+// keeps a thin applyDeepLink that assigns the parsed intent to state.
+//
+// Every rule below reproduces the original inline logic exactly: KNOWN key
+// gating, bounds, venue/side normalization, leverage snapping, the
+// bookTab/cmd/tab precedence chain, and funds > ticket > alerts overlays.
+
+import {
+  PHOENIX_TIMEFRAMES,
+  type PhoenixTimeframe,
+} from "$lib/phoenix-market-data";
+
+export const DEEP_LINK_KNOWN_PARAMS = [
+  "asset",
+  "venue",
+  "side",
+  "size",
+  "leverage",
+  "type",
+  "price",
+  "tp",
+  "sl",
+  "ticket",
+  "tf",
+  "mode",
+  "fund",
+  "tab",
+  "alerts",
+  "cmd",
+  "watch",
+] as const;
+
+export type TerminalDeepLinkOverlay =
+  | { kind: "funds"; tab: "convert" | "phoenix" | null }
+  | { kind: "ticket" }
+  | { kind: "alerts" };
+
+export type TerminalDeepLinkIntent = {
+  venue: "perp" | "spot" | null;
+  symbol: string | null; // perp symbol, uppercased, -PERP suffix stripped
+  spotAssetId: string | null; // spot asset id, lowercased
+  side: "buy" | "sell" | null;
+  sizeUsd: number | null;
+  leverage: number | null; // already snapped to the select's options
+  orderType: "limit" | "market" | null;
+  limitPrice: number | null;
+  takeProfit: number | null;
+  stopLoss: number | null;
+  bookTab: "book" | "trade" | null;
+  timeframe: PhoenixTimeframe | null;
+  priceMode: "last" | "mark" | null;
+  watchSymbols: string[];
+  cmd: string | null;
+  overlay: TerminalDeepLinkOverlay | null;
+};
+
+/** Snap a requested leverage to the nearest allowed select option. */
+export function snapLeverage(value: number, allowed: number[]): number {
+  return allowed.reduce((best, option) =>
+    Math.abs(option - value) < Math.abs(best - value) ? option : best,
+  );
+}
+
+/**
+ * Parse a location.search string into a deep-link intent, or null when no
+ * KNOWN param is present (the caller then skips history.replaceState too —
+ * a URL without our params is left untouched).
+ */
+export function parseTerminalDeepLink(
+  search: string,
+): TerminalDeepLinkIntent | null {
+  const params = new URLSearchParams(search);
+  if (!DEEP_LINK_KNOWN_PARAMS.some((key) => params.has(key))) return null;
+
+  const str = (key: string) => params.get(key)?.trim() || null;
+  const lower = (key: string) => str(key)?.toLowerCase() ?? null;
+  // Positive finite number within sane bounds, else null.
+  const numParam = (key: string, max: number): number | null => {
+    const value = Number(str(key));
+    return Number.isFinite(value) && value > 0 && value <= max ? value : null;
+  };
+  const flag = (key: string) => {
+    const value = lower(key);
+    return value !== null && value !== "0" && value !== "false";
+  };
+
+  const asset = str("asset");
+  const venueRaw = lower("venue");
+  const sideRaw = lower("side");
+  const isPerp = venueRaw === "perp" || venueRaw === "perps";
+  const wantsSell = sideRaw === "sell" || sideRaw === "short";
+  const size = numParam("size", 10_000_000);
+  const tab = lower("tab");
+
+  const intent: TerminalDeepLinkIntent = {
+    venue: null,
+    symbol: null,
+    spotAssetId: null,
+    side: null,
+    sizeUsd: null,
+    leverage: null,
+    orderType: null,
+    limitPrice: null,
+    takeProfit: null,
+    stopLoss: null,
+    bookTab: null,
+    timeframe: null,
+    priceMode: null,
+    watchSymbols: [],
+    cmd: null,
+    overlay: null,
+  };
+
+  if (isPerp) {
+    intent.venue = "perp";
+    if (asset) intent.symbol = asset.toUpperCase().replace(/-PERP$/, "");
+    if (sideRaw) intent.side = wantsSell ? "sell" : "buy";
+    if (size !== null) intent.sizeUsd = size;
+
+    const leverage = numParam("leverage", 100);
+    if (leverage !== null) {
+      // Snap to the select's options so the binding displays correctly.
+      intent.leverage = snapLeverage(leverage, [1, 2, 5, 10, 20]);
+    }
+
+    const limitPrice = numParam("price", 100_000_000);
+    const type = lower("type");
+    if (limitPrice !== null) {
+      intent.orderType = "limit";
+      intent.limitPrice = limitPrice;
+    } else if (type === "limit" || type === "market") {
+      intent.orderType = type;
+    }
+    const takeProfit = numParam("tp", 100_000_000);
+    const stopLoss = numParam("sl", 100_000_000);
+    if (takeProfit !== null) intent.takeProfit = takeProfit;
+    if (stopLoss !== null) intent.stopLoss = stopLoss;
+
+    intent.bookTab = tab === "book" ? "book" : "trade";
+  } else if (asset || venueRaw || sideRaw || size !== null) {
+    // Default venue is spot — the broader universe.
+    intent.venue = "spot";
+    if (asset) intent.spotAssetId = asset.toLowerCase();
+    if (sideRaw) intent.side = wantsSell ? "sell" : "buy";
+    if (size !== null) intent.sizeUsd = size;
+    const spotLimit = numParam("price", 100_000_000);
+    if (spotLimit !== null) {
+      intent.orderType = "limit";
+      intent.limitPrice = spotLimit;
+    }
+    if (asset || sideRaw || size !== null) {
+      intent.bookTab = tab === "book" ? "book" : "trade";
+    }
+  }
+  if (tab === "book" || tab === "trade") intent.bookTab = tab;
+
+  const tf = lower("tf");
+  if (PHOENIX_TIMEFRAMES.includes(tf as PhoenixTimeframe)) {
+    intent.timeframe = tf as PhoenixTimeframe;
+  }
+  const mode = lower("mode");
+  if (mode === "last" || mode === "mark") intent.priceMode = mode;
+
+  const watch = str("watch");
+  if (watch) {
+    intent.watchSymbols = watch
+      .split(",")
+      .map((sym) => sym.trim().toUpperCase())
+      .filter((sym) => /^[A-Z0-9]{1,12}$/.test(sym));
+  }
+
+  const cmd = str("cmd");
+  if (cmd) {
+    intent.cmd = cmd;
+    intent.bookTab = "trade"; // cmd parses straight into the ticket
+  }
+
+  // Overlays — at most one (funds > ticket > alerts), modals never stack.
+  const fund = lower("fund");
+  if (fund) {
+    intent.overlay = {
+      kind: "funds",
+      tab: fund === "convert" || fund === "phoenix" ? fund : null,
+    };
+  } else if (flag("ticket") && isPerp) {
+    intent.overlay = { kind: "ticket" };
+  } else if (flag("alerts")) {
+    intent.overlay = { kind: "alerts" };
+  }
+
+  return intent;
+}

--- a/apps/portal/src/lib/terminal/palette.test.ts
+++ b/apps/portal/src/lib/terminal/palette.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  PhoenixDailyStat,
+  PhoenixMarketConfig,
+} from "$lib/phoenix-market-data";
+import type { PhoenixOpenOrder, PhoenixPosition } from "$lib/phoenix-trade";
+import type { SpotAsset } from "$lib/spot";
+import { buildPaletteRows, PALETTE_TABS, type PaletteTab } from "./palette";
+
+function market(symbol: string, maxLeverage = 20): PhoenixMarketConfig {
+  return {
+    symbol,
+    marketStatus: "active",
+    isolatedOnly: true,
+    makerFee: null,
+    takerFee: null,
+    maxLeverage,
+    commodity: false,
+    nextTransitionUtc: null,
+  };
+}
+
+function asset(overrides: Partial<SpotAsset> = {}): SpotAsset {
+  return {
+    assetId: "asset-sol",
+    symbol: "SOL",
+    hub: "crypto",
+    name: "Solana",
+    imageUrl: "https://img/sol.png",
+    mint: "So11111111111111111111111111111111111111112",
+    decimals: 9,
+    trustTier: "high",
+    price: 150,
+    change24hPct: 2.5,
+    volume24hUsd: 1_000_000,
+    marketCap: null,
+    liquidityUsd: null,
+    ...overrides,
+  };
+}
+
+function phoenixPosition(
+  overrides: Partial<PhoenixPosition> = {},
+): PhoenixPosition {
+  return {
+    symbol: "SOL",
+    size: 10,
+    entryPrice: 100,
+    liquidationPrice: null,
+    unrealizedPnl: 12.5,
+    positionValue: 1_000,
+    takeProfitPrice: null,
+    stopLossPrice: null,
+    traderPdaIndex: 0,
+    subaccountIndex: 1,
+    marginUsd: 100,
+    ...overrides,
+  };
+}
+
+function order(overrides: Partial<PhoenixOpenOrder> = {}): PhoenixOpenOrder {
+  return {
+    symbol: "SOL",
+    side: "bid",
+    price: 100,
+    remaining: 1,
+    orderSequenceNumber: "1",
+    isStopLoss: false,
+    isStopLossDirection: false,
+    ...overrides,
+  };
+}
+
+const noop = (): void => {};
+
+function rows(input: {
+  markets?: PhoenixMarketConfig[];
+  assets?: SpotAsset[];
+  mids?: Record<string, number>;
+  stats?: Record<string, PhoenixDailyStat>;
+  query?: string;
+  tab?: PaletteTab;
+  positions?: PhoenixPosition[];
+  orders?: PhoenixOpenOrder[];
+  closePosition?: (position: PhoenixPosition) => void;
+  cancelSymbolOrders?: (symbol: string) => void;
+  flattenAll?: () => void;
+}) {
+  return buildPaletteRows(
+    input.markets ?? [],
+    input.assets ?? [],
+    input.mids ?? {},
+    input.stats ?? {},
+    input.query ?? "",
+    input.tab ?? "all",
+    input.positions ?? [],
+    input.orders ?? [],
+    input.closePosition ?? noop,
+    input.cancelSymbolOrders ?? noop,
+    input.flattenAll ?? noop,
+  );
+}
+
+describe("buildPaletteRows ordering", () => {
+  test("all tab: actions lead, then perps, then spot by volume", () => {
+    const result = rows({
+      markets: [market("SOL"), market("BTC")],
+      assets: [
+        asset({ assetId: "a", symbol: "AAA", volume24hUsd: 10 }),
+        asset({ assetId: "b", symbol: "BBB", volume24hUsd: 30 }),
+      ],
+      positions: [phoenixPosition()],
+    });
+    expect(result.map((row) => row.kind)).toEqual([
+      "action",
+      "perp",
+      "perp",
+      "spot",
+      "spot",
+    ]);
+    expect(result[3].symbol).toBe("BBB");
+    expect(result[4].symbol).toBe("AAA");
+  });
+
+  test("spot rows with null volume sort last", () => {
+    const result = rows({
+      assets: [
+        asset({ assetId: "a", symbol: "AAA", volume24hUsd: null }),
+        asset({ assetId: "b", symbol: "BBB", volume24hUsd: 5 }),
+        asset({ assetId: "c", symbol: "CCC", volume24hUsd: 0 }),
+      ],
+    });
+    expect(result.map((row) => row.symbol)).toEqual(["BBB", "CCC", "AAA"]);
+  });
+});
+
+describe("buildPaletteRows tabs", () => {
+  test("perps tab keeps actions and perps, drops spot", () => {
+    const result = rows({
+      markets: [market("SOL")],
+      assets: [asset()],
+      positions: [phoenixPosition()],
+      tab: "perps",
+    });
+    expect(result.map((row) => row.kind)).toEqual(["action", "perp"]);
+  });
+
+  test("hub tabs filter the spot catalog only", () => {
+    const result = rows({
+      markets: [market("SOL")],
+      assets: [
+        asset({ assetId: "a", symbol: "AAA", hub: "crypto" }),
+        asset({ assetId: "b", symbol: "NVDA", hub: "equities" }),
+      ],
+      positions: [phoenixPosition()],
+      tab: "equities",
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe("spot");
+    expect(result[0].symbol).toBe("NVDA");
+  });
+});
+
+describe("buildPaletteRows query", () => {
+  const inputs = {
+    markets: [market("SOL"), market("BTC")],
+    assets: [asset({ assetId: "b", symbol: "WBTC", name: "Wrapped Bitcoin" })],
+  };
+
+  test("matches symbol case-insensitively", () => {
+    const result = rows({ ...inputs, query: "btc" });
+    expect(result.map((row) => row.symbol)).toEqual(["BTC", "WBTC"]);
+  });
+
+  test("matches name when the symbol misses", () => {
+    const result = rows({ ...inputs, query: "wrapped" });
+    expect(result.map((row) => row.symbol)).toEqual(["WBTC"]);
+  });
+});
+
+describe("buildPaletteRows perp price fallback", () => {
+  const stats: Record<string, PhoenixDailyStat> = {
+    SOL: { lastPrice: 149, change24hPct: 1, volume24hUsd: 500 },
+  };
+
+  test("live mid wins, then daily lastPrice, then null", () => {
+    const withMid = rows({
+      markets: [market("SOL")],
+      mids: { SOL: 151 },
+      stats,
+    });
+    expect(withMid[0].price).toBe(151);
+    const fromStats = rows({ markets: [market("SOL")], stats });
+    expect(fromStats[0].price).toBe(149);
+    const bare = rows({ markets: [market("SOL")] });
+    expect(bare[0].price).toBeNull();
+    expect(bare[0].change24hPct).toBeNull();
+    expect(bare[0].volumeUsd).toBeNull();
+  });
+});
+
+describe("buildPaletteRows action rows", () => {
+  test("close rows carry the signed uPnL and call the handler with the position", () => {
+    const seen: PhoenixPosition[] = [];
+    const winner = phoenixPosition({ unrealizedPnl: 12.5 });
+    const loser = phoenixPosition({
+      symbol: "BTC",
+      subaccountIndex: 2,
+      unrealizedPnl: -3.25,
+    });
+    const result = rows({
+      positions: [winner, loser],
+      closePosition: (position) => seen.push(position),
+    });
+    expect(result[0].name).toBe("Close SOL-PERP · +$12.50");
+    expect(result[1].name).toBe("Close BTC-PERP · -$3.25");
+    expect(result[0].key).toBe("action:close:SOL:1");
+    result[1].action?.();
+    expect(seen).toEqual([loser]);
+  });
+
+  test("close row omits the uPnL segment when unknown", () => {
+    const result = rows({
+      positions: [phoenixPosition({ unrealizedPnl: null })],
+    });
+    expect(result[0].name).toBe("Close SOL-PERP");
+  });
+
+  test("cancel rows count book orders per symbol, excluding stop-losses", () => {
+    const cancelled: string[] = [];
+    const result = rows({
+      orders: [
+        order(),
+        order({ orderSequenceNumber: "2" }),
+        order({ orderSequenceNumber: "3", isStopLoss: true }),
+        order({ symbol: "BTC", orderSequenceNumber: "4" }),
+      ],
+      cancelSymbolOrders: (symbol) => cancelled.push(symbol),
+    });
+    expect(result[0].name).toBe("Cancel 2 SOL-PERP orders");
+    expect(result[1].name).toBe("Cancel 1 BTC-PERP order");
+    result[0].action?.();
+    expect(cancelled).toEqual(["SOL"]);
+  });
+
+  test("flatten appears only with more than one position", () => {
+    let flattened = 0;
+    const single = rows({ positions: [phoenixPosition()] });
+    expect(single.some((row) => row.key === "action:flatten")).toBe(false);
+    const multi = rows({
+      positions: [phoenixPosition(), phoenixPosition({ symbol: "BTC" })],
+      flattenAll: () => {
+        flattened += 1;
+      },
+    });
+    const flatten = multi.find((row) => row.key === "action:flatten");
+    expect(flatten?.name).toBe("Flatten all positions");
+    flatten?.action?.();
+    expect(flattened).toBe(1);
+  });
+});
+
+describe("buildPaletteRows cap", () => {
+  test("caps at 80 rows", () => {
+    const assets: SpotAsset[] = [];
+    for (let index = 0; index < 100; index += 1) {
+      assets.push(
+        asset({
+          assetId: `asset-${index}`,
+          symbol: `T${index}`,
+          volume24hUsd: index,
+        }),
+      );
+    }
+    expect(rows({ assets, tab: "crypto" })).toHaveLength(80);
+  });
+});
+
+describe("PALETTE_TABS", () => {
+  test("holds the five shipped tabs in order", () => {
+    expect(PALETTE_TABS.map((tab) => tab.key)).toEqual([
+      "all",
+      "perps",
+      "crypto",
+      "equities",
+      "pre-ipo",
+    ]);
+  });
+});

--- a/apps/portal/src/lib/terminal/palette.ts
+++ b/apps/portal/src/lib/terminal/palette.ts
@@ -1,0 +1,139 @@
+// Market palette rows — the "/" picker for every tradable market.
+// One primitive for both venues: perp markets (live mids) and the spot
+// catalog (full 24h stats). Action rows (close/cancel/flatten on live
+// state) lead when applicable; the handlers are injected by the page.
+import type {
+  PhoenixDailyStat,
+  PhoenixMarketConfig,
+} from "$lib/phoenix-market-data";
+import type { PhoenixOpenOrder, PhoenixPosition } from "$lib/phoenix-trade";
+import type { SpotAsset } from "$lib/spot";
+import { formatNumber } from "$lib/utils";
+
+export type PaletteRow = {
+  kind: "perp" | "spot" | "action";
+  key: string;
+  symbol: string;
+  name: string;
+  imageUrl: string | null;
+  lev: number | null;
+  price: number | null;
+  change24hPct: number | null;
+  volumeUsd: number | null;
+  hub: "perps" | "crypto" | "equities" | "pre-ipo";
+  asset?: SpotAsset;
+  action?: () => void;
+};
+export type PaletteTab = "all" | "perps" | "crypto" | "equities" | "pre-ipo";
+export const PALETTE_TABS: { key: PaletteTab; label: string }[] = [
+  { key: "all", label: "All" },
+  { key: "perps", label: "Perps" },
+  { key: "crypto", label: "Crypto" },
+  { key: "equities", label: "Equities" },
+  { key: "pre-ipo", label: "Pre-IPO" },
+];
+
+export function buildPaletteRows(
+  perpMarkets: PhoenixMarketConfig[],
+  assets: SpotAsset[],
+  mids: Record<string, number>,
+  stats: Record<string, PhoenixDailyStat>,
+  query: string,
+  tab: PaletteTab,
+  positions: PhoenixPosition[],
+  orders: PhoenixOpenOrder[],
+  closePosition: (position: PhoenixPosition) => void,
+  cancelSymbolOrders: (symbol: string) => void,
+  flattenAll: () => void,
+): PaletteRow[] {
+  // Live-state actions: one Close per position, one Cancel per symbol with
+  // book orders, Flatten once there is more than one position to close.
+  const blank = {
+    imageUrl: null,
+    lev: null,
+    price: null,
+    change24hPct: null,
+    volumeUsd: null,
+    hub: "perps" as const,
+  };
+  const actions: PaletteRow[] = positions.map((position) => ({
+    kind: "action",
+    key: `action:close:${position.symbol}:${position.subaccountIndex}`,
+    symbol: position.symbol,
+    name: `Close ${position.symbol}-PERP${
+      position.unrealizedPnl !== null
+        ? ` · ${position.unrealizedPnl >= 0 ? "+" : "-"}$${formatNumber(Math.abs(position.unrealizedPnl), 2)}`
+        : ""
+    }`,
+    ...blank,
+    action: () => closePosition(position),
+  }));
+  const bookCounts = new Map<string, number>();
+  for (const order of orders) {
+    if (order.isStopLoss) continue;
+    bookCounts.set(order.symbol, (bookCounts.get(order.symbol) ?? 0) + 1);
+  }
+  for (const [symbol, count] of bookCounts) {
+    actions.push({
+      kind: "action",
+      key: `action:cancel:${symbol}`,
+      symbol,
+      name: `Cancel ${count} ${symbol}-PERP order${count === 1 ? "" : "s"}`,
+      ...blank,
+      action: () => cancelSymbolOrders(symbol),
+    });
+  }
+  if (positions.length > 1) {
+    actions.push({
+      kind: "action",
+      key: "action:flatten",
+      symbol: "FLATTEN",
+      name: "Flatten all positions",
+      ...blank,
+      action: () => flattenAll(),
+    });
+  }
+  const perps: PaletteRow[] = perpMarkets.map((market) => ({
+    kind: "perp",
+    key: `perp:${market.symbol}`,
+    symbol: market.symbol,
+    name: `${market.symbol}-PERP`,
+    imageUrl: null,
+    lev: market.maxLeverage,
+    price: mids[market.symbol] ?? stats[market.symbol]?.lastPrice ?? null,
+    change24hPct: stats[market.symbol]?.change24hPct ?? null,
+    volumeUsd: stats[market.symbol]?.volume24hUsd ?? null,
+    hub: "perps",
+  }));
+  const spots: PaletteRow[] = assets.map((asset) => ({
+    kind: "spot",
+    key: `spot:${asset.assetId}`,
+    symbol: asset.symbol,
+    name: asset.name,
+    imageUrl: asset.imageUrl || null,
+    lev: null,
+    price: asset.price,
+    change24hPct: asset.change24hPct,
+    volumeUsd: asset.volume24hUsd,
+    hub: asset.hub,
+  }));
+  for (const [index, asset] of assets.entries()) spots[index].asset = asset;
+  spots.sort((a, b) => (b.volumeUsd ?? -1) - (a.volumeUsd ?? -1));
+  // Actions lead, then perps — this is a perp terminal first; spot
+  // follows by volume.
+  let rows =
+    tab === "perps"
+      ? [...actions, ...perps]
+      : tab === "all"
+        ? [...actions, ...perps, ...spots]
+        : spots.filter((row) => row.hub === tab);
+  const q = query.trim().toLowerCase();
+  if (q) {
+    rows = rows.filter(
+      (row) =>
+        row.symbol.toLowerCase().includes(q) ||
+        row.name.toLowerCase().includes(q),
+    );
+  }
+  return rows.slice(0, 80);
+}

--- a/apps/portal/src/lib/terminal/panels.test.ts
+++ b/apps/portal/src/lib/terminal/panels.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  PhoenixDailyStat,
+  PhoenixMarketConfig,
+} from "$lib/phoenix-market-data";
+import type { SpotAsset } from "$lib/spot";
+import {
+  buildMonitorRows,
+  buildScreenRows,
+  buildWatchRows,
+  disconnectedPanel,
+  emptyMarketStats,
+  selectedMarketTableRows,
+  summarizeEdgeStatus,
+} from "./panels";
+
+function market(overrides: Partial<PhoenixMarketConfig>): PhoenixMarketConfig {
+  return {
+    symbol: "SOL",
+    marketId: 0,
+    marketStatus: "active",
+    maxLeverage: 20,
+    makerFee: 0.0002,
+    takerFee: 0.0005,
+    isolatedOnly: false,
+    baseLotsDecimals: null,
+    nextTransitionUtc: null,
+    ...overrides,
+  } as PhoenixMarketConfig;
+}
+
+function stat(overrides: Partial<PhoenixDailyStat>): PhoenixDailyStat {
+  return {
+    lastPrice: null,
+    change24hPct: null,
+    volume24hUsd: null,
+    ...overrides,
+  } as PhoenixDailyStat;
+}
+
+function asset(overrides: Partial<SpotAsset>): SpotAsset {
+  return {
+    symbol: "SOL",
+    name: "Solana",
+    mint: "m",
+    decimals: 9,
+    hub: "crypto",
+    price: 100,
+    change24hPct: 1,
+    volume24hUsd: 1000,
+    marketCap: 10_000,
+    ...overrides,
+  } as SpotAsset;
+}
+
+describe("buildMonitorRows", () => {
+  const markets = [market({ symbol: "SOL" }), market({ symbol: "BTC" })];
+  const stats = {
+    SOL: stat({ change24hPct: -2, volume24hUsd: 500 }),
+    BTC: stat({ change24hPct: 3, volume24hUsd: null }),
+  };
+
+  test("volume sort puts null volumes last (−1 sentinel)", () => {
+    const rows = buildMonitorRows(markets, {}, stats, "volume");
+    expect(rows.map((r) => r.symbol)).toEqual(["SOL", "BTC"]);
+  });
+
+  test("change sort descends with −1e9 null sentinel", () => {
+    const rows = buildMonitorRows(markets, {}, stats, "change");
+    expect(rows.map((r) => r.symbol)).toEqual(["BTC", "SOL"]);
+  });
+
+  test("symbol sort is alphabetical", () => {
+    const rows = buildMonitorRows(markets, {}, stats, "symbol");
+    expect(rows.map((r) => r.symbol)).toEqual(["BTC", "SOL"]);
+  });
+
+  test("mid prefers live mids over daily lastPrice", () => {
+    const rows = buildMonitorRows(
+      [market({ symbol: "SOL" })],
+      { SOL: 151 },
+      { SOL: stat({ lastPrice: 150 }) },
+      "volume",
+    );
+    expect(rows[0].mid).toBe(151);
+  });
+});
+
+describe("buildWatchRows", () => {
+  test("spot price wins; basis in bps against perp mid", () => {
+    const rows = buildWatchRows(
+      ["SOL"],
+      [asset({ symbol: "sol", price: 100 })],
+      { SOL: 101 },
+      [],
+    );
+    expect(rows[0].price).toBe(100);
+    expect(rows[0].hasPerp).toBe(true);
+    expect(rows[0].basisBps).toBeCloseTo(100, 5);
+  });
+
+  test("no spot, no mid → perp flag from market list, null basis", () => {
+    const rows = buildWatchRows(["SOL"], [], {}, [market({ symbol: "SOL" })]);
+    expect(rows[0].hasPerp).toBe(true);
+    expect(rows[0].price).toBeNull();
+    expect(rows[0].basisBps).toBeNull();
+  });
+});
+
+describe("buildScreenRows", () => {
+  const assets = [
+    asset({ symbol: "A", change24hPct: -9, marketCap: 1, volume24hUsd: 1 }),
+    asset({ symbol: "B", change24hPct: 2, marketCap: 3, volume24hUsd: 5 }),
+    asset({
+      symbol: "C",
+      hub: "equities",
+      change24hPct: 4,
+      marketCap: 2,
+      volume24hUsd: 3,
+    }),
+  ];
+
+  test("movers sorts by |change| descending", () => {
+    expect(
+      buildScreenRows(assets, "all", "movers").map((a) => a.symbol),
+    ).toEqual(["A", "C", "B"]);
+  });
+
+  test("cap and volume sorts", () => {
+    expect(buildScreenRows(assets, "all", "cap").map((a) => a.symbol)).toEqual([
+      "B",
+      "C",
+      "A",
+    ]);
+    expect(
+      buildScreenRows(assets, "all", "volume").map((a) => a.symbol),
+    ).toEqual(["B", "C", "A"]);
+  });
+
+  test("hub filter", () => {
+    expect(
+      buildScreenRows(assets, "equities", "movers").map((a) => a.symbol),
+    ).toEqual(["C"]);
+  });
+
+  test("caps at 20 rows", () => {
+    const many = Array.from({ length: 30 }, (_, i) =>
+      asset({ symbol: `S${i}` }),
+    );
+    expect(buildScreenRows(many, "all", "volume")).toHaveLength(20);
+  });
+});
+
+describe("selectedMarketTableRows", () => {
+  test("null market → disconnected row", () => {
+    const rows = selectedMarketTableRows(null, null, null);
+    expect(rows[0].value).toBe("Not connected");
+  });
+
+  test("fee row formats maker/taker percent pair", () => {
+    const rows = selectedMarketTableRows(market({}), null, 100);
+    const fees = rows.find((r) => r.label === "Fees");
+    expect(fees?.status).toBe("maker/taker");
+    expect(fees?.value).toContain("/");
+    const margin = rows.find((r) => r.label === "Margin");
+    expect(margin?.value).toBe("cross + isolated");
+    expect(margin?.status).toContain("20");
+  });
+});
+
+describe("edge status helpers", () => {
+  test("summarizeEdgeStatus: any ready wins; else first non-ready", () => {
+    const ready = disconnectedPanel("x");
+    ready.status = "ready";
+    expect(summarizeEdgeStatus([disconnectedPanel("a"), ready])).toBe("ready");
+    expect(summarizeEdgeStatus([disconnectedPanel("a")])).toBe("not connected");
+  });
+
+  test("emptyMarketStats zeroes every field to null", () => {
+    const stats = emptyMarketStats("SOL");
+    expect(stats.symbol).toBe("SOL");
+    expect(stats.markPx).toBeNull();
+    expect(stats.funding).toBeNull();
+  });
+});

--- a/apps/portal/src/lib/terminal/panels.ts
+++ b/apps/portal/src/lib/terminal/panels.ts
@@ -1,0 +1,181 @@
+// Pure row builders for the terminal's data panels — monitor, watchlist,
+// screener, selected-market table, and the disconnected/edge-status
+// helpers. Bodies moved verbatim from the page; the three reactive row
+// builders are the same expressions parameterized on their inputs.
+
+import type { DataPanel, DataRow } from "$lib/edge-data";
+import type {
+  PhoenixDailyStat,
+  PhoenixMarketConfig,
+  PhoenixMarketStats,
+} from "$lib/phoenix-market-data";
+import type { SpotAsset } from "$lib/spot";
+import { formatNumber, formatPercent, formatPrice } from "$lib/utils";
+
+export type SignalRow = DataRow;
+
+export type MonitorSort = "volume" | "change" | "symbol";
+export type ScreenSort = "movers" | "volume" | "cap";
+export type ScreenHub = "all" | "crypto" | "equities" | "pre-ipo";
+
+export type MonitorRow = {
+  symbol: string;
+  lev: number | null;
+  mid: number | null;
+  change: number | null;
+  volume: number | null;
+};
+
+export type WatchRow = {
+  sym: string;
+  spot: SpotAsset | null;
+  hasPerp: boolean;
+  price: number | null;
+  change: number | null;
+  basisBps: number | null;
+};
+
+export function buildMonitorRows(
+  markets: PhoenixMarketConfig[],
+  mids: Record<string, number>,
+  stats: Record<string, PhoenixDailyStat>,
+  sort: MonitorSort,
+): MonitorRow[] {
+  return markets
+    .map((config) => ({
+      symbol: config.symbol,
+      lev: config.maxLeverage,
+      mid: mids[config.symbol] ?? stats[config.symbol]?.lastPrice ?? null,
+      change: stats[config.symbol]?.change24hPct ?? null,
+      volume: stats[config.symbol]?.volume24hUsd ?? null,
+    }))
+    .sort((a, b) =>
+      sort === "symbol"
+        ? a.symbol.localeCompare(b.symbol)
+        : sort === "change"
+          ? (b.change ?? -1e9) - (a.change ?? -1e9)
+          : (b.volume ?? -1) - (a.volume ?? -1),
+    );
+}
+
+export function buildWatchRows(
+  watchlist: string[],
+  spotAssets: SpotAsset[],
+  mids: Record<string, number>,
+  markets: PhoenixMarketConfig[],
+): WatchRow[] {
+  return watchlist.map((sym) => {
+    const spot =
+      spotAssets.find((asset) => asset.symbol.toUpperCase() === sym) ?? null;
+    const mid = mids[sym] ?? null;
+    const hasPerp =
+      mid !== null || markets.some((market) => market.symbol === sym);
+    return {
+      sym,
+      spot,
+      hasPerp,
+      price: spot?.price ?? mid,
+      change: spot?.change24hPct ?? null,
+      basisBps:
+        spot?.price && mid ? ((mid - spot.price) / spot.price) * 10_000 : null,
+    };
+  });
+}
+
+export function buildScreenRows(
+  assets: SpotAsset[],
+  hub: ScreenHub,
+  sort: ScreenSort,
+): SpotAsset[] {
+  return [...assets]
+    .filter((asset) => hub === "all" || asset.hub === hub)
+    .sort((a, b) =>
+      sort === "movers"
+        ? Math.abs(b.change24hPct ?? 0) - Math.abs(a.change24hPct ?? 0)
+        : sort === "cap"
+          ? (b.marketCap ?? 0) - (a.marketCap ?? 0)
+          : (b.volume24hUsd ?? 0) - (a.volume24hUsd ?? 0),
+    )
+    .slice(0, 20);
+}
+
+export function disconnectedRows(reason: string): SignalRow[] {
+  return [
+    {
+      label: "Status",
+      value: "Not connected",
+      status: reason,
+    },
+  ];
+}
+
+export function disconnectedPanel(reason: string): DataPanel {
+  return {
+    rows: disconnectedRows(reason),
+    status: "not connected",
+    source: "",
+  };
+}
+
+export function summarizeEdgeStatus(panels: DataPanel[]): string {
+  if (panels.some((panel) => panel.status === "ready")) return "ready";
+  const first = panels.find((panel) => panel.status !== "ready");
+  return first?.status ?? "not connected";
+}
+
+export function selectedMarketTableRows(
+  market: PhoenixMarketConfig | null,
+  stats: PhoenixMarketStats | null,
+  price: number | null,
+): SignalRow[] {
+  if (!market) {
+    return disconnectedRows("Phoenix market metadata loading");
+  }
+  return [
+    {
+      label: "Market",
+      value: `${market.symbol}-PERP`,
+      status: market.marketStatus,
+    },
+    {
+      label: "Mark",
+      value: formatPrice(stats?.markPx ?? price),
+      status: `oracle ${formatPrice(stats?.oraclePx)}`,
+    },
+    {
+      label: "Open interest",
+      value: formatNumber(stats?.openInterest, 2),
+      status: "base",
+    },
+    {
+      label: "Funding",
+      value: formatPercent((stats?.funding ?? 0) * 100),
+      status: "rate",
+    },
+    {
+      label: "Fees",
+      value: `${formatPercent((market.makerFee ?? 0) * 100)} / ${formatPercent((market.takerFee ?? 0) * 100)}`,
+      status: "maker/taker",
+    },
+    {
+      label: "Margin",
+      value: market.isolatedOnly ? "isolated only" : "cross + isolated",
+      status: market.maxLeverage
+        ? `${formatNumber(market.maxLeverage, 0)}x max`
+        : "--",
+    },
+  ];
+}
+
+export function emptyMarketStats(symbol: string): PhoenixMarketStats {
+  return {
+    symbol,
+    dayNtlVlm: null,
+    prevDayPx: null,
+    markPx: null,
+    midPx: null,
+    funding: null,
+    openInterest: null,
+    oraclePx: null,
+  };
+}

--- a/apps/portal/src/lib/terminal/prefs.test.ts
+++ b/apps/portal/src/lib/terminal/prefs.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_PANEL_ORDER, mergeLayout, parsePrefs } from "./prefs";
+
+describe("parsePrefs", () => {
+  test("null/malformed/non-object → empty", () => {
+    expect(parsePrefs(null)).toEqual({});
+    expect(parsePrefs("not-json{")).toEqual({});
+    expect(parsePrefs('"a string"')).toEqual({});
+  });
+
+  test("accepts every whitelisted field", () => {
+    const prefs = parsePrefs(
+      JSON.stringify({
+        symbol: "BTC",
+        timeframe: "1h",
+        priceMode: "mark",
+        chartScale: "percent",
+        chartAxisMode: "log",
+        visibleCandleCount: 120,
+        tradeMode: "spot",
+        spotAssetId: "sol",
+        watchlist: ["sol", "btc"],
+        screenSort: "cap",
+        screenHub: "crypto",
+        sizingMode: "risk",
+        tradeAmount: "500",
+        tradeRiskUsd: "25",
+        tradeLeverage: 10,
+      }),
+    );
+    expect(prefs.symbol).toBe("BTC");
+    expect(prefs.timeframe).toBe("1h");
+    expect(prefs.priceMode).toBe("mark");
+    expect(prefs.chartScale).toBe("percent");
+    expect(prefs.chartAxisMode).toBe("log");
+    expect(prefs.visibleCandleCount).toBe(120);
+    expect(prefs.tradeMode).toBe("spot");
+    expect(prefs.watchlist).toEqual(["SOL", "BTC"]);
+    expect(prefs.screenSort).toBe("cap");
+    expect(prefs.screenHub).toBe("crypto");
+    expect(prefs.sizingMode).toBe("risk");
+    expect(prefs.tradeAmount).toBe("500");
+    expect(prefs.tradeRiskUsd).toBe("25");
+    expect(prefs.tradeLeverage).toBe(10);
+  });
+
+  test("rejects out-of-enum values field by field", () => {
+    const prefs = parsePrefs(
+      JSON.stringify({
+        timeframe: "7d",
+        priceMode: "oracle",
+        chartScale: "sqrt",
+        screenSort: "alphabetical",
+        screenHub: "bonds",
+        sizingMode: "yolo",
+        tradeMode: "perps",
+        tradeLeverage: 3,
+        visibleCandleCount: Number.NaN,
+      }),
+    );
+    expect(prefs).toEqual({});
+  });
+
+  test("watchlist uppercases, drops non-strings, caps at 24", () => {
+    const prefs = parsePrefs(
+      JSON.stringify({
+        watchlist: ["sol", 7, ...Array.from({ length: 30 }, (_, i) => `t${i}`)],
+      }),
+    );
+    expect(prefs.watchlist?.[0]).toBe("SOL");
+    expect(prefs.watchlist).toHaveLength(24);
+    expect(prefs.watchlist?.includes("7" as string)).toBe(false);
+  });
+
+  test("tradeLeverage only from the snap set", () => {
+    for (const [input, expected] of [
+      [1, 1],
+      [20, 20],
+      [3, undefined],
+      [100, undefined],
+    ] as const) {
+      expect(
+        parsePrefs(JSON.stringify({ tradeLeverage: input })).tradeLeverage,
+      ).toBe(expected as number);
+    }
+  });
+});
+
+describe("mergeLayout", () => {
+  test("non-array → defaults copy", () => {
+    const merged = mergeLayout("junk", DEFAULT_PANEL_ORDER);
+    expect(merged).toEqual(DEFAULT_PANEL_ORDER);
+    expect(merged).not.toBe(DEFAULT_PANEL_ORDER); // fresh copy, not the shared const
+  });
+
+  test("preserves saved order and appends missing defaults", () => {
+    const merged = mergeLayout(
+      ["journal", "watch"],
+      ["watch", "perp", "journal"],
+    );
+    expect(merged).toEqual(["journal", "watch", "perp"]);
+  });
+
+  test("drops unknown ids from stale saves", () => {
+    const merged = mergeLayout(["ghost", "watch"], ["watch", "perp"]);
+    expect(merged).toEqual(["watch", "perp"]);
+  });
+
+  test("drops non-string entries", () => {
+    const merged = mergeLayout([42, "perp"], ["watch", "perp"]);
+    expect(merged).toEqual(["perp", "watch"]);
+  });
+});

--- a/apps/portal/src/lib/terminal/prefs.ts
+++ b/apps/portal/src/lib/terminal/prefs.ts
@@ -1,0 +1,201 @@
+// Terminal preference/layout persistence — storage keys, the pref
+// serializer, and the pure parse/merge cores. The page keeps thin
+// loadPrefs/loadLayout appliers that assign whatever parsePrefs returns;
+// everything here is testable without a DOM.
+
+import {
+  PHOENIX_TIMEFRAMES,
+  type PhoenixTimeframe,
+} from "$lib/phoenix-market-data";
+
+export const PREFS_STORAGE_KEY = "trader-ralph-terminal/prefs/v1";
+export const ALERTS_STORAGE_KEY = "trader-ralph-terminal/alerts/v1";
+export const LAYOUT_STORAGE_KEY = "trader-ralph-terminal/layout/v1";
+export const CACHE_PANELS = "trader-ralph-terminal/cache/panels/v1";
+export const CACHE_NEWS = "trader-ralph-terminal/cache/news/v1";
+export const CACHE_MARKETS = "trader-ralph-terminal/cache/markets/v1";
+export const CACHE_READS = "trader-ralph-terminal/cache/reads/v1";
+export const CACHE_MAX_AGE = 30 * 60_000;
+export const MARKETS_MAX_AGE = 24 * 60 * 60_000;
+export const ALERT_LOG_KEY = "trader-ralph-alert-log";
+export const ONBOARD_KEY = "trader-ralph-terminal/phx-referral/v2";
+
+// Draggable dashboard: reorderable info panels (chart + book stay anchored).
+// NOTE: "markets" appears twice — a latent duplicate-id bug preserved
+// verbatim here; the layout-store phase fixes it with a migration.
+export const DEFAULT_PANEL_ORDER = [
+  "watch",
+  "markets",
+  "perp",
+  "spot",
+  "screener",
+  "macro",
+  "fred",
+  "etf",
+  "stablecoins",
+  "oil",
+  "events",
+  "ideas",
+  "markets",
+  "journal",
+];
+
+export const SECTION_LINKS: { id: string; label: string }[] = [
+  { id: "section-chart", label: "Chart" },
+  { id: "section-book", label: "Book" },
+  { id: "section-perp", label: "Perp" },
+  { id: "section-markets", label: "Markets" },
+  { id: "section-macro", label: "Macro" },
+];
+
+export type TerminalPrefs = {
+  symbol: string;
+  timeframe: PhoenixTimeframe;
+  priceMode: "last" | "mark";
+  chartScale: "price" | "percent";
+  chartAxisMode: "linear" | "log";
+  visibleCandleCount: number;
+  tradeMode: "spot";
+  spotAssetId: string;
+  watchlist: string[];
+  screenSort: "movers" | "volume" | "cap";
+  screenHub: "all" | "crypto" | "equities" | "pre-ipo";
+  sizingMode: "usd" | "risk";
+  tradeAmount: string;
+  tradeRiskUsd: string;
+  tradeLeverage: number;
+};
+
+/**
+ * Validate a raw localStorage prefs payload into the subset of fields that
+ * pass the same whitelists loadPrefs applied inline — every branch below is
+ * the original condition, field for field. Unknown/invalid fields are simply
+ * absent from the result.
+ */
+export function parsePrefs(raw: string | null): Partial<TerminalPrefs> {
+  const prefs: Partial<TerminalPrefs> = {};
+  if (!raw) return prefs;
+  let data: Record<string, unknown>;
+  try {
+    data = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return prefs; // malformed persisted preferences — ignore
+  }
+  if (data === null || typeof data !== "object") return prefs;
+  if (typeof data.symbol === "string") prefs.symbol = data.symbol;
+  if (PHOENIX_TIMEFRAMES.includes(data.timeframe as PhoenixTimeframe)) {
+    prefs.timeframe = data.timeframe as PhoenixTimeframe;
+  }
+  if (data.priceMode === "last" || data.priceMode === "mark") {
+    prefs.priceMode = data.priceMode;
+  }
+  if (data.chartScale === "price" || data.chartScale === "percent") {
+    prefs.chartScale = data.chartScale;
+  }
+  if (data.chartAxisMode === "linear" || data.chartAxisMode === "log") {
+    prefs.chartAxisMode = data.chartAxisMode;
+  }
+  if (
+    typeof data.visibleCandleCount === "number" &&
+    Number.isFinite(data.visibleCandleCount)
+  ) {
+    prefs.visibleCandleCount = data.visibleCandleCount;
+  }
+  if (data.tradeMode === "spot") prefs.tradeMode = "spot";
+  if (typeof data.spotAssetId === "string")
+    prefs.spotAssetId = data.spotAssetId;
+  if (Array.isArray(data.watchlist)) {
+    prefs.watchlist = data.watchlist
+      .filter((sym): sym is string => typeof sym === "string")
+      .map((sym) => sym.toUpperCase())
+      .slice(0, 24);
+  }
+  if (
+    data.screenSort === "movers" ||
+    data.screenSort === "volume" ||
+    data.screenSort === "cap"
+  ) {
+    prefs.screenSort = data.screenSort;
+  }
+  if (
+    data.screenHub === "all" ||
+    data.screenHub === "crypto" ||
+    data.screenHub === "equities" ||
+    data.screenHub === "pre-ipo"
+  ) {
+    prefs.screenHub = data.screenHub;
+  }
+  if (data.sizingMode === "usd" || data.sizingMode === "risk") {
+    prefs.sizingMode = data.sizingMode;
+  }
+  if (typeof data.tradeAmount === "string")
+    prefs.tradeAmount = data.tradeAmount;
+  if (typeof data.tradeRiskUsd === "string") {
+    prefs.tradeRiskUsd = data.tradeRiskUsd;
+  }
+  if (
+    typeof data.tradeLeverage === "number" &&
+    [1, 2, 5, 10, 20].includes(data.tradeLeverage)
+  ) {
+    prefs.tradeLeverage = data.tradeLeverage;
+  }
+  return prefs;
+}
+
+/**
+ * Merge a saved panel order against the defaults: keep saved ids that still
+ * exist, append any defaults the save predates, drop unknown ids. Guards
+ * layout migration across releases.
+ */
+export function mergeLayout(saved: unknown, defaults: string[]): string[] {
+  if (!Array.isArray(saved)) return [...defaults];
+  const known = saved.filter(
+    (id): id is string => typeof id === "string" && defaults.includes(id),
+  );
+  const missing = defaults.filter((id) => !known.includes(id));
+  return [...known, ...missing];
+}
+
+export function persistPrefs(
+  _symbol: string,
+  _timeframe: PhoenixTimeframe,
+  _priceMode: "last" | "mark",
+  _scale: "price" | "percent",
+  _axis: "linear" | "log",
+  _visible: number,
+  _tradeMode: "perps" | "spot",
+  _spotAssetId: string | null,
+  _watchlist: string[],
+  _screenSort: string,
+  _screenHub: string,
+  _sizingMode: string,
+  _tradeAmount: string,
+  _tradeRiskUsd: string,
+  _tradeLeverage: number,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      PREFS_STORAGE_KEY,
+      JSON.stringify({
+        symbol: _symbol,
+        timeframe: _timeframe,
+        priceMode: _priceMode,
+        chartScale: _scale,
+        chartAxisMode: _axis,
+        visibleCandleCount: _visible,
+        tradeMode: _tradeMode,
+        spotAssetId: _spotAssetId,
+        watchlist: _watchlist,
+        screenSort: _screenSort,
+        screenHub: _screenHub,
+        sizingMode: _sizingMode,
+        tradeAmount: _tradeAmount,
+        tradeRiskUsd: _tradeRiskUsd,
+        tradeLeverage: _tradeLeverage,
+      }),
+    );
+  } catch {
+    // storage may be unavailable (private mode, quota) — non-fatal
+  }
+}

--- a/apps/portal/src/lib/terminal/trade-math.test.ts
+++ b/apps/portal/src/lib/terminal/trade-math.test.ts
@@ -1,0 +1,374 @@
+import { describe, expect, test } from "bun:test";
+import type { DepthLevel, PhoenixMarketConfig } from "$lib/phoenix-market-data";
+import type { PhoenixPosition } from "$lib/phoenix-trade";
+import {
+  buildTradePreview,
+  clampLeverage,
+  enrichPosition,
+  fmtTriggerPrice,
+  liqDistancePct,
+  riskNotional,
+  SL_CHIP_PCTS,
+  TP_CHIP_PCTS,
+  triggerPriceForPct,
+} from "./trade-math";
+
+function level(price: number, size: number): DepthLevel {
+  return { price, size, cum: 0 };
+}
+
+function position(overrides: Partial<PhoenixPosition> = {}): PhoenixPosition {
+  return {
+    symbol: "SOL",
+    size: 10,
+    entryPrice: 100,
+    liquidationPrice: null,
+    unrealizedPnl: null,
+    positionValue: 1_000,
+    takeProfitPrice: null,
+    stopLossPrice: null,
+    traderPdaIndex: 0,
+    subaccountIndex: 1,
+    marginUsd: 100,
+    ...overrides,
+  };
+}
+
+function market(
+  overrides: Partial<PhoenixMarketConfig> = {},
+): PhoenixMarketConfig {
+  return {
+    symbol: "SOL",
+    marketStatus: "active",
+    isolatedOnly: true,
+    makerFee: null,
+    takerFee: null,
+    maxLeverage: 20,
+    commodity: false,
+    nextTransitionUtc: null,
+    ...overrides,
+  };
+}
+
+describe("buildTradePreview", () => {
+  const asks = [level(100, 1), level(101, 1), level(102, 1)];
+  const bids = [level(99, 1), level(98, 1), level(97, 1)];
+
+  test("returns null on empty, non-numeric, and non-positive size", () => {
+    expect(
+      buildTradePreview("buy", "", 10, "market", "", asks, bids, 100, null),
+    ).toBeNull();
+    expect(
+      buildTradePreview("buy", "abc", 10, "market", "", asks, bids, 100, null),
+    ).toBeNull();
+    expect(
+      buildTradePreview("buy", "-5", 10, "market", "", asks, bids, 100, null),
+    ).toBeNull();
+    expect(
+      buildTradePreview("buy", "0", 10, "market", "", asks, bids, 100, null),
+    ).toBeNull();
+  });
+
+  test("market buy walks ask levels: avg entry + slippage bps", () => {
+    // $150 takes all of level 1 ($100) and $50 of level 2 at 101.
+    const preview = buildTradePreview(
+      "buy",
+      "150",
+      10,
+      "market",
+      "",
+      asks,
+      bids,
+      100,
+      null,
+    );
+    expect(preview).not.toBeNull();
+    const qty = 1 + 50 / 101;
+    const avg = 150 / qty;
+    expect(preview?.entry).toBeCloseTo(avg, 10);
+    expect(preview?.slippageBps).toBeCloseTo(((avg - 100) / 100) * 10_000, 8);
+    expect(preview?.fillable).toBe(true);
+    expect(preview?.notionalUsd).toBe(150);
+  });
+
+  test("market sell walks bid levels", () => {
+    // $99 exactly consumes the top bid — no slippage.
+    const preview = buildTradePreview(
+      "sell",
+      "99",
+      10,
+      "market",
+      "",
+      asks,
+      bids,
+      100,
+      null,
+    );
+    expect(preview?.entry).toBe(99);
+    expect(preview?.slippageBps).toBe(0);
+    expect(preview?.fillable).toBe(true);
+  });
+
+  test("book too thin: partial fill flags fillable=false, avg over filled qty", () => {
+    // Total ask notional is 100+101+102 = $303 < $1000.
+    const preview = buildTradePreview(
+      "buy",
+      "1000",
+      10,
+      "market",
+      "",
+      asks,
+      bids,
+      100,
+      null,
+    );
+    expect(preview?.fillable).toBe(false);
+    expect(preview?.entry).toBeCloseTo(101, 10);
+    expect(preview?.slippageBps).toBeCloseTo(100, 8);
+  });
+
+  test("empty book falls back to refPrice with no slippage", () => {
+    const preview = buildTradePreview(
+      "buy",
+      "150",
+      10,
+      "market",
+      "",
+      [],
+      [],
+      42,
+      null,
+    );
+    expect(preview?.entry).toBe(42);
+    expect(preview?.slippageBps).toBeNull();
+    expect(preview?.fillable).toBe(true);
+  });
+
+  test("limit price overrides the book entry and skips slippage", () => {
+    const preview = buildTradePreview(
+      "buy",
+      "150",
+      10,
+      "limit",
+      "95",
+      asks,
+      bids,
+      100,
+      null,
+    );
+    expect(preview?.entry).toBe(95);
+    expect(preview?.slippageBps).toBeNull();
+    expect(preview?.fillable).toBe(true);
+  });
+
+  test("invalid limit string keeps the best level as entry", () => {
+    const preview = buildTradePreview(
+      "buy",
+      "150",
+      10,
+      "limit",
+      "nope",
+      asks,
+      bids,
+      100,
+      null,
+    );
+    expect(preview?.entry).toBe(100);
+  });
+
+  test("liq estimate: long below entry, short above entry, scaled by leverage", () => {
+    const long = buildTradePreview(
+      "buy",
+      "100",
+      10,
+      "limit",
+      "100",
+      asks,
+      bids,
+      100,
+      null,
+    );
+    expect(long?.liqPrice).toBeCloseTo(100 * (1 - 1 / 10), 10);
+    const short = buildTradePreview(
+      "sell",
+      "100",
+      4,
+      "limit",
+      "100",
+      asks,
+      bids,
+      100,
+      null,
+    );
+    expect(short?.liqPrice).toBeCloseTo(100 * (1 + 1 / 4), 10);
+  });
+
+  test("funding preview: pct of notional per 8h; null passes through", () => {
+    const preview = buildTradePreview(
+      "buy",
+      "150",
+      10,
+      "limit",
+      "100",
+      asks,
+      bids,
+      100,
+      0.01,
+    );
+    expect(preview?.fundingPer8hUsd).toBeCloseTo((0.01 / 100) * 150, 12);
+    const noFunding = buildTradePreview(
+      "buy",
+      "150",
+      10,
+      "limit",
+      "100",
+      asks,
+      bids,
+      100,
+      null,
+    );
+    expect(noFunding?.fundingPer8hUsd).toBeNull();
+  });
+});
+
+describe("enrichPosition", () => {
+  test("long: mark uPnL and reconstructed liq below entry", () => {
+    const enriched = enrichPosition(position(), 105, market());
+    expect(enriched.unrealizedPnl).toBe((105 - 100) * 10);
+    // mmr = 0.5/20 = 0.025; liq = (100·10 − 100) / (10 − 0.025·10)
+    expect(enriched.liquidationPrice).toBeCloseTo(900 / 9.75, 10);
+  });
+
+  test("short: mark uPnL sign flips and liq lands above entry", () => {
+    const enriched = enrichPosition(position({ size: -10 }), 95, market());
+    expect(enriched.unrealizedPnl).toBe((95 - 100) * -10);
+    // liq = (100·(−10) − 100) / (−10 − 0.025·10)
+    expect(enriched.liquidationPrice).toBeCloseTo(-1_100 / -10.25, 10);
+    expect(enriched.liquidationPrice ?? 0).toBeGreaterThan(100);
+  });
+
+  test("mmr falls back to 0.005 without a market config or max leverage", () => {
+    const noConfig = enrichPosition(position(), 105, undefined);
+    expect(noConfig.liquidationPrice).toBeCloseTo(900 / 9.95, 10);
+    const nullLev = enrichPosition(
+      position(),
+      105,
+      market({ maxLeverage: null }),
+    );
+    expect(nullLev.liquidationPrice).toBeCloseTo(900 / 9.95, 10);
+  });
+
+  test("null mark keeps the API uPnL and still reconstructs liq", () => {
+    const enriched = enrichPosition(
+      position({ unrealizedPnl: 7 }),
+      null,
+      market(),
+    );
+    expect(enriched.unrealizedPnl).toBe(7);
+    expect(enriched.liquidationPrice).toBeCloseTo(900 / 9.75, 10);
+  });
+
+  test("non-positive liq estimate becomes null (over-collateralized long)", () => {
+    const enriched = enrichPosition(
+      position({ size: 1, marginUsd: 200 }),
+      105,
+      market(),
+    );
+    expect(enriched.liquidationPrice).toBeNull();
+  });
+
+  test("missing entry/margin or flat size keeps the input liq untouched", () => {
+    const noEntry = enrichPosition(
+      position({ entryPrice: null, liquidationPrice: 88 }),
+      105,
+      market(),
+    );
+    expect(noEntry.liquidationPrice).toBe(88);
+    const noMargin = enrichPosition(
+      position({ marginUsd: null, liquidationPrice: 88 }),
+      105,
+      market(),
+    );
+    expect(noMargin.liquidationPrice).toBe(88);
+    const flat = enrichPosition(
+      position({ size: 0, liquidationPrice: 88 }),
+      105,
+      market(),
+    );
+    expect(flat.liquidationPrice).toBe(88);
+  });
+});
+
+describe("riskNotional", () => {
+  test("sizes notional from stop distance", () => {
+    expect(riskNotional(100, 100, 95)).toBeCloseTo((100 * 100) / 5, 10);
+  });
+
+  test("5 bps min-stop guard: too-tight stop returns null, just-wide passes", () => {
+    // entry·0.0005 = 0.05 — a 0.04 stop distance is inside the guard.
+    expect(riskNotional(100, 100, 100.04)).toBeNull();
+    expect(riskNotional(100, 100, 99.94)).toBeCloseTo((100 * 100) / 0.06, 6);
+  });
+
+  test("non-positive inputs return null", () => {
+    expect(riskNotional(0, 100, 95)).toBeNull();
+    expect(riskNotional(-1, 100, 95)).toBeNull();
+    expect(riskNotional(100, 0, 95)).toBeNull();
+    expect(riskNotional(100, 100, 0)).toBeNull();
+  });
+});
+
+describe("liqDistancePct", () => {
+  test("distance as percent of mark, direction-agnostic", () => {
+    expect(liqDistancePct(position({ liquidationPrice: 90 }), 100)).toBe(10);
+    expect(liqDistancePct(position({ liquidationPrice: 110 }), 100)).toBe(10);
+  });
+
+  test("null when mark or liq is unknown, or mark is zero", () => {
+    expect(liqDistancePct(position({ liquidationPrice: 90 }), null)).toBeNull();
+    expect(
+      liqDistancePct(position({ liquidationPrice: null }), 100),
+    ).toBeNull();
+    expect(liqDistancePct(position({ liquidationPrice: 90 }), 0)).toBeNull();
+  });
+});
+
+describe("triggerPriceForPct", () => {
+  test("TP moves with the trade side", () => {
+    expect(triggerPriceForPct(100, "buy", 5, "tp")).toBeCloseTo(105, 10);
+    expect(triggerPriceForPct(100, "sell", 5, "tp")).toBeCloseTo(95, 10);
+  });
+
+  test("SL moves against the trade side", () => {
+    expect(triggerPriceForPct(100, "buy", 5, "sl")).toBeCloseTo(95, 10);
+    expect(triggerPriceForPct(100, "sell", 5, "sl")).toBeCloseTo(105, 10);
+  });
+});
+
+describe("fmtTriggerPrice", () => {
+  test("precision scales with magnitude and stays Number()-parseable", () => {
+    expect(fmtTriggerPrice(1234.56)).toBe("1234.6");
+    expect(fmtTriggerPrice(1000)).toBe("1000.0");
+    expect(fmtTriggerPrice(56.789)).toBe("56.79");
+    expect(fmtTriggerPrice(10)).toBe("10.00");
+    expect(fmtTriggerPrice(5.6789)).toBe("5.679");
+    expect(fmtTriggerPrice(1)).toBe("1.000");
+    expect(fmtTriggerPrice(0.123456)).toBe("0.12346");
+  });
+});
+
+describe("clampLeverage", () => {
+  test("rounds and clamps into [1, 20]", () => {
+    expect(clampLeverage(0)).toBe(1);
+    expect(clampLeverage(25)).toBe(20);
+    expect(clampLeverage(7.4)).toBe(7);
+    expect(clampLeverage(7.5)).toBe(8);
+  });
+});
+
+describe("TP/SL chip presets", () => {
+  test("hold the shipped percentages", () => {
+    expect(TP_CHIP_PCTS).toEqual([2, 5, 10]);
+    expect(SL_CHIP_PCTS).toEqual([1, 2, 5]);
+  });
+});

--- a/apps/portal/src/lib/terminal/trade-math.ts
+++ b/apps/portal/src/lib/terminal/trade-math.ts
@@ -1,0 +1,162 @@
+// Pure money math for the perp ticket and position cards. Everything here
+// is called per tick from the terminal page's `$:` statements — keep flat
+// positional args and zero component state.
+import type { DepthLevel, PhoenixMarketConfig } from "$lib/phoenix-market-data";
+import type { PhoenixPosition } from "$lib/phoenix-trade";
+
+export type TradePreview = {
+  notionalUsd: number;
+  entry: number | null;
+  slippageBps: number | null;
+  liqPrice: number | null;
+  fundingPer8hUsd: number | null;
+  fillable: boolean;
+};
+
+export const TP_CHIP_PCTS = [2, 5, 10];
+export const SL_CHIP_PCTS = [1, 2, 5];
+
+export function buildTradePreview(
+  side: "buy" | "sell",
+  amountStr: string,
+  leverage: number,
+  type: "market" | "limit",
+  limitStr: string,
+  askLevels: DepthLevel[],
+  bidLevels: DepthLevel[],
+  refPrice: number | null,
+  fundingPct: number | null,
+): TradePreview | null {
+  const notionalUsd = Number(amountStr);
+  if (!Number.isFinite(notionalUsd) || notionalUsd <= 0) return null;
+  const levels = side === "buy" ? askLevels : bidLevels;
+  const best = levels[0]?.price ?? refPrice ?? null;
+
+  let entry = best;
+  let slippageBps: number | null = null;
+  let fillable = true;
+
+  if (type === "limit") {
+    const limit = Number(limitStr);
+    if (Number.isFinite(limit) && limit > 0) entry = limit;
+  } else if (levels.length > 0 && best) {
+    let remaining = notionalUsd;
+    let cost = 0;
+    let qty = 0;
+    for (const level of levels) {
+      const levelNotional = level.price * level.size;
+      const take = Math.min(remaining, levelNotional);
+      qty += take / level.price;
+      cost += take;
+      remaining -= take;
+      if (remaining <= 0) break;
+    }
+    fillable = remaining <= 0;
+    const avg = qty > 0 ? cost / qty : best;
+    entry = avg;
+    slippageBps = best > 0 ? Math.abs((avg - best) / best) * 10_000 : null;
+  }
+
+  const liqPrice =
+    entry && leverage > 0
+      ? side === "buy"
+        ? entry * (1 - 1 / leverage)
+        : entry * (1 + 1 / leverage)
+      : null;
+  const fundingPer8hUsd =
+    fundingPct != null ? (fundingPct / 100) * notionalUsd : null;
+
+  return {
+    notionalUsd,
+    entry,
+    slippageBps,
+    liqPrice,
+    fundingPer8hUsd,
+    fillable,
+  };
+}
+
+export function clampLeverage(value: number): number {
+  return Math.max(1, Math.min(20, Math.round(value)));
+}
+
+// Plain Number()-parseable price string, precision scaled to magnitude.
+export function fmtTriggerPrice(value: number): string {
+  if (value >= 1000) return value.toFixed(1);
+  if (value >= 10) return value.toFixed(2);
+  if (value >= 1) return value.toFixed(3);
+  return value.toFixed(5);
+}
+
+// The trader API stopped shipping uPnL/liq per position; reconstruct
+// client-side: uPnL from live mids, liq from the isolated subaccount's
+// margin with an estimated maintenance ratio (half the initial margin at
+// max leverage). Labeled "est." wherever rendered.
+export function enrichPosition(
+  position: PhoenixPosition,
+  mark: number | null,
+  marketConfig: PhoenixMarketConfig | undefined,
+): PhoenixPosition {
+  const entry = position.entryPrice;
+  const upnl =
+    mark !== null && entry !== null
+      ? (mark - entry) * position.size
+      : position.unrealizedPnl;
+  const mmr = marketConfig?.maxLeverage
+    ? 0.5 / marketConfig.maxLeverage
+    : 0.005;
+  const margin = position.marginUsd;
+  let liq: number | null = position.liquidationPrice;
+  if (entry !== null && margin !== null && position.size !== 0) {
+    const denom = position.size - mmr * Math.abs(position.size);
+    if (denom !== 0) {
+      const estimate = (entry * position.size - margin) / denom;
+      liq = Number.isFinite(estimate) && estimate > 0 ? estimate : null;
+    }
+  }
+  return { ...position, unrealizedPnl: upnl, liquidationPrice: liq };
+}
+
+// Risk-based sizing: notional from stop distance, guarded by a 5 bps
+// minimum stop distance so a stop at the entry can't size to infinity.
+export function riskNotional(
+  riskUsd: number,
+  entry: number,
+  stop: number,
+): number | null {
+  return riskUsd > 0 &&
+    stop > 0 &&
+    entry > 0 &&
+    Math.abs(entry - stop) > entry * 0.0005
+    ? (riskUsd * entry) / Math.abs(entry - stop)
+    : null;
+}
+
+export function liqDistancePct(
+  position: PhoenixPosition,
+  mark: number | null,
+): number | null {
+  if (mark === null || position.liquidationPrice === null || mark === 0) {
+    return null;
+  }
+  return (Math.abs(mark - position.liquidationPrice) / mark) * 100;
+}
+
+// Factor core of the TP/SL quick-set chips: TP moves with the trade side,
+// SL against it.
+export function triggerPriceForPct(
+  ref: number,
+  side: "buy" | "sell",
+  pct: number,
+  kind: "tp" | "sl",
+): number {
+  const factor =
+    kind === "tp"
+      ? side === "buy"
+        ? 1 + pct / 100
+        : 1 - pct / 100
+      : side === "buy"
+        ? 1 - pct / 100
+        : 1 + pct / 100;
+  return ref * factor;
+}

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -15,6 +15,11 @@
   } from "$lib/ai";
   import { track } from "$lib/telemetry";
   import {
+    type Alert,
+    headlineMatches,
+    matchAlerts,
+  } from "$lib/terminal/alerts";
+  import {
     aiErr,
     humanizeBalanceError,
     humanizePrivyError,
@@ -77,6 +82,7 @@
     screenSolanaAddress,
     type NewsItem,
   } from "$lib/intel";
+  import { fetchSolanaLamports, solanaRpcUrl } from "$lib/solana-rpc";
   import { swrRead, swrWrite } from "$lib/swr";
   import {
     edgeApiBase,
@@ -147,6 +153,7 @@
     getSpotSwapTransaction,
     spotIntervalFor,
     tokenToAtoms,
+    triggerOrderView,
     usdcToAtoms,
     USDC_MINT as SPOT_USDC_MINT,
     type SpotAsset,
@@ -232,7 +239,6 @@
 
   const UP_COLOR = colors.up;
   const DOWN_COLOR = colors.down; // was #ff5a5f — unified to the token red
-  const SOLANA_MAINNET_RPC = "https://api.mainnet-beta.solana.com";
 
   let selectedSymbol = DEFAULT_PHOENIX_SYMBOL;
   let selectedTimeframe: PhoenixTimeframe = PHOENIX_TIMEFRAME;
@@ -455,14 +461,6 @@
   let screenedAddress = "";
 
   // Alert engine.
-  type Alert = {
-    id: string;
-    symbol: string;
-    op: "above" | "below";
-    price: number;
-    tier: "FLASH" | "PRIORITY" | "ROUTINE";
-    triggered: boolean;
-  };
   let alerts: Alert[] = [];
   let alertsOpen = false;
   let alertOp: "above" | "below" = "above";
@@ -1492,9 +1490,6 @@
   let newsLinked = true;
   $: activeNewsSymbol =
     tradeMode === "spot" ? (spotAsset?.symbol ?? null) : selectedSymbol;
-  function headlineMatches(title: string, symbol: string): boolean {
-    return title.toUpperCase().includes(symbol.toUpperCase());
-  }
   $: linkedNews =
     newsLinked && activeNewsSymbol
       ? news.filter((item) => headlineMatches(item.title, activeNewsSymbol))
@@ -1508,25 +1503,18 @@
     : 0;
 
   function checkAlerts(price: number | null): void {
-    if (price === null || alerts.length === 0) return;
-    let changed = false;
-    for (const alert of alerts) {
-      if (alert.triggered || alert.symbol !== selectedSymbol) continue;
-      const hit =
-        alert.op === "above" ? price >= alert.price : price <= alert.price;
-      if (hit) {
-        alert.triggered = true;
-        changed = true;
-        void fireAlert(
-          `${alert.tier} · ${alert.symbol}-PERP`,
-          `${alert.symbol} ${alert.op} ${alert.price} — now ${formatPrice(price)}`,
-        );
-      }
+    if (price === null) return;
+    const hits = matchAlerts(alerts, price, selectedSymbol);
+    if (!hits) return;
+    for (const alert of hits) {
+      alert.triggered = true;
+      void fireAlert(
+        `${alert.tier} · ${alert.symbol}-PERP`,
+        `${alert.symbol} ${alert.op} ${alert.price} — now ${formatPrice(price)}`,
+      );
     }
-    if (changed) {
-      alerts = [...alerts];
-      saveAlerts();
-    }
+    alerts = [...alerts];
+    saveAlerts();
   }
 
   // Fired alerts become a persistent, timestamped log plus toasts —
@@ -1943,49 +1931,6 @@
 
   // Session state for the selected market from its exchange calendar.
   $: sessionNote = sessionNoteOf(tradeMode, selectedMarket, nowMs);
-
-  async function fetchSolanaLamports(address: string): Promise<string> {
-    const response = await fetch(solanaRpcUrl(), {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: "trader-ralph-wallet-balance",
-        method: "getBalance",
-        // "processed" over the default "finalized": received SOL shows in
-        // about a slot instead of ~12s. Display-only, so the tiny rollback
-        // window is acceptable.
-        params: [address, { commitment: "processed" }],
-      }),
-    });
-    const payload = (await response.json().catch(() => null)) as unknown;
-    if (!response.ok) throw new Error(`solana-rpc-http-${response.status}`);
-    if (!isRecord(payload)) throw new Error("solana-rpc-invalid-response");
-    if (isRecord(payload.error)) {
-      throw new Error(String(payload.error.message ?? "solana-rpc-error"));
-    }
-    const result = isRecord(payload.result) ? payload.result : null;
-    const value = result?.value;
-    if (typeof value === "number" && Number.isFinite(value)) {
-      return Math.max(0, Math.trunc(value)).toString();
-    }
-    if (typeof value === "string" && /^\d+$/.test(value)) return value;
-    throw new Error("solana-balance-missing");
-  }
-
-  function solanaRpcUrl(): string {
-    const env = import.meta.env as Record<string, string | undefined>;
-    const configured = String(
-      env.PUBLIC_SOLANA_RPC_URL ??
-        env.VITE_SOLANA_RPC_URL ??
-        env.NEXT_PUBLIC_SOLANA_RPC_URL ??
-        "",
-    )
-      .trim()
-      .replace(/^"+|"+$/g, "")
-      .replace(/\\n$/, "");
-    return configured || SOLANA_MAINNET_RPC;
-  }
 
   type TransactionSummary = {
     title: string;
@@ -4170,28 +4115,6 @@
     } catch {
       // keep the last list on a read hiccup
     }
-  }
-
-  function triggerOrderView(order: TriggerOrder): {
-    side: "buy" | "sell";
-    symbol: string;
-    notionalUsd: number | null;
-    limitPrice: number | null;
-  } | null {
-    const isBuy = order.inputMint === SPOT_USDC_MINT;
-    const tokenMint = isBuy ? order.outputMint : order.inputMint;
-    const asset = spotAssets.find((candidate) => candidate.mint === tokenMint);
-    if (!asset) return null;
-    const usdAtoms = isBuy ? order.makingAmountAtoms : order.takingAmountAtoms;
-    const tokenAtoms = isBuy ? order.takingAmountAtoms : order.makingAmountAtoms;
-    const usd = usdAtoms / 1e6;
-    const qty = tokenAtoms / 10 ** asset.decimals;
-    return {
-      side: isBuy ? "buy" : "sell",
-      symbol: asset.symbol,
-      notionalUsd: Number.isFinite(usd) && usd > 0 ? usd : null,
-      limitPrice: qty > 0 && usd > 0 ? usd / qty : null,
-    };
   }
 
   async function submitSpotLimitOrder(): Promise<void> {
@@ -6663,7 +6586,7 @@
     {#if triggerOrders.length > 0}
       <div class="venue-section">Open limit orders</div>
       {#each triggerOrders as order (order.orderKey)}
-        {@const view = triggerOrderView(order)}
+        {@const view = triggerOrderView(order, spotAssets)}
         {#if view}
           <div class="venue-row">
             <span class={view.side === "buy" ? "positive" : "negative"}>

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -19,6 +19,8 @@
     headlineMatches,
     matchAlerts,
   } from "$lib/terminal/alerts";
+  import { buildChartLineSpecs } from "$lib/terminal/chart-lines";
+  import { parseTerminalDeepLink } from "$lib/terminal/deep-link";
   import {
     aiErr,
     humanizeBalanceError,
@@ -3796,111 +3798,52 @@
   // overlay (funds > ticket > alerts) opens per link — modals never stack.
   function applyDeepLink(): void {
     if (typeof window === "undefined") return;
-    const params = new URLSearchParams(window.location.search);
-    const KNOWN = [
-      "asset", "venue", "side", "size", "leverage", "type", "price", "tp",
-      "sl", "ticket", "tf", "mode", "fund", "tab", "alerts", "cmd", "watch",
-    ];
-    if (!KNOWN.some((key) => params.has(key))) return;
+    const intent = parseTerminalDeepLink(window.location.search);
+    if (!intent) return;
 
-    const str = (key: string) => params.get(key)?.trim() || null;
-    const lower = (key: string) => str(key)?.toLowerCase() ?? null;
-    // Positive finite number within sane bounds, else null.
-    const numParam = (key: string, max: number): number | null => {
-      const value = Number(str(key));
-      return Number.isFinite(value) && value > 0 && value <= max ? value : null;
-    };
-    const flag = (key: string) => {
-      const value = lower(key);
-      return value !== null && value !== "0" && value !== "false";
-    };
-
-    const asset = str("asset");
-    const venue = lower("venue");
-    const side = lower("side");
-    const isPerp = venue === "perp" || venue === "perps";
-    const wantsSell = side === "sell" || side === "short";
-    const size = numParam("size", 10_000_000);
-    const tab = lower("tab");
-
-    if (isPerp) {
+    if (intent.venue === "perp") {
       pendingTradeMode = null;
-      if (asset) selectedSymbol = asset.toUpperCase().replace(/-PERP$/, "");
-      if (side) tradeSide = wantsSell ? "sell" : "buy";
-      if (size !== null) tradeAmount = String(size);
-
-      const leverage = numParam("leverage", 100);
-      if (leverage !== null) {
-        // Snap to the select's options so the binding displays correctly.
-        const allowed = [1, 2, 5, 10, 20];
-        tradeLeverage = allowed.reduce((best, option) =>
-          Math.abs(option - leverage) < Math.abs(best - leverage) ? option : best,
-        );
-      }
-
-      const limitPrice = numParam("price", 100_000_000);
-      const type = lower("type");
-      if (limitPrice !== null) {
+      if (intent.symbol) selectedSymbol = intent.symbol;
+      if (intent.side) tradeSide = intent.side;
+      if (intent.sizeUsd !== null) tradeAmount = String(intent.sizeUsd);
+      if (intent.leverage !== null) tradeLeverage = intent.leverage;
+      if (intent.limitPrice !== null) {
         tradeType = "limit";
-        tradeLimitPrice = String(limitPrice);
-      } else if (type === "limit" || type === "market") {
-        tradeType = type;
+        tradeLimitPrice = String(intent.limitPrice);
+      } else if (intent.orderType) {
+        tradeType = intent.orderType;
       }
-      const takeProfit = numParam("tp", 100_000_000);
-      const stopLoss = numParam("sl", 100_000_000);
-      if (takeProfit !== null) tradeTakeProfit = String(takeProfit);
-      if (stopLoss !== null) tradeStopLoss = String(stopLoss);
-
-      bookTab = tab === "book" ? "book" : "trade";
-    } else if (asset || venue || side || size !== null) {
-      // Default venue is spot — the broader universe.
+      if (intent.takeProfit !== null) tradeTakeProfit = String(intent.takeProfit);
+      if (intent.stopLoss !== null) tradeStopLoss = String(intent.stopLoss);
+    } else if (intent.venue === "spot") {
       pendingTradeMode = "spot";
-      if (asset) pendingSpotAssetId = asset.toLowerCase();
-      if (side) spotSide = wantsSell ? "sell" : "buy";
-      if (size !== null) spotAmount = String(size);
-      const spotLimit = numParam("price", 100_000_000);
-      if (spotLimit !== null) {
+      if (intent.spotAssetId) pendingSpotAssetId = intent.spotAssetId;
+      if (intent.side) spotSide = intent.side;
+      if (intent.sizeUsd !== null) spotAmount = String(intent.sizeUsd);
+      if (intent.limitPrice !== null) {
         spotOrderType = "limit";
-        spotLimitPrice = String(spotLimit);
+        spotLimitPrice = String(intent.limitPrice);
       }
-      if (asset || side || size !== null) bookTab = tab === "book" ? "book" : "trade";
     }
-    if (tab === "book" || tab === "trade") bookTab = tab;
-
-    const tf = lower("tf");
-    if (PHOENIX_TIMEFRAMES.includes(tf as PhoenixTimeframe)) {
-      selectedTimeframe = tf as PhoenixTimeframe;
+    if (intent.bookTab) bookTab = intent.bookTab;
+    if (intent.timeframe) selectedTimeframe = intent.timeframe;
+    if (intent.priceMode) priceMode = intent.priceMode;
+    if (intent.watchSymbols.length > 0) {
+      watchlist = [...new Set([...watchlist, ...intent.watchSymbols])].slice(0, 24);
     }
-    const mode = lower("mode");
-    if (mode === "last" || mode === "mark") priceMode = mode;
-
-    const watch = str("watch");
-    if (watch) {
-      const symbols = watch
-        .split(",")
-        .map((sym) => sym.trim().toUpperCase())
-        .filter((sym) => /^[A-Z0-9]{1,12}$/.test(sym));
-      watchlist = [...new Set([...watchlist, ...symbols])].slice(0, 24);
-    }
-
-    const cmd = str("cmd");
-    if (cmd) {
-      bookTab = "trade";
-      void runCommand(cmd.slice(0, 200)); // parses straight into the ticket
-    }
+    if (intent.cmd) void runCommand(intent.cmd.slice(0, 200)); // parses straight into the ticket
 
     // Overlays — at most one (funds > ticket > alerts), modals never stack.
-    const fund = lower("fund");
-    if (fund) {
+    if (intent.overlay?.kind === "funds") {
       openFunds();
-      if (fund === "convert" || fund === "phoenix") fundsTab = fund;
-    } else if (flag("ticket") && isPerp) {
+      if (intent.overlay.tab) fundsTab = intent.overlay.tab;
+    } else if (intent.overlay?.kind === "ticket") {
       phoenixActionError = "";
       phoenixActionErrorDetail = "";
       phoenixActionRetry = null;
       lastTradeSignature = "";
       tradeOpen = true;
-    } else if (flag("alerts")) {
+    } else if (intent.overlay?.kind === "alerts") {
       alertsOpen = true;
     }
 
@@ -3947,86 +3890,15 @@
     if (!series) return;
     for (const line of liqLines) series.removePriceLine(line);
     liqLines = [];
-    if (mode !== "perps") return;
-    const add = (options: Parameters<typeof series.createPriceLine>[0]) =>
-      liqLines.push(series.createPriceLine(options));
-
-    for (const position of positions) {
-      if (position.symbol !== symbol) continue;
-      const side = position.size > 0 ? "LONG" : "SHORT";
-      const sideColor = position.size > 0 ? colors.up : colors.down;
-      if (prefs.pos && position.entryPrice !== null) {
-        const upnl =
-          position.unrealizedPnl !== null
-            ? ` · ${position.unrealizedPnl >= 0 ? "+" : "-"}$${formatNumber(Math.abs(position.unrealizedPnl), 2)}`
-            : "";
-        add({
-          price: position.entryPrice,
-          color: sideColor,
-          lineWidth: 2,
-          lineStyle: 0, // solid
-          axisLabelVisible: true,
-          title: `${side} ${formatNumber(Math.abs(position.size), 4)} @ ${formatPrice(position.entryPrice)}${upnl}`,
-        });
-      }
-      if (prefs.pos && position.liquidationPrice !== null) {
-        add({
-          price: position.liquidationPrice,
-          color: colors.down,
-          lineWidth: 1,
-          lineStyle: 2, // dashed
-          axisLabelVisible: true,
-          title: "LIQ est",
-        });
-      }
-      if (prefs.tpsl && position.takeProfitPrice !== null && position.entryPrice !== null) {
-        const gain = Math.abs(position.takeProfitPrice - position.entryPrice) * Math.abs(position.size);
-        add({
-          price: position.takeProfitPrice,
-          color: colors.up,
-          lineWidth: 1,
-          lineStyle: 2,
-          axisLabelVisible: true,
-          title: `TP · +$${formatNumber(gain, 2)}`,
-        });
-      }
-      if (prefs.tpsl && position.stopLossPrice !== null && position.entryPrice !== null) {
-        const loss = Math.abs(position.stopLossPrice - position.entryPrice) * Math.abs(position.size);
-        add({
-          price: position.stopLossPrice,
-          color: colors.down,
-          lineWidth: 1,
-          lineStyle: 2,
-          axisLabelVisible: true,
-          title: `SL · -$${formatNumber(loss, 2)}`,
-        });
-      }
-    }
-    if (prefs.orders) {
-      for (const order of orders) {
-        if (order.symbol !== symbol || order.price === null) continue;
-        add({
-          price: order.price,
-          color: colors.amber,
-          lineWidth: 1,
-          lineStyle: 1, // dotted
-          axisLabelVisible: true,
-          title: `${order.side === "bid" ? "BID" : "ASK"} ${order.remaining !== null ? formatNumber(order.remaining, 4) : ""}`.trim(),
-        });
-      }
-    }
-    if (prefs.alerts) {
-      for (const alert of armed) {
-        if (alert.symbol !== symbol || alert.triggered) continue;
-        add({
-          price: alert.price,
-          color: colors.accent,
-          lineWidth: 1,
-          lineStyle: 1,
-          axisLabelVisible: true,
-          title: `ALERT ${alert.op === "above" ? "↑" : "↓"}`,
-        });
-      }
+    for (const spec of buildChartLineSpecs(
+      positions,
+      orders,
+      armed,
+      prefs,
+      symbol,
+      mode,
+    )) {
+      liqLines.push(series.createPriceLine(spec));
     }
   }
 

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -33,6 +33,34 @@
     maxBookNotional,
   } from "$lib/terminal/book";
   import {
+    ALERT_LOG_KEY,
+    ALERTS_STORAGE_KEY,
+    CACHE_MARKETS,
+    CACHE_MAX_AGE,
+    CACHE_NEWS,
+    CACHE_PANELS,
+    CACHE_READS,
+    DEFAULT_PANEL_ORDER,
+    LAYOUT_STORAGE_KEY,
+    MARKETS_MAX_AGE,
+    mergeLayout,
+    ONBOARD_KEY,
+    parsePrefs,
+    persistPrefs,
+    PREFS_STORAGE_KEY,
+    SECTION_LINKS,
+  } from "$lib/terminal/prefs";
+  import {
+    buildMonitorRows,
+    buildScreenRows,
+    buildWatchRows,
+    disconnectedPanel,
+    disconnectedRows,
+    emptyMarketStats,
+    selectedMarketTableRows,
+    summarizeEdgeStatus,
+  } from "$lib/terminal/panels";
+  import {
     chartLinePrefs,
     equityBaselines,
     equityHistory,
@@ -250,21 +278,7 @@
   }
 
   let monitorSort: "volume" | "change" | "symbol" = "volume";
-  $: monitorRows = markets
-    .map((config) => ({
-      symbol: config.symbol,
-      lev: config.maxLeverage,
-      mid: marketMids[config.symbol] ?? dailyStats[config.symbol]?.lastPrice ?? null,
-      change: dailyStats[config.symbol]?.change24hPct ?? null,
-      volume: dailyStats[config.symbol]?.volume24hUsd ?? null,
-    }))
-    .sort((a, b) =>
-      monitorSort === "symbol"
-        ? a.symbol.localeCompare(b.symbol)
-        : monitorSort === "change"
-          ? (b.change ?? -1e9) - (a.change ?? -1e9)
-          : (b.volume ?? -1) - (a.volume ?? -1),
-    );
+  $: monitorRows = buildMonitorRows(markets, marketMids, dailyStats, monitorSort);
 
   function chooseMonitorRow(symbol: string): void {
     if (tradeMode !== "perps") setTradeMode("perps", false);
@@ -456,39 +470,12 @@
   let alertTier: Alert["tier"] = "PRIORITY";
   let notifyReady = false;
 
-  // Draggable dashboard: reorderable info panels (chart + book stay anchored).
-  const DEFAULT_PANEL_ORDER = [
-    "watch",
-    "markets",
-    "perp",
-    "spot",
-    "screener",
-    "macro",
-    "fred",
-    "etf",
-    "stablecoins",
-    "oil",
-    "events",
-    "ideas",
-    "markets",
-    "journal",
-  ];
   let panelOrder: string[] = [...DEFAULT_PANEL_ORDER];
   let draggedPanel: string | null = null;
   let dragOverPanel: string | null = null;
 
-  const PREFS_STORAGE_KEY = "trader-ralph-terminal/prefs/v1";
-  const ALERTS_STORAGE_KEY = "trader-ralph-terminal/alerts/v1";
-  const LAYOUT_STORAGE_KEY = "trader-ralph-terminal/layout/v1";
   const OPEN_BETA_BANNER_STORAGE_KEY =
     "trader-ralph-terminal/open-beta-banner/v1";
-  // Stale-while-revalidate widget caches (instant paint on reload).
-  const CACHE_PANELS = "trader-ralph-terminal/cache/panels/v1";
-  const CACHE_NEWS = "trader-ralph-terminal/cache/news/v1";
-  const CACHE_MARKETS = "trader-ralph-terminal/cache/markets/v1";
-  const CACHE_READS = "trader-ralph-terminal/cache/reads/v1";
-  const CACHE_MAX_AGE = 30 * 60_000;
-  const MARKETS_MAX_AGE = 24 * 60 * 60_000;
   let showOpenBetaBanner = false;
 
   $: selectedMarket = markets.find((market) => market.symbol === selectedSymbol) ?? null;
@@ -972,19 +959,7 @@
       : null;
 
   // ── Watchlist rows: price from spot, fall back to perp mid; basis when both ──
-  $: watchRows = watchlist.map((sym) => {
-    const spot = spotAssets.find((asset) => asset.symbol.toUpperCase() === sym) ?? null;
-    const mid = marketMids[sym] ?? null;
-    const hasPerp = mid !== null || markets.some((market) => market.symbol === sym);
-    return {
-      sym,
-      spot,
-      hasPerp,
-      price: spot?.price ?? mid,
-      change: spot?.change24hPct ?? null,
-      basisBps: spot?.price && mid ? ((mid - spot.price) / spot.price) * 10_000 : null,
-    };
-  });
+  $: watchRows = buildWatchRows(watchlist, spotAssets, marketMids, markets);
 
   // ── Account exposure / leverage (margin meter, deterministic) ──
   $: accountExposureUsd = (phoenixTrader?.positions ?? []).reduce(
@@ -1014,16 +989,7 @@
       : tradeAmount;
 
   // ── Screener rows over the catalog ──
-  $: screenRows = [...spotAssets]
-    .filter((asset) => screenHub === "all" || asset.hub === screenHub)
-    .sort((a, b) =>
-      screenSort === "movers"
-        ? Math.abs(b.change24hPct ?? 0) - Math.abs(a.change24hPct ?? 0)
-        : screenSort === "cap"
-          ? (b.marketCap ?? 0) - (a.marketCap ?? 0)
-          : (b.volume24hUsd ?? 0) - (a.volume24hUsd ?? 0),
-    )
-    .slice(0, 20);
+  $: screenRows = buildScreenRows(spotAssets, screenHub, screenSort);
 
   // ── Journal-derived views + AI notes (facts computed, AI narrates) ──
   $: journalToday = entriesToday(journalEntries, Date.now());
@@ -1566,7 +1532,6 @@
   // Fired alerts become a persistent, timestamped log plus toasts —
   // Bloomberg's message-pane pattern in miniature.
   type FiredAlert = { ts: number; title: string; body: string };
-  const ALERT_LOG_KEY = "trader-ralph-alert-log";
   let alertLog: FiredAlert[] = [];
   let toasts: (FiredAlert & { toastId: number })[] = [];
   let toastSeq = 0;
@@ -1631,13 +1596,7 @@
     try {
       const raw = window.localStorage.getItem(LAYOUT_STORAGE_KEY);
       if (!raw) return;
-      const saved = JSON.parse(raw);
-      if (!Array.isArray(saved)) return;
-      const known = saved.filter(
-        (id): id is string => typeof id === "string" && DEFAULT_PANEL_ORDER.includes(id),
-      );
-      const missing = DEFAULT_PANEL_ORDER.filter((id) => !known.includes(id));
-      panelOrder = [...known, ...missing];
+      panelOrder = mergeLayout(JSON.parse(raw), DEFAULT_PANEL_ORDER);
     } catch {
       // ignore malformed layout
     }
@@ -2523,7 +2482,6 @@
   }
 
   // ── Phoenix onboarding ────────────────────────────────────────────
-  const ONBOARD_KEY = "trader-ralph-terminal/phx-referral/v2";
 
   async function ensurePhoenixOnboarding(authority: string): Promise<void> {
     if (!authority || onboardedAddress === authority) return;
@@ -3477,30 +3435,6 @@
     }
   }
 
-  function disconnectedRows(reason: string): SignalRow[] {
-    return [
-      {
-        label: "Status",
-        value: "Not connected",
-        status: reason,
-      },
-    ];
-  }
-
-  function disconnectedPanel(reason: string): DataPanel {
-    return {
-      rows: disconnectedRows(reason),
-      status: "not connected",
-      source: "",
-    };
-  }
-
-  function summarizeEdgeStatus(panels: DataPanel[]): string {
-    if (panels.some((panel) => panel.status === "ready")) return "ready";
-    const first = panels.find((panel) => panel.status !== "ready");
-    return first?.status ?? "not connected";
-  }
-
   function setPriceMode(mode: "last" | "mark"): void {
     if (priceMode === mode) return;
     priceMode = mode;
@@ -3758,61 +3692,6 @@
     const current = timeScale.options().barSpacing ?? 6;
     const next = direction === "in" ? current * 1.3 : current / 1.3;
     timeScale.applyOptions({ barSpacing: Math.max(2, Math.min(48, next)) });
-  }
-
-  function selectedMarketTableRows(
-    market: PhoenixMarketConfig | null,
-    stats: PhoenixMarketStats | null,
-    price: number | null,
-  ): SignalRow[] {
-    if (!market) {
-      return disconnectedRows("Phoenix market metadata loading");
-    }
-    return [
-      {
-        label: "Market",
-        value: `${market.symbol}-PERP`,
-        status: market.marketStatus,
-      },
-      {
-        label: "Mark",
-        value: formatPrice(stats?.markPx ?? price),
-        status: `oracle ${formatPrice(stats?.oraclePx)}`,
-      },
-      {
-        label: "Open interest",
-        value: formatNumber(stats?.openInterest, 2),
-        status: "base",
-      },
-      {
-        label: "Funding",
-        value: formatPercent((stats?.funding ?? 0) * 100),
-        status: "rate",
-      },
-      {
-        label: "Fees",
-        value: `${formatPercent((market.makerFee ?? 0) * 100)} / ${formatPercent((market.takerFee ?? 0) * 100)}`,
-        status: "maker/taker",
-      },
-      {
-        label: "Margin",
-        value: market.isolatedOnly ? "isolated only" : "cross + isolated",
-        status: market.maxLeverage ? `${formatNumber(market.maxLeverage, 0)}x max` : "--",
-      },
-    ];
-  }
-
-  function emptyMarketStats(symbol: string): PhoenixMarketStats {
-    return {
-      symbol,
-      dayNtlVlm: null,
-      prevDayPx: null,
-      markPx: null,
-      midPx: null,
-      funding: null,
-      openInterest: null,
-      oraclePx: null,
-    };
   }
 
   function openPhoenixFunding(): void {
@@ -4402,57 +4281,30 @@
 
   function loadPrefs(): void {
     if (typeof window === "undefined") return;
+    let raw: string | null = null;
     try {
-      const raw = window.localStorage.getItem(PREFS_STORAGE_KEY);
-      if (!raw) return;
-      const data = JSON.parse(raw) as Record<string, unknown>;
-      if (typeof data.symbol === "string") selectedSymbol = data.symbol;
-      if (PHOENIX_TIMEFRAMES.includes(data.timeframe as PhoenixTimeframe)) {
-        selectedTimeframe = data.timeframe as PhoenixTimeframe;
-      }
-      if (data.priceMode === "last" || data.priceMode === "mark") {
-        priceMode = data.priceMode;
-      }
-      if (data.chartScale === "price" || data.chartScale === "percent") {
-        chartScale = data.chartScale;
-      }
-      if (data.chartAxisMode === "linear" || data.chartAxisMode === "log") {
-        chartAxisMode = data.chartAxisMode;
-      }
-      if (typeof data.visibleCandleCount === "number" && Number.isFinite(data.visibleCandleCount)) {
-        visibleCandleCount = data.visibleCandleCount;
-      }
-      if (data.tradeMode === "spot") pendingTradeMode = "spot";
-      if (typeof data.spotAssetId === "string") pendingSpotAssetId = data.spotAssetId;
-      if (Array.isArray(data.watchlist)) {
-        watchlist = data.watchlist
-          .filter((sym): sym is string => typeof sym === "string")
-          .map((sym) => sym.toUpperCase())
-          .slice(0, 24);
-      }
-      if (data.screenSort === "movers" || data.screenSort === "volume" || data.screenSort === "cap") {
-        screenSort = data.screenSort;
-      }
-      if (
-        data.screenHub === "all" || data.screenHub === "crypto" ||
-        data.screenHub === "equities" || data.screenHub === "pre-ipo"
-      ) {
-        screenHub = data.screenHub;
-      }
-      if (data.sizingMode === "usd" || data.sizingMode === "risk") {
-        sizingMode = data.sizingMode;
-      }
-      if (typeof data.tradeAmount === "string") tradeAmount = data.tradeAmount;
-      if (typeof data.tradeRiskUsd === "string") tradeRiskUsd = data.tradeRiskUsd;
-      if (
-        typeof data.tradeLeverage === "number" &&
-        [1, 2, 5, 10, 20].includes(data.tradeLeverage)
-      ) {
-        tradeLeverage = data.tradeLeverage;
-      }
+      raw = window.localStorage.getItem(PREFS_STORAGE_KEY);
     } catch {
-      // ignore malformed persisted preferences
+      return; // storage unavailable — keep defaults
     }
+    const prefs = parsePrefs(raw);
+    if (prefs.symbol !== undefined) selectedSymbol = prefs.symbol;
+    if (prefs.timeframe !== undefined) selectedTimeframe = prefs.timeframe;
+    if (prefs.priceMode !== undefined) priceMode = prefs.priceMode;
+    if (prefs.chartScale !== undefined) chartScale = prefs.chartScale;
+    if (prefs.chartAxisMode !== undefined) chartAxisMode = prefs.chartAxisMode;
+    if (prefs.visibleCandleCount !== undefined) {
+      visibleCandleCount = prefs.visibleCandleCount;
+    }
+    if (prefs.tradeMode === "spot") pendingTradeMode = "spot";
+    if (prefs.spotAssetId !== undefined) pendingSpotAssetId = prefs.spotAssetId;
+    if (prefs.watchlist !== undefined) watchlist = prefs.watchlist;
+    if (prefs.screenSort !== undefined) screenSort = prefs.screenSort;
+    if (prefs.screenHub !== undefined) screenHub = prefs.screenHub;
+    if (prefs.sizingMode !== undefined) sizingMode = prefs.sizingMode;
+    if (prefs.tradeAmount !== undefined) tradeAmount = prefs.tradeAmount;
+    if (prefs.tradeRiskUsd !== undefined) tradeRiskUsd = prefs.tradeRiskUsd;
+    if (prefs.tradeLeverage !== undefined) tradeLeverage = prefs.tradeLeverage;
   }
 
   function loadOpenBetaBanner(): void {
@@ -4478,58 +4330,6 @@
       // storage unavailable — banner is still hidden for this session
     }
   }
-
-  function persistPrefs(
-    _symbol: string,
-    _timeframe: PhoenixTimeframe,
-    _priceMode: "last" | "mark",
-    _scale: ChartScale,
-    _axis: ChartAxisMode,
-    _visible: number,
-    _tradeMode: "perps" | "spot",
-    _spotAssetId: string | null,
-    _watchlist: string[],
-    _screenSort: string,
-    _screenHub: string,
-    _sizingMode: string,
-    _tradeAmount: string,
-    _tradeRiskUsd: string,
-    _tradeLeverage: number,
-  ): void {
-    if (typeof window === "undefined") return;
-    try {
-      window.localStorage.setItem(
-        PREFS_STORAGE_KEY,
-        JSON.stringify({
-          symbol: _symbol,
-          timeframe: _timeframe,
-          priceMode: _priceMode,
-          chartScale: _scale,
-          chartAxisMode: _axis,
-          visibleCandleCount: _visible,
-          tradeMode: _tradeMode,
-          spotAssetId: _spotAssetId,
-          watchlist: _watchlist,
-          screenSort: _screenSort,
-          screenHub: _screenHub,
-          sizingMode: _sizingMode,
-          tradeAmount: _tradeAmount,
-          tradeRiskUsd: _tradeRiskUsd,
-          tradeLeverage: _tradeLeverage,
-        }),
-      );
-    } catch {
-      // storage may be unavailable (private mode, quota) — non-fatal
-    }
-  }
-
-  const SECTION_LINKS: { id: string; label: string }[] = [
-    { id: "section-chart", label: "Chart" },
-    { id: "section-book", label: "Book" },
-    { id: "section-perp", label: "Perp" },
-    { id: "section-markets", label: "Markets" },
-    { id: "section-macro", label: "Macro" },
-  ];
 
   function scrollToSection(id: string): void {
     activeSection = id;

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -15,6 +15,24 @@
   } from "$lib/ai";
   import { track } from "$lib/telemetry";
   import {
+    aiErr,
+    humanizeBalanceError,
+    humanizePrivyError,
+    shortAddress,
+    shortEmail,
+    walletFundsLabel,
+    walletStatusText,
+  } from "$lib/terminal/account-format";
+  import {
+    BOOK_LADDER_LEVELS,
+    BOOK_LADDER_LEVELS_STACKED,
+    bookLevelNotional,
+    bookLevelTotalNotional,
+    depthWidth,
+    formatBookPrice,
+    maxBookNotional,
+  } from "$lib/terminal/book";
+  import {
     chartLinePrefs,
     equityBaselines,
     equityHistory,
@@ -138,6 +156,33 @@
     isRecord,
   } from "$lib/utils";
   import {
+    buildTradePreview,
+    clampLeverage,
+    enrichPosition,
+    fmtTriggerPrice,
+    liqDistancePct,
+    riskNotional,
+    SL_CHIP_PCTS,
+    TP_CHIP_PCTS,
+    triggerPriceForPct,
+  } from "$lib/terminal/trade-math";
+  import {
+    computeMarketChange,
+    DEFAULT_VISIBLE_CANDLES,
+    formatCandleCountdown,
+    formatChartRange,
+    MAX_VISIBLE_CANDLES,
+    sessionNote as sessionNoteOf,
+    toCandle,
+    toVolume,
+  } from "$lib/terminal/chart-format";
+  import {
+    buildPaletteRows,
+    PALETTE_TABS,
+    type PaletteRow,
+    type PaletteTab,
+  } from "$lib/terminal/palette";
+  import {
     CandlestickSeries,
     ColorType,
     createChart,
@@ -156,21 +201,7 @@
   type SignalRow = DataRow;
   type ChartScale = "price" | "percent";
   type ChartAxisMode = "linear" | "log";
-  type TradePreview = {
-    notionalUsd: number;
-    entry: number | null;
-    slippageBps: number | null;
-    liqPrice: number | null;
-    fundingPer8hUsd: number | null;
-    fillable: boolean;
-  };
 
-  const DEFAULT_VISIBLE_CANDLES = 150;
-  const MAX_VISIBLE_CANDLES = 180;
-  const BOOK_LADDER_LEVELS = 10;
-  // Stacked desktop shares the panel with the ticket — cap the ladder so
-  // both stay readable; the narrow-viewport tabs keep the full depth.
-  const BOOK_LADDER_LEVELS_STACKED = 8;
   const UP_COLOR = colors.up;
   const DOWN_COLOR = colors.down; // was #ff5a5f — unified to the token red
   const SOLANA_MAINNET_RPC = "https://api.mainnet-beta.solana.com";
@@ -530,11 +561,7 @@
     : BOOK_LADDER_LEVELS;
   $: visibleAskLevels = asks.slice(0, ladderLevelCap).reverse();
   $: visibleBidLevels = bids.slice(0, ladderLevelCap);
-  $: bookMaxNotional = Math.max(
-    1,
-    ...visibleAskLevels.map(bookLevelTotalNotional),
-    ...visibleBidLevels.map(bookLevelTotalNotional),
-  );
+  $: bookMaxNotional = maxBookNotional(visibleAskLevels, visibleBidLevels);
   $: chartPrice =
     priceMode === "mark" ? marketStats?.markPx ?? latestPrice : latestPrice;
   // The chart surface is owned by exactly one mode; all derived UI follows it.
@@ -635,28 +662,14 @@
   // client-side: uPnL from live mids, liq from the isolated subaccount's
   // margin with an estimated maintenance ratio (half the initial margin at
   // max leverage). Labeled "est." wherever rendered.
-  $: enrichedPositions = (phoenixTrader?.positions ?? []).map((position) => {
-    const mark =
+  $: enrichedPositions = (phoenixTrader?.positions ?? []).map((position) =>
+    enrichPosition(
+      position,
       marketMids[position.symbol] ??
-      (position.symbol === selectedSymbol ? latestPrice : null);
-    const entry = position.entryPrice;
-    const upnl =
-      mark !== null && entry !== null
-        ? (mark - entry) * position.size
-        : position.unrealizedPnl;
-    const config = markets.find((m) => m.symbol === position.symbol);
-    const mmr = config?.maxLeverage ? 0.5 / config.maxLeverage : 0.005;
-    const margin = position.marginUsd;
-    let liq: number | null = position.liquidationPrice;
-    if (entry !== null && margin !== null && position.size !== 0) {
-      const denom = position.size - mmr * Math.abs(position.size);
-      if (denom !== 0) {
-        const estimate = (entry * position.size - margin) / denom;
-        liq = Number.isFinite(estimate) && estimate > 0 ? estimate : null;
-      }
-    }
-    return { ...position, unrealizedPnl: upnl, liquidationPrice: liq };
-  });
+        (position.symbol === selectedSymbol ? latestPrice : null),
+      markets.find((m) => m.symbol === position.symbol),
+    ),
+  );
   $: accountUpnlUsd = enrichedPositions.reduce(
     (sum, position) => sum + (position.unrealizedPnl ?? 0),
     0,
@@ -704,13 +717,11 @@
   }
 
   function liqDistancePctOf(position: PhoenixPosition): number | null {
-    const mark =
+    return liqDistancePct(
+      position,
       marketMids[position.symbol] ??
-      (position.symbol === selectedSymbol ? latestPrice : null);
-    if (mark === null || position.liquidationPrice === null || mark === 0) {
-      return null;
-    }
-    return (Math.abs(mark - position.liquidationPrice) / mark) * 100;
+        (position.symbol === selectedSymbol ? latestPrice : null),
+    );
   }
 
   $: selectedPosition =
@@ -731,8 +742,6 @@
   // submit validation uses; the inputs stay the source of truth so precise
   // hand-entry still works. Wrong-side values are flagged as you type
   // instead of failing at submit.
-  const TP_CHIP_PCTS = [2, 5, 10];
-  const SL_CHIP_PCTS = [1, 2, 5];
   $: triggerRefPrice =
     tradeType === "limit" && Number(tradeLimitPrice) > 0
       ? Number(tradeLimitPrice)
@@ -774,24 +783,18 @@
   $: orderBusy = phoenixBusyKeys.has(orderBusyKey);
   $: orderStageEntry = txStages[orderBusyKey] ?? null;
 
-  // Plain Number()-parseable price string, precision scaled to magnitude.
-  function fmtTriggerPrice(value: number): string {
-    if (value >= 1000) return value.toFixed(1);
-    if (value >= 10) return value.toFixed(2);
-    if (value >= 1) return value.toFixed(3);
-    return value.toFixed(5);
-  }
-
   function setTakeProfitPct(pct: number): void {
     if (!triggerRefPrice) return;
-    const factor = tradeSide === "buy" ? 1 + pct / 100 : 1 - pct / 100;
-    tradeTakeProfit = fmtTriggerPrice(triggerRefPrice * factor);
+    tradeTakeProfit = fmtTriggerPrice(
+      triggerPriceForPct(triggerRefPrice, tradeSide, pct, "tp"),
+    );
   }
 
   function setStopLossPct(pct: number): void {
     if (!triggerRefPrice) return;
-    const factor = tradeSide === "buy" ? 1 - pct / 100 : 1 + pct / 100;
-    tradeStopLoss = fmtTriggerPrice(triggerRefPrice * factor);
+    tradeStopLoss = fmtTriggerPrice(
+      triggerPriceForPct(triggerRefPrice, tradeSide, pct, "sl"),
+    );
   }
 
   // ── Size presets ───────────────────────────────────────────────────
@@ -1000,12 +1003,8 @@
       : (latestPrice ?? 0);
   $: riskStopPrice = Number(tradeStopLoss);
   $: riskNotionalUsd =
-    sizingMode === "risk" &&
-    Number(tradeRiskUsd) > 0 &&
-    riskStopPrice > 0 &&
-    riskEntryPrice > 0 &&
-    Math.abs(riskEntryPrice - riskStopPrice) > riskEntryPrice * 0.0005
-      ? (Number(tradeRiskUsd) * riskEntryPrice) / Math.abs(riskEntryPrice - riskStopPrice)
+    sizingMode === "risk"
+      ? riskNotional(Number(tradeRiskUsd), riskEntryPrice, riskStopPrice)
       : null;
   $: effectiveTradeAmount =
     sizingMode === "risk"
@@ -1801,12 +1800,6 @@
   $: layoutCustomized =
     panelOrder.join(",") !== DEFAULT_PANEL_ORDER.join(",");
 
-  function aiErr(error: unknown): string {
-    const message = error instanceof Error ? error.message : "ai-error";
-    if (message === "ai-proxy-unavailable") return "AI offline (dev proxy only)";
-    return message;
-  }
-
   async function runMacroRead(): Promise<void> {
     const meaningful = macroPanel.rows.filter(
       (row) => row.value && row.value !== "--" && row.value !== "Not connected",
@@ -1865,59 +1858,6 @@
     }
   }
 
-  function buildTradePreview(
-    side: "buy" | "sell",
-    amountStr: string,
-    leverage: number,
-    type: "market" | "limit",
-    limitStr: string,
-    askLevels: DepthLevel[],
-    bidLevels: DepthLevel[],
-    refPrice: number | null,
-    fundingPct: number | null,
-  ): TradePreview | null {
-    const notionalUsd = Number(amountStr);
-    if (!Number.isFinite(notionalUsd) || notionalUsd <= 0) return null;
-    const levels = side === "buy" ? askLevels : bidLevels;
-    const best = levels[0]?.price ?? refPrice ?? null;
-
-    let entry = best;
-    let slippageBps: number | null = null;
-    let fillable = true;
-
-    if (type === "limit") {
-      const limit = Number(limitStr);
-      if (Number.isFinite(limit) && limit > 0) entry = limit;
-    } else if (levels.length > 0 && best) {
-      let remaining = notionalUsd;
-      let cost = 0;
-      let qty = 0;
-      for (const level of levels) {
-        const levelNotional = level.price * level.size;
-        const take = Math.min(remaining, levelNotional);
-        qty += take / level.price;
-        cost += take;
-        remaining -= take;
-        if (remaining <= 0) break;
-      }
-      fillable = remaining <= 0;
-      const avg = qty > 0 ? cost / qty : best;
-      entry = avg;
-      slippageBps = best > 0 ? Math.abs((avg - best) / best) * 10_000 : null;
-    }
-
-    const liqPrice =
-      entry && leverage > 0
-        ? side === "buy"
-          ? entry * (1 - 1 / leverage)
-          : entry * (1 + 1 / leverage)
-        : null;
-    const fundingPer8hUsd =
-      fundingPct != null ? (fundingPct / 100) * notionalUsd : null;
-
-    return { notionalUsd, entry, slippageBps, liqPrice, fundingPer8hUsd, fillable };
-  }
-
   // Headless command parse — the visible "Parse" field is gone, but the
   // ?cmd= deep link (distribution surface contract) still lands orders by
   // filling the ticket. Failures fall back to the default ticket silently.
@@ -1954,10 +1894,6 @@
     }
   }
 
-  function clampLeverage(value: number): number {
-    return Math.max(1, Math.min(20, Math.round(value)));
-  }
-
   async function activePrivyAccessToken(): Promise<string | null> {
     if (!$privyAuth.authenticated) return $privyAuth.accessToken;
     try {
@@ -1965,24 +1901,6 @@
     } catch {
       return $privyAuth.accessToken;
     }
-  }
-
-  function walletFundsLabel(
-    auth: PrivyAuthState,
-    balanceStatus: "idle" | "loading" | "ready" | "error",
-    fundsText: string,
-  ): string {
-    if (!auth.authenticated) {
-      if (!auth.configured) return "Auth unconfigured";
-      if (!auth.ready) return "Privy loading";
-      return "Account not connected";
-    }
-    if (auth.walletStatus === "creating") return "Creating wallet";
-    if (auth.walletStatus === "error") return "Wallet unavailable";
-    if (!auth.walletAddress) return "Wallet pending";
-    if (balanceStatus === "loading") return "Loading funds";
-    if (balanceStatus === "error") return "Balance unavailable";
-    return fundsText;
   }
 
   async function refreshWalletBalance(
@@ -2065,29 +1983,7 @@
   }
 
   // Session state for the selected market from its exchange calendar.
-  $: sessionNote = (() => {
-    if (tradeMode === "spot") return "24/7 · Jupiter";
-    const next = selectedMarket?.nextTransitionUtc;
-    if (!next) return "24/7";
-    const ms = Date.parse(next) - nowMs;
-    if (!Number.isFinite(ms)) return "24/7";
-    const hours = Math.floor(Math.abs(ms) / 3_600_000);
-    const minutes = Math.floor((Math.abs(ms) % 3_600_000) / 60_000);
-    const span = hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
-    if (ms <= 0) return "session transition due";
-    return selectedMarket?.marketStatus === "active"
-      ? `closes ${span}`
-      : `opens ${span}`;
-  })();
-
-  function humanizeBalanceError(raw: string): string {
-    if (/-40[13]$/.test(raw) || /forbidden/i.test(raw)) {
-      return "RPC blocked the request. Set PUBLIC_SOLANA_RPC_URL to a browser-accessible endpoint.";
-    }
-    if (/-429$/.test(raw)) return "RPC rate-limited. Set a dedicated PUBLIC_SOLANA_RPC_URL.";
-    if (/^solana-rpc-http-/.test(raw)) return "RPC request failed. Check PUBLIC_SOLANA_RPC_URL.";
-    return raw;
-  }
+  $: sessionNote = sessionNoteOf(tradeMode, selectedMarket, nowMs);
 
   async function fetchSolanaLamports(address: string): Promise<string> {
     const response = await fetch(solanaRpcUrl(), {
@@ -3546,58 +3442,6 @@
     }
   }
 
-  function shortAddress(value: string | null): string {
-    const trimmed = String(value ?? "").trim();
-    if (!trimmed) return "--";
-    if (trimmed.length <= 14) return trimmed;
-    return `${trimmed.slice(0, 6)}...${trimmed.slice(-4)}`;
-  }
-
-  function shortEmail(value: string): string {
-    const trimmed = value.trim();
-    if (trimmed.length <= 22) return trimmed;
-    const [name, domain] = trimmed.split("@");
-    if (!domain) return `${trimmed.slice(0, 19)}…`;
-    const head = name.length > 10 ? `${name.slice(0, 9)}…` : name;
-    return `${head}@${domain}`;
-  }
-
-  function walletStatusText(
-    status: "missing" | "creating" | "ready" | "error",
-  ): string {
-    switch (status) {
-      case "ready":
-        return "Wallet ready";
-      case "creating":
-        return "Creating wallet…";
-      case "error":
-        return "Wallet error";
-      default:
-        return "No wallet";
-    }
-  }
-
-  function humanizePrivyError(value: string | null | undefined): string {
-    const raw = String(value ?? "").trim();
-    if (!raw) return "";
-    const known: Record<string, string> = {
-      "email-required": "Enter a valid email address.",
-      "code-required": "Enter the 6-digit code we emailed you.",
-      "privy-app-id-missing": "Auth is not configured for this environment.",
-      "privy-not-configured": "Auth is not configured for this environment.",
-      "privy-code-send-failed": "Couldn't send the code. Check the email and try again.",
-      "privy-login-failed": "That code didn't work. Request a new one and retry.",
-      "privy-logout-failed": "Couldn't log out cleanly. Try again.",
-      "Code sent.": "Code sent — check your inbox.",
-    };
-    if (known[raw]) return known[raw];
-    // Surface Privy SDK messages verbatim; tidy our internal kebab-case codes.
-    if (/^[a-z0-9-]+$/.test(raw)) {
-      return raw.replace(/-/g, " ").replace(/^\w/, (c) => c.toUpperCase());
-    }
-    return raw;
-  }
-
   function toggleAccountMenu(event: MouseEvent): void {
     event.stopPropagation();
     accountMenuOpen = !accountMenuOpen;
@@ -3662,28 +3506,6 @@
     priceMode = mode;
     // Re-render the candle series in the selected price basis.
     setChartData();
-  }
-
-  function toCandle(point: MarketPoint): CandlestickData<UTCTimestamp> {
-    // Mark mode renders the mark-price OHLC series (the smoother series that
-    // drives funding/liquidations); falls back to last-trade when absent.
-    const useMark = priceMode === "mark";
-    return {
-      time: Math.floor(point.ts / 1000) as UTCTimestamp,
-      open: useMark ? point.markOpen ?? point.open : point.open,
-      high: useMark ? point.markHigh ?? point.high : point.high,
-      low: useMark ? point.markLow ?? point.low : point.low,
-      close: useMark ? point.markClose ?? point.close : point.close,
-    };
-  }
-
-  function toVolume(point: MarketPoint) {
-    const up = point.close >= point.open;
-    return {
-      time: Math.floor(point.ts / 1000) as UTCTimestamp,
-      value: point.volumeQuote ?? point.volume ?? 0,
-      color: up ? "rgba(44, 233, 127, 0.45)" : "rgba(255, 90, 106, 0.45)",
-    };
   }
 
   function createChartInstance(): void {
@@ -3835,7 +3657,7 @@
 
   function renderChartSeries(points: MarketPoint[]): void {
     if (!candleSeries || !volumeSeries) return;
-    candleSeries.setData(points.map(toCandle));
+    candleSeries.setData(points.map((point) => toCandle(point, priceMode)));
     volumeSeries.setData(points.map(toVolume));
   }
 
@@ -3850,7 +3672,7 @@
     // Spot mode owns the chart surface — perp ticks must not repaint it.
     if (tradeMode === "spot") return;
     if (!candleSeries || !volumeSeries) return;
-    candleSeries.update(toCandle(point));
+    candleSeries.update(toCandle(point, priceMode));
     volumeSeries.update(toVolume(point));
   }
 
@@ -3936,54 +3758,6 @@
     const current = timeScale.options().barSpacing ?? 6;
     const next = direction === "in" ? current * 1.3 : current / 1.3;
     timeScale.applyOptions({ barSpacing: Math.max(2, Math.min(48, next)) });
-  }
-
-  function formatChartRange(points: MarketPoint[]): string {
-    const first = points.at(0);
-    const last = points.at(-1);
-    if (!first || !last) return "--";
-    const formatter = new Intl.DateTimeFormat(undefined, {
-      hour: "2-digit",
-      minute: "2-digit",
-      month: "short",
-      day: "numeric",
-    });
-    return `${formatter.format(first.ts)} - ${formatter.format(last.ts)}`;
-  }
-
-  function computeMarketChange(
-    price: number | null,
-    stats: PhoenixMarketStats | null,
-    points: MarketPoint[],
-  ): number | null {
-    if (price && stats?.prevDayPx && stats.prevDayPx > 0) {
-      return ((price - stats.prevDayPx) / stats.prevDayPx) * 100;
-    }
-    const latest = points.at(-1);
-    const anchor = points.at(-80) ?? points.at(0);
-    if (!latest || !anchor || anchor.price <= 0) return null;
-    return ((latest.price - anchor.price) / anchor.price) * 100;
-  }
-
-  function formatCandleCountdown(
-    point: MarketPoint | null,
-    timeframe: PhoenixTimeframe,
-    currentTime: number,
-  ): string {
-    if (!point) return "--";
-    const duration = timeframeMs(timeframe);
-    const remaining = Math.max(0, point.ts + duration - currentTime);
-    const minutes = Math.floor(remaining / 60_000);
-    const seconds = Math.floor((remaining % 60_000) / 1_000);
-    return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
-  }
-
-  function timeframeMs(timeframe: PhoenixTimeframe): number {
-    if (timeframe.endsWith("m")) return Number(timeframe.slice(0, -1)) * 60_000;
-    if (timeframe.endsWith("h")) {
-      return Number(timeframe.slice(0, -1)) * 60 * 60_000;
-    }
-    return 60_000;
   }
 
   function selectedMarketTableRows(
@@ -4101,32 +3875,6 @@
     // narrow-viewport fallback where the rail lives below the fold.
     if (!railTicketUsable()) tradeOpen = true;
     focusTicketSize();
-  }
-
-  function bookLevelNotional(level: DepthLevel | null | undefined): number | null {
-    if (!level) return null;
-    return level.price * level.size;
-  }
-
-  function bookLevelTotalNotional(level: DepthLevel | null | undefined): number {
-    if (!level) return 0;
-    return level.price * level.cum;
-  }
-
-  function depthWidth(level: DepthLevel): number {
-    return Math.min(100, Math.max(2, (bookLevelTotalNotional(level) / bookMaxNotional) * 100));
-  }
-
-  function formatBookPrice(value: number | null | undefined): string {
-    if (value === null || value === undefined || !Number.isFinite(value)) {
-      return "--";
-    }
-    const abs = Math.abs(value);
-    const digits = abs >= 1_000 ? 0 : abs >= 1 ? 2 : 4;
-    return value.toLocaleString(undefined, {
-      minimumFractionDigits: digits,
-      maximumFractionDigits: digits,
-    });
   }
 
   function openAuthModal(): void {
@@ -4793,141 +4541,12 @@
   // One primitive for both venues: perp markets (live mids) and the spot
   // catalog (full 24h stats). Selecting a row switches venue if needed.
   // Action rows (close/cancel/flatten on live state) lead when applicable.
-  type PaletteRow = {
-    kind: "perp" | "spot" | "action";
-    key: string;
-    symbol: string;
-    name: string;
-    imageUrl: string | null;
-    lev: number | null;
-    price: number | null;
-    change24hPct: number | null;
-    volumeUsd: number | null;
-    hub: "perps" | "crypto" | "equities" | "pre-ipo";
-    asset?: SpotAsset;
-    action?: () => void;
-  };
-  type PaletteTab = "all" | "perps" | "crypto" | "equities" | "pre-ipo";
-  const PALETTE_TABS: { key: PaletteTab; label: string }[] = [
-    { key: "all", label: "All" },
-    { key: "perps", label: "Perps" },
-    { key: "crypto", label: "Crypto" },
-    { key: "equities", label: "Equities" },
-    { key: "pre-ipo", label: "Pre-IPO" },
-  ];
   let paletteOpen = false;
   let paletteQuery = "";
   let paletteTab: PaletteTab = "all";
   let paletteIndex = 0;
   let paletteInput: HTMLInputElement | null = null;
   let paletteList: HTMLDivElement | null = null;
-
-  function buildPaletteRows(
-    perpMarkets: PhoenixMarketConfig[],
-    assets: SpotAsset[],
-    mids: Record<string, number>,
-    stats: Record<string, PhoenixDailyStat>,
-    query: string,
-    tab: PaletteTab,
-    positions: PhoenixPosition[],
-    orders: PhoenixOpenOrder[],
-  ): PaletteRow[] {
-    // Live-state actions: one Close per position, one Cancel per symbol with
-    // book orders, Flatten once there is more than one position to close.
-    const blank = {
-      imageUrl: null,
-      lev: null,
-      price: null,
-      change24hPct: null,
-      volumeUsd: null,
-      hub: "perps" as const,
-    };
-    const actions: PaletteRow[] = positions.map((position) => ({
-      kind: "action",
-      key: `action:close:${position.symbol}:${position.subaccountIndex}`,
-      symbol: position.symbol,
-      name: `Close ${position.symbol}-PERP${
-        position.unrealizedPnl !== null
-          ? ` · ${position.unrealizedPnl >= 0 ? "+" : "-"}$${formatNumber(Math.abs(position.unrealizedPnl), 2)}`
-          : ""
-      }`,
-      ...blank,
-      action: () =>
-        void closePhoenixPosition(
-          position.symbol,
-          position.size,
-          position.subaccountIndex,
-        ),
-    }));
-    const bookCounts = new Map<string, number>();
-    for (const order of orders) {
-      if (order.isStopLoss) continue;
-      bookCounts.set(order.symbol, (bookCounts.get(order.symbol) ?? 0) + 1);
-    }
-    for (const [symbol, count] of bookCounts) {
-      actions.push({
-        kind: "action",
-        key: `action:cancel:${symbol}`,
-        symbol,
-        name: `Cancel ${count} ${symbol}-PERP order${count === 1 ? "" : "s"}`,
-        ...blank,
-        action: () => void cancelSymbolBookOrders(symbol),
-      });
-    }
-    if (positions.length > 1) {
-      actions.push({
-        kind: "action",
-        key: "action:flatten",
-        symbol: "FLATTEN",
-        name: "Flatten all positions",
-        ...blank,
-        action: () => void closeAllPhoenixPositions(),
-      });
-    }
-    const perps: PaletteRow[] = perpMarkets.map((market) => ({
-      kind: "perp",
-      key: `perp:${market.symbol}`,
-      symbol: market.symbol,
-      name: `${market.symbol}-PERP`,
-      imageUrl: null,
-      lev: market.maxLeverage,
-      price: mids[market.symbol] ?? stats[market.symbol]?.lastPrice ?? null,
-      change24hPct: stats[market.symbol]?.change24hPct ?? null,
-      volumeUsd: stats[market.symbol]?.volume24hUsd ?? null,
-      hub: "perps",
-    }));
-    const spots: PaletteRow[] = assets.map((asset) => ({
-      kind: "spot",
-      key: `spot:${asset.assetId}`,
-      symbol: asset.symbol,
-      name: asset.name,
-      imageUrl: asset.imageUrl || null,
-      lev: null,
-      price: asset.price,
-      change24hPct: asset.change24hPct,
-      volumeUsd: asset.volume24hUsd,
-      hub: asset.hub,
-    }));
-    for (const [index, asset] of assets.entries()) spots[index].asset = asset;
-    spots.sort((a, b) => (b.volumeUsd ?? -1) - (a.volumeUsd ?? -1));
-    // Actions lead, then perps — this is a perp terminal first; spot
-    // follows by volume.
-    let rows =
-      tab === "perps"
-        ? [...actions, ...perps]
-        : tab === "all"
-          ? [...actions, ...perps, ...spots]
-          : spots.filter((row) => row.hub === tab);
-    const q = query.trim().toLowerCase();
-    if (q) {
-      rows = rows.filter(
-        (row) =>
-          row.symbol.toLowerCase().includes(q) ||
-          row.name.toLowerCase().includes(q),
-      );
-    }
-    return rows.slice(0, 80);
-  }
 
   $: paletteRows = buildPaletteRows(
     markets,
@@ -4938,6 +4557,14 @@
     paletteTab,
     enrichedPositions,
     perpOpenOrders,
+    (position) =>
+      void closePhoenixPosition(
+        position.symbol,
+        position.size,
+        position.subaccountIndex,
+      ),
+    (symbol) => void cancelSymbolBookOrders(symbol),
+    () => void closeAllPhoenixPositions(),
   );
   $: if (paletteIndex >= paletteRows.length) {
     paletteIndex = Math.max(0, paletteRows.length - 1);
@@ -7615,7 +7242,7 @@
 
     {#each visibleAskLevels as ask}
       <button type="button" class="book-row ask" onclick={() => prefillFromBook(ask.price, "ask")}>
-        <span class="depth-bar" style={`width: ${depthWidth(ask)}%;`}></span>
+        <span class="depth-bar" style={`width: ${depthWidth(ask, bookMaxNotional)}%;`}></span>
         <span class="book-price">{formatBookPrice(ask.price)}</span>
         <span>{formatNumber(bookLevelNotional(ask), 0)}</span>
         <span>{formatNumber(bookLevelTotalNotional(ask), 0)}</span>
@@ -7630,7 +7257,7 @@
 
     {#each visibleBidLevels as bid}
       <button type="button" class="book-row bid" onclick={() => prefillFromBook(bid.price, "bid")}>
-        <span class="depth-bar" style={`width: ${depthWidth(bid)}%;`}></span>
+        <span class="depth-bar" style={`width: ${depthWidth(bid, bookMaxNotional)}%;`}></span>
         <span class="book-price">{formatBookPrice(bid.price)}</span>
         <span>{formatNumber(bookLevelNotional(bid), 0)}</span>
         <span>{formatNumber(bookLevelTotalNotional(bid), 0)}</span>

--- a/apps/portal/tsconfig.json
+++ b/apps/portal/tsconfig.json
@@ -9,6 +9,7 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "types": ["bun-types"]
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "@sveltejs/adapter-vercel": "^6.3.3",
         "@sveltejs/kit": "^2.48.0",
         "@types/qrcode": "^1.5.6",
+        "bun-types": "^1.3.14",
         "svelte": "^5.43.0",
         "svelte-check": "^4.3.0",
         "typescript": "^5.9.3",


### PR DESCRIPTION
Phase 0 + Phase 1 of the terminal split & performance plan. Strictly behavior-preserving: every move is verbatim except the plan's sanctioned deltas (noted below). The page loses ~900 lines of script; the portal gains its first unit-test suite — **150 tests, 333 assertions** locking the semantics of everything that moved.

## New modules (`$lib/terminal/` unless noted)
| Module | What moved | Notable tests |
| --- | --- | --- |
| `trade-math` | buildTradePreview, liq reconstruction, risk sizing, TP/SL trigger math | book-walk slippage, liq long/short, mmr fallback, min-stop guard |
| `chart-format` | candle/volume mapping, timeframe math, countdowns, market change | mark-OHLC fallback chain, prevDay vs 80-candle anchor |
| `palette` | PaletteRow + buildPaletteRows | perps-before-spot, null-volume ordering, 80-row cap |
| `book` | ladder notionals, depth widths, book price formatter | 2–100% clamp, digit tiers. **Sanctioned change:** `depthWidth(level, max)` takes the max explicitly |
| `panels` | monitor/watch/screener row builders, market table, edge status | sort-mode + null-sentinel semantics per builder |
| `account-format` | address/email truncation, wallet copy, error humanizers | Privy known-code table, RPC error guidance |
| `prefs` | storage keys, persistPrefs, new parsePrefs/mergeLayout cores | enum whitelists field-by-field (incl. the ergonomics sizing fields), layout migration |
| `alerts` | matchAlerts pure core + headlineMatches | allocation-free no-hit path (reference-asserted) |
| `deep-link` | **parity split** of applyDeepLink → parseTerminalDeepLink + snapLeverage | every KNOWN key, bounds, tab/cmd precedence, funds > ticket > alerts — the external share-link contract is now regression-locked |
| `chart-lines` | **parity split** of refreshChartLines → buildChartLineSpecs | field-for-field option objects: uPnL entry labels, TP/SL dollar deltas, pref gating — prerequisite for the perf-phase memo |
| `$lib/solana-rpc` | RPC URL resolution + parseLamportsResponse | env precedence; every parse branch. **web3.js-free by design** (bundle boundary) |
| `$lib/spot` (+) | triggerOrderView | mint orientation, non-6-decimal atoms math |

Also: `bun test` wired into the portal package; build chunk-size baseline captured for the upcoming perf/load phases.

## Validation
- typecheck 0 errors / 0 warnings (1,529 files) · biome clean · **portal 150/150** + ui 16/16 tests · production build clean · unused-CSS selectors: 0
- Known latent duplicate `"markets"` panel-id preserved verbatim (fix scheduled with the layout-store phase, with migration)

Part 1 of ~4 split/perf PRs (next: leaf components → panels/tickets → runtime+load fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)