### PR TITLE
Factory v0: skills-first orchestration (CLAUDE.md, .factory/, factory-* skills)

### DIFF
--- a/.claude/skills/factory-dispatch/SKILL.md
+++ b/.claude/skills/factory-dispatch/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: factory-dispatch
+description: Dispatch one work order to its delegate model via pi, then run the review gate and commit on pass. Use after /factory-prd has written orders and Guillaume confirmed the dispatch plan.
+---
+
+# factory-dispatch — run one work package through a delegate
+
+Takes one order (`.factory/orders/<slug>/wpN.md`), runs the assigned
+delegate, reviews the result adversarially, and commits only what survives.
+
+## Pre-flight (hard gates)
+
+1. **PAUSE check**: if `.factory/PAUSE` exists → stop, dispatch nothing,
+   tell Guillaume the factory is paused.
+2. Working tree must be clean apart from expected untracked files
+   (`git status --porcelain`) — never dispatch onto a dirty tree.
+3. The order file exists and has no unfilled `<placeholders>`.
+
+## Dispatch
+
+Pick the invocation from the CLAUDE.md routing table. Default
+(implementation WP):
+
+```bash
+cd /Users/guillaume/Github/serious-trader-ralph
+pi --provider glm-cloud --model glm-5.2 --thinking high -p "$(cat .factory/orders/<slug>/wpN.md)"
+```
+
+Backend/config WP: `--provider openai-codex --model gpt-5.5`. Routine WP:
+`--provider north-mini-code --model north-mini-code`.
+
+- Fresh session per WP (no `--continue` across WPs).
+- Run in background for long WPs; watch for stalls. If a delegate stalls
+  twice on the same WP, take it over by hand — don't spin a third time.
+
+## Review gate (nothing is committed until ALL pass)
+
+1. **File-list match**: `git status --porcelain` output must exactly match
+   the order's declared create/modify/delete lists. Any extra file =
+   reject (revert the stray change or restart the WP).
+2. **Adversarial diff read**: read the full diff assuming the delegate is
+   plausible-but-wrong. Check PITFALLS compliance (scoped CSS moved with
+   markup, runes in new components, byte-identical moves, no dialect
+   crossing, no fake data).
+3. **Validation reproduced locally** — never trust pasted output:
+   `bun run typecheck && bun run lint && bun run test`, then
+   `cd apps/portal && bun test`, then `bun run build` with build output
+   grepped for `unused css selector` (must be 0).
+4. **Browser smoke for UI changes**: real Chrome
+   (`chromium.launch({ channel: "chrome" })` — headless blocks Phoenix WS),
+   screenshot the affected surface for the proof bundle.
+
+## On failure
+
+- One `--session`-continue with a precise fix order (quote the exact
+  failure output), same WP only.
+- Second failure → Claude fixes by hand or rewrites the order. Note the
+  failure mode in `.factory/PITFALLS.md` if it's general.
+
+## On pass
+
+Claude commits (delegates never do), one commit per accepted WP — message
+describes the WP, so every commit is a clean rollback point. Then report:
+what shipped, validation summary, what was rejected/amended and why.

