### PR TITLE
Monitor panel responsiveness: chip/price overlap fix + width-adaptive columns

### DIFF
--- a/.factory/orders/monitor-row-overlap/wp1.md
+++ b/.factory/orders/monitor-row-overlap/wp1.md
@@ -1,0 +1,111 @@
+# WP1 — Monitor panel: leverage chip must never overlap the MARK column
+
+You are implementing one scoped work package in the `serious-trader-ralph`
+repo. Follow this order exactly. Read `AGENTS.md` and `.factory/PITFALLS.md`
+before touching anything — every rule in them is binding.
+
+## Goal
+
+In the terminal's Markets/monitor panel, at narrow panel widths the leverage
+chip (`20x`, `60x`…) beside the market symbol overflows the symbol cell and
+collides with the MARK price column (screenshot evidence: GOLD/COPPER/AMZN
+rows). Fix: the symbol cell must contain its content — symbol text truncates
+with an ellipsis under pressure, the chip never shrinks and never overlaps
+the price — and the numeric columns give up the dead space they don't need.
+
+## Non-goals
+
+- Do NOT touch any other panel (Screener, Watch, Events, Spot) even if they
+  look similar.
+- Do NOT change fonts, colors, paddings, hover/active styles, sort logic,
+  or any TypeScript.
+- Do NOT introduce media/container queries — this fix is intrinsic sizing
+  only.
+
+## Files
+
+Create: none
+
+Modify:
+- /Users/guillaume/Github/serious-trader-ralph/apps/portal/src/routes/terminal/components/MonitorPanel.svelte
+  — markup: wrap the symbol text node in a span; CSS: 4 small changes below.
+
+Delete: none
+
+Touch NOTHING outside this list. If the task seems to require another file,
+STOP and report why instead of editing it.
+
+## Load-bearing payloads
+
+1. Markup (currently lines 84–87). Replace:
+
+```svelte
+        <span class="monitor-sym">
+          {row.symbol}
+          {#if row.lev}<i>{row.lev}x</i>{/if}
+        </span>
+```
+
+with:
+
+```svelte
+        <span class="monitor-sym">
+          <span class="sym-name">{row.symbol}</span>
+          {#if row.lev}<i>{row.lev}x</i>{/if}
+        </span>
+```
+
+2. CSS — in the `<style>` block of the same file:
+
+a. In `.monitor-row`, replace the line
+   `grid-template-columns: minmax(0, 1fr) 5.5rem 4.5rem 6rem;`
+   with
+   `grid-template-columns: minmax(0, 1fr) 5rem 3.6rem 5.2rem;`
+   (widest real content: mark "63,853.50" ≈ 4.3rem, 24h "-1.14%" ≈ 2.9rem,
+   volume "$7,308,420" ≈ 4.8rem — all still fit right-aligned.)
+
+b. In `.monitor-sym`, add `min-width: 0;` (keep existing properties):
+   `.monitor-sym { font-weight: 700; display: flex; gap: 0.35rem; align-items: baseline; min-width: 0; }`
+
+c. Add a new rule directly below `.monitor-sym`:
+   `.monitor-sym .sym-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }`
+
+d. In `.monitor-sym i`, add `flex-shrink: 0;` (keep existing properties).
+
+## Acceptance criteria
+
+- Symbol text ellipsizes under width pressure; the leverage chip stays fully
+  visible and never renders over the MARK column at any panel width.
+- At comfortable widths nothing visually changes except the numeric columns
+  sitting slightly tighter (still right-aligned, nothing clipped).
+- The sticky header row (`.monitor-head`, which shares `.monitor-row`'s
+  grid) still aligns with the body columns.
+- Zero new `unused css selector` warnings (the new `.sym-name` rule must
+  match the new markup).
+
+## Validation (run all, paste FULL output)
+
+```bash
+bun run typecheck
+bun run lint
+bun run test
+cd apps/portal && bun test
+bun run build
+```
+
+Also grep the build output for `unused css selector` — must be 0 occurrences.
+
+## Report format
+
+1. Summary of what changed, per file.
+2. Full validation output (verbatim, no truncation).
+3. Anything you could not do, skipped, or are unsure about — say so plainly.
+4. NO claims of success without the validation output to back them.
+
+## Rules (non-negotiable)
+
+- Git is READ-ONLY for you: `git status` / `git diff` / `git log` only.
+  Never commit, push, stash, restore, reset, or clean.
+- Stay inside the file list above.
+- Kill any dev server you start.
+- All pitfalls in `.factory/PITFALLS.md` apply.

