### PR TITLE
Factory retro 2: gate/preview scripts, approval lane, glm-claude lane

### DIFF
--- a/.claude/skills/factory-dispatch/SKILL.md
+++ b/.claude/skills/factory-dispatch/SKILL.md
@@ -23,17 +23,27 @@ delegate, reviews the result adversarially, and commits only what survives.
 ## Dispatch
 
 Pick the invocation from the CLAUDE.md routing table. Default
-(implementation WP):
+(implementation WP) — **glm-claude**, GLM 5.2 under the Claude Code
+harness, git read-only enforced by tool permissions:
 
 ```bash
 cd /Users/guillaume/Github/serious-trader-ralph
-pi --provider glm-cloud --model glm-5.2 --thinking high -p "$(cat .factory/orders/<slug>/wpN.md)"
+glm-claude -p "$(cat .factory/orders/<slug>/wpN.md)" \
+  --allowedTools "Read" "Edit" "Write" "Grep" "Glob" \
+  "Bash(bun:*)" "Bash(bunx:*)" \
+  "Bash(git status:*)" "Bash(git diff:*)" "Bash(git log:*)" \
+  "Bash(curl:*)" "Bash(ls:*)" "Bash(cat:*)" "Bash(head:*)" "Bash(tail:*)" \
+  "Bash(grep:*)" "Bash(rg:*)" "Bash(lsof:*)" "Bash(kill:*)" "Bash(sleep:*)"
 ```
 
-Backend/config WP: `--provider openai-codex --model gpt-5.5`. Routine WP:
-`--provider north-mini-code --model north-mini-code`.
+(`glm-claude` = `~/bin/glm-claude`: Z.ai Anthropic endpoint, isolated
+`~/.claude-glm` config. Never widen --allowedTools to bare "Bash".)
 
-- Fresh session per WP (no `--continue` across WPs).
+Backend/config WP: `pi --provider openai-codex --model gpt-5.5 --thinking
+high -p "$(cat ...)"`. Routine WP: `pi --provider north-mini-code --model
+north-mini-code -p "..."`.
+
+- Fresh session per WP (no `--continue`/`--session` reuse across WPs).
 - Run in background for long WPs; watch for stalls. If a delegate stalls
   twice on the same WP, take it over by hand — don't spin a third time.
 

--- a/.claude/skills/factory-ship/SKILL.md
+++ b/.claude/skills/factory-ship/SKILL.md
@@ -1,13 +1,21 @@
 ---
 name: factory-ship
-description: Ship the current branch to production — validate, open a PR with a proof bundle, gate to merge, verify main CI and the Vercel production deployment. Use when accepted work packages are committed and ready to release.
+description: Ship the current branch — validate, open a PR with a proof bundle, then either gate straight to production (auto lane) or post the preview URL and wait for Guillaume's approval (approval lane). Use when accepted work packages are committed and ready to release.
 ---
 
-# factory-ship — validate → PR → gate → verify prod
+# factory-ship — validate → PR → [approval] → gate → verify prod
 
-Ships the current `codex/<slug>` branch through the full pipeline and
-reports the outcome honestly. Never declare success before the deployment
-status is verified.
+Ships the current `codex/<slug>` branch and reports the outcome honestly.
+Never declare success before the deployment status is verified.
+
+## Lanes — pick one first
+
+- **auto** — docs, retro, factory-internal changes: gate immediately after
+  the PR opens.
+- **approval** (default for feature/UI work, mandatory for PRD #493-era
+  feature tickets): open the PR, post the **preview URL** to Guillaume,
+  and STOP. Only run the gate after an explicit "approve #N". Mark the PR
+  body "DO NOT MERGE — awaiting Guillaume's preview QA".
 
 ## 1. Validate (all green before any push)
 
@@ -24,67 +32,39 @@ grep -ci "unused css selector" /tmp/ship-build.log   # must print 0
 Push the branch and open a PR against `main` with the WORKFLOW.md proof
 bundle: change summary, validation commands + results, local URL used for
 UI verification, browser artifacts (screenshots) for UI changes, risk
-notes / deferred items.
+notes / deferred items. Reference the ticket (`Closes #N`).
 