--- a/.claude/skills/factory-prd/SKILL.md
+++ b/.claude/skills/factory-prd/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: factory-prd
+description: Intake a PRD and decompose it into dispatchable work orders under .factory/orders/. Use when Guillaume supplies a PRD, feature request, or asks to "run this through the factory".
+---
+
+# factory-prd — PRD intake and decomposition
+
+Turn a PRD (argument text, a file path, or the current conversation) into
+work orders ready for `/factory-dispatch`. This skill produces PLANNING
+ARTIFACTS ONLY — no code changes, no delegate invocations.
+
+## Procedure
+
+1. **Read the PRD.** If the argument is a file path, read it; if it's inline
+   text, use it; if empty, ask Guillaume for the PRD. Restate the goal in one
+   sentence and list acceptance criteria you can verify.
+
+2. **Interrogate repo state before decomposing.** Grep/read the touched
+   areas (respect reading discipline: grep first, bounded reads). Identify
+   existing utilities to reuse — never order new code where a suitable
+   implementation exists. Check `.factory/PITFALLS.md` for constraints that
+   shape the design.
+
+3. **Decompose into 1–N work packages.** Each WP must be:
+   - Independently validatable (the full validation suite passes after it).
+   - ≤ ~400 changed lines.
+   - Assigned to a delegate per the CLAUDE.md routing table (GLM 5.2 =
+     implementation, GPT 5.5 = backend/config/scripts, north-mini = routine
+     read-heavy tasks). Work needing judgment, ambiguity resolution, or
+     taste stays with Claude.
+   - Free of product ambiguity. If the PRD leaves a real decision open,
+     STOP and ask Guillaume — never resolve product ambiguity by assumption.
+
+4. **Write the orders.** Slug the feature (`<slug>`), then write
+   `.factory/orders/<slug>/wp1.md`, `wp2.md`, … from
+   `.factory/ORDER_TEMPLATE.md`. Fill every section — exact absolute file
+   lists, verbatim load-bearing payloads, acceptance criteria, validation
+   commands. An order a delegate could misread is a defective order.
+
+5. **Print the dispatch plan** as a table: WP → goal → delegate → risk notes
+   → suggested order (note WPs that must run serially vs can parallel).
+
+6. **Confirm before dispatch.** End by asking Guillaume to confirm (or
+   amend) the plan. Do not invoke `/factory-dispatch` without confirmation
+   while the factory is human-in-the-loop.
+
+## Retro duty
+
+After the feature ships, fold anything that creaked (bad decomposition,
+missing pitfall, unclear order section) back into `CLAUDE.md`,
+`.factory/PITFALLS.md`, or these skills.

--- a/.claude/skills/factory-ship/SKILL.md
+++ b/.claude/skills/factory-ship/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: factory-ship
+description: Ship the current branch to production — validate, open a PR with a proof bundle, gate to merge, verify main CI and the Vercel production deployment. Use when accepted work packages are committed and ready to release.
+---
+
+# factory-ship — validate → PR → gate → verify prod
+
+Ships the current `codex/<slug>` branch through the full pipeline and
+reports the outcome honestly. Never declare success before the deployment
+status is verified.
+
+## 1. Validate (all green before any push)
+
+```bash
+cd /Users/guillaume/Github/serious-trader-ralph
+bun run typecheck && bun run lint && bun run test
+(cd apps/portal && bun test)
+bun run build 2>&1 | tee /tmp/ship-build.log
+grep -ci "unused css selector" /tmp/ship-build.log   # must print 0
+```
+
+## 2. PR
+
+Push the branch and open a PR against `main` with the WORKFLOW.md proof
+bundle: change summary, validation commands + results, local URL used for
+UI verification, browser artifacts (screenshots) for UI changes, risk
+notes / deferred items.
+
+## 3. Gate (run in background; fail-fast, never lie)
+
+Materialize this as `/tmp/gate-<pr>.sh` with `PR` and `BRANCH` filled, run
+with `run_in_background`:
+
+```bash
+#!/bin/zsh
+PR=<pr-number>; BRANCH=<branch-name>
+cd /Users/guillaume/Github/serious-trader-ralph
+merged=0
+for i in $(seq 1 60); do
+  state=$(gh pr view $PR --json mergeStateStatus,state -q '.mergeStateStatus + " " + .state')
+  checks=$(gh pr checks $PR 2>/dev/null | grep -c fail || true)
+  if [[ "$checks" != "0" ]]; then echo "$PR CHECK FAILURE"; gh pr checks $PR; exit 1; fi
+  if [[ "$state" == "CLEAN OPEN" ]]; then
+    echo "$PR CLEAN — merging"
+    gh pr merge $PR --merge || exit 1
+    git push origin --delete $BRANCH || true
+    merged=1
+    break
+  fi
+  sleep 20
+done
+# Never lie on timeout: only verify if we actually merged.
+if [[ "$merged" != "1" ]]; then echo "TIMEOUT: $PR never reached CLEAN (last: $state)"; exit 1; fi
+sha=$(gh pr view $PR --json mergeCommit -q '.mergeCommit.oid')
+echo "MERGED, merge commit $sha"
+for i in $(seq 1 90); do
+  run=$(gh run list --branch main --commit $sha --json conclusion,status -q '.[0] | .status + ":" + (.conclusion // "")' 2>/dev/null)
+  [[ "$run" == "completed:success" ]] && { echo "main CI: success"; break; }
+  [[ "$run" == completed:* ]] && { echo "main CI FAILED: $run"; exit 1; }
+  sleep 20
+done
+for i in $(seq 1 90); do
+  dep=$(gh api "repos/GuiBibeau/serious-trader-ralph/deployments?sha=$sha&per_page=1" -q '.[0].id' 2>/dev/null)
+  if [[ -n "$dep" && "$dep" != "null" ]]; then
+    st=$(gh api "repos/GuiBibeau/serious-trader-ralph/deployments/$dep/statuses" -q '.[0].state' 2>/dev/null)
+    [[ "$st" == "success" ]] && { echo "production deployment: success"; exit 0; }
+    [[ "$st" == "failure" || "$st" == "error" ]] && { echo "production deployment: $st"; exit 1; }
+  fi
+  sleep 20
+done
+echo "deployment: timed out"; exit 1
+```
+
+## Gate outcomes — how to react
+
+- `CHECK FAILURE` → fix on the branch, push, rerun the gate.
+- `BLOCKED` with green checks → branch behind main (merge `origin/main` in,
+  push) OR unresolved review conversation (reply, then GraphQL
+  `resolveReviewThread`); then rerun the gate. Treat bot review comments as
+  possibly correct — verify before dismissing.
+- Local branch delete may fail (worktrees hold `main`) — remote delete via
+  `git push origin --delete` is what matters; confirm merge with
+  `gh pr view $PR --json state,mergeCommit`.
+- Timeout → report it as a timeout. NEVER infer success from
+  `git ls-remote` or a green main; only `mergeCommit` counts.
+
+## 4. Report
+
+Merge commit sha · main CI result · production deployment result — exactly
+as observed. If any step failed or was skipped, say so plainly.

