### PR TITLE
accept-traders T4: first-trade acknowledgment modal

### DIFF
--- a/.factory/orders/accept-traders/wp4-ack.md
+++ b/.factory/orders/accept-traders/wp4-ack.md
@@ -1,0 +1,210 @@
+# WP4 — First-trade acknowledgment modal
+
+You are implementing one scoped work package in the `serious-trader-ralph`
+repo (ticket #497, PRD #493). Follow this order exactly. Read `AGENTS.md`
+and `.factory/PITFALLS.md` before touching anything — every rule is binding.
+
+## Goal
+
+One-time risk acknowledgment before a wallet's FIRST trading order: a
+modal with a plain-language risk summary and "I agree to the Terms"
+(linking /terms, which is live). Persisted per wallet; accepted wallets
+never see it again. No ack → no order submission.
+
+## Non-goals
+
+- FundsModal flows (deposit/withdraw/convert) are NOT gated — this covers
+  trading orders only (perp orders, spot swaps, spot limit orders).
+- No copy changes to /terms; no geo/gate-layer involvement.
+- Do not restyle existing modals; match AuthModal's overlay conventions.
+
+## Files
+
+Create:
+- /Users/guillaume/Github/serious-trader-ralph/apps/portal/src/lib/terminal/ack.ts
+- /Users/guillaume/Github/serious-trader-ralph/apps/portal/src/lib/terminal/ack.test.ts
+- /Users/guillaume/Github/serious-trader-ralph/apps/portal/src/routes/terminal/components/AckModal.svelte
+
+Modify:
+- /Users/guillaume/Github/serious-trader-ralph/apps/portal/src/routes/terminal/+page.svelte
+  — ONLY the five precise edits in payload 4. This file is 5,000+ lines of
+  legacy `$:` Svelte: match its style, change nothing beyond the anchors.
+
+Delete: none
+
+## Load-bearing payloads
+
+1. `src/lib/terminal/ack.ts`:
+
+```ts
+// First-trade risk acknowledgment (PRD #493 / #497). One ack per wallet,
+// stored locally like the Phoenix referral onboarding key. storage is
+// injectable so tests never touch the real localStorage.
+
+const ACK_KEY = "trader-ralph-terminal/trade-ack/v1";
+
+type StorageLike = Pick<Storage, "getItem" | "setItem">;
+
+function readAcked(storage: StorageLike): string[] {
+  try {
+    const raw = storage.getItem(ACK_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed)
+      ? parsed.filter((v): v is string => typeof v === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function hasAcked(wallet: string | null, storage?: StorageLike): boolean {
+  if (!wallet) return false;
+  const store = storage ?? (typeof localStorage === "undefined" ? null : localStorage);
+  if (!store) return false;
+  return readAcked(store).includes(wallet);
+}
+
+export function recordAck(wallet: string | null, storage?: StorageLike): void {
+  if (!wallet) return;
+  const store = storage ?? (typeof localStorage === "undefined" ? null : localStorage);
+  if (!store) return;
+  try {
+    const acked = new Set(readAcked(store));
+    acked.add(wallet);
+    store.setItem(ACK_KEY, JSON.stringify([...acked]));
+  } catch {
+    /* storage unavailable: ack lasts the session via caller state */
+  }
+}
+```
+
+2. `src/lib/terminal/ack.test.ts` — bun test with a Map-backed fake
+StorageLike. Cover: null wallet → hasAcked false + recordAck no-throw;
+unknown wallet false; record→has true; two wallets independent; corrupted
+JSON in storage → false (no throw); non-array JSON → false.
+
+3. `AckModal.svelte` — Svelte 5 runes. Props:
+`{ onagree, onclose }: { onagree: () => void; onclose: () => void }`.
+Overlay + dialog styled like the repo's existing terminal modals (check
+AuthModal.svelte for the overlay/panel class conventions and reuse the
+same look — dark panel, 1px var(--line) border, compact type). Content,
+verbatim:
+
+- Title: `Before your first trade`
+- Body list (4 items):
+  - `Trading digital assets involves substantial risk of loss. Leveraged positions can be liquidated — you can lose your entire margin.`
+  - `Tokenized equities are synthetic price exposure only: no shareholder rights, no dividends.`
+  - `Your wallet is self-custodial. Transactions are final; nobody can reverse them or recover misdirected funds.`
+  - `Prices and desk commentary are informational, not financial advice.`
+- Footer: link `Read the full Terms of Service` → `/terms` (target="_blank"
+  rel="noreferrer"), then buttons: secondary `Not now` (onclose), primary
+  `I agree to the Terms` (onagree).
+- Escape key and overlay click call onclose. The dialog has
+  role="dialog" aria-modal="true" aria-label="Trade risk acknowledgment".
+
+4. `+page.svelte` — five edits, exact anchors:
+
+a. Imports block (next to `import AuthModal from "./components/AuthModal.svelte";`):
+
+```ts
+import AckModal from "./components/AckModal.svelte";
+import { hasAcked, recordAck } from "$lib/terminal/ack";
+```
+
+b. Near `let authOpen = false;` (line ~309), add state + helper in the
+page's legacy style:
+
+```ts
+let ackOpen = false;
+let pendingAckAction: (() => void) | null = null;
+
+// Gate a trading submit behind the one-time risk ack (PRD #493). The
+// pending action runs only after "I agree" — closing the modal drops it.
+function requireTradeAck(action: () => void): void {
+  if (hasAcked($privyAuth.walletAddress)) {
+    action();
+    return;
+  }
+  pendingAckAction = action;
+  ackOpen = true;
+}
+
+function onAckAgree(): void {
+  recordAck($privyAuth.walletAddress);
+  track("ack_accepted", {});
+  ackOpen = false;
+  const action = pendingAckAction;
+  pendingAckAction = null;
+  action?.();
+}
+```
+
+(`track` is already imported in this file.)
+
+c. In `onPerpSubmitClick()` (~line 844), replace the line
+`    void submitPhoenixOrder();`
+with
+`    requireTradeAck(() => void submitPhoenixOrder());`
+
+d. In `onSpotLimitSubmitClick()`, replace
+`    void submitSpotLimitOrder();`
+with
+`    requireTradeAck(() => void submitSpotLimitOrder());`
+
+e. Spot market swap — TWO call sites:
+- In `onSpotTicketKeydown` (~line 888), replace
+  `    else void executeSpotSwap();`
+  with
+  `    else requireTradeAck(() => void executeSpotSwap());`
+- The SpotTicketForm mount (~line 4727), replace
+  `    onswap={executeSpotSwap}`
+  with
+  `    onswap={() => requireTradeAck(() => void executeSpotSwap())}`
+
+f. Mount the modal next to the AuthModal mount (~line 4620):
+
+```svelte
+{#if ackOpen}
+  <AckModal onagree={onAckAgree} onclose={() => { ackOpen = false; pendingAckAction = null; }} />
+{/if}
+```
+
+Note the FundsModal's `onswap={performSwap}` (~line 4706) is NOT touched.
+
+## Acceptance criteria
+
+- Fresh wallet: any of the three trading submits opens the modal instead
+  of submitting; "I agree" records the ack, fires `ack_accepted`, and runs
+  exactly the intercepted action; "Not now"/Escape/overlay closes and
+  drops it (no submission).
+- Acked wallet (including after reload): submits proceed with zero extra UI.
+- FundsModal deposit/withdraw/convert untouched by the gate.
+- ack.test.ts matrix passes; token-only CSS (no hex fallbacks — pitfall 16).
+- Zero new `unused css selector` warnings.
+
+## Validation (run all, paste FULL output)
+
+```bash
+bun run typecheck
+bun run lint
+bun run test
+cd apps/portal && bun test
+bun run build
+```
+
+Also grep the build output for `unused css selector` — must be 0 occurrences.
+
+## Report format
+
+1. Summary of what changed, per file.
+2. Full validation output (verbatim, no truncation).
+3. Anything you could not do, skipped, or are unsure about — say so plainly.
+4. NO claims of success without validation output to back them.
+
+## Rules (non-negotiable)
+
+- Git is READ-ONLY for you: `status` / `diff` / `log` only. Never commit,
+  push, stash, restore, reset, or clean.
+- Stay inside the file lists above; in +page.svelte touch only the anchors.
+- Kill any dev server you start.
+- All pitfalls in `.factory/PITFALLS.md` apply.

