### PR TITLE
Day-trading rewrite 2: execution presets, token safety rails, repeat-last, session stats

### DIFF
--- a/apps/portal/src/lib/solana-rpc.test.ts
+++ b/apps/portal/src/lib/solana-rpc.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseLamportsResponse } from "./solana-rpc";
+import { parseLamportsResponse, parseMintAccount } from "./solana-rpc";
 
 describe("parseLamportsResponse", () => {
   test("http failure → coded error with status", () => {
@@ -47,6 +47,48 @@ describe("parseLamportsResponse", () => {
   test("missing value → balance-missing", () => {
     expect(() => parseLamportsResponse({ result: {} }, true, 200)).toThrow(
       "solana-balance-missing",
+    );
+  });
+});
+
+describe("parseMintAccount", () => {
+  // Build an 82-byte SPL mint image: u32 mintAuthorityOption @0,
+  // 32-byte authority @4, u64 supply @36, u8 decimals @44,
+  // u8 isInitialized @45, u32 freezeAuthorityOption @46, 32 bytes @50.
+  function mintBase64(opts: {
+    mintAuth: boolean;
+    freezeAuth: boolean;
+    decimals: number;
+  }): string {
+    const bytes = new Uint8Array(82);
+    bytes[0] = opts.mintAuth ? 1 : 0;
+    bytes[44] = opts.decimals;
+    bytes[45] = 1; // initialized
+    bytes[46] = opts.freezeAuth ? 1 : 0;
+    return btoa(String.fromCharCode(...bytes));
+  }
+
+  test("revoked authorities decode as safe", () => {
+    const safety = parseMintAccount(
+      mintBase64({ mintAuth: false, freezeAuth: false, decimals: 6 }),
+    );
+    expect(safety.mintAuthorityRevoked).toBe(true);
+    expect(safety.freezeAuthorityRevoked).toBe(true);
+    expect(safety.decimals).toBe(6);
+  });
+
+  test("live authorities decode as unsafe", () => {
+    const safety = parseMintAccount(
+      mintBase64({ mintAuth: true, freezeAuth: true, decimals: 9 }),
+    );
+    expect(safety.mintAuthorityRevoked).toBe(false);
+    expect(safety.freezeAuthorityRevoked).toBe(false);
+    expect(safety.decimals).toBe(9);
+  });
+
+  test("truncated accounts throw instead of guessing", () => {
+    expect(() => parseMintAccount(btoa("short"))).toThrow(
+      "mint-account-too-short",
     );
   });
 });

--- a/apps/portal/src/lib/solana-rpc.ts
+++ b/apps/portal/src/lib/solana-rpc.ts
@@ -62,3 +62,54 @@ export async function fetchSolanaLamports(address: string): Promise<string> {
   const payload = (await response.json().catch(() => null)) as unknown;
   return parseLamportsResponse(payload, response.ok, response.status);
 }
+
+// ── SPL mint safety (meme-coin rails) ────────────────────────────────
+// Decodes the two authority slots of an SPL mint account straight from a
+// raw getAccountInfo — no web3.js. A revoked mint authority means supply
+// is fixed; a revoked freeze authority means holders can't be frozen.
+// Token-2022 shares the same base layout (extensions live past byte 82).
+
+export type MintSafety = {
+  mintAuthorityRevoked: boolean;
+  freezeAuthorityRevoked: boolean;
+  decimals: number;
+};
+
+/** Pure decoder for a base64 SPL mint account — testable with fixtures. */
+export function parseMintAccount(base64Data: string): MintSafety {
+  const raw = atob(base64Data);
+  if (raw.length < 82) throw new Error("mint-account-too-short");
+  const u32 = (offset: number) =>
+    raw.charCodeAt(offset) |
+    (raw.charCodeAt(offset + 1) << 8) |
+    (raw.charCodeAt(offset + 2) << 16) |
+    (raw.charCodeAt(offset + 3) << 24);
+  return {
+    mintAuthorityRevoked: u32(0) === 0,
+    decimals: raw.charCodeAt(44),
+    freezeAuthorityRevoked: u32(46) === 0,
+  };
+}
+
+export async function fetchMintSafety(mint: string): Promise<MintSafety> {
+  const response = await fetch(solanaRpcUrl(), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: "trader-ralph-mint-safety",
+      method: "getAccountInfo",
+      params: [mint, { encoding: "base64" }],
+    }),
+  });
+  const payload = (await response.json().catch(() => null)) as unknown;
+  if (!response.ok) throw new Error(`solana-rpc-http-${response.status}`);
+  if (!isRecord(payload) || !isRecord(payload.result)) {
+    throw new Error("solana-rpc-invalid-response");
+  }
+  const value = payload.result.value;
+  if (!isRecord(value) || !Array.isArray(value.data)) {
+    throw new Error("mint-account-missing");
+  }
+  return parseMintAccount(String(value.data[0]));
+}

--- a/apps/portal/src/lib/terminal/palette.test.ts
+++ b/apps/portal/src/lib/terminal/palette.test.ts
@@ -287,3 +287,45 @@ describe("PALETTE_TABS", () => {
     ]);
   });
 });
