### PR TITLE
Factory retro 1: order-writing and dispatch learnings from #491

### DIFF
--- a/.claude/skills/factory-dispatch/SKILL.md
+++ b/.claude/skills/factory-dispatch/SKILL.md
@@ -15,6 +15,10 @@ delegate, reviews the result adversarially, and commits only what survives.
 2. Working tree must be clean apart from expected untracked files
    (`git status --porcelain`) — never dispatch onto a dirty tree.
 3. The order file exists and has no unfilled `<placeholders>`.
+4. **Branch**: for a slug's first WP, `git fetch origin main` and cut
+   `codex/<slug>` from `origin/main` before dispatching; for later WPs,
+   confirm you're already on that branch. The delegate mutates whatever
+   is checked out — never dispatch from a stale or unrelated branch.
 
 ## Dispatch
 

--- a/.claude/skills/factory-prd/SKILL.md
+++ b/.claude/skills/factory-prd/SKILL.md
@@ -21,6 +21,14 @@ ARTIFACTS ONLY — no code changes, no delegate invocations.
    implementation exists. Check `.factory/PITFALLS.md` for constraints that
    shape the design.
 
+   For UI/layout WPs: **measure the component's real rendered size range
+   before writing acceptance criteria** — check its grid span, the page's
+   media queries, and compute (or probe) the actual min/max container
+   width. Never anchor acceptance to an assumed viewport. (Learned on
+   monitor-row-overlap: the order fixed "no overlap at ~900px viewport"
+   without knowing the panel shrinks to ~230px there — the delegate
+   executed a perfect fix to an insufficient spec.)
+
 3. **Decompose into 1–N work packages.** Each WP must be:
    - Independently validatable (the full validation suite passes after it).
    - ≤ ~400 changed lines.

--- a/.factory/PITFALLS.md
+++ b/.factory/PITFALLS.md
@@ -40,3 +40,8 @@ gate.
 13. **Kill any dev server you start** before reporting done.
 14. **No fake data.** Missing feeds render as explicit unavailable/gated
     states, never invented rows or stats.
+15. **Terminal panels get much narrower than you think.** On 720–1100px
+    viewports the dashboard grid stays 12-col, so a `span 4` panel is only
+    ~230–340px wide. Design rows for the panel's own width (inline-size
+    container queries are established practice — see MonitorPanel), and
+    verify layout claims with a real-browser geometry probe, not by eye.


### PR DESCRIPTION
## Summary

Retro from the factory's first dispatched work package (#491), folded back per the loop's design:

- **`factory-prd`**: UI orders must measure the component's real rendered size range (grid span + media queries) before writing acceptance criteria — the #491 order anchored to an assumed viewport and specified an insufficient fix.
- **`factory-dispatch`**: pre-flight now includes cutting `codex/<slug>` from freshly-fetched `origin/main` (was done by convention, not written down).
- **`.factory/PITFALLS.md`** #15: terminal panels shrink to ~230–340px on 720–1100px viewports; design for the panel's own width and verify with a real-browser geometry probe.

Docs only.

## Validation

- `bun run lint` clean; no code touched (typecheck/tests/build unaffected — CI will confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)