### PR TITLE
funding-wizard W1: Jupiter Ultra client (order/execute, gasless detection)

### DIFF
--- a/.factory/orders/funding-wizard/wp1-ultra.md
+++ b/.factory/orders/funding-wizard/wp1-ultra.md
@@ -1,0 +1,182 @@
+# WP1 — Jupiter Ultra client: order/execute + gasless eligibility (no UI)
+
+You are implementing one scoped work package in the `serious-trader-ralph`
+repo (ticket #511, PRD #510). Follow this order exactly. Read `AGENTS.md`
+and `.factory/PITFALLS.md` before touching anything — every rule is binding.
+
+## Goal
+
+A typed client for Jupiter Ultra (order → sign → execute, RPC-less,
+gasless-capable) in the funding lib, fully unit-tested with injected
+fetch. Capability only: NOTHING consumes it yet (the funding wizard does,
+next tickets). The existing Convert flow (getJupiterQuote /
+getJupiterSwapTransaction) stays byte-identical.
+
+## Non-goals
+
+- No call-site changes anywhere (no +page.svelte, no FundsModal).
+- No proxy changes — `/jupiter` already targets https://lite-api.jup.ag,
+  so Ultra is reachable at `/jupiter/ultra/v1/...`.
+- No retries/queues; callers own retry policy.
+
+## Files
+
+Create:
+- /Users/guillaume/Github/serious-trader-ralph/apps/portal/src/lib/funding-ultra.test.ts
+
+Modify:
+- /Users/guillaume/Github/serious-trader-ralph/apps/portal/src/lib/funding.ts
+  — append the Ultra section below. Touch nothing above it.
+
+Delete: none
+
+## Load-bearing payloads
+
+Append to `funding.ts` (adjust ONLY if biome formatting requires):
+
+```ts
+// ── Jupiter Ultra (RPC-less swaps, gasless-capable) ────────────────────
+// Order → sign → execute: Ultra builds the transaction, we sign it with
+// the user's wallet, Ultra broadcasts and polls. Routed through the
+// same-origin /jupiter proxy (lite-api.jup.ag). Gasless eligibility is
+// derived defensively from the order response — a null means "could not
+// determine", and callers must treat null as NOT gasless (honest-data
+// rule: never promise free gas we can't verify).
+
+export type UltraOrder = {
+  requestId: string;
+  /** base64 unsigned transaction; null when Ultra returned no route. */
+  transaction: string | null;
+  inAmount: string | null;
+  outAmount: string | null;
+  gasless: boolean | null;
+  router: string | null;
+  raw: Record<string, unknown>;
+};
+
+export type UltraExecuteResult = {
+  status: string;
+  signature: string | null;
+  raw: Record<string, unknown>;
+};
+
+/** Best-effort gasless detection across Ultra response variants. */
+export function deriveUltraGasless(raw: Record<string, unknown>): boolean | null {
+  if (raw.gasless === true) return true;
+  if (raw.gasless === false) return false;
+  const router = typeof raw.router === "string" ? raw.router.toLowerCase() : "";
+  const swapType = typeof raw.swapType === "string" ? raw.swapType.toLowerCase() : "";
+  // JupiterZ / RFQ routes: the market maker is the fee payer.
+  if (router.includes("rfq") || router.includes("jupiterz") || swapType === "rfq") return true;
+  const sigFee = raw.signatureFee ?? raw.signatureFeeLamports;
+  if (typeof sigFee === "number") return sigFee === 0;
+  return null;
+}
+
+export function parseUltraOrder(raw: Record<string, unknown>): UltraOrder {
+  return {
+    requestId: typeof raw.requestId === "string" ? raw.requestId : "",
+    transaction: typeof raw.transaction === "string" ? raw.transaction : null,
+    inAmount: typeof raw.inAmount === "string" ? raw.inAmount : null,
+    outAmount: typeof raw.outAmount === "string" ? raw.outAmount : null,
+    gasless: deriveUltraGasless(raw),
+    router: typeof raw.router === "string" ? raw.router : null,
+    raw,
+  };
+}
+
+export async function getUltraOrder(
+  inputMint: string,
+  outputMint: string,
+  amountAtoms: string,
+  taker: string,
+  fetcher: typeof fetch = fetch,
+): Promise<UltraOrder> {
+  const params = new URLSearchParams({
+    inputMint,
+    outputMint,
+    amount: amountAtoms,
+    taker,
+  });
+  const response = await fetcher(`/jupiter/ultra/v1/order?${params}`);
+  if (!response.ok) throw new Error(`ultra-order-${response.status}`);
+  const data = (await response.json()) as Record<string, unknown>;
+  const order = parseUltraOrder(data);
+  if (!order.requestId) throw new Error("ultra-no-request-id");
+  return order;
+}
+
+export async function executeUltraOrder(
+  signedTransactionBase64: string,
+  requestId: string,
+  fetcher: typeof fetch = fetch,
+): Promise<UltraExecuteResult> {
+  const response = await fetcher("/jupiter/ultra/v1/execute", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ signedTransaction: signedTransactionBase64, requestId }),
+  });
+  if (!response.ok) throw new Error(`ultra-execute-${response.status}`);
+  const data = (await response.json()) as Record<string, unknown>;
+  const status = typeof data.status === "string" ? data.status : "unknown";
+  if (status.toLowerCase() === "failed") {
+    const err = typeof data.error === "string" ? data.error : "unknown";
+    throw new Error(`ultra-execute-failed-${err}`);
+  }
+  return {
+    status,
+    signature: typeof data.signature === "string" ? data.signature : null,
+    raw: data,
+  };
+}
+```
+
+`funding-ultra.test.ts` — bun test, pure, fetch injected as a stub that
+records calls and returns canned Response objects. Cover AT MINIMUM:
+- getUltraOrder builds `/jupiter/ultra/v1/order?...` with all four params
+  (assert exact URL), returns parsed order, throws `ultra-order-500` on
+  !ok and `ultra-no-request-id` when requestId missing.
+- deriveUltraGasless: `{gasless:true}`→true; `{gasless:false}`→false;
+  `{router:"JupiterZ"}`→true; `{swapType:"rfq"}`→true;
+  `{signatureFee:0}`→true; `{signatureFee:5000}`→false; `{}`→null.
+- parseUltraOrder: missing/malformed fields → nulls, raw preserved.
+- executeUltraOrder: posts exact JSON body; success returns
+  status+signature; `{status:"Failed",error:"slippage"}` → throws
+  `ultra-execute-failed-slippage`; HTTP 502 → `ultra-execute-502`.
+
+Run `bunx biome check --write` on both files before validating.
+
+## Acceptance criteria
+
+- All tests above pass; no network in tests.
+- Existing funding.ts exports and behavior untouched (getJupiterQuote /
+  getJupiterSwapTransaction byte-identical).
+- Nothing imports the new functions yet (`rg "getUltraOrder" apps` shows
+  only funding.ts + the test).
+
+## Validation (run all, paste FULL output)
+
+```bash
+bun run typecheck
+bun run lint
+bun run test
+cd apps/portal && bun test
+bun run build
+```
+
+Also grep the build output for `unused css selector` — must be 0 occurrences.
+
+## Report format
+
+1. Summary of what changed, per file.
+2. Full validation output (verbatim, no truncation).
+3. Anything you could not do, skipped, or are unsure about — say so plainly.
+4. NO claims of success without validation output to back them.
+
+## Rules (non-negotiable)
+
+- Git is READ-ONLY for you: `status` / `diff` / `log` only. Never commit,
+  push, stash, restore, reset, or clean.
+- Stay inside the file lists above.
+- Kill any dev server you start.
+- All pitfalls in `.factory/PITFALLS.md` apply.

--- a/apps/portal/src/lib/funding-ultra.test.ts
+++ b/apps/portal/src/lib/funding-ultra.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test } from "bun:test";
+import {
+  deriveUltraGasless,
+  executeUltraOrder,
+  getUltraOrder,
+  parseUltraOrder,
+} from "./funding";
+
+type FetchCall = {
+  input: Parameters<typeof fetch>[0];
+  init: Parameters<typeof fetch>[1];
+};
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+function makeJsonFetcher(responses: Response[]): {
+  calls: FetchCall[];
+  fetcher: typeof fetch;
+} {
+  const calls: FetchCall[] = [];
+  const fetcher = Object.assign(
+    async (...args: Parameters<typeof fetch>): Promise<Response> => {
+      const [input, init] = args;
+      calls.push({ input, init });
+      const response = responses.shift();
+      if (!response) throw new Error("unexpected-fetch-call");
+      return response;
+    },
+    { preconnect: fetch.preconnect },
+  );
+  return { calls, fetcher };
+}
+
+describe("deriveUltraGasless", () => {
+  test("detects gasless from explicit booleans", () => {
+    expect(deriveUltraGasless({ gasless: true })).toBe(true);
+    expect(deriveUltraGasless({ gasless: false })).toBe(false);
+  });
+
+  test("detects gasless RFQ routes", () => {
+    expect(deriveUltraGasless({ router: "JupiterZ" })).toBe(true);
+    expect(deriveUltraGasless({ swapType: "rfq" })).toBe(true);
+  });
+
+  test("detects gasless from signature fee when present", () => {
+    expect(deriveUltraGasless({ signatureFee: 0 })).toBe(true);
+    expect(deriveUltraGasless({ signatureFee: 5000 })).toBe(false);
+  });
+
+  test("returns null when gasless eligibility cannot be determined", () => {
+    expect(deriveUltraGasless({})).toBeNull();
+  });
+});
+
+describe("parseUltraOrder", () => {
+  test("parses known fields and preserves raw payload", () => {
+    const raw = {
+      requestId: "req-1",
+      transaction: "unsigned-tx",
+      inAmount: "100",
+      outAmount: "90",
+      gasless: true,
+      router: "JupiterZ",
+    };
+
+    expect(parseUltraOrder(raw)).toEqual({
+      requestId: "req-1",
+      transaction: "unsigned-tx",
+      inAmount: "100",
+      outAmount: "90",
+      gasless: true,
+      router: "JupiterZ",
+      raw,
+    });
+  });
+
+  test("missing or malformed optional fields become nulls and raw is preserved", () => {
+    const raw = {
+      requestId: 7,
+      transaction: 8,
+      inAmount: null,
+      outAmount: false,
+      router: 9,
+    };
+    const order = parseUltraOrder(raw);
+
+    expect(order).toEqual({
+      requestId: "",
+      transaction: null,
+      inAmount: null,
+      outAmount: null,
+      gasless: null,
+      router: null,
+      raw,
+    });
+    expect(order.raw).toBe(raw);
+  });
+});
+
+describe("getUltraOrder", () => {
+  test("builds the Ultra order URL and returns a parsed order", async () => {
+    const raw = {
+      requestId: "req-1",
+      transaction: "unsigned-tx",
+      inAmount: "12345",
+      outAmount: "67890",
+      router: "JupiterZ",
+    };
+    const { calls, fetcher } = makeJsonFetcher([jsonResponse(raw)]);
+
+    const order = await getUltraOrder(
+      "So111",
+      "USDC111",
+      "12345",
+      "TakerPubkey",
+      fetcher,
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(String(calls[0]?.input)).toBe(
+      "/jupiter/ultra/v1/order?inputMint=So111&outputMint=USDC111&amount=12345&taker=TakerPubkey",
+    );
+    expect(calls[0]?.init).toBeUndefined();
+    expect(order).toEqual({
+      requestId: "req-1",
+      transaction: "unsigned-tx",
+      inAmount: "12345",
+      outAmount: "67890",
+      gasless: true,
+      router: "JupiterZ",
+      raw,
+    });
+  });
+
+  test("throws coded error on HTTP failure", async () => {
+    const { fetcher } = makeJsonFetcher([
+      jsonResponse({ error: "boom" }, { status: 500 }),
+    ]);
+
+    await expect(
+      getUltraOrder("So111", "USDC111", "12345", "TakerPubkey", fetcher),
+    ).rejects.toThrow("ultra-order-500");
+  });
+
+  test("throws when requestId is missing", async () => {
+    const { fetcher } = makeJsonFetcher([jsonResponse({ transaction: "tx" })]);
+
+    await expect(
+      getUltraOrder("So111", "USDC111", "12345", "TakerPubkey", fetcher),
+    ).rejects.toThrow("ultra-no-request-id");
+  });
+});
+
+describe("executeUltraOrder", () => {
+  test("posts the signed transaction and returns status plus signature", async () => {
+    const { calls, fetcher } = makeJsonFetcher([
+      jsonResponse({ status: "Success", signature: "sig-1" }),
+    ]);
+
+    const result = await executeUltraOrder("signed-tx", "req-1", fetcher);
+
+    expect(calls).toHaveLength(1);
+    expect(String(calls[0]?.input)).toBe("/jupiter/ultra/v1/execute");
+    expect(calls[0]?.init?.method).toBe("POST");
+    expect(calls[0]?.init?.headers).toEqual({
+      "content-type": "application/json",
+    });
+    expect(calls[0]?.init?.body).toBe(
+      JSON.stringify({ signedTransaction: "signed-tx", requestId: "req-1" }),
+    );
+    expect(result).toEqual({
+      status: "Success",
+      signature: "sig-1",
+      raw: { status: "Success", signature: "sig-1" },
+    });
+  });
+
+  test("throws when Ultra reports failed execution", async () => {
+    const { fetcher } = makeJsonFetcher([
+      jsonResponse({ status: "Failed", error: "slippage" }),
+    ]);
+
+    await expect(
+      executeUltraOrder("signed-tx", "req-1", fetcher),
+    ).rejects.toThrow("ultra-execute-failed-slippage");
+  });
+
+  test("throws coded error on HTTP failure", async () => {
+    const { fetcher } = makeJsonFetcher([
+      jsonResponse({ error: "bad gateway" }, { status: 502 }),
+    ]);
+
+    await expect(
+      executeUltraOrder("signed-tx", "req-1", fetcher),
+    ).rejects.toThrow("ultra-execute-502");
+  });
+});
+
+test("parseUltraOrder normalizes empty-string transaction to null (live API shape)", () => {
+  const order = parseUltraOrder({ requestId: "r1", transaction: "" });
+  expect(order.transaction).toBeNull();
+});

--- a/apps/portal/src/lib/funding.ts
+++ b/apps/portal/src/lib/funding.ts
@@ -99,3 +99,114 @@ export async function getJupiterSwapTransaction(
   if (!data.swapTransaction) throw new Error("jupiter-no-transaction");
   return data.swapTransaction;
 }
+
+// ── Jupiter Ultra (RPC-less swaps, gasless-capable) ────────────────────
+// Order → sign → execute: Ultra builds the transaction, we sign it with
+// the user's wallet, Ultra broadcasts and polls. Routed through the
+// same-origin /jupiter proxy (lite-api.jup.ag). Gasless eligibility is
+// derived defensively from the order response — a null means "could not
+// determine", and callers must treat null as NOT gasless (honest-data
+// rule: never promise free gas we can't verify).
+
+export type UltraOrder = {
+  requestId: string;
+  /** base64 unsigned transaction; null when Ultra returned no route. */
+  transaction: string | null;
+  inAmount: string | null;
+  outAmount: string | null;
+  gasless: boolean | null;
+  router: string | null;
+  raw: Record<string, unknown>;
+};
+
+export type UltraExecuteResult = {
+  status: string;
+  signature: string | null;
+  raw: Record<string, unknown>;
+};
+
+/** Best-effort gasless detection across Ultra response variants. */
+export function deriveUltraGasless(
+  raw: Record<string, unknown>,
+): boolean | null {
+  if (raw.gasless === true) return true;
+  if (raw.gasless === false) return false;
+  const router = typeof raw.router === "string" ? raw.router.toLowerCase() : "";
+  const swapType =
+    typeof raw.swapType === "string" ? raw.swapType.toLowerCase() : "";
+  // JupiterZ / RFQ routes: the market maker is the fee payer.
+  if (
+    router.includes("rfq") ||
+    router.includes("jupiterz") ||
+    swapType === "rfq"
+  )
+    return true;
+  const sigFee = raw.signatureFee ?? raw.signatureFeeLamports;
+  if (typeof sigFee === "number") return sigFee === 0;
+  return null;
+}
+
+export function parseUltraOrder(raw: Record<string, unknown>): UltraOrder {
+  return {
+    requestId: typeof raw.requestId === "string" ? raw.requestId : "",
+    // Live API returns "" (not absent) when there's no signable route —
+    // normalize both to null so callers have one no-route signal.
+    transaction:
+      typeof raw.transaction === "string" && raw.transaction.length > 0
+        ? raw.transaction
+        : null,
+    inAmount: typeof raw.inAmount === "string" ? raw.inAmount : null,
+    outAmount: typeof raw.outAmount === "string" ? raw.outAmount : null,
+    gasless: deriveUltraGasless(raw),
+    router: typeof raw.router === "string" ? raw.router : null,
+    raw,
+  };
+}
+
+export async function getUltraOrder(
+  inputMint: string,
+  outputMint: string,
+  amountAtoms: string,
+  taker: string,
+  fetcher: typeof fetch = fetch,
+): Promise<UltraOrder> {
+  const params = new URLSearchParams({
+    inputMint,
+    outputMint,
+    amount: amountAtoms,
+    taker,
+  });
+  const response = await fetcher(`/jupiter/ultra/v1/order?${params}`);
+  if (!response.ok) throw new Error(`ultra-order-${response.status}`);
+  const data = (await response.json()) as Record<string, unknown>;
+  const order = parseUltraOrder(data);
+  if (!order.requestId) throw new Error("ultra-no-request-id");
+  return order;
+}
+
+export async function executeUltraOrder(
+  signedTransactionBase64: string,
+  requestId: string,
+  fetcher: typeof fetch = fetch,
+): Promise<UltraExecuteResult> {
+  const response = await fetcher("/jupiter/ultra/v1/execute", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      signedTransaction: signedTransactionBase64,
+      requestId,
+    }),
+  });
+  if (!response.ok) throw new Error(`ultra-execute-${response.status}`);
+  const data = (await response.json()) as Record<string, unknown>;
+  const status = typeof data.status === "string" ? data.status : "unknown";
+  if (status.toLowerCase() === "failed") {
+    const err = typeof data.error === "string" ? data.error : "unknown";
+    throw new Error(`ultra-execute-failed-${err}`);
+  }
+  return {
+    status,
+    signature: typeof data.signature === "string" ? data.signature : null,
+    raw: data,
+  };
+}


