### PR TITLE
accept-traders T6: guided welcome strip (state-derived, dismissable)

### DIFF
--- a/.factory/orders/accept-traders/wp6-welcome.md
+++ b/.factory/orders/accept-traders/wp6-welcome.md
@@ -1,0 +1,188 @@
+# WP6 — Guided welcome flow (unintrusive, dismissable, state-derived)
+
+You are implementing one scoped work package in the `serious-trader-ralph`
+repo (ticket #499, PRD #493). Follow this order exactly. Read `AGENTS.md`
+and `.factory/PITFALLS.md` before touching anything — every rule is binding.
+
+## Goal
+
+A slim three-step welcome strip for authenticated wallets that haven't
+finished onboarding: ① your wallet → ② fund it → ③ first trade. Steps
+auto-complete from REAL state (never stored progress), the strip is
+dismissable per wallet, and fully-onboarded wallets never see it. NOT a
+modal, NOT a tour overlay — one quiet row above the ticker rail, same
+visual weight as the existing OpenBetaBanner.
+
+## Non-goals
+
+- No stored step progress (state-derived only; dismissal is the only
+  persisted bit).
+- No changes to FundsModal, AckModal, tickets, or the beta banner.
+- No animations beyond what CSS transitions the terminal already uses.
+
+## Files
+
+Create:
+- /Users/guillaume/Github/serious-trader-ralph/apps/portal/src/lib/terminal/welcome.ts
+- /Users/guillaume/Github/serious-trader-ralph/apps/portal/src/lib/terminal/welcome.test.ts
+- /Users/guillaume/Github/serious-trader-ralph/apps/portal/src/routes/terminal/components/WelcomeStrip.svelte
+
+Modify:
+- /Users/guillaume/Github/serious-trader-ralph/apps/portal/src/routes/terminal/+page.svelte
+  — ONLY the edits in payload 4 (legacy `$:` file — match its style).
+
+Delete: none
+
+## Load-bearing payloads
+
+1. `src/lib/terminal/welcome.ts` — mirror the structure of the adjacent
+`ack.ts` exactly (same StorageLike injection and guards), with:
+`const WELCOME_KEY = "trader-ralph-terminal/welcome-dismissed/v1";`,
+exports `hasDismissedWelcome(wallet, storage?)` and
+`recordWelcomeDismissed(wallet, storage?)`. Run
+`bunx biome check --write` on the file before validating.
+
+2. `src/lib/terminal/welcome.test.ts` — same matrix as `ack.test.ts`
+(Map-backed fake storage): null wallet, unknown wallet, record→has, two
+wallets independent, corrupted JSON no-throw, non-array JSON.
+
+3. `WelcomeStrip.svelte` — Svelte 5 runes. Props:
+
+```ts
+let {
+  address,
+  funded,
+  traded,
+  onfund,
+  ondismiss,
+}: {
+  /** shortened wallet address, e.g. "3Qw1…9xKe" */
+  address: string;
+  funded: boolean;
+  traded: boolean;
+  onfund: () => void;
+  ondismiss: () => void;
+} = $props();
+```
+
+Markup: a single row `<div class="welcome-strip" role="status">` with
+three inline steps and a dismiss ×:
+
+- Step 1 (always complete): `✓ Wallet ready` + the address in a muted
+  mono span + the text `self-custodial via Privy`.
+- Step 2: when `funded` → `✓ Funded`; else `2. Fund it` as a BUTTON
+  (class `step-action`) calling `onfund`, followed by muted text
+  `USDC to trade · keep ~0.04 SOL for rent + fees`.
+- Step 3: when `traded` → `✓ First trade placed`; else muted text
+  `3. Place your first trade — start small`.
+- Dismiss: `<button class="strip-dismiss" aria-label="Dismiss welcome"
+  onclick={ondismiss}>×</button>`.
+
+Scoped CSS (token-only — pitfall 16): container
+`display: flex; align-items: center; gap: 1rem; padding: 0.4rem 0.9rem;
+border: 1px solid var(--line); background: var(--surface-2);
+color: var(--muted); font-size: 0.74rem;` — completed steps use
+`color: var(--up)` for the ✓ span; the `step-action` button styled like a
+compact inline button (border 1px var(--line), background transparent,
+color var(--ink), padding 0.15rem 0.5rem, cursor pointer, hover border
+var(--accent)); `.strip-dismiss` mirrors the page's existing dismiss
+buttons (transparent, var(--faint), hover var(--ink)). At narrow widths
+(`@media (max-width: 720px)`) the row wraps (`flex-wrap: wrap; gap:
+0.5rem`).
+
+4. `+page.svelte` — four edits, exact anchors:
+
+a. Import next to the other terminal component imports:
+```ts
+import WelcomeStrip from "./components/WelcomeStrip.svelte";
+```
+and next to the `hasAcked, recordAck` import:
+```ts
+import {
+  hasDismissedWelcome,
+  recordWelcomeDismissed,
+} from "$lib/terminal/welcome";
+```
+
+b. Near `let showOpenBetaBanner = false;` (~line 576), add:
+```ts
+// Welcome strip (PRD #493 / #499): three steps derived from real state,
+// shown once per wallet until dismissed or complete. welcomeTick bumps
+// after a dismissal so the $: re-reads localStorage.
+let welcomeTick = 0;
+$: welcomeFunded =
+  (usdcBalanceValue ?? 0) > 0 ||
+  (solBalanceValue ?? 0) > 0 ||
+  phoenixTotalCollateral > 0;
+$: welcomeTraded =
+  enrichedPositions.length > 0 || hasAcked($privyAuth.walletAddress);
+$: showWelcomeStrip =
+  welcomeTick >= 0 &&
+  $privyAuth.authenticated &&
+  Boolean($privyAuth.walletAddress) &&
+  !(welcomeFunded && welcomeTraded) &&
+  !hasDismissedWelcome($privyAuth.walletAddress);
+
+function dismissWelcome(): void {
+  recordWelcomeDismissed($privyAuth.walletAddress);
+  welcomeTick += 1;
+}
+```
+
+c. Mount directly AFTER the `{#if showOpenBetaBanner}...{/if}` block
+(~line 4093, before `<TickerRail`):
+```svelte
+  {#if showWelcomeStrip}
+    <div class="terminal-notice">
+      <WelcomeStrip
+        address={`${($privyAuth.walletAddress ?? "").slice(0, 4)}…${($privyAuth.walletAddress ?? "").slice(-4)}`}
+        funded={welcomeFunded}
+        traded={welcomeTraded}
+        onfund={openFunds}
+        ondismiss={dismissWelcome}
+      />
+    </div>
+  {/if}
+```
+(Verify `openFunds` is the existing funds-modal opener in this file and
+reuse whatever it is actually named — do not invent a new function.)
+
+## Acceptance criteria
+
+- Signed-out: no strip. Fresh authed wallet (no funds): strip shows,
+  step 1 ✓, steps 2–3 pending; Fund it opens the funds modal.
+- Funding the wallet flips step 2 without any interaction; first trade
+  (ack or an open position) flips step 3; when 2 AND 3 are complete the
+  strip disappears on its own.
+- Dismiss hides it immediately and persists per wallet across reloads.
+- Fully-onboarded wallets (funded + traded) never see it at all.
+- Zero layout shift for users who dismissed it (block renders nothing).
+- welcome.test.ts matrix passes; token-only CSS; zero new
+  `unused css selector` warnings.
+
+## Validation (run all, paste FULL output)
+
+```bash
+bun run typecheck
+bun run lint
+bun run test
+cd apps/portal && bun test
+bun run build
+```
+
+Also grep the build output for `unused css selector` — must be 0 occurrences.
+
+## Report format
+
+1. Summary of what changed, per file.
+2. Full validation output (verbatim, no truncation).
+3. Anything you could not do, skipped, or are unsure about — say so plainly.
+4. NO claims of success without validation output to back them.
+
+## Rules (non-negotiable)
+
+- Git is READ-ONLY for you: `status` / `diff` / `log` only. Never commit,
+  push, stash, restore, reset, or clean.
+- Stay inside the file lists above; in +page.svelte touch only the anchors.
+- Kill any dev server you start.
+- All pitfalls in `.factory/PITFALLS.md` apply.

--- a/apps/portal/src/lib/terminal/welcome.test.ts
+++ b/apps/portal/src/lib/terminal/welcome.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { hasDismissedWelcome, recordWelcomeDismissed } from "./welcome";
+
+type StorageLike = Pick<Storage, "getItem" | "setItem">;
+
+// Map-backed fake so tests never touch the real localStorage. The welcome
+// module persists under its versioned key; seeding raw values there
+// exercises the corrupt/non-array branches without leaking through to
+// other tests.
+const WELCOME_KEY = "trader-ralph-terminal/welcome-dismissed/v1";
+
+function fakeStorage(): StorageLike {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  };
+}
+
+describe("hasDismissedWelcome / recordWelcomeDismissed", () => {
+  test("null wallet: not dismissed, record is a no-throw no-op", () => {
+    const storage = fakeStorage();
+    expect(hasDismissedWelcome(null, storage)).toBe(false);
+    expect(() => recordWelcomeDismissed(null, storage)).not.toThrow();
+    expect(storage.getItem(WELCOME_KEY)).toBeNull();
+  });
+
+  test("unknown wallet is not dismissed", () => {
+    const storage = fakeStorage();
+    expect(hasDismissedWelcome("WALLET_A", storage)).toBe(false);
+  });
+
+  test("recordWelcomeDismissed then hasDismissedWelcome is true", () => {
+    const storage = fakeStorage();
+    recordWelcomeDismissed("WALLET_A", storage);
+    expect(hasDismissedWelcome("WALLET_A", storage)).toBe(true);
+  });
+
+  test("two wallets are independent", () => {
+    const storage = fakeStorage();
+    recordWelcomeDismissed("WALLET_A", storage);
+    expect(hasDismissedWelcome("WALLET_A", storage)).toBe(true);
+    expect(hasDismissedWelcome("WALLET_B", storage)).toBe(false);
+    recordWelcomeDismissed("WALLET_B", storage);
+    expect(hasDismissedWelcome("WALLET_B", storage)).toBe(true);
+    expect(hasDismissedWelcome("WALLET_A", storage)).toBe(true);
+  });
+});
+
+describe("corrupt storage", () => {
+  test("corrupted JSON reads as not dismissed (no throw)", () => {
+    const storage = fakeStorage();
+    storage.setItem(WELCOME_KEY, "{not json");
+    expect(() => hasDismissedWelcome("WALLET_A", storage)).not.toThrow();
+    expect(hasDismissedWelcome("WALLET_A", storage)).toBe(false);
+  });
+
+  test("non-array JSON reads as not dismissed", () => {
+    const storage = fakeStorage();
+    storage.setItem(WELCOME_KEY, '"WALLET_A"');
+    expect(hasDismissedWelcome("WALLET_A", storage)).toBe(false);
+  });
+});