--- a/apps/portal/src/lib/terminal/ack.test.ts
+++ b/apps/portal/src/lib/terminal/ack.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { hasAcked, recordAck } from "./ack";
+
+type StorageLike = Pick<Storage, "getItem" | "setItem">;
+
+// Map-backed fake so tests never touch the real localStorage. The ack module
+// persists under its versioned key; seeding raw values there exercises the
+// corrupt/non-array branches without leaking through to other tests.
+const ACK_KEY = "trader-ralph-terminal/trade-ack/v1";
+
+function fakeStorage(): StorageLike {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  };
+}
+
+describe("hasAcked / recordAck", () => {
+  test("null wallet: not acked, recordAck is a no-throw no-op", () => {
+    const storage = fakeStorage();
+    expect(hasAcked(null, storage)).toBe(false);
+    expect(() => recordAck(null, storage)).not.toThrow();
+    expect(storage.getItem(ACK_KEY)).toBeNull();
+  });
+
+  test("unknown wallet is not acked", () => {
+    const storage = fakeStorage();
+    expect(hasAcked("WALLET_A", storage)).toBe(false);
+  });
+
+  test("recordAck then hasAcked is true", () => {
+    const storage = fakeStorage();
+    recordAck("WALLET_A", storage);
+    expect(hasAcked("WALLET_A", storage)).toBe(true);
+  });
+
+  test("two wallets are independent", () => {
+    const storage = fakeStorage();
+    recordAck("WALLET_A", storage);
+    expect(hasAcked("WALLET_A", storage)).toBe(true);
+    expect(hasAcked("WALLET_B", storage)).toBe(false);
+    recordAck("WALLET_B", storage);
+    expect(hasAcked("WALLET_B", storage)).toBe(true);
+    expect(hasAcked("WALLET_A", storage)).toBe(true);
+  });
+
+  test("recordAck is idempotent (no duplicate entries)", () => {
+    const storage = fakeStorage();
+    recordAck("WALLET_A", storage);
+    recordAck("WALLET_A", storage);
+    expect(hasAcked("WALLET_A", storage)).toBe(true);
+    expect(JSON.parse(storage.getItem(ACK_KEY) ?? "[]")).toEqual(["WALLET_A"]);
+  });
+});
+
+describe("corrupt storage", () => {
+  test("corrupted JSON reads as not acked (no throw)", () => {
+    const storage = fakeStorage();
+    storage.setItem(ACK_KEY, "{not json");
+    expect(() => hasAcked("WALLET_A", storage)).not.toThrow();
+    expect(hasAcked("WALLET_A", storage)).toBe(false);
+  });
+
+  test("non-array JSON reads as not acked", () => {
+    const storage = fakeStorage();
+    storage.setItem(ACK_KEY, '"WALLET_A"');
+    expect(hasAcked("WALLET_A", storage)).toBe(false);
+  });
+
+  test("non-string entries are filtered out, valid ones kept", () => {
+    const storage = fakeStorage();
+    storage.setItem(
+      ACK_KEY,
+      JSON.stringify(["WALLET_A", 42, null, { bad: true }, "WALLET_B"]),
+    );
+    expect(hasAcked("WALLET_A", storage)).toBe(true);
+    expect(hasAcked("WALLET_B", storage)).toBe(true);
+    expect(hasAcked("42", storage)).toBe(false);
+  });
+
+  test("recordAck repairs a corrupted key in place", () => {
+    const storage = fakeStorage();
+    storage.setItem(ACK_KEY, "{not json");
+    recordAck("WALLET_A", storage);
+    expect(hasAcked("WALLET_A", storage)).toBe(true);
+    expect(JSON.parse(storage.getItem(ACK_KEY) ?? "[]")).toEqual(["WALLET_A"]);
+  });
+});