--- a/.factory/ORDER_TEMPLATE.md
+++ b/.factory/ORDER_TEMPLATE.md
@@ -1,0 +1,65 @@
+# WP<N> — <one-line goal>
+
+You are implementing one scoped work package in the `serious-trader-ralph`
+repo. Follow this order exactly. Read `AGENTS.md` and `.factory/PITFALLS.md`
+before touching anything — every rule in them is binding.
+
+## Goal
+
+<What "done" means, in 2–4 sentences. Include the user-visible outcome.>
+
+## Non-goals
+
+<Explicitly out of scope. Adjacent code that must NOT be touched or
+"improved". Refactors not asked for.>
+
+## Files
+
+Create:
+- /Users/guillaume/Github/serious-trader-ralph/<absolute path>
+
+Modify:
+- /Users/guillaume/Github/serious-trader-ralph/<absolute path> — <what changes>
+
+Delete:
+- <none | absolute paths>
+
+Touch NOTHING outside these lists. If the task seems to require another file,
+STOP and report why instead of editing it.
+
+## Load-bearing payloads
+
+<Verbatim content that must land exactly as written: export maps, token
+tables, type signatures, CSS blocks, config snippets. The delegate copies
+these, never re-derives them.>
+
+## Acceptance criteria
+
+- <observable, checkable statements — exact test names, exact behaviors>
+
+## Validation (run all, paste FULL output)
+
+```bash
+bun run typecheck
+bun run lint
+bun run test
+cd apps/portal && bun test
+bun run build
+```
+
+Also grep the build output for `unused css selector` — must be 0 occurrences.
+
+## Report format
+
+1. Summary of what changed, per file.
+2. Full validation output (verbatim, no truncation).
+3. Anything you could not do, skipped, or are unsure about — say so plainly.
+4. NO claims of success without the validation output to back them.
+
+## Rules (non-negotiable)
+
+- Git is READ-ONLY for you: `git status` / `git diff` / `git log` only.
+  Never commit, push, stash, restore, reset, or clean.
+- Stay inside the file lists above.
+- Kill any dev server you start.
+- All pitfalls in `.factory/PITFALLS.md` apply.

