### PR TITLE
accept-traders T3: legal baseline — /terms, /privacy, footer links

### DIFF
--- a/.factory/orders/accept-traders/wp3-legal.md
+++ b/.factory/orders/accept-traders/wp3-legal.md
@@ -1,0 +1,208 @@
+# WP3 — Legal baseline: /terms, /privacy, footer links
+
+You are implementing one scoped work package in the `serious-trader-ralph`
+repo (ticket #496, PRD #493). Follow this order exactly. Read `AGENTS.md`
+and `.factory/PITFALLS.md` before touching anything — every rule is binding.
+
+## Goal
+
+Two static legal pages (/terms, /privacy) in the marketing style, linked
+from the shared SiteFooter and the home page's own footer. The COPY BELOW
+IS FINAL for this WP — lay it out verbatim; do not rewrite, embellish, or
+add legal language of your own. (Guillaume reviews the copy on the PR
+preview; edits happen there, not by you.)
+
+## Non-goals
+
+- No terminal-side links or modals (that's ticket #497).
+- No cookie banners, no consent tooling.
+- No new dependencies; no OG images for these pages.
+
+## Files
+
+Create:
+- /Users/guillaume/Github/serious-trader-ralph/apps/portal/src/routes/terms/+page.svelte
+- /Users/guillaume/Github/serious-trader-ralph/apps/portal/src/routes/privacy/+page.svelte
+
+Modify:
+- /Users/guillaume/Github/serious-trader-ralph/packages/ui/src/components/SiteFooter.svelte
+  — add two links to the `.links` nav, after the Terminal link:
+  `<a href="/terms">Terms</a>` and `<a href="/privacy">Privacy</a>`.
+  Change nothing else.
+- /Users/guillaume/Github/serious-trader-ralph/apps/portal/src/routes/+page.svelte
+  — the home page has its OWN footer (`<footer class="footer">`, ~line
+  230). Inside it, add the same two links wherever its existing nav links
+  live, matching the local markup/classes. Change nothing else in this
+  file.
+
+Delete: none
+
+## Page pattern
+
+Both pages follow the repo's marketing-page conventions: import
+`{ SiteNav, SiteFooter }` from `@trader-ralph/ui` exactly as
+`src/routes/news/+page.svelte` does (check its head/imports and copy the
+skeleton: `<svelte:head>` with title + meta description, `<SiteNav />`,
+a main content column, `<SiteFooter />`). Content column: max-width
+~46rem, centered, headings + paragraphs styled with existing CSS tokens
+(--ink, --muted, --line-soft). Svelte 5 runes if any script is needed
+(none should be — these are static).
+
+`<svelte:head>`: terms → title "Terms of Service — Trader Ralph",
+privacy → title "Privacy Policy — Trader Ralph"; meta descriptions one
+sentence each.
+
+## Load-bearing payload — /terms copy (verbatim)
+
+# Terms of Service
+
+Last updated: July 6, 2026
+
+## 1. What Trader Ralph is
+
+Trader Ralph ("the Service") is a self-custodial trading interface. It
+displays market data and lets you construct transactions — spot swaps and
+perpetual futures orders — that you sign with your own wallet and that
+execute on public Solana protocols (Phoenix, Jupiter). We do not take
+custody of your funds, execute trades on your behalf, operate an exchange,
+or act as a broker, dealer, or investment adviser.
+
+## 2. Your wallet, your keys
+
+Signing in creates an embedded self-custodial wallet operated by Privy.
+You control it; we cannot move your funds, reverse your transactions, or
+recover assets sent to the wrong address. On-chain transactions are final.
+
+## 3. Eligibility
+
+You must be of legal age in your jurisdiction and permitted under the laws
+that apply to you to use self-custodial trading software. You are
+responsible for your own tax and legal obligations. Wallets are screened
+against the OFAC SDN list; access from sanctioned jurisdictions is
+prohibited. Availability of specific features may be restricted by region.
+
+## 4. Risk disclosure
+
+Trading digital assets involves substantial risk of loss. Leveraged
+perpetual futures can be liquidated: you can lose your entire margin, and
+markets can move faster than you can react. Tokenized equities provide
+synthetic price exposure only — they carry no shareholder rights, no
+dividends, and no claim on any issuer. Prices, market data, and desk
+commentary shown in the Service are informational, may be delayed or
+wrong, and are not financial advice. Trade only what you can afford to
+lose.
+
+## 5. The protocols are not ours
+
+Orders execute on third-party protocols and infrastructure (Solana,
+Phoenix, Jupiter, RPC providers). We do not control them and are not
+responsible for their availability, behavior, fees, or failures.
+
+## 6. Acceptable use
+
+Do not use the Service to break the law, evade sanctions, manipulate
+markets, or probe, disrupt, or reverse-engineer the Service or the
+protocols it connects to.
+
+## 7. No warranties; limitation of liability
+
+The Service is provided "as is", without warranties of any kind. To the
+maximum extent permitted by law, we are not liable for trading losses,
+lost profits, or any indirect, incidental, or consequential damages
+arising from your use of the Service — including losses caused by data
+errors, downtime, network failures, or protocol behavior.
+
+## 8. Changes
+
+We may update the Service and these terms. Continued use after an update
+constitutes acceptance. Material changes will be reflected in the "Last
+updated" date above.
+
+## 9. Contact
+
+Questions about these terms: gui.bibeau@solana.org.
+
+## Load-bearing payload — /privacy copy (verbatim)
+
+# Privacy Policy
+
+Last updated: July 6, 2026
+
+## What we collect
+
+- **Email address** — used by Privy to authenticate you and create your
+  embedded wallet. We see the email you sign in with.
+- **Wallet address** — public by nature; used to display your balances and
+  positions and to build your transactions.
+- **Usage telemetry** — anonymous product events (orders submitted,
+  markets viewed, errors) tied to session identifiers, stored in
+  aggregate logs to improve the product.
+- **Approximate location** — country/region inferred from your IP by our
+  hosting provider at request time, recorded in telemetry. We do not
+  store your IP address in our logs.
+
+## What we do NOT collect
+
+Private keys (they live in Privy's isolated infrastructure — we never see
+them), government ID, payment cards, or bank details. We do not sell or
+rent any of your data, and we do not use advertising trackers.
+
+## Third parties we rely on
+
+- **Privy** — authentication and embedded wallets (email, wallet keys).
+- **Vercel** — hosting and request-time geolocation.
+- **Solana RPC, Phoenix, Jupiter, market-data providers** — receive the
+  public wallet addresses and transactions inherent to using them.
+
+Each processes data under its own privacy policy.
+
+## Retention and your choices
+
+Telemetry is retained in rolling aggregate logs. You can stop using the
+Service at any time; your wallet remains yours through Privy
+independently of us. For data questions or deletion requests:
+gui.bibeau@solana.org.
+
+## Changes
+
+Material changes will be reflected in the "Last updated" date above.
+
+## Acceptance criteria
+
+- /terms and /privacy render the copy above verbatim, styled consistently
+  with the marketing pages (dark theme, readable measure, real heading
+  hierarchy).
+- SiteFooter on news/hub/slug/share pages and the home page footer show
+  Terms + Privacy links; no other footer content changed.
+- No dead links; pages return 200 in dev.
+- Zero new `unused css selector` warnings.
+
+## Validation (run all, paste FULL output)
+
+```bash
+bun run typecheck
+bun run lint
+bun run test
+cd apps/portal && bun test
+bun run build
+```
+
+Also grep the build output for `unused css selector` — must be 0
+occurrences. Then start the dev server, `curl -sf -o /dev/null -w "%{http_code}"`
+for /terms and /privacy (expect 200 each), and KILL the dev server.
+
+## Report format
+
+1. Summary of what changed, per file.
+2. Full validation output (verbatim, no truncation).
+3. Anything you could not do, skipped, or are unsure about — say so plainly.
+4. NO claims of success without validation output to back them.
+
+## Rules (non-negotiable)
+
+- Git is READ-ONLY for you: `status` / `diff` / `log` only. Never commit,
+  push, stash, restore, reset, or clean.
+- Stay inside the file lists above.
+- The legal copy is verbatim — no rewording.
+- All pitfalls in `.factory/PITFALLS.md` apply (packages/ui edit: no
+  `$lib`/`$app`/`$env` imports there).

--- a/apps/portal/src/routes/+page.svelte
+++ b/apps/portal/src/routes/+page.svelte
@@ -246,6 +246,8 @@
       Trading involves risk. Tokenized equities provide synthetic exposure and carry no
       shareholder rights. Desk commentary is informational, not financial advice.
       <a href="/llms.txt">llms.txt</a>
+      <a href="/terms">Terms</a>
+      <a href="/privacy">Privacy</a>
     </div>
   </footer>
 </div>

--- a/apps/portal/src/routes/privacy/+page.svelte
+++ b/apps/portal/src/routes/privacy/+page.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import { SiteFooter, SiteNav } from "@trader-ralph/ui";
+</script>
+
+<svelte:head>
+  <title>Privacy Policy — Trader Ralph</title>
+  <meta
+    name="description"
+    content="What Trader Ralph collects — email, wallet address, usage telemetry, approximate region — and the third parties it relies on."
+  />
+</svelte:head>
+
+<div class="site">
+  <SiteNav />
+
+  <main class="page">
+    <h1>Privacy Policy</h1>
+    <p class="updated">Last updated: July 6, 2026</p>
+
+    <section class="doc">
+      <h2>What we collect</h2>
+      <ul class="list">
+        <li>
+          <strong>Email address</strong> — used by Privy to authenticate you and
+          create your embedded wallet. We see the email you sign in with.
+        </li>
+        <li>
+          <strong>Wallet address</strong> — public by nature; used to display
+          your balances and positions and to build your transactions.
+        </li>
+        <li>
+          <strong>Usage telemetry</strong> — anonymous product events (orders
+          submitted, markets viewed, errors) tied to session identifiers, stored
+          in aggregate logs to improve the product.
+        </li>
+        <li>
+          <strong>Approximate location</strong> — country/region inferred from
+          your IP by our hosting provider at request time, recorded in
+          telemetry. We do not store your IP address in our logs.
+        </li>
+      </ul>
+
+      <h2>What we do NOT collect</h2>
+      <p>
+        Private keys (they live in Privy's isolated infrastructure — we never
+        see them), government ID, payment cards, or bank details. We do not sell
+        or rent any of your data, and we do not use advertising trackers.
+      </p>
+
+      <h2>Third parties we rely on</h2>
+      <ul class="list">
+        <li>
+          <strong>Privy</strong> — authentication and embedded wallets (email,
+          wallet keys).
+        </li>
+        <li><strong>Vercel</strong> — hosting and request-time geolocation.</li>
+        <li>
+          <strong>Solana RPC, Phoenix, Jupiter, market-data providers</strong>
+          — receive the public wallet addresses and transactions inherent to
+          using them.
+        </li>
+      </ul>
+      <p>Each processes data under its own privacy policy.</p>
+
+      <h2>Retention and your choices</h2>
+      <p>
+        Telemetry is retained in rolling aggregate logs. You can stop using the
+        Service at any time; your wallet remains yours through Privy
+        independently of us. For data questions or deletion requests:
+        gui.bibeau@solana.org.
+      </p>
+
+      <h2>Changes</h2>
+      <p>
+        Material changes will be reflected in the "Last updated" date above.
+      </p>
+    </section>
+  </main>
+
+  <SiteFooter />
+</div>
+
+<style>
+  .site { min-height: 100vh; background: var(--paper); color: var(--ink); }
+  .page { max-width: 46rem; margin: 0 auto; padding: 3rem 1.5rem 5rem; }
+  h1 { font-size: clamp(2rem, 4.5vw, 2.8rem); letter-spacing: -0.02em; line-height: 1.1; margin: 0 0 0.5rem; }
+  .updated {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.74rem;
+    color: var(--faint);
+    margin: 0 0 2.5rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--line-soft);
+  }
+  .doc h2 { font-size: 1.15rem; letter-spacing: -0.01em; margin: 2.4rem 0 0.7rem; }
+  .doc p { color: var(--muted); font-size: 0.95rem; line-height: 1.7; margin: 0; }
+  .list { list-style: none; margin: 0; padding: 0; }
+  .list li {
+    color: var(--muted);
+    font-size: 0.95rem;
+    line-height: 1.65;
+    padding: 0.55rem 0;
+    border-bottom: 1px solid var(--line-soft);
+  }
+  .list strong { color: var(--ink); font-weight: 600; }
+</style>

--- a/apps/portal/src/routes/terms/+page.svelte
+++ b/apps/portal/src/routes/terms/+page.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+  import { SiteFooter, SiteNav } from "@trader-ralph/ui";
+</script>
+
+<svelte:head>
+  <title>Terms of Service — Trader Ralph</title>
+  <meta
+    name="description"
+    content="The terms that govern your use of Trader Ralph, a self-custodial trading interface for spot and perpetual futures on Solana."
+  />
+</svelte:head>
+
+<div class="site">
+  <SiteNav />
+
+  <main class="page">
+    <h1>Terms of Service</h1>
+    <p class="updated">Last updated: July 6, 2026</p>
+
+    <section class="doc">
+      <h2>1. What Trader Ralph is</h2>
+      <p>
+        Trader Ralph ("the Service") is a self-custodial trading interface. It
+        displays market data and lets you construct transactions — spot swaps
+        and perpetual futures orders — that you sign with your own wallet and
+        that execute on public Solana protocols (Phoenix, Jupiter). We do not
+        take custody of your funds, execute trades on your behalf, operate an
+        exchange, or act as a broker, dealer, or investment adviser.
+      </p>
+
+      <h2>2. Your wallet, your keys</h2>
+      <p>
+        Signing in creates an embedded self-custodial wallet operated by Privy.
+        You control it; we cannot move your funds, reverse your transactions, or
+        recover assets sent to the wrong address. On-chain transactions are
+        final.
+      </p>
+
+      <h2>3. Eligibility</h2>
+      <p>
+        You must be of legal age in your jurisdiction and permitted under the
+        laws that apply to you to use self-custodial trading software. You are
+        responsible for your own tax and legal obligations. Wallets are screened
+        against the OFAC SDN list; access from sanctioned jurisdictions is
+        prohibited. Availability of specific features may be restricted by
+        region.
+      </p>
+
+      <h2>4. Risk disclosure</h2>
+      <p>
+        Trading digital assets involves substantial risk of loss. Leveraged
+        perpetual futures can be liquidated: you can lose your entire margin,
+        and markets can move faster than you can react. Tokenized equities
+        provide synthetic price exposure only — they carry no shareholder
+        rights, no dividends, and no claim on any issuer. Prices, market data,
+        and desk commentary shown in the Service are informational, may be
+        delayed or wrong, and are not financial advice. Trade only what you can
+        afford to lose.
+      </p>
+
+      <h2>5. The protocols are not ours</h2>
+      <p>
+        Orders execute on third-party protocols and infrastructure (Solana,
+        Phoenix, Jupiter, RPC providers). We do not control them and are not
+        responsible for their availability, behavior, fees, or failures.
+      </p>
+
+      <h2>6. Acceptable use</h2>
+      <p>
+        Do not use the Service to break the law, evade sanctions, manipulate
+        markets, or probe, disrupt, or reverse-engineer the Service or the
+        protocols it connects to.
+      </p>
+
+      <h2>7. No warranties; limitation of liability</h2>
+      <p>
+        The Service is provided "as is", without warranties of any kind. To the
+        maximum extent permitted by law, we are not liable for trading losses,
+        lost profits, or any indirect, incidental, or consequential damages
+        arising from your use of the Service — including losses caused by data
+        errors, downtime, network failures, or protocol behavior.
+      </p>
+
+      <h2>8. Changes</h2>
+      <p>
+        We may update the Service and these terms. Continued use after an update
+        constitutes acceptance. Material changes will be reflected in the "Last
+        updated" date above.
+      </p>
+
+      <h2>9. Contact</h2>
+      <p>Questions about these terms: gui.bibeau@solana.org.</p>
+    </section>
+  </main>
+
+  <SiteFooter />
+</div>
+
+<style>
+  .site { min-height: 100vh; background: var(--paper); color: var(--ink); }
+  .page { max-width: 46rem; margin: 0 auto; padding: 3rem 1.5rem 5rem; }
+  h1 { font-size: clamp(2rem, 4.5vw, 2.8rem); letter-spacing: -0.02em; line-height: 1.1; margin: 0 0 0.5rem; }
+  .updated {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.74rem;
+    color: var(--faint);
+    margin: 0 0 2.5rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--line-soft);
+  }
+  .doc h2 { font-size: 1.15rem; letter-spacing: -0.01em; margin: 2.4rem 0 0.7rem; }
+  .doc p { color: var(--muted); font-size: 0.95rem; line-height: 1.7; margin: 0; }
+</style>

