### PR TITLE
Stacked book/ticket: ticket height floor — controls never clip behind the ladder

### DIFF
--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -8317,14 +8317,15 @@
   }
 
   /* Desktop stack: ladder on top, ticket pinned below — both always live.
-     The stack's floor holds ~8 levels a side (proportional on cramped
-     heights); the ticket takes what's left, scrolling internally under
-     its sticky actions footer. */
+     The TICKET is the priority element: it keeps a floor tall enough that
+     side/size/TP-SL never hide behind the ladder; the ladder takes what's
+     left and scrolls its own depth on cramped heights. Floors sum < 90%,
+     so the pair never overflows the panel. */
   .book-stack {
     display: flex;
     flex: 1 1 0;
     flex-direction: column;
-    min-height: min(24rem, 55%);
+    min-height: min(12rem, 30%);
   }
 
   .book-stack .tape {
@@ -8334,6 +8335,7 @@
 
   .orderbook-panel .panel-ticket.stacked {
     flex: 0 1 auto;
+    min-height: min(26rem, 56%);
     border-top: 1px solid var(--line-soft);
   }
 


### PR DESCRIPTION
Fixes the regression reported from the ergonomics release: on shorter panels the order-book stack squeezed the ticket into a sliver, hiding side/size/TP-SL above an unreachable scroll viewport.

- `.book-stack` floor: `min(24rem, 55%)` → `min(12rem, 30%)` — the ladder yields and scrolls its own depth
- `.panel-ticket.stacked` gains `min-height: min(26rem, 56%)` — the ticket is the priority element
- Floors sum <90%, so the pair can never overflow the panel (which is `overflow: hidden`)

Verified with a real browser at a 1440×760 viewport: side toggle, size + chips, leverage, type, limit, TP/SL chips all simultaneously visible; ticket still scrolls for the estimate rows; ladder keeps its slot.

Validation: typecheck 0/0, lint clean, production build clean, unused-CSS 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)