### PR DESCRIPTION
Closes #511 · Part of PRD #510 · **DO NOT MERGE — awaiting Guillaume's preview QA**

## Summary

- `getUltraOrder` / `executeUltraOrder` in `funding.ts` — Ultra's order→sign→execute flow through the **existing `/jupiter` proxy** (lite-api already serves `/ultra/v1`; zero infra added).
- `deriveUltraGasless`: primary check is Ultra's first-class `gasless` boolean, with router/RFQ and `signatureFeeLamports` heuristics as fallback; **`null` = unverifiable = treated as NOT gasless** (honest-data rule).
- 13 deterministic tests (injected fetch, exact URL/body assertions, failure taxonomies).
- **Live-smoke verified** against the real endpoint during review: 1 SOL → 7.73 USDC quote, `gasless: true` present, `signatureFeeLamports: 0` — and one real-world catch: the API returns `transaction: ""` (not absent) when there's no signable route; parse now normalizes to `null` (Claude amendment + test).
- Scope note (also on #511): capability only — Convert flow untouched; nothing consumes Ultra until the wizard (W4 proves it end-to-end).

## Validation

typecheck 0/0 · lint clean · 16 ui + **247 portal tests** (13 new) · build, unused-css = 0 · `rg getUltraOrder` shows lib+test only.

## QA notes for preview

Nothing visible changes (capability-only) — preview QA = terminal/Convert behave exactly as prod. The interesting review is the diff itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)