-## 3. Gate (run in background; fail-fast, never lie)
-
-Materialize this as `/tmp/gate-<pr>.sh` with `PR` and `BRANCH` filled, run
-with `run_in_background`:
+## 3. Preview URL (approval lane)
 
 ```bash
-#!/bin/zsh
-PR=<pr-number>; BRANCH=<branch-name>
-cd /Users/guillaume/Github/serious-trader-ralph
-merged=0
-for i in $(seq 1 60); do
-  state=$(gh pr view $PR --json mergeStateStatus,state -q '.mergeStateStatus + " " + .state')
-  checks=$(gh pr checks $PR 2>/dev/null | grep -c fail || true)
-  if [[ "$checks" != "0" ]]; then echo "$PR CHECK FAILURE"; gh pr checks $PR; exit 1; fi
-  if [[ "$state" == "CLEAN OPEN" ]]; then
-    echo "$PR CLEAN — merging"
-    gh pr merge $PR --merge || exit 1
-    git push origin --delete $BRANCH || true
-    merged=1
-    break
-  fi
-  sleep 20
-done
-# Never lie on timeout: only verify if we actually merged.
-if [[ "$merged" != "1" ]]; then echo "TIMEOUT: $PR never reached CLEAN (last: $state)"; exit 1; fi
-sha=$(gh pr view $PR --json mergeCommit -q '.mergeCommit.oid')
-echo "MERGED, merge commit $sha"
-for i in $(seq 1 90); do
-  run=$(gh run list --branch main --commit $sha --json conclusion,status -q '.[0] | .status + ":" + (.conclusion // "")' 2>/dev/null)
-  [[ "$run" == "completed:success" ]] && { echo "main CI: success"; break; }
-  [[ "$run" == completed:* ]] && { echo "main CI FAILED: $run"; exit 1; }
-  sleep 20
-done
-for i in $(seq 1 90); do
-  dep=$(gh api "repos/GuiBibeau/serious-trader-ralph/deployments?sha=$sha&per_page=1" -q '.[0].id' 2>/dev/null)
-  if [[ -n "$dep" && "$dep" != "null" ]]; then
-    st=$(gh api "repos/GuiBibeau/serious-trader-ralph/deployments/$dep/statuses" -q '.[0].state' 2>/dev/null)
-    [[ "$st" == "success" ]] && { echo "production deployment: success"; exit 0; }
-    [[ "$st" == "failure" || "$st" == "error" ]] && { echo "production deployment: $st"; exit 1; }
-  fi
-  sleep 20
-done
-echo "deployment: timed out"; exit 1
+scripts/factory/preview.sh <pr-number>
 ```
 
-## Gate outcomes — how to react
+Post PR link + preview URL + concrete QA notes ("what to check") to
+Guillaume. Wait. Do not gate.
 
+## 4. Gate (after approval, or immediately in the auto lane)
+
+```bash
+scripts/factory/gate.sh <pr-number> [<pr-number>...]
+```
+
+Run in background. Multiple approved PRs can be passed at once — the
+script serializes them and refreshes each subsequent branch onto the new
+main between merges.
+
+Gate outcomes:
 - `CHECK FAILURE` → fix on the branch, push, rerun the gate.
-- `BLOCKED` with green checks → branch behind main (merge `origin/main` in,
-  push) OR unresolved review conversation (reply, then GraphQL
-  `resolveReviewThread`); then rerun the gate. Treat bot review comments as
-  possibly correct — verify before dismissing.
-- Local branch delete may fail (worktrees hold `main`) — remote delete via
-  `git push origin --delete` is what matters; confirm merge with
-  `gh pr view $PR --json state,mergeCommit`.
-- Timeout → report it as a timeout. NEVER infer success from
-  `git ls-remote` or a green main; only `mergeCommit` counts.
+- `BLOCKED` + green checks → branch behind main (script handles this for
+  queued PRs; for a single PR, merge origin/main in and push) OR an
+  **unresolved review conversation** — the codex bot reviews most PRs and
+  its P2s are usually right: fix, reply, resolve via GraphQL
+  `resolveReviewThread`, and the still-polling gate picks it up.
+- Timeout → it is a timeout; report it as one. Never infer success.
+- Local branch delete may fail (worktrees hold `main`) — remote delete is
+  what matters; confirm with `gh pr view N --json state,mergeCommit`.
 
-## 4. Report
+## 5. Report
 
 Merge commit sha · main CI result · production deployment result — exactly
 as observed. If any step failed or was skipped, say so plainly.

--- a/.factory/PITFALLS.md
+++ b/.factory/PITFALLS.md
@@ -45,3 +45,13 @@ gate.
     ~230–340px wide. Design rows for the panel's own width (inline-size
     container queries are established practice — see MonitorPanel), and
     verify layout claims with a real-browser geometry probe, not by eye.