--- a/apps/portal/src/routes/terminal/components/MonitorPanel.svelte
+++ b/apps/portal/src/routes/terminal/components/MonitorPanel.svelte
@@ -82,7 +82,7 @@
         onclick={() => onselect(row.symbol)}
       >
         <span class="monitor-sym">
-          {row.symbol}
+          <span class="sym-name">{row.symbol}</span>
           {#if row.lev}<i>{row.lev}x</i>{/if}
         </span>
         <span class="r mono">{formatPrice(row.mid)}</span>
@@ -105,6 +105,9 @@
     display: flex;
     flex-direction: column;
     max-height: 26rem;
+    /* Rows adapt to the panel's own width (it ranges ~230-340px on
+       720-1100px viewports where the dashboard grid stays 12-col). */
+    container-type: inline-size;
   }
 
   /* ── Markets monitor panel ───────────────────────────────────────── */
@@ -134,7 +137,7 @@
 
   .monitor-row {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 5.5rem 4.5rem 6rem;
+    grid-template-columns: minmax(0, 1fr) 5rem 3.6rem 5.2rem;
     gap: 0.5rem;
     width: 100%;
     padding: 0.3rem 0.9rem;
@@ -162,8 +165,30 @@
     background: var(--surface);
   }
 
-  .monitor-sym { font-weight: 700; display: flex; gap: 0.35rem; align-items: baseline; }
+  /* Shed the lowest-value columns as the panel narrows: volume first,
+     then 24h — the symbol + mark price must always stay legible. */
+  @container (max-width: 21rem) {
+    .monitor-row {
+      grid-template-columns: minmax(0, 1fr) 5rem 3.6rem;
+    }
+    .monitor-row > :nth-child(4) {
+      display: none;
+    }
+  }
+
+  @container (max-width: 16rem) {
+    .monitor-row {
+      grid-template-columns: minmax(0, 1fr) 5rem;
+    }
+    .monitor-row > :nth-child(3) {
+      display: none;
+    }
+  }
+
+  .monitor-sym { font-weight: 700; display: flex; gap: 0.35rem; align-items: baseline; min-width: 0; }
+  .monitor-sym .sym-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .monitor-sym i {
+    flex-shrink: 0;
     font-style: normal;
     font-family: ui-monospace, monospace;
     font-size: 0.6rem;


### PR DESCRIPTION
## Summary

Bug (screenshot report): leverage chips (`20x`, `60x`…) overlapped the MARK price column in the Markets/monitor panel at narrow panel widths.

Two-layer fix in `MonitorPanel.svelte` (first factory-dispatched WP — order at `.factory/orders/monitor-row-overlap/wp1.md`, implemented by GLM 5.2, amended by Claude after the geometry probe):

1. **Containment** (delegate): symbol text wrapped in `.sym-name` with ellipsis, chip `flex-shrink: 0`, `.monitor-sym min-width: 0`; numeric tracks trimmed to real content widths (`5rem 3.6rem 5.2rem`).
2. **Width-adaptive columns** (amendment): on 720–1100px viewports the dashboard grid stays 12-col, so the panel is only ~230–340px — four columns cannot fit. The panel is now an inline-size container: VOLUME drops below 21rem panel width, 24H below 16rem. Symbol + mark price stay legible at every width.

## Validation

- typecheck 0/0 · lint clean · 16/16 ui + 204/204 portal tests · build success · `unused css selector` = 0
- **Real-Chrome geometry probe** (51 live markets): 0 overlapping rows at 1440/1200/1000/900/800/760/721/700/600px viewports; column count adapts 4→3→2→4(stacked). Before fix: 51/51 rows overlapped at 900px.
- Screenshots: panel at 285px shows 3 clean columns, all symbols+chips legible; 1440px unchanged 4-column layout.

## Risk notes

- First use of a CSS container query in the repo (`container-type: inline-size` on the panel; supported in all evergreen browsers). Scoped to this component.
- Local URL used for verification: http://localhost:3000/terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)