+
+describe("repeat-last action row", () => {
+  test("leads the action list when provided and fires its apply", () => {
+    let applied = false;
+    const rows = buildPaletteRows(
+      [],
+      [],
+      {},
+      {},
+      "",
+      "all",
+      [],
+      [],
+      () => {},
+      () => {},
+      () => {},
+      { label: "Repeat last · LONG $50 SOL 5x", apply: () => (applied = true) },
+    );
+    expect(rows[0]?.kind).toBe("action");
+    expect(rows[0]?.name).toContain("Repeat last");
+    rows[0]?.action?.();
+    expect(applied).toBe(true);
+  });
+
+  test("absent when null", () => {
+    const rows = buildPaletteRows(
+      [],
+      [],
+      {},
+      {},
+      "",
+      "all",
+      [],
+      [],
+      () => {},
+      () => {},
+      () => {},
+      null,
+    );
+    expect(rows.some((row) => row.key === "action:repeat-last")).toBe(false);
+  });
+});

--- a/apps/portal/src/lib/terminal/palette.ts
+++ b/apps/portal/src/lib/terminal/palette.ts
@@ -45,6 +45,7 @@ export function buildPaletteRows(
   closePosition: (position: PhoenixPosition) => void,
   cancelSymbolOrders: (symbol: string) => void,
   flattenAll: () => void,
+  repeatLast: { label: string; apply: () => void } | null = null,
 ): PaletteRow[] {
   // Live-state actions: one Close per position, one Cancel per symbol with
   // book orders, Flatten once there is more than one position to close.
@@ -56,18 +57,33 @@ export function buildPaletteRows(
     volumeUsd: null,
     hub: "perps" as const,
   };
-  const actions: PaletteRow[] = positions.map((position) => ({
-    kind: "action",
-    key: `action:close:${position.symbol}:${position.subaccountIndex}`,
-    symbol: position.symbol,
-    name: `Close ${position.symbol}-PERP${
-      position.unrealizedPnl !== null
-        ? ` · ${position.unrealizedPnl >= 0 ? "+" : "-"}$${formatNumber(Math.abs(position.unrealizedPnl), 2)}`
-        : ""
-    }`,
-    ...blank,
-    action: () => closePosition(position),
-  }));
+  const actions: PaletteRow[] = [];
+  if (repeatLast) {
+    actions.push({
+      kind: "action",
+      key: "action:repeat-last",
+      symbol: "REPEAT",
+      name: repeatLast.label,
+      ...blank,
+      action: repeatLast.apply,
+    });
+  }
+  actions.push(
+    ...positions.map(
+      (position): PaletteRow => ({
+        kind: "action",
+        key: `action:close:${position.symbol}:${position.subaccountIndex}`,
+        symbol: position.symbol,
+        name: `Close ${position.symbol}-PERP${
+          position.unrealizedPnl !== null
+            ? ` · ${position.unrealizedPnl >= 0 ? "+" : "-"}$${formatNumber(Math.abs(position.unrealizedPnl), 2)}`
+            : ""
+        }`,
+        ...blank,
+        action: () => closePosition(position),
+      }),
+    ),
+  );
   const bookCounts = new Map<string, number>();
   for (const order of orders) {
     if (order.isStopLoss) continue;

--- a/apps/portal/src/lib/terminal/spot-ticket.ts
+++ b/apps/portal/src/lib/terminal/spot-ticket.ts
@@ -40,6 +40,8 @@ export function createSpotTicket(options: SpotTicketOptions) {
   const spotAmount = writable("25");
   const spotOrderType = writable<SpotOrderType>("market");
   const spotLimitPrice = writable("");
+  // Meme execution preset: 50 bps default; volatile pairs need 1–5%.
+  const spotSlippageBps = writable(50);
   const spotQuote = writable<SpotQuote | null>(null);
   const spotQuoteStatus = writable<SpotQuoteStatus>("idle");
   const spotQuoteError = writable("");
@@ -79,12 +81,14 @@ export function createSpotTicket(options: SpotTicketOptions) {
               asset.mint,
               usdcToAtoms(amount),
               asset.decimals,
+              get(spotSlippageBps),
             )
           : await fetchQuote(
               asset.mint,
               USDC_MINT,
               tokenToAtoms(amount, asset.decimals),
               6,
+              get(spotSlippageBps),
             );
       if (seq !== quoteSeq) return; // stale response — newer request owns state
       spotQuote.set(quote);
@@ -141,6 +145,7 @@ export function createSpotTicket(options: SpotTicketOptions) {
   return {
     spotSide,
     spotAmount,
+    spotSlippageBps,
     spotOrderType,
     spotLimitPrice,
     spotQuote,

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -102,7 +102,7 @@
     screenSolanaAddress,
     type NewsItem,
   } from "$lib/intel";
-  import { fetchSolanaLamports, solanaRpcUrl } from "$lib/solana-rpc";
+  import { fetchMintSafety, fetchSolanaLamports, solanaRpcUrl } from "$lib/solana-rpc";
   import { swrRead, swrWrite } from "$lib/swr";
   import {
     edgeApiBase,
@@ -271,6 +271,22 @@
     } catch {
       // sweep is best-effort; keep last values
     }
+  }
+
+  function applyLastOrderIntent(): void {
+    const intent = lastOrderIntent;
+    if (!intent) return;
+    if (tradeMode !== "perps") setTradeMode("perps", false);
+    // switchPhoenixMarket clears price-anchored fields synchronously at its
+    // top, so re-applying after the call keeps the intent's values.
+    if (intent.symbol !== selectedSymbol) void switchPhoenixMarket(intent.symbol);
+    $tradeSide = intent.side;
+    $tradeType = intent.type;
+    $tradeAmount = intent.amount;
+    $tradeLeverage = intent.leverage;
+    $tradeLimitPrice = intent.limitPrice;
+    $tradeTakeProfit = intent.tp;
+    $tradeStopLoss = intent.sl;
   }
 
   function chooseMonitorRow(symbol: string): void {
@@ -490,6 +506,33 @@
   let dockTab: "desk" | "journal" | "alerts" = "desk";
   let macroOpen = false;
   const { alertLog } = alertsStore;
+  // Meme safety rails: SPL authority checks per selected mint (cached —
+  // authorities effectively never un-revoke).
+  let mintSafetyCache: Record<string, import("$lib/solana-rpc").MintSafety> = {};
+  let mintSafetyMisses: Record<string, true> = {};
+  $: if (spotAsset && !mintSafetyCache[spotAsset.mint] && !mintSafetyMisses[spotAsset.mint]) {
+    const mint = spotAsset.mint;
+    mintSafetyMisses = { ...mintSafetyMisses, [mint]: true };
+    void fetchMintSafety(mint)
+      .then((safety) => {
+        mintSafetyCache = { ...mintSafetyCache, [mint]: safety };
+      })
+      .catch(() => {
+        // decode failed (RPC hiccup / exotic mint) — chips stay amber
+      });
+  }
+  // Repeat-last-order: the exact ticket inputs of the last CONFIRMED perp
+  // order; the palette re-applies them (never auto-submits).
+  let lastOrderIntent: {
+    symbol: string;
+    side: "buy" | "sell";
+    type: "market" | "limit";
+    amount: string;
+    leverage: number;
+    limitPrice: string;
+    tp: string;
+    sl: string;
+  } | null = null;
 
   $: selectedMarket = markets.find((market) => market.symbol === selectedSymbol) ?? null;
   // Funds = everything the user considers theirs: wallet USDC + ALL Phoenix
@@ -2241,6 +2284,18 @@
   async function submitPhoenixOrder(): Promise<void> {
     const symbol = selectedSymbol;
     const busyKey = `order:${symbol}`;
+    // Snapshot the ticket inputs now — on confirm they become the
+    // repeat-last intent exactly as sent, even if edited mid-flight.
+    const intentSnapshot = {
+      symbol,
+      side: $tradeSide,
+      type: $tradeType,
+      amount: $tradeAmount,
+      leverage: $tradeLeverage,
+      limitPrice: $tradeLimitPrice,
+      tp: $tradeTakeProfit,
+      sl: $tradeStopLoss,
+    };
     if (!phoenixAuthority || phoenixBusyKeys.has(busyKey) || !$tradePreview) return;
     // Freeze the ticket state before the first await — inputs stay editable
     // while the tx confirms, so a live read after an await could describe a
@@ -2337,6 +2392,7 @@
         side,
         signature: lastTradeSignature,
       });
+      lastOrderIntent = intentSnapshot;
       noteTrade({
         ts: Date.now(),
         venue: "perp",
@@ -4237,7 +4293,13 @@
       </div>
       <div class="dock-body">
         {#if dockTab === "journal"}
-          <JournalPanel {journalEntries} {journalToday} {recapRead} onwipe={wipeJournal} />
+          <JournalPanel
+            {journalEntries}
+            {journalToday}
+            {recapRead}
+            {sessionPnlUsd}
+            onwipe={wipeJournal}
+          />
         {:else if dockTab === "alerts"}
           <div class="dock-alert-log">
             {#each $alertLog as fired (fired.ts)}
@@ -4609,6 +4671,12 @@
       )}
     oncancelorders={(symbol) => void cancelSymbolBookOrders(symbol)}
     onflatten={() => void closeAllPhoenixPositions()}
+    repeatLast={lastOrderIntent
+      ? {
+          label: `Repeat last · ${lastOrderIntent.side === "buy" ? "LONG" : "SHORT"} $${lastOrderIntent.amount} ${lastOrderIntent.symbol} ${lastOrderIntent.leverage}x`,
+          apply: applyLastOrderIntent,
+        }
+      : null}
     onselect={choosePalette}
     ontogglewatch={toggleWatch}
     onclose={() => (paletteOpen = false)}
@@ -4655,6 +4723,7 @@
     limitDeviationPct={spotLimitDeviationPct}
     {triggerOrders}
     {triggerBusy}
+    mintSafety={spotAsset ? (mintSafetyCache[spotAsset.mint] ?? null) : null}
     onswap={executeSpotSwap}
     onlimitsubmit={onSpotLimitSubmitClick}
     onopenauth={openAuthModal}

--- a/apps/portal/src/routes/terminal/components/CommandPalette.svelte
+++ b/apps/portal/src/routes/terminal/components/CommandPalette.svelte
@@ -25,6 +25,7 @@
     oncloseposition,
     oncancelorders,
     onflatten,
+    repeatLast,
     onselect,
     ontogglewatch,
     onclose,
@@ -39,6 +40,7 @@
     oncloseposition: (position: PhoenixPosition) => void;
     oncancelorders: (symbol: string) => void;
     onflatten: () => void;
+    repeatLast: { label: string; apply: () => void } | null;
     onselect: (row: PaletteRow) => void;
     ontogglewatch: (symbol: string) => void;
     onclose: () => void;
@@ -67,6 +69,7 @@
       oncloseposition,
       oncancelorders,
       onflatten,
+      repeatLast,
     ),
   );
   $effect(() => {

--- a/apps/portal/src/routes/terminal/components/JournalPanel.svelte
+++ b/apps/portal/src/routes/terminal/components/JournalPanel.svelte
@@ -10,11 +10,14 @@
     journalEntries,
     journalToday,
     recapRead,
+    sessionPnlUsd,
     onwipe,
   }: {
     journalEntries: JournalEntry[];
     journalToday: JournalEntry[];
     recapRead: AiRead;
+    /** Day P&L from the equity baseline — null when no wallet/history. */
+    sessionPnlUsd: number | null;
     // Wiping resets page-owned state too (entries source + recap AI state),
     // so the clear action stays a page callback.
     onwipe: () => void;
@@ -58,6 +61,26 @@
       <button class="row-action" type="button" onclick={onwipe}>Clear</button>
     {/if}
   </div>
+  <!-- Session strip: honest numbers only — trade count and notional come
+       from the journal; day P&L from the equity baseline. Win rates wait
+       for a real fills feed. -->
+  <div class="session-strip">
+    <span>Trades <b>{journalToday.length}</b></span>
+    <span>
+      Notional
+      <b>
+        ${formatNumber(
+          journalToday.reduce((sum, entry) => sum + (entry.notionalUsd ?? 0), 0),
+          0,
+        )}
+      </b>
+    </span>
+    {#if sessionPnlUsd !== null}
+      <span class={sessionPnlUsd >= 0 ? "up" : "down"}>
+        Day P&L <b>{sessionPnlUsd >= 0 ? "+" : "-"}${formatNumber(Math.abs(sessionPnlUsd), 2)}</b>
+      </span>
+    {/if}
+  </div>
   {#if journalToday.length >= 2}
     <AiReadLine read={recapRead} />
   {/if}
@@ -88,6 +111,20 @@
 </section>
 
 <style>
+  .session-strip {
+    display: flex;
+    gap: 0.9rem;
+    padding: 0.35rem 0;
+    font-size: 0.72rem;
+    color: var(--muted);
+    border-bottom: 1px solid var(--line-soft);
+  }
+  .session-strip b {
+    color: var(--ink);
+    font-variant-numeric: tabular-nums;
+  }
+  .session-strip .up b { color: var(--up); }
+  .session-strip .down b { color: var(--down); }
   .journal-list { display: grid; }
   .journal-row {
     display: grid;

--- a/apps/portal/src/routes/terminal/components/SpotTicketForm.svelte
+++ b/apps/portal/src/routes/terminal/components/SpotTicketForm.svelte
@@ -29,6 +29,7 @@
     limitDeviationPct,
     triggerOrders,
     triggerBusy,
+    mintSafety,
     onswap,
     onlimitsubmit,
     onopenauth,
@@ -50,6 +51,9 @@
     limitDeviationPct: number | null;
     triggerOrders: TriggerOrder[];
     triggerBusy: boolean;
+    // null = loading/unknown for the selected mint (rugs hide in unknowns —
+    // the chips render amber until the account decode lands).
+    mintSafety: import("$lib/solana-rpc").MintSafety | null;
     onswap: () => void | Promise<void>;
     onlimitsubmit: () => void;
     onopenauth: () => void;
@@ -68,9 +72,13 @@
     spotQuote,
     spotQuoteStatus,
     spotQuoteError,
+    spotSlippageBps,
     scheduleQuote,
     flipSide,
   } = ticket;
+
+  const SLIPPAGE_CHOICES = [50, 100, 500] as const; // 0.5% / 1% / 5%
+  const QUICK_BUY_USD = [10, 50, 100] as const;
 
   // ── Spot size chips ────────────────────────────────────────────────
   // % of wallet USDC on buy, % of the token holding on sell — the same
@@ -160,7 +168,53 @@
       >
         Max
       </button>
+      {#if $spotSide === "buy"}
+        {#each QUICK_BUY_USD as usd (usd)}
+          <button
+            class="pct-chip"
+            type="button"
+            onclick={() => {
+              $spotAmount = String(usd);
+              scheduleQuote();
+            }}
+          >
+            ${usd}
+          </button>
+        {/each}
+      {/if}
     </div>
+    <div class="chip-row" role="group" aria-label="Slippage tolerance">
+      <span class="slippage-label">Slip</span>
+      {#each SLIPPAGE_CHOICES as bps (bps)}
+        <button
+          class="pct-chip"
+          class:active={$spotSlippageBps === bps}
+          type="button"
+          onclick={() => {
+            $spotSlippageBps = bps;
+            scheduleQuote();
+          }}
+        >
+          {bps / 100}%
+        </button>
+      {/each}
+    </div>
+  </div>
+
+  <!-- Token safety rails: SPL authority checks straight from the chain.
+       Green = revoked (safe), red = live authority (supply can inflate /
+       holders can be frozen), amber = not yet decoded. -->
+  <div class="safety-row" role="group" aria-label="Token safety checks">
+    {#if mintSafety}
+      <span class="safety-chip" class:up={mintSafety.mintAuthorityRevoked} class:down={!mintSafety.mintAuthorityRevoked}>
+        mint {mintSafety.mintAuthorityRevoked ? "revoked ✓" : "LIVE ✗"}
+      </span>
+      <span class="safety-chip" class:up={mintSafety.freezeAuthorityRevoked} class:down={!mintSafety.freezeAuthorityRevoked}>
+        freeze {mintSafety.freezeAuthorityRevoked ? "revoked ✓" : "LIVE ✗"}
+      </span>
+    {:else}
+      <span class="safety-chip warn">checking mint…</span>
+    {/if}
   </div>
 
   {#if $spotOrderType === "limit"}
@@ -341,6 +395,50 @@
   .pct-chip:hover:not(:disabled) {
     color: var(--ink);
     border-color: var(--muted);
+  }
+
+  .pct-chip.active {
+    color: var(--ink);
+    border-color: var(--accent);
+  }
+
+  .slippage-label {
+    align-self: center;
+    color: var(--faint);
+    font-size: 0.62rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    margin-right: 0.15rem;
+  }
+
+  .safety-row {
+    display: flex;
+    gap: 0.35rem;
+    flex-wrap: wrap;
+  }
+
+  .safety-chip {
+    font-size: 0.62rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    padding: 0.15rem 0.4rem;
+    border: 1px solid var(--line-soft);
+    color: var(--muted);
+  }
+
+  .safety-chip.up {
+    color: var(--up);
+    border-color: var(--up);
+  }
+
+  .safety-chip.down {
+    color: var(--down);
+    border-color: var(--down);
+  }
+
+  .safety-chip.warn {
+    color: var(--amber);
+    border-color: var(--amber);
   }
 
   .pct-chip:disabled {


### PR DESCRIPTION
Phases 3–5 (the implementable-now core) of the day-trading/meme cleanup.

## Execution presets (spot ticket)
- **Slippage chips** `0.5% | 1% | 5%` — threads `slippageBps` through the Jupiter quote engine (was hardcoded 50); active chip highlighted; requotes on change.
- **Quick-buy chips** `$10 | $50 | $100` on the buy side.

## Token safety rails
- SPL **mint authority** + **freeze authority** decoded straight from a raw `getAccountInfo` — no web3.js, fixture-tested byte-layout parser in `solana-rpc.ts`, cached per mint.
- Chips in the spot ticket: green `revoked ✓` / red `LIVE ✗` / amber `checking…`. Verified live: wrapped SOL decodes revoked/revoked correctly.
- Liquidity-lock/holder-concentration checks need an indexer and land with the meme-API integration.

## Repeat-last-order
- The exact ticket inputs of the last **confirmed** perp order (snapshotted at submit, so mid-flight edits can't corrupt it) become a `Repeat last · LONG $50 SOL 5x` palette action row — re-applies to the ticket and never auto-submits; correctly survives the market-switch field-clearing.

## Session stats
- Journal dock tab gains a strip: trades today, notional traded, day P&L (equity-baseline). Win rates deliberately omitted until a real fills feed exists — no fake numbers.

Validation: typecheck 0/0 · lint clean · **204/204 tests** · build clean · unused-CSS 0 · browser-verified (chips render + toggle, safety decode against mainnet, journal strip live).

With #486, this completes the currently-implementable rewrite; the remaining proposal items (discovery hubs, liq/holder safety, fills-based stats) are blocked on the meme-coin data source and land with that integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)