### PR TITLE
Fix: chart collapse on 720–1100px viewports + shattered phone grid

### DIFF
--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -5025,9 +5025,12 @@
     gap: 0.75rem;
     min-height: 0;
   }
-  .chart-col .chart-panel {
-    grid-column: auto;
-  }
+  /* NOTE: no `.chart-col .chart-panel { grid-column: auto }` here — inside
+     the flex .chart-col grid-column is inert anyway, and because
+     display: contents (≤1100px) removes the box but NOT the element, the
+     descendant selector kept matching at narrow widths and its higher
+     specificity defeated the full-width override below — the chart
+     collapsed to one auto-placed grid column (bug, 2026-07-07). */
   .dock {
     grid-column: 1 / -1;
     order: 1;
@@ -5792,10 +5795,16 @@
       grid-template-columns: 1fr;
     }
 
-    .chart-panel,
-    .orderbook-panel,
-    .macro-panel {
-      grid-column: span 1;
+    /* Every panel goes full-width on phones. The :global child reset is
+       load-bearing: component panels (monitor, watch, spot, …) carry
+       `grid-column: span N` in their OWN scoped styles, which this page's
+       media query can't otherwise reach — their spans were forcing implicit
+       columns and shattering the 1fr grid. chart-panel is listed explicitly
+       because it's a grandchild via the display:contents .chart-col, so the
+       direct-child selector misses it. */
+    .dashboard > :global(*),
+    .chart-panel {
+      grid-column: 1 / -1;
     }
 
     /* Ticket + funds forms collapse to a single column on phones —


### PR DESCRIPTION
Prod layout bug (Guillaume's screenshot at ~1000px viewport): chart squeezed to ~72px, dead space everywhere. **Not from this week's PRs** — latent since the day-trading grid (#486).

## Root causes (both the same trap)
1. `.chart-col .chart-panel { grid-column: auto }` — `display: contents` (≤1100px) removes the wrapper's **box but not the element**, so this descendant rule kept matching at narrow widths and its (0,3,0) specificity defeated the `1 / -1` media override. At wide widths it was inert anyway (flex parent). **Deleted**, with a comment explaining the trap.
2. ≤720px: the phone grid (`1fr`) was shattered by component panels' own scoped `grid-column: span N` (unreachable from the page's media query) → implicit-column blowout. **`.dashboard > :global(*) { grid-column: 1 / -1 }`** reset; `.chart-panel` listed explicitly (grandchild via the contents wrapper).

## Validation
typecheck 0/0 · lint clean · build, unused-css = 0 · real-Chrome sweep at 1440/1200/1100/1000/900/800/720/700/500/390: wide unchanged (chart 0.73 of dashboard), 800–1100 chart 0.97, ≤720 every panel 0.94–0.97 full-width. Screenshots at 1000×675 and 390×844 in session log — phone layout renders correctly for the first time.

Auto lane — prod regression fix (precedent #488).

🤖 Generated with [Claude Code](https://claude.com/claude-code)