--- a/.factory/PITFALLS.md
+++ b/.factory/PITFALLS.md
@@ -1,0 +1,42 @@
+# Pitfalls — binding for every delegate, every order
+
+Learned in production on this repo. Violating any of these fails the review
+gate.
+
+1. **bun only.** `bun install` after any package.json change; never
+   `bun update`, never `--frozen-lockfile` locally, never npm/pnpm/yarn.
+2. **Typecheck from root.** `bun run typecheck` (it runs svelte-kit sync and
+   chains packages/ui then apps/portal). Never bare `svelte-check`.
+3. **No `$lib` / `$app` / `$env` inside `packages/*`** — relative imports
+   only; those aliases exist only in the app.
+4. **Scoped-CSS breakage is the #1 silent failure.** When moving or
+   extracting Svelte markup, move its `<style>` rules with it. Grep the build
+   output for `unused css selector` after every change — must stay at 0. The
+   compiler does NOT warn in the other direction (markup that lost its
+   styles) — check that by eye.
+5. **Svelte 5 runes only in new/extracted components**: `$props()`, `$state`,
+   `$derived`, Snippet/`{@render}`. No `export let`, no `$:`, no `<slot>`.
+   (The legacy terminal page keeps its existing `$:` style — match the file
+   you are in.)
+6. **Move code byte-identically.** No reformatting, no renaming, no
+   drive-by "improvements" unless the order explicitly asks.
+7. **Git is read-only** (`status`/`diff`/`log`). Never commit, push, stash,
+   restore, reset, or clean. Claude commits.
+8. **Server-only boundaries**: `apps/portal/src/lib/server/` and
+   `routes/og/` run under Node on Vercel — no `.svelte` imports, no
+   client-only modules. `$lib/solana-rpc.ts` must stay free of
+   @solana/web3.js.
+9. **Biome doesn't lint `.svelte`, but lints `.ts` strictly**
+   (noExplicitAny, noNonNullAssertion). Run `bun run lint` before reporting.
+10. **Build needs no env vars; dev does.** Dev proxies 500 without keys —
+    a page rendering with gated/unavailable states is acceptable in dev;
+    build success is the bar.
+11. **Never touch** `static/`, `.svelte-kit/`, `node_modules/`, `bun.lock`
+    (except via `bun install`), or any generated directory.
+12. **Two formatter dialects by design**: `@trader-ralph/ui/format` renders
+    "—" (marketing/OG); `apps/portal/src/lib/utils.ts` renders "--"
+    (terminal). Never merge or cross-use them. `formatSubZeroPrice` output is
+    display-only — never feed it to `Number()`.
+13. **Kill any dev server you start** before reporting done.
+14. **No fake data.** Missing feeds render as explicit unavailable/gated
+    states, never invented rows or stats.

--- a/.factory/README.md
+++ b/.factory/README.md
@@ -1,0 +1,9 @@
+# .factory/
+
+Working area for the factory loop (see `CLAUDE.md` at the repo root).
+
+- `ORDER_TEMPLATE.md` — the work-order format Claude fills per work package.
+- `PITFALLS.md` — the shared pitfall list every order points delegates at.
+- `orders/<slug>/wpN.md` — live work orders, one directory per feature.
+- `PAUSE` — kill switch: if this file exists, nothing is dispatched to any
+  delegate until it is removed. `touch .factory/PAUSE` to halt the factory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,3 +88,12 @@
 - If the repo owner or operator explicitly authorizes merge in-thread, OpenAI
   or Codex review with no blocking findings can satisfy the final review gate
   without a separate human GitHub review.
