### PR TITLE
Fix: monitor scanner-line placement + ticket field alignment

### DIFF
--- a/apps/portal/src/routes/terminal/components/MonitorPanel.svelte
+++ b/apps/portal/src/routes/terminal/components/MonitorPanel.svelte
@@ -68,8 +68,8 @@
         >{key}</button>
       {/each}
     </div>
-  <AiReadLine read={scannerRead} />
   </div>
+  <AiReadLine read={scannerRead} />
   <div class="monitor-list">
     <div class="monitor-row monitor-head" aria-hidden="true">
       <span>Market</span><span class="r">Mark</span><span class="r">24h</span><span class="r">Volume</span>

--- a/apps/portal/src/routes/terminal/terminal.css
+++ b/apps/portal/src/routes/terminal/terminal.css
@@ -614,6 +614,10 @@ button.account-row.copyable:hover:not(:disabled) {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 0.45rem 0.6rem;
+  /* start, not stretch: a bare label paired with a taller field (size input
+     + preset chips) must top-align — stretch centers its control in the
+     leftover space and the rows read misaligned. */
+  align-items: start;
 }
 
 /* Panel-header dialect on ticket labels; inputs keep body sizing. The


### PR DESCRIPTION
Two visual regressions from the rewrite, both reported from production:

1. **Monitor panel broken layout** — the scanner AI line was inserted *inside* the flex `.panel-head` during the market-list merge (#486), rendering as a one-word-per-line column spanning the panel and overlapping the sort tabs. Moved to its own row below the head.
2. **Ticket fields misaligned** — `.ticket-grid-2` stretched a bare label (Leverage / Limit price) to match the taller size-field cell (input + preset chips), centering its control in the leftover space. `align-items: start` top-aligns the rows.

Verified in a real browser: size input and leverage select tops both at 306px; monitor renders header → scanner row → table with no overlap (screenshot in thread).

Validation: typecheck 0/0 · lint clean · 204/204 tests · build clean · unused-CSS 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)