+16. **Token-only CSS — no fallback hexes.** `var(--amber)` yes,
+    `var(--amber, #d9a441)` no. Palette hexes outside `packages/ui` are
+    forbidden (AGENTS.md) except the terminal chart theme and
+    `static/brand`; fallbacks silently drift from the real token and dodge
+    the drift guard. Applies to order payloads too — reject them in review.
+17. **The codex review bot is part of the pipeline.** It reviews most PRs
+    and its P2 findings are usually correct — treat them as review input,
+    not noise. Unresolved threads hold the PR at BLOCKED
+    (`required_conversation_resolution`): fix, reply, resolve via GraphQL
+    `resolveReviewThread`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ pick up without further human context.
 | Work class | Model | Invocation |
 |---|---|---|
 | Plan, decompose, adversarial review, commit, merge, deploy verify, anything ambiguous | Claude (this session) | — |
-| Implementation WPs (Svelte/UI/features) — favored implementer | GLM 5.2 | `pi --provider glm-cloud --model glm-5.2 --thinking high -p "$(cat .factory/orders/<slug>/wpN.md)"` |
+| Implementation WPs (Svelte/UI/features) — favored implementer | GLM 5.2 | `glm-claude -p "$(cat .factory/orders/<slug>/wpN.md)" --allowedTools ...` (Claude Code harness via Z.ai; git read-only enforced by tool permissions — see factory-dispatch skill for the exact whitelist; `pi --provider glm-cloud` is the fallback) |
 | Backend-ish work: scripts, config, CI, data plumbing, heavy refactors | GPT 5.5 | `pi --provider openai-codex --model gpt-5.5 --thinking high -p "$(cat ...)"` |
 | Routine read-heavy/write-light: triage, PR summaries, changelogs, doc sync | north-mini (local) | `pi --provider north-mini-code --model north-mini-code -p "..."` |
 

--- a/scripts/factory/gate.sh
+++ b/scripts/factory/gate.sh
@@ -1,0 +1,78 @@
+#!/bin/zsh
+# Factory merge gate (see CLAUDE.md ship pipeline / factory-ship skill).
+#
+# Usage: scripts/factory/gate.sh <pr-number> [<pr-number>...]
+#
+# For each PR in order: poll mergeStateStatus to CLEAN (fail-fast on any
+# failing check), merge, delete the remote branch, verify main CI for the
+# exact merge commit, verify the production deployment for that sha.
+# Between PRs, the next branch is refreshed onto the new main so serialized
+# approvals don't strand it at BLOCKED.
+#
+# Honesty invariants (learned in production — do not weaken):
+# - NEVER report success on timeout: the merged flag gates verification.
+# - The verification sha comes from `gh pr view --json mergeCommit`, never
+#   from ls-remote or the main ref.
+# - Local branch deletion is expected to fail (worktrees hold main);
+#   only the remote delete matters.
+
+set -u
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+REPO_SLUG=$(cd "$REPO_DIR" && gh repo view --json nameWithOwner -q .nameWithOwner)
+cd "$REPO_DIR"
+
+gate_one() {
+  local PR=$1 merged=0 state checks sha run dep st BRANCH
+  BRANCH=$(gh pr view $PR --json headRefName -q .headRefName)
+  for i in $(seq 1 60); do
+    state=$(gh pr view $PR --json mergeStateStatus,state -q '.mergeStateStatus + " " + .state')
+    checks=$(gh pr checks $PR 2>/dev/null | grep -c fail || true)
+    if [[ "$checks" != "0" ]]; then echo "$PR CHECK FAILURE"; gh pr checks $PR; return 1; fi
+    if [[ "$state" == "CLEAN OPEN" ]]; then
+      echo "$PR CLEAN — merging"
+      gh pr merge $PR --merge || return 1
+      git push origin --delete "$BRANCH" 2>/dev/null || true
+      merged=1; break
+    fi
+    sleep 20
+  done
+  if [[ "$merged" != "1" ]]; then
+    echo "TIMEOUT: $PR never reached CLEAN (last: $state)"
+    echo "Hint: BLOCKED + green checks = branch behind main OR unresolved review thread."
+    return 1
+  fi
+  sha=$(gh pr view $PR --json mergeCommit -q '.mergeCommit.oid')
+  echo "$PR MERGED, merge commit $sha"
+  for i in $(seq 1 90); do
+    run=$(gh run list --branch main --commit $sha --json conclusion,status -q '.[0] | .status + ":" + (.conclusion // "")' 2>/dev/null)
+    [[ "$run" == "completed:success" ]] && { echo "$PR main CI: success"; break; }
+    [[ "$run" == completed:* ]] && { echo "$PR main CI FAILED: $run"; return 1; }
+    sleep 20
+  done
+  for i in $(seq 1 90); do
+    dep=$(gh api "repos/$REPO_SLUG/deployments?sha=$sha&per_page=1" -q '.[0].id' 2>/dev/null)
+    if [[ -n "$dep" && "$dep" != "null" ]]; then
+      st=$(gh api "repos/$REPO_SLUG/deployments/$dep/statuses" -q '.[0].state' 2>/dev/null)
+      [[ "$st" == "success" ]] && { echo "$PR production deployment: success"; return 0; }
+      [[ "$st" == "failure" || "$st" == "error" ]] && { echo "$PR production deployment: $st"; return 1; }
+    fi
+    sleep 20
+  done
+  echo "$PR deployment: timed out"; return 1
+}
+
+refresh_branch() {
+  local PR=$1 BRANCH
+  BRANCH=$(gh pr view $PR --json headRefName -q .headRefName)
+  git fetch origin -q
+  git checkout -q "$BRANCH" && git merge -q origin/main --no-edit && git push -q origin "$BRANCH" \
+    && echo "$PR branch ($BRANCH) refreshed onto main"
+}
+
+first=1
+for PR in "$@"; do
+  if [[ "$first" != "1" ]]; then refresh_branch "$PR" || exit 1; fi
+  first=0
+  gate_one "$PR" || exit 1
+done
+echo "ALL MERGED AND DEPLOYED: $*"