+
+## Factory
+
+- This repo runs a factory loop orchestrated by Claude: PRDs become work
+  orders under `.factory/orders/`, dispatched to delegate models. See
+  `CLAUDE.md` (operating manual) and `.factory/README.md`.
+- If you were invoked with a work order: the order's file lists, validation
+  commands, and `.factory/PITFALLS.md` are binding. Git is read-only for
+  delegates — never commit, push, stash, reset, or clean.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,100 @@
+# CLAUDE.md — Factory Operating Manual
+
+Claude is the planner/orchestrator of this repo's software factory: Guillaume
+supplies a PRD (or a conversation), Claude decomposes it into work packages
+(WPs), dispatches them to delegate models, reviews everything, and ships
+through the pipeline. Delegates implement; Claude decides, verifies, commits.
+
+The factory loop is encoded as project skills: `/factory-prd` (decompose) →
+`/factory-dispatch` (run one WP through a delegate + review gate) →
+`/factory-ship` (validate → PR → gate → verify prod). Orders and shared
+pitfalls live in `.factory/`. `AGENTS.md` is the instruction sheet every
+delegate must follow; this file is how Claude runs the floor.
+
+## Routing table
+
+| Work class | Model | Invocation |
+|---|---|---|
+| Plan, decompose, adversarial review, commit, merge, deploy verify, anything ambiguous | Claude (this session) | — |
+| Implementation WPs (Svelte/UI/features) — favored implementer | GLM 5.2 | `pi --provider glm-cloud --model glm-5.2 --thinking high -p "$(cat .factory/orders/<slug>/wpN.md)"` |
+| Backend-ish work: scripts, config, CI, data plumbing, heavy refactors | GPT 5.5 | `pi --provider openai-codex --model gpt-5.5 --thinking high -p "$(cat ...)"` |
+| Routine read-heavy/write-light: triage, PR summaries, changelogs, doc sync | north-mini (local) | `pi --provider north-mini-code --model north-mini-code -p "..."` |
+
+- Fresh `pi` session per WP. `--session`-continue ONLY to fix a failed
+  validation within the same WP — never to start the next one.
+- north-mini has an 8K output ceiling — give it reading jobs, not writing jobs.
+- The native `codex` CLI is broken locally; GPT 5.5 goes through pi.
+
+## Ship pipeline (every change, no exceptions)
+
+1. `git fetch origin main` then branch `codex/<slug>` from `origin/main`
+   (fetch before EVERY cut — a stale origin/main once dropped a merged PR).
+2. Validate: `bun run typecheck` (0 errors) · `bun run lint` (0) ·
+   `bun run test` (root) · `cd apps/portal && bun test` · `bun run build`
+   with build log grepped for `unused css selector` = 0.
+3. PR against `main` with the WORKFLOW.md proof bundle (summary, validation
+   output, local URL, browser artifacts for UI, risk notes).
+4. Gate (background): poll `mergeStateStatus == CLEAN`, fail-fast on any
+   check failure, merge, then verify — never walk away before this is green.
+5. Verify main CI for the exact merge sha, then the Vercel production
+   deployment status for that sha. Report the merge commit honestly.
+
+Gate gotchas (each learned the hard way):
+- **Never report success on timeout.** Track a `merged` flag; if the CLEAN
+  poll times out, exit non-zero. A fall-through once reported the previous
+  PR's merge as this PR's success.
+- Verification sha comes from `gh pr view N --json mergeCommit` — never from
+  `git ls-remote origin main`.
+- `BLOCKED` with all checks green = branch behind main (merge origin/main in
+  and push) OR an unresolved review conversation
+  (`required_conversation_resolution` is on — resolve via GraphQL
+  `resolveReviewThread` after replying).
+- Guillaume keeps worktrees (`serious-trader-ralph-ci` holds `main`), so
+  `gh pr merge --delete-branch` fails locally AFTER remote success. Confirm
+  with `gh pr view N --json state,mergeCommit`; delete remote branches with
+  `git push origin --delete <branch>`.
+- Never `--delete-branch` a PR that has a stacked PR based on it.
+- Local biome sometimes accepts formatting CI rejects (version skew); when CI
+  lint fails on formatting, apply CI's preference manually.
+
+## Delegation contract
+
+- Work orders live at `.factory/orders/<slug>/wpN.md`, written by Claude from
+  `.factory/ORDER_TEMPLATE.md`. Every order carries: goal + non-goals, exact
+  create/modify/delete file lists (absolute paths), verbatim load-bearing
+  payloads, validation commands with "paste full output", the report format,
+  and a pointer to `.factory/PITFALLS.md`.
+- **Delegates are git read-only** (`status`/`diff`/`log` only). Only Claude
+  commits — per accepted WP, so every commit is a clean rollback point.
+- Review gate before any commit (see `/factory-dispatch`):
+  `git status --porcelain` must exactly match the order's declared files;
+  adversarial diff read; full validation green; browser smoke for UI changes.
+- A delegate's claim of success is worth nothing until validation output is
+  reproduced locally. CI is the arbiter, not any model's report.
+
+## Failsafes
+
+- **PAUSE**: if `.factory/PAUSE` exists, dispatch nothing. Check before every
+  delegate invocation.
+- **Blast radius**: ≤ ~400 changed lines per WP (split bigger); one PR in
+  flight per lane at a time.
+- **Prod regression**: revert first, investigate second.
+- **Ambiguity**: escalate to Guillaume with a concrete question — never
+  resolve product ambiguity by assumption.
+- **Honest data**: never render fake market/account/outcome data; missing
+  feeds show as explicit unavailable/gated states (see AGENTS.md).
+- **Retro**: after each factory run, fold what creaked into this file,
+  `.factory/PITFALLS.md`, or the skills — the factory is also on the line.
+
+## Testing policy (anti-flake)
+
+- Unit tests (`bun test`) must be pure and deterministic: no network, no
+  timers, no DOM, no ordering/time dependence. Exact-output assertions
+  preferred (e.g. formatter tests).
+- Browser verification (real Chrome via Playwright script, screenshots,
+  geometry probes) is a **proof-bundle step**, never a CI assertion — no e2e
+  test suite.
+- Prod monitoring alerts (future sentinel leg) alert; they do not block
+  builds.
+- Headless Chromium cannot hold the Phoenix WS — use
+  `chromium.launch({ channel: "chrome" })` for anything live.