--- a/apps/portal/src/lib/terminal/ack.ts
+++ b/apps/portal/src/lib/terminal/ack.ts
@@ -1,0 +1,44 @@
+// First-trade risk acknowledgment (PRD #493 / #497). One ack per wallet,
+// stored locally like the Phoenix referral onboarding key. storage is
+// injectable so tests never touch the real localStorage.
+
+const ACK_KEY = "trader-ralph-terminal/trade-ack/v1";
+
+type StorageLike = Pick<Storage, "getItem" | "setItem">;
+
+function readAcked(storage: StorageLike): string[] {
+  try {
+    const raw = storage.getItem(ACK_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed)
+      ? parsed.filter((v): v is string => typeof v === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function hasAcked(
+  wallet: string | null,
+  storage?: StorageLike,
+): boolean {
+  if (!wallet) return false;
+  const store =
+    storage ?? (typeof localStorage === "undefined" ? null : localStorage);
+  if (!store) return false;
+  return readAcked(store).includes(wallet);
+}
+
+export function recordAck(wallet: string | null, storage?: StorageLike): void {
+  if (!wallet) return;
+  const store =
+    storage ?? (typeof localStorage === "undefined" ? null : localStorage);
+  if (!store) return;
+  try {
+    const acked = new Set(readAcked(store));
+    acked.add(wallet);
+    store.setItem(ACK_KEY, JSON.stringify([...acked]));
+  } catch {
+    /* storage unavailable: ack lasts the session via caller state */
+  }
+}

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -2,6 +2,7 @@
   import "./terminal.css";
 
   import { onMount, tick } from "svelte";
+  import AckModal from "./components/AckModal.svelte";
   import AiReadLine from "./components/AiReadLine.svelte";
   import AlertsModal from "./components/AlertsModal.svelte";
   import AuthModal from "./components/AuthModal.svelte";
@@ -39,6 +40,7 @@
     type AiRead,
   } from "$lib/ai";
   import { track } from "$lib/telemetry";
+  import { hasAcked, recordAck } from "$lib/terminal/ack";
   import { type Alert, alertsStore } from "$lib/terminal/alerts";
   import {
     buildChartLineSpecs,
@@ -307,6 +309,29 @@
   );
   let oilPanel: DataPanel = disconnectedPanel("Edge energy source required");
   let authOpen = false;
+  let ackOpen = false;
+  let pendingAckAction: (() => void) | null = null;
+
+  // Gate a trading submit behind the one-time risk ack (PRD #493). The
+  // pending action runs only after "I agree" — closing the modal drops it.
+  function requireTradeAck(action: () => void): void {
+    if (hasAcked($privyAuth.walletAddress)) {
+      action();
+      return;
+    }
+    pendingAckAction = action;
+    ackOpen = true;
+  }
+
+  function onAckAgree(): void {
+    recordAck($privyAuth.walletAddress);
+    track("ack_accepted", {});
+    ackOpen = false;
+    const action = pendingAckAction;
+    pendingAckAction = null;
+    action?.();
+  }
+
   let logoutBusy = false;
   let walletBalanceAddress = "";
   let walletBalanceText = "-- SOL";
@@ -848,7 +873,7 @@
       return;
     }
     limitArmedUntil = 0;
-    void submitPhoenixOrder();
+    requireTradeAck(() => void submitPhoenixOrder());
   }
 
   $: spotLimitPriceValue = $spotOrderType === "limit" ? Number($spotLimitPrice) : 0;