--- a/packages/ui/src/components/SiteFooter.svelte
+++ b/packages/ui/src/components/SiteFooter.svelte
@@ -11,6 +11,8 @@
     <a href="/pre-ipo">Pre-IPO</a>
     <a href="/crypto">Crypto</a>
     <a href="/terminal">Terminal</a>
+    <a href="/terms">Terms</a>
+    <a href="/privacy">Privacy</a>
   </div>
   <p class="provenance">
     Data: tokens.xyz, Phoenix, Jupiter, Yahoo Finance. Wallets by Privy,


### PR DESCRIPTION
Closes #496 · Part of PRD #493 · **DO NOT MERGE — copy needs Guillaume's explicit review on the preview**

## Summary

- `/terms`: what the service is (self-custodial interface, not a broker/exchange/adviser), wallet custody, eligibility + OFAC, risk disclosure (leverage/liquidation, synthetic equities, informational-not-advice), third-party protocols, acceptable use, warranties/liability, changes, contact.
- `/privacy`: what we collect (email via Privy, wallet address, telemetry, IP-derived geo) and don't (keys, ID, cards), third parties (Privy/Vercel/protocols), retention + contact.
- Terms/Privacy links in the shared `SiteFooter` (news/hub/slug/share) and the home page footer (placed beside `llms.txt` in the legal block — flagged judgment call).
- First factory dispatch through the **glm-claude harness** (GLM 5.2 under Claude Code, git read-only enforced by tool permissions). Delegate honestly flagged: footer placement judgment, plain-text emails (no mailto), curl-only smoke.

## Validation

typecheck 0/0 · lint clean · 16 ui + 204 portal tests · build, unused-css = 0 · /terms + /privacy 200 with real content · full-page screenshots taken in review (clean marketing-style render).

## QA notes for preview

**Read the copy** — it's factory-drafted; your edits are the review. Check /terms, /privacy, and the footers (home + news). Emails are plain text by strict-verbatim reading; say the word for mailto links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)