### PR DESCRIPTION
## Summary

Software-factory scaffolding, skills-first and laptop-only (per plan): Guillaume writes a PRD, Claude orchestrates delegate models (GLM 5.2 / GPT 5.5 / north-mini via `pi`) through versioned, invokable procedures.

- **`CLAUDE.md`** — operating manual: model routing table, ship pipeline with gate gotchas, delegation contract (delegates git read-only, Claude commits), failsafes (`.factory/PAUSE` kill switch, ≤400-line WPs, revert-first, escalate ambiguity), anti-flake testing policy.
- **`.factory/`** — `ORDER_TEMPLATE.md` (proven WP order format), `PITFALLS.md` (14 production-learned rules binding on every delegate), `orders/` workspace, README with PAUSE semantics.
- **`.claude/skills/`** — `/factory-prd` (PRD → work orders), `/factory-dispatch` (delegate one WP + adversarial review gate), `/factory-ship` (validate → PR → fail-fast gate → prod verify).
- **`AGENTS.md`** — short Factory pointer section appended; no behavioral rewrites.

Docs/skills only — zero app code changed.

## Validation

- `bun run typecheck` — 0 errors / 0 warnings (packages/ui 237 files, apps/portal 1563 files)
- `bun run lint` — clean (109 files)
- `bun run test` — 16/16 (packages/ui)
- `apps/portal bun test` — 204/204
- `bun run build` — success, `unused css selector` = 0

## Risk notes

- No runtime surface touched; worst case is doc drift, corrected via the retro loop built into the skills.
- Skills load on next Claude Code session start in this repo (discoverability verified next session; frontmatter follows the standard SKILL.md format).
- Deferred deliberately: scripts/ extraction, Vercel cron sentinel, queue automation (plan Milestone B+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)