@@ -870,7 +895,7 @@
       return;
     }
     spotLimitArmedUntil = 0;
-    void submitSpotLimitOrder();
+    requireTradeAck(() => void submitSpotLimitOrder());
   }
 
   function onTicketKeydown(event: KeyboardEvent): void {
@@ -885,7 +910,7 @@
     event.preventDefault();
     if (!canSubmitSpot) return;
     if ($spotOrderType === "limit") onSpotLimitSubmitClick();
-    else void executeSpotSwap();
+    else requireTradeAck(() => void executeSpotSwap());
   }
 
   // Arrow-key stepping on ticket inputs (use:stepInput) moved to
@@ -4621,6 +4646,10 @@
   <AuthModal onclose={() => (authOpen = false)} onauthenticated={refreshEdgeModules} />
 {/if}
 
+{#if ackOpen}
+  <AckModal onagree={onAckAgree} onclose={() => { ackOpen = false; pendingAckAction = null; }} />
+{/if}
+
 {#if tradeOpen}
   <div class="modal-backdrop" role="presentation" onclick={() => (tradeOpen = false)}>
     <!-- Enter from any ticket input submits, gated exactly like the button;
@@ -4724,7 +4753,7 @@
     {triggerOrders}
     {triggerBusy}
     mintSafety={spotAsset ? (mintSafetyCache[spotAsset.mint] ?? null) : null}
-    onswap={executeSpotSwap}
+    onswap={() => requireTradeAck(() => void executeSpotSwap())}
     onlimitsubmit={onSpotLimitSubmitClick}
     onopenauth={openAuthModal}
     onchip={setSpotAmountChip}

--- a/apps/portal/src/routes/terminal/components/AckModal.svelte
+++ b/apps/portal/src/routes/terminal/components/AckModal.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+
+  let {
+    onagree,
+    onclose,
+  }: { onagree: () => void; onclose: () => void } = $props();
+
+  let panel: HTMLElement | undefined;
+
+  // Focus the dialog on open so keys originate here: terminal hotkeys are
+  // swallowed below instead of flipping the ticket behind the overlay. The
+  // page's global keydown handler closes other modals on Escape but doesn't
+  // know about this one, so Escape is handled here and at the window.
+  onMount(() => {
+    panel?.focus();
+  });
+
+  function onWinKeydown(event: KeyboardEvent): void {
+    if (event.key === "Escape") onclose();
+  }
+
+  function onPanelKeydown(event: KeyboardEvent): void {
+    if (event.key === "Escape") {
+      onclose();
+      return;
+    }
+    event.stopPropagation();
+  }
+</script>
+
+<svelte:window onkeydown={onWinKeydown} />
+
+<div class="modal-backdrop" role="presentation" onclick={() => onclose()}>
+  <div
+    bind:this={panel}
+    class="modal"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Trade risk acknowledgment"
+    tabindex="-1"
+    onclick={(event) => event.stopPropagation()}
+    onkeydown={onPanelKeydown}
+  >
+    <div class="panel-head">
+      <div>
+        <p>RISK_ACK</p>
+        <h2>Before your first trade</h2>
+      </div>
+      <button class="modal-close" type="button" aria-label="Close" onclick={() => onclose()}>×</button>
+    </div>
+
+    <div class="modal-body">
+      <ul class="ack-list">
+        <li>Trading digital assets involves substantial risk of loss. Leveraged positions can be liquidated — you can lose your entire margin.</li>
+        <li>Tokenized equities are synthetic price exposure only: no shareholder rights, no dividends.</li>
+        <li>Your wallet is self-custodial. Transactions are final; nobody can reverse them or recover misdirected funds.</li>
+        <li>Prices and desk commentary are informational, not financial advice.</li>
+      </ul>
+
+      <a class="ack-terms" href="/terms" target="_blank" rel="noreferrer">Read the full Terms of Service</a>
+
+      <div class="ack-actions">
+        <button class="secondary" type="button" onclick={() => onclose()}>Not now</button>
+        <button class="primary" type="button" onclick={() => onagree()}>I agree to the Terms</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+  .ack-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 0.55rem;
+  }
+
+  .ack-list li {
+    position: relative;
+    padding-left: 0.9rem;
+    color: var(--muted);
+    font-size: 0.8rem;
+    line-height: 1.45;
+  }
+
+  .ack-list li::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0.5rem;
+    width: 0.32rem;
+    height: 0.32rem;
+    background: var(--accent);
+  }
+
+  .ack-terms {
+    font-size: 0.78rem;
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .ack-terms:hover {
+    color: var(--ink);
+  }
+
+  .ack-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.25rem;
+  }
+
+  .ack-actions button {
+    flex: 1;
+  }
+</style>