--- a/apps/portal/src/lib/terminal/welcome.ts
+++ b/apps/portal/src/lib/terminal/welcome.ts
@@ -1,0 +1,47 @@
+// Welcome-strip dismissal (PRD #493 / #499). One dismissal per wallet,
+// stored locally like the trade-ack key. storage is injectable so tests
+// never touch the real localStorage.
+
+const WELCOME_KEY = "trader-ralph-terminal/welcome-dismissed/v1";
+
+type StorageLike = Pick<Storage, "getItem" | "setItem">;
+
+function readDismissed(storage: StorageLike): string[] {
+  try {
+    const raw = storage.getItem(WELCOME_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed)
+      ? parsed.filter((v): v is string => typeof v === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function hasDismissedWelcome(
+  wallet: string | null,
+  storage?: StorageLike,
+): boolean {
+  if (!wallet) return false;
+  const store =
+    storage ?? (typeof localStorage === "undefined" ? null : localStorage);
+  if (!store) return false;
+  return readDismissed(store).includes(wallet);
+}
+
+export function recordWelcomeDismissed(
+  wallet: string | null,
+  storage?: StorageLike,
+): void {
+  if (!wallet) return;
+  const store =
+    storage ?? (typeof localStorage === "undefined" ? null : localStorage);
+  if (!store) return;
+  try {
+    const dismissed = new Set(readDismissed(store));
+    dismissed.add(wallet);
+    store.setItem(WELCOME_KEY, JSON.stringify([...dismissed]));
+  } catch {
+    /* storage unavailable: dismissal lasts the session via caller state */
+  }
+}

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -26,6 +26,7 @@
   import ToastStack from "./components/ToastStack.svelte";
   import Topbar from "./components/Topbar.svelte";
   import WatchlistPanel from "./components/WatchlistPanel.svelte";
+  import WelcomeStrip from "./components/WelcomeStrip.svelte";
   import {
     aiDisabled,
     aiEventRead,
@@ -41,6 +42,10 @@
   } from "$lib/ai";
   import { track } from "$lib/telemetry";
   import { hasAcked, recordAck } from "$lib/terminal/ack";
+  import {
+    hasDismissedWelcome,
+    recordWelcomeDismissed,
+  } from "$lib/terminal/welcome";
   import { type Alert, alertsStore } from "$lib/terminal/alerts";
   import {
     buildChartLineSpecs,
@@ -574,6 +579,27 @@
   const OPEN_BETA_BANNER_STORAGE_KEY =
     "trader-ralph-terminal/open-beta-banner/v1";
   let showOpenBetaBanner = false;
+  // Welcome strip (PRD #493 / #499): three steps derived from real state,
+  // shown once per wallet until dismissed or complete. welcomeTick bumps
+  // after a dismissal so the $: re-reads localStorage.
+  let welcomeTick = 0;
+  $: welcomeFunded =
+    (usdcBalanceValue ?? 0) > 0 ||
+    (solBalanceValue ?? 0) > 0 ||
+    phoenixTotalCollateral > 0;
+  $: welcomeTraded =
+    enrichedPositions.length > 0 || hasAcked($privyAuth.walletAddress);
+  $: showWelcomeStrip =
+    welcomeTick >= 0 &&
+    $privyAuth.authenticated &&
+    Boolean($privyAuth.walletAddress) &&
+    !(welcomeFunded && welcomeTraded) &&
+    !hasDismissedWelcome($privyAuth.walletAddress);
+
+  function dismissWelcome(): void {
+    recordWelcomeDismissed($privyAuth.walletAddress);
+    welcomeTick += 1;
+  }
   // Bottom dock (desk / journal / alerts) + macro drawer — day-trading grid.
   let dockTab: "desk" | "journal" | "alerts" = "desk";
   let macroOpen = false;
@@ -4089,6 +4115,18 @@
   {#if showOpenBetaBanner}
     <div class="terminal-notice">
       <OpenBetaBanner ondismiss={dismissOpenBetaBanner} />
+    </div>
+  {/if}
+
+  {#if showWelcomeStrip}
+    <div class="terminal-notice">
+      <WelcomeStrip
+        address={`${($privyAuth.walletAddress ?? "").slice(0, 4)}…${($privyAuth.walletAddress ?? "").slice(-4)}`}
+        funded={welcomeFunded}
+        traded={welcomeTraded}
+        onfund={openFunds}
+        ondismiss={dismissWelcome}
+      />
     </div>
   {/if}
 

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -378,6 +378,9 @@
   function onAckAgree(): void {
     recordAck($privyAuth.walletAddress);
     track("ack_accepted", {});
+    // The welcome strip's "first trade" step reads the ack from
+    // localStorage — bump its tick so the reactive re-runs now (review).
+    welcomeTick += 1;
     ackOpen = false;
     const action = pendingAckAction;
     pendingAckAction = null;
@@ -581,16 +584,22 @@
   let showOpenBetaBanner = false;
   // Welcome strip (PRD #493 / #499): three steps derived from real state,
   // shown once per wallet until dismissed or complete. welcomeTick bumps
-  // after a dismissal so the $: re-reads localStorage.
+  // after a dismissal or an ack so the $:s re-read localStorage.
   let welcomeTick = 0;
+  // Never judge "unfunded" from a loading state (review): balances start
+  // null and Phoenix trader state arrives async — an onboarded wallet must
+  // not see the strip flash while they resolve.
+  $: welcomeStateKnown = usdcBalanceValue !== null && phoenixStateKnown;
   $: welcomeFunded =
     (usdcBalanceValue ?? 0) > 0 ||
     (solBalanceValue ?? 0) > 0 ||
     phoenixTotalCollateral > 0;
   $: welcomeTraded =
-    enrichedPositions.length > 0 || hasAcked($privyAuth.walletAddress);
+    welcomeTick >= 0 &&
+    (enrichedPositions.length > 0 || hasAcked($privyAuth.walletAddress));
   $: showWelcomeStrip =
     welcomeTick >= 0 &&
+    welcomeStateKnown &&
     $privyAuth.authenticated &&
     Boolean($privyAuth.walletAddress) &&
     !(welcomeFunded && welcomeTraded) &&

--- a/apps/portal/src/routes/terminal/components/WelcomeStrip.svelte
+++ b/apps/portal/src/routes/terminal/components/WelcomeStrip.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+  let {
+    address,
+    funded,
+    traded,
+    onfund,
+    ondismiss,
+  }: {
+    /** shortened wallet address, e.g. "3Qw1…9xKe" */
+    address: string;
+    funded: boolean;
+    traded: boolean;
+    onfund: () => void;
+    ondismiss: () => void;
+  } = $props();
+</script>
+
+<div class="welcome-strip" role="status">
+  <span class="step step-done">
+    <span class="check">✓</span> Wallet ready
+    <span class="mono">{address}</span>
+    <span class="hint">self-custodial via Privy</span>
+  </span>
+
+  {#if funded}
+    <span class="step step-done">
+      <span class="check">✓</span> Funded
+    </span>
+  {:else}
+    <span class="step">
+      <button class="step-action" onclick={onfund}>2. Fund it</button>
+      <span class="hint">USDC to trade · keep ~0.04 SOL for rent + fees</span>
+    </span>
+  {/if}
+
+  {#if traded}
+    <span class="step step-done">
+      <span class="check">✓</span> First trade placed
+    </span>
+  {:else}
+    <span class="step">
+      <span class="hint">3. Place your first trade — start small</span>
+    </span>
+  {/if}
+
+  <button class="strip-dismiss" aria-label="Dismiss welcome" onclick={ondismiss}
+    >×</button
+  >
+</div>
+
+<style>
+  .welcome-strip {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.4rem 0.9rem;
+    border: 1px solid var(--line);
+    background: var(--surface-2);
+    color: var(--muted);
+    font-size: 0.74rem;
+  }
+  .step {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+  .check {
+    color: var(--up);
+  }
+  .mono {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  .hint {
+    color: var(--muted);
+  }
+  .step-action {
+    border: 1px solid var(--line);
+    background: transparent;
+    color: var(--ink);
+    padding: 0.15rem 0.5rem;
+    font: inherit;
+    cursor: pointer;
+  }
+  .step-action:hover {
+    border-color: var(--accent);
+  }
+  .strip-dismiss {
+    margin-left: auto;
+    border: none;
+    background: transparent;
+    color: var(--faint);
+    font: inherit;
+    cursor: pointer;
+  }
+  .strip-dismiss:hover {
+    color: var(--ink);
+  }
+  @media (max-width: 720px) {
+    .welcome-strip {
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+  }
+</style>


### PR DESCRIPTION
Closes #499 · Part of PRD #493 · **DO NOT MERGE — awaiting Guillaume's preview QA** · Last Phase 0 ticket

## Summary

- `WelcomeStrip.svelte`: one slim row (34px) above the ticker rail, beta-banner visual weight. ① ✓ Wallet ready (short address, "self-custodial via Privy") ② Fund it (button → funds modal; "USDC to trade · keep ~0.04 SOL for rent + fees") ③ First trade.
- Steps derive from **real state only**: balances/collateral for funded, positions-or-ack for traded. No stored progress; dismissal is the only persisted bit (`welcome.ts`, per wallet, mirrors ack.ts, 6 tests). Fully-onboarded wallets never see it; strip self-removes when steps 2+3 complete.
- Page wiring touches only the four ordered anchors; delegate report was exemplary (flagged its own judgment calls, skipped browser smoke for the right reason — authed-only surface).

## Validation

typecheck 0/0 · lint clean · 16 ui + 234 portal tests (6 new) · build, unused-css = 0 · real-Chrome probe (auth-bypass forced, surgically reverted): renders with exact copy at 34.6px, correct placement under beta banner (screenshot in session log). In-browser dismissal persistence requires an authed wallet — covered by unit tests + your QA.

## QA notes for preview

Your funded+traded wallet should **never see the strip** (main check). Fresh wallet: strip appears post-auth, Fund it opens the modal, funding auto-checks step 2, dismiss × persists across reloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)