--- a/scripts/factory/preview.sh
+++ b/scripts/factory/preview.sh
@@ -1,0 +1,23 @@
+#!/bin/zsh
+# Print the Vercel preview URL for a PR's head commit (polls until the
+# deployment succeeds or ~4 minutes pass).
+#
+# Usage: scripts/factory/preview.sh <pr-number>
+
+set -u
+PR=$1
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+REPO_SLUG=$(cd "$REPO_DIR" && gh repo view --json nameWithOwner -q .nameWithOwner)
+
+sha=$(gh pr view $PR --json headRefOid -q .headRefOid)
+for i in $(seq 1 12); do
+  id=$(gh api "repos/$REPO_SLUG/deployments?sha=$sha&environment=Preview&per_page=1" -q '.[0].id' 2>/dev/null)
+  if [[ -n "$id" && "$id" != "null" ]]; then
+    read -r state url <<< "$(gh api "repos/$REPO_SLUG/deployments/$id/statuses" -q '.[0] | .state + " " + (.environment_url // "")' 2>/dev/null)"
+    if [[ "$state" == "success" && -n "$url" ]]; then echo "$url"; exit 0; fi
+    [[ "$state" == "failure" || "$state" == "error" ]] && { echo "preview deployment $state" >&2; exit 1; }
+  fi
+  sleep 20
+done
+echo "preview not ready after timeout (sha $sha)" >&2
+exit 1


### PR DESCRIPTION
## Summary

Wave-1 learnings folded back (auto lane — factory-internal):
- `scripts/factory/gate.sh` — canonical merge gate, now multi-PR: serializes approvals and refreshes each next branch onto the new main between merges (the #502→#503 pattern, scripted). Honest-timeout invariants preserved.
- `scripts/factory/preview.sh` — preview URL for a PR, polling until the deployment succeeds.
- `factory-ship` — explicit **auto** vs **approval** lanes; approval = PR + preview URL + wait for "approve #N" (the PRD #493 flow, now written down).
- `factory-dispatch` — GLM lane defaults to the **glm-claude** harness (tool-permission-enforced git read-only) with the exact --allowedTools whitelist; pi stays for GPT 5.5 / north-mini.
- PITFALLS #16 token-only CSS (no fallback hexes — the #502 bot catch), #17 codex bot reviews are pipeline input; resolve threads via GraphQL.
- CLAUDE.md routing table updated accordingly.

## Validation

lint clean · typecheck 0/0 · `zsh -n` both scripts · gate.sh is a direct extraction of the script that shipped #502+#503 minutes ago.

🤖 Generated with [Claude Code](https://claude.com/claude-code)