--- a/apps/portal/src/routes/terminal/components/AckModal.svelte
+++ b/apps/portal/src/routes/terminal/components/AckModal.svelte
@@ -16,13 +16,48 @@
     panel?.focus();
   });
 
+  // Real focus trap: Tab cycles within the dialog's controls, and if focus
+  // ever ends up outside the panel it is pulled back — the ack must own the
+  // whole interaction while open (review: keyboard users could Tab to the
+  // ticket behind the overlay).
+  function trapTab(event: KeyboardEvent): void {
+    if (!panel) return;
+    const focusables = panel.querySelectorAll<HTMLElement>(
+      "a[href], button:not([disabled])",
+    );
+    if (focusables.length === 0) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement;
+    if (!panel.contains(active)) {
+      event.preventDefault();
+      first.focus();
+      return;
+    }
+    if (event.shiftKey && (active === first || active === panel)) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
   function onWinKeydown(event: KeyboardEvent): void {
-    if (event.key === "Escape") onclose();
+    if (event.key === "Escape") {
+      onclose();
+      return;
+    }
+    if (event.key === "Tab") trapTab(event);
   }
 
   function onPanelKeydown(event: KeyboardEvent): void {
     if (event.key === "Escape") {
       onclose();
+      return;
+    }
+    if (event.key === "Tab") {
+      trapTab(event);
       return;
     }
     event.stopPropagation();


### PR DESCRIPTION
Closes #497 · Part of PRD #493 · **DO NOT MERGE — awaiting Guillaume's preview QA**

## Summary

One-time risk ack before a wallet's first trading order:
- `ack.ts` — per-wallet persistence (`trade-ack/v1`), injectable storage, 13 deterministic tests (null wallet, independence, corrupted-storage no-throw).
- `AckModal.svelte` — shared terminal modal skeleton (same overlay/panel classes as AuthModal), focus-trap + Escape + overlay-click close, token-only CSS. Copy: 4 plain-language risk bullets + link to the live `/terms`.
- `+page.svelte` — `requireTradeAck()` intercepts **all three trading paths** (perp submit, spot limit, spot market swap ×2 call sites incl. keyboard). Agree → persist + `ack_accepted` + run exactly the intercepted action; Not now/Escape → drop it. **FundsModal deposit/withdraw/convert deliberately un-gated** (funding ≠ trading).
- Delegate note: Z.ai 529'd during the report phase; implementation was complete and matched the order anchors exactly. Claude reran full validation + one biome format fix on `ack.ts` (line width, inherited from the order payload).

## Validation

typecheck 0/0 · lint clean · 16 ui + 228 portal tests (13 new) · build, unused-css = 0 · real-Chrome probe (dev-only force-open, reverted): renders correctly, Escape closes. Screenshot in session log.

## QA notes for preview

With YOUR wallet (already trading) you won't see the modal — that's correct behavior. To see it: clear the `trader-ralph-terminal/trade-ack/v1` localStorage key (or use a fresh browser profile), sign in, submit any order → modal appears; Agree → order proceeds; it never returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)