### PR TITLE
funding-wizard W2: wizard shell — full-screen 3-step modal + strip integration

### DIFF
--- a/.factory/orders/funding-wizard/wp2-shell.md
+++ b/.factory/orders/funding-wizard/wp2-shell.md
@@ -1,0 +1,219 @@
+# WP2 — Funding wizard shell: full-screen modal, 3-step spine, strip integration
+
+You are implementing one scoped work package in the `serious-trader-ralph`
+repo (ticket #512, PRD #510). Follow this order exactly. Read `AGENTS.md`
+and `.factory/PITFALLS.md` before touching anything — every rule is binding.
+
+## Goal
+
+The funding wizard's shell: a full-screen guided modal over the terminal
+(desk visible behind a scrim), a three-step spine whose active step derives
+from real account state, and two-way integration with the welcome strip
+(strip click opens the wizard; wizard is the strip's expanded form). Step
+BODIES are minimal-but-useful in this WP — each step shows its real title,
+one line of copy, and wires to an EXISTING action (funds modal / desk).
+Later tickets (W3-W5) replace the bodies; the shell, navigation, animation,
+and state plumbing you build here are final.
+
+## Non-goals
+
+- No Ultra/gasless usage (W4). No QR/receive internals (W3). No starter
+  ticket (W5).
+- No changes to FundsModal, AckModal, or ticket components.
+- Do not remove or restyle the welcome strip beyond adding the open
+  affordance described below.
+
+## Files
+
+Create:
+- /Users/guillaume/Github/serious-trader-ralph/apps/portal/src/routes/terminal/components/FundingWizard.svelte
+
+Modify:
+- /Users/guillaume/Github/serious-trader-ralph/apps/portal/src/lib/terminal/welcome.ts
+  — append two functions (payload 2).
+- /Users/guillaume/Github/serious-trader-ralph/apps/portal/src/lib/terminal/welcome.test.ts
+  — extend the matrix for them.
+- /Users/guillaume/Github/serious-trader-ralph/apps/portal/src/routes/terminal/components/WelcomeStrip.svelte
+  — payload 3 (open affordance).
+- /Users/guillaume/Github/serious-trader-ralph/apps/portal/src/routes/terminal/+page.svelte
+  — ONLY the edits in payload 4 (legacy `$:` file — match its style).
+
+Delete: none
+
+## Design constraints (binding)
+
+- Animation: transform + opacity ONLY. Overlay fades in 220ms; the dialog
+  enters translateY(12px)→0 + opacity 0→1, 260ms
+  `cubic-bezier(0.23, 1, 0.32, 1)` (strong ease-out). Step changes
+  crossfade + 8px slide, 240ms, same curve. Everything inside
+  `@media (prefers-reduced-motion: reduce)` drops to none. NEVER
+  scale(0). No keyframes for interruptible things — CSS transitions.
+- Focus: trap Tab/Shift+Tab inside the dialog and recover focus if it
+  escapes (copy the trapTab pattern from AckModal.svelte verbatim,
+  adapted). Escape and scrim-click close. role="dialog" aria-modal="true"
+  aria-label="Funding wizard".
+- Scrim: `rgba(0, 0, 0, 0.55)` + `backdrop-filter: blur(2px)` — the desk
+  must remain recognizable behind it.
+- Token-only CSS (pitfall 16). No new fonts, no new colors.
+
+## Load-bearing payloads
+
+1. `FundingWizard.svelte` — runes. Props:
+
+```ts
+let {
+  address,
+  funded,
+  collateralized,
+  traded,
+  onopenfunds,
+  onclose,
+}: {
+  address: string;
+  funded: boolean;
+  collateralized: boolean;
+  traded: boolean;
+  onopenfunds: () => void;
+  onclose: () => void;
+} = $props();
+
+// Active step derives from real state — never stored:
+const step = $derived(!funded ? 1 : !collateralized ? 2 : 3);
+```
+
+Layout: fixed inset-0 wrapper (z-index above the terminal chrome — check
+what AuthModal/AckModal use and go one step above only if required);
+scrim div; centered dialog `min(40rem, 92vw)` wide, max-height 86vh,
+panel styling per the terminal modal conventions (var(--surface), 1px
+var(--line) border).
+
+Dialog structure:
+- Header: kicker `GET FUNDED`, title `Three steps to your first trade`,
+  close × (aria-label="Close wizard").
+- Step indicator: three segments (`1 Receive`, `2 Activate`, `3 Trade`)
+  — completed = var(--up) check, active = var(--accent) underline,
+  upcoming = var(--faint).
+- Body (crossfade region), per step:
+  - Step 1 — title `Send funds to your wallet`; copy
+    `USDC or SOL on Solana. Your address:` + address in mono with a Copy
+    button (navigator.clipboard.writeText, "Copied" state 1.5s); hint
+    `Sends of $10+ unlock gasless setup. This screen will advance on its
+    own when funds arrive.`
+  - Step 2 — title `Make it tradable`; copy `Move USDC into your Phoenix
+    margin account — rent ~0.04 SOL, explained before you sign.`; primary
+    button `Open funding` → onopenfunds() (the existing modal, for now).
+  - Step 3 — title `You're set`; copy `Funded and ready. Start small.`;
+    primary button `Go to the desk` → onclose().
+- Footer: `step {step} of 3` in var(--faint) mono.
+
+2. Append to `welcome.ts` (mirror existing style; biome-format):
+`hasAutoOpenedWizard(wallet, storage?)` / `recordWizardAutoOpened(wallet,
+storage?)` on key `trader-ralph-terminal/wizard-auto/v1`. Extend
+`welcome.test.ts` with the same matrix as the dismissal pair.
+
+3. `WelcomeStrip.svelte` — the strip becomes the wizard's re-entry point:
+add prop `onopen: () => void;`. Wrap the three step spans region in a
+button-like affordance: give the container a click/keyboard path — an
+explicit `<button class="strip-open" onclick={onopen}>` wrapping the steps
+(reset button styling: transparent, inherit, text-align left, cursor
+pointer, flex 1, same internal flex layout as before). The existing
+"2. Fund it" `step-action` button must now call `onopen` INSTEAD of
+`onfund` (the wizard owns funding guidance; keep the `onfund` prop wired
+in the page but it may become unused — if so REMOVE the prop entirely
+from both component and page mount to avoid dead API). Dismiss ×
+unchanged and must not trigger onopen (stopPropagation).
+
+4. `+page.svelte` edits:
+
+a. Import next to WelcomeStrip's import:
+```ts
+import FundingWizard from "./components/FundingWizard.svelte";
+```
+and extend the welcome.ts import with
+`hasAutoOpenedWizard, recordWizardAutoOpened`.
+
+b. Near the welcome-strip state block, add:
+```ts
+let wizardOpen = false;
+$: welcomeCollateralized = phoenixTotalCollateral > 0;
+// Auto-open once per wallet for fresh authed accounts that still need
+// onboarding — afterwards the strip is the re-entry point.
+$: if (
+  showWelcomeStrip &&
+  !wizardOpen &&
+  $privyAuth.walletAddress &&
+  !hasAutoOpenedWizard($privyAuth.walletAddress)
+) {
+  recordWizardAutoOpened($privyAuth.walletAddress);
+  wizardOpen = true;
+}
+```
+
+c. WelcomeStrip mount: add `onopen={() => (wizardOpen = true)}` (and drop
+`onfund` if payload 3 removed it).
+
+d. Mount the wizard next to the AckModal mount:
+```svelte
+{#if wizardOpen}
+  <FundingWizard
+    address={`${($privyAuth.walletAddress ?? "").slice(0, 4)}…${($privyAuth.walletAddress ?? "").slice(-4)}`}
+    funded={welcomeFunded}
+    collateralized={welcomeCollateralized}
+    traded={welcomeTraded}
+    onopenfunds={() => {
+      wizardOpen = false;
+      openFunds();
+    }}
+    onclose={() => (wizardOpen = false)}
+  />
+{/if}
+```
+(Verify `openFunds` is the funds-modal opener's real name; reuse the
+actual one.)
+
+Note: step 1 needs the FULL address for receiving funds, not the
+shortened one — pass `address={$privyAuth.walletAddress ?? ""}` instead
+if step 1's copy button is to be useful. Use the full address; the
+component may shorten for DISPLAY but must copy the full value.
+
+## Acceptance criteria
+
+- Fresh authed wallet: wizard auto-opens exactly once (reload → doesn't
+  re-open; strip click re-opens). Signed-out: never.
+- Active step tracks real state: no funds → 1; funds but no Phoenix
+  collateral → 2; collateral → 3. No stored step.
+- Copy button copies the FULL wallet address.
+- Escape, scrim, and × all close; focus cannot Tab out while open;
+  reduced-motion kills all transitions.
+- Strip dismiss still works and never opens the wizard.
+- Zero visible change for fully-onboarded wallets (no strip → no wizard
+  auto-open).
+- welcome.test.ts extended matrix passes; token-only CSS; zero new
+  `unused css selector` warnings.
+
+## Validation (run all, paste FULL output)
+
+```bash
+bun run typecheck
+bun run lint
+bun run test
+cd apps/portal && bun test
+bun run build
+```
+
+Also grep the build output for `unused css selector` — must be 0 occurrences.
+
+## Report format
+
+1. Summary of what changed, per file.
+2. Full validation output (verbatim, no truncation).
+3. Anything you could not do, skipped, or are unsure about — say so plainly.
+4. NO claims of success without validation output to back them.
+
+## Rules (non-negotiable)
+
+- Git is READ-ONLY for you: `status` / `diff` / `log` only. Never commit,
+  push, stash, restore, reset, or clean.
+- Stay inside the file lists above; in +page.svelte touch only the anchors.
+- Kill any dev server you start.
+- All pitfalls in `.factory/PITFALLS.md` apply.

--- a/apps/portal/src/lib/terminal/welcome.test.ts
+++ b/apps/portal/src/lib/terminal/welcome.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { hasDismissedWelcome, recordWelcomeDismissed } from "./welcome";
+import {
+  hasAutoOpenedWizard,
+  hasDismissedWelcome,
+  recordWelcomeDismissed,
+  recordWizardAutoOpened,
+} from "./welcome";
 
 type StorageLike = Pick<Storage, "getItem" | "setItem">;
 
@@ -8,6 +13,7 @@ type StorageLike = Pick<Storage, "getItem" | "setItem">;
 // exercises the corrupt/non-array branches without leaking through to
 // other tests.
 const WELCOME_KEY = "trader-ralph-terminal/welcome-dismissed/v1";
+const WIZARD_KEY = "trader-ralph-terminal/wizard-auto/v1";
 
 function fakeStorage(): StorageLike {
   const store = new Map<string, string>();
@@ -61,5 +67,57 @@ describe("corrupt storage", () => {
     const storage = fakeStorage();
     storage.setItem(WELCOME_KEY, '"WALLET_A"');
     expect(hasDismissedWelcome("WALLET_A", storage)).toBe(false);
+  });
+});
+
+describe("hasAutoOpenedWizard / recordWizardAutoOpened", () => {
+  test("null wallet: not opened, record is a no-throw no-op", () => {
+    const storage = fakeStorage();
+    expect(hasAutoOpenedWizard(null, storage)).toBe(false);
+    expect(() => recordWizardAutoOpened(null, storage)).not.toThrow();
+    expect(storage.getItem(WIZARD_KEY)).toBeNull();
+  });
+
+  test("unknown wallet has not auto-opened", () => {
+    const storage = fakeStorage();
+    expect(hasAutoOpenedWizard("WALLET_A", storage)).toBe(false);
+  });
+
+  test("recordWizardAutoOpened then hasAutoOpenedWizard is true", () => {
+    const storage = fakeStorage();
+    recordWizardAutoOpened("WALLET_A", storage);
+    expect(hasAutoOpenedWizard("WALLET_A", storage)).toBe(true);
+  });
+
+  test("two wallets are independent", () => {
+    const storage = fakeStorage();
+    recordWizardAutoOpened("WALLET_A", storage);
+    expect(hasAutoOpenedWizard("WALLET_A", storage)).toBe(true);
+    expect(hasAutoOpenedWizard("WALLET_B", storage)).toBe(false);
+    recordWizardAutoOpened("WALLET_B", storage);
+    expect(hasAutoOpenedWizard("WALLET_B", storage)).toBe(true);
+    expect(hasAutoOpenedWizard("WALLET_A", storage)).toBe(true);
+  });
+
+  test("wizard and dismissal keys are independent stores", () => {
+    const storage = fakeStorage();
+    recordWizardAutoOpened("WALLET_A", storage);
+    expect(hasAutoOpenedWizard("WALLET_A", storage)).toBe(true);
+    expect(hasDismissedWelcome("WALLET_A", storage)).toBe(false);
+  });
+});
+
+describe("corrupt wizard storage", () => {
+  test("corrupted JSON reads as not opened (no throw)", () => {
+    const storage = fakeStorage();
+    storage.setItem(WIZARD_KEY, "{not json");
+    expect(() => hasAutoOpenedWizard("WALLET_A", storage)).not.toThrow();
+    expect(hasAutoOpenedWizard("WALLET_A", storage)).toBe(false);
+  });
+
+  test("non-array JSON reads as not opened", () => {
+    const storage = fakeStorage();
+    storage.setItem(WIZARD_KEY, '"WALLET_A"');
+    expect(hasAutoOpenedWizard("WALLET_A", storage)).toBe(false);
   });
 });

--- a/apps/portal/src/lib/terminal/welcome.ts
+++ b/apps/portal/src/lib/terminal/welcome.ts
@@ -4,6 +4,11 @@
 
 const WELCOME_KEY = "trader-ralph-terminal/welcome-dismissed/v1";
 
+// Wizard auto-open (PRD #510): the funding wizard auto-opens once per wallet
+// for fresh authed accounts that still need onboarding; afterwards the strip
+// is the re-entry point. Same shape as the dismissal key so tests mirror.
+const WIZARD_KEY = "trader-ralph-terminal/wizard-auto/v1";
+
 type StorageLike = Pick<Storage, "getItem" | "setItem">;
 
 function readDismissed(storage: StorageLike): string[] {
@@ -43,5 +48,45 @@ export function recordWelcomeDismissed(
     store.setItem(WELCOME_KEY, JSON.stringify([...dismissed]));
   } catch {
     /* storage unavailable: dismissal lasts the session via caller state */
+  }
+}
+
+function readWizardOpened(storage: StorageLike): string[] {
+  try {
+    const raw = storage.getItem(WIZARD_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed)
+      ? parsed.filter((v): v is string => typeof v === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function hasAutoOpenedWizard(
+  wallet: string | null,
+  storage?: StorageLike,
+): boolean {
+  if (!wallet) return false;
+  const store =
+    storage ?? (typeof localStorage === "undefined" ? null : localStorage);
+  if (!store) return false;
+  return readWizardOpened(store).includes(wallet);
+}
+
+export function recordWizardAutoOpened(
+  wallet: string | null,
+  storage?: StorageLike,
+): void {
+  if (!wallet) return;
+  const store =
+    storage ?? (typeof localStorage === "undefined" ? null : localStorage);
+  if (!store) return;
+  try {
+    const opened = new Set(readWizardOpened(store));
+    opened.add(wallet);
+    store.setItem(WIZARD_KEY, JSON.stringify([...opened]));
+  } catch {
+    /* storage unavailable: auto-open lasts the session via caller state */
   }
 }

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -618,13 +618,19 @@
   // afterwards the strip is the re-entry point. Reload never re-opens (the
   // wizard-auto key is set on first open); signed-out never opens.
   let wizardOpen = false;
+  // In-memory guard alongside the persisted key: if the localStorage write
+  // fails (private mode, quota), the reactive must NOT re-fire and reopen
+  // the wizard every time it closes (review). Session memory wins.
+  const wizardAutoOpenedSession = new Set<string>();
   $: welcomeCollateralized = phoenixTotalCollateral > 0;
   $: if (
     showWelcomeStrip &&
     !wizardOpen &&
     $privyAuth.walletAddress &&
+    !wizardAutoOpenedSession.has($privyAuth.walletAddress) &&
     !hasAutoOpenedWizard($privyAuth.walletAddress)
   ) {
+    wizardAutoOpenedSession.add($privyAuth.walletAddress);
     recordWizardAutoOpened($privyAuth.walletAddress);
     wizardOpen = true;
   }

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -11,6 +11,7 @@
   import CommandPalette from "./components/CommandPalette.svelte";
   import DragHead from "./components/DragHead.svelte";
   import EventsPanel from "./components/EventsPanel.svelte";
+  import FundingWizard from "./components/FundingWizard.svelte";
   import FundsModal from "./components/FundsModal.svelte";
   import JournalPanel from "./components/JournalPanel.svelte";
   import MacroPanel from "./components/MacroPanel.svelte";
@@ -43,8 +44,10 @@
   import { track } from "$lib/telemetry";
   import { hasAcked, recordAck } from "$lib/terminal/ack";
   import {
+    hasAutoOpenedWizard,
     hasDismissedWelcome,
     recordWelcomeDismissed,
+    recordWizardAutoOpened,
   } from "$lib/terminal/welcome";
   import { type Alert, alertsStore } from "$lib/terminal/alerts";
   import {
@@ -608,6 +611,22 @@
   function dismissWelcome(): void {
     recordWelcomeDismissed($privyAuth.walletAddress);
     welcomeTick += 1;
+  }
+
+  // Funding wizard (PRD #510): the welcome strip's expanded form. Auto-opens
+  // once per wallet for fresh authed accounts that still need onboarding —
+  // afterwards the strip is the re-entry point. Reload never re-opens (the
+  // wizard-auto key is set on first open); signed-out never opens.
+  let wizardOpen = false;
+  $: welcomeCollateralized = phoenixTotalCollateral > 0;
+  $: if (
+    showWelcomeStrip &&
+    !wizardOpen &&
+    $privyAuth.walletAddress &&
+    !hasAutoOpenedWizard($privyAuth.walletAddress)
+  ) {
+    recordWizardAutoOpened($privyAuth.walletAddress);
+    wizardOpen = true;
   }
   // Bottom dock (desk / journal / alerts) + macro drawer — day-trading grid.
   let dockTab: "desk" | "journal" | "alerts" = "desk";
@@ -4133,7 +4152,7 @@
         address={`${($privyAuth.walletAddress ?? "").slice(0, 4)}…${($privyAuth.walletAddress ?? "").slice(-4)}`}
         funded={welcomeFunded}
         traded={welcomeTraded}
-        onfund={openFunds}
+        onopen={() => (wizardOpen = true)}
         ondismiss={dismissWelcome}
       />
     </div>
@@ -4756,6 +4775,20 @@
 
 {#if ackOpen}
   <AckModal onagree={onAckAgree} onclose={() => { ackOpen = false; pendingAckAction = null; }} />
+{/if}
+
+{#if wizardOpen}
+  <FundingWizard
+    address={$privyAuth.walletAddress ?? ""}
+    funded={welcomeFunded}
+    collateralized={welcomeCollateralized}
+    traded={welcomeTraded}
+    onopenfunds={() => {
+      wizardOpen = false;
+      openFunds();
+    }}
+    onclose={() => (wizardOpen = false)}
+  />
 {/if}
 
 {#if tradeOpen}

--- a/apps/portal/src/routes/terminal/components/FundingWizard.svelte
+++ b/apps/portal/src/routes/terminal/components/FundingWizard.svelte
@@ -1,0 +1,344 @@
+<script lang="ts">
+  import { onDestroy, onMount } from "svelte";
+
+  let {
+    address,
+    funded,
+    collateralized,
+    traded,
+    onopenfunds,
+    onclose,
+  }: {
+    // Full wallet address — step 1 copies this verbatim. Display wraps.
+    address: string;
+    funded: boolean;
+    collateralized: boolean;
+    /** plumbed for later tickets (W5 first-trade); the spine ends at "ready". */
+    traded: boolean;
+    onopenfunds: () => void;
+    onclose: () => void;
+  } = $props();
+
+  // Active step derives from real state — never stored. No funds → 1; funds
+  // but no Phoenix collateral → 2; collateral present → 3. The wizard is the
+  // welcome strip's expanded form: advancing here mirrors the strip's state.
+  const step = $derived(!funded ? 1 : !collateralized ? 2 : 3);
+
+  let panel: HTMLDivElement | undefined;
+  // Single mount flips these to drive the CSS-transition entrances (no
+  // keyframes — interruptible by design; the page's {#if} unmounts cleanly).
+  let mounted = $state(false);
+  let copied = $state(false);
+  let stepBodyReady = $state(false);
+  let copyTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Focus the dialog on open so keys originate here: terminal hotkeys are
+  // swallowed below instead of flipping the ticket behind the overlay. The
+  // page's global keydown handler closes other modals on Escape but doesn't
+  // know about this one, so Escape is handled here and at the window.
+  onMount(() => {
+    panel?.focus();
+    mounted = true;
+  });
+
+  // Step crossfade + 8px slide replays on every step change (manual or
+  // state-driven auto-advance). The transition lives on `.ready`, so dropping
+  // it snaps the body back to its initial offset instantly (no fade-out) and
+  // re-adding it animates the new body in. Double-rAF guarantees the hidden
+  // frame paints before the flip, so the transition always fires.
+  $effect(() => {
+    step;
+    stepBodyReady = false;
+    let raf2 = 0;
+    const raf1 = requestAnimationFrame(() => {
+      raf2 = requestAnimationFrame(() => (stepBodyReady = true));
+    });
+    return () => {
+      cancelAnimationFrame(raf1);
+      cancelAnimationFrame(raf2);
+    };
+  });
+
+  onDestroy(() => {
+    if (copyTimer) clearTimeout(copyTimer);
+  });
+
+  // Real focus trap: Tab cycles within the dialog's controls, and if focus
+  // ever ends up outside the panel it is pulled back — the wizard must own
+  // the whole interaction while open. Adapted verbatim from AckModal.svelte.
+  function trapTab(event: KeyboardEvent): void {
+    if (!panel) return;
+    const focusables = panel.querySelectorAll<HTMLElement>(
+      "a[href], button:not([disabled])",
+    );
+    if (focusables.length === 0) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement;
+    if (!panel.contains(active)) {
+      event.preventDefault();
+      first.focus();
+      return;
+    }
+    if (event.shiftKey && (active === first || active === panel)) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  function onWinKeydown(event: KeyboardEvent): void {
+    if (event.key === "Escape") {
+      onclose();
+      return;
+    }
+    if (event.key === "Tab") trapTab(event);
+  }
+
+  function onPanelKeydown(event: KeyboardEvent): void {
+    if (event.key === "Escape") {
+      onclose();
+      return;
+    }
+    if (event.key === "Tab") {
+      trapTab(event);
+      return;
+    }
+    event.stopPropagation();
+  }
+
+  async function copyAddress(): Promise<void> {
+    if (!address) return;
+    try {
+      await navigator.clipboard.writeText(address);
+      copied = true;
+      if (copyTimer) clearTimeout(copyTimer);
+      copyTimer = setTimeout(() => (copied = false), 1500);
+    } catch {
+      /* clipboard unavailable: leave the hint as "Copy" */
+    }
+  }
+</script>
+
+<svelte:window onkeydown={onWinKeydown} />
+
+<div class="wizard-scrim" role="presentation" class:ready={mounted} onclick={() => onclose()}>
+  <div
+    bind:this={panel}
+    class="wizard-dialog"
+    class:ready={mounted}
+    role="dialog"
+    aria-modal="true"
+    aria-label="Funding wizard"
+    tabindex="-1"
+    onclick={(event) => event.stopPropagation()}
+    onkeydown={onPanelKeydown}
+  >
+    <div class="panel-head">
+      <div>
+        <p>GET_FUNDED</p>
+        <h2>Three steps to your first trade</h2>
+      </div>
+      <button class="modal-close" type="button" aria-label="Close wizard" onclick={() => onclose()}>×</button>
+    </div>
+
+    <div class="wizard-scroll">
+      <ol class="wizard-spine" aria-label="Funding wizard progress">
+        <li class="spine-seg" class:done={1 < step} class:active={step === 1}>
+          {#if 1 < step}<span class="spine-check" aria-hidden="true">✓</span>{:else}<span class="spine-num">1</span>{/if}
+          Receive
+        </li>
+        <li class="spine-seg" class:done={2 < step} class:active={step === 2}>
+          {#if 2 < step}<span class="spine-check" aria-hidden="true">✓</span>{:else}<span class="spine-num">2</span>{/if}
+          Activate
+        </li>
+        <li class="spine-seg" class:active={step === 3}>
+          <span class="spine-num">3</span> Trade
+        </li>
+      </ol>
+
+      <div class="step-body" class:ready={stepBodyReady}>
+        {#if step === 1}
+          <h3 class="step-title">Send funds to your wallet</h3>
+          <p class="step-copy">USDC or SOL on Solana. Your address:</p>
+          <button class="address-copy" type="button" onclick={copyAddress}>
+            <span class="mono">{address || "—"}</span>
+            <span class="copy-hint">{copied ? "Copied" : "Copy"}</span>
+          </button>
+          <p class="step-hint">
+            Sends of $10+ unlock gasless setup. This screen will advance on its own when funds arrive.
+          </p>
+        {:else if step === 2}
+          <h3 class="step-title">Make it tradable</h3>
+          <p class="step-copy">
+            Move USDC into your Phoenix margin account — rent ~0.04 SOL, explained before you sign.
+          </p>
+          <button class="primary wide" type="button" onclick={onopenfunds}>Open funding</button>
+        {:else}
+          <h3 class="step-title">You're set</h3>
+          <p class="step-copy">Funded and ready. Start small.</p>
+          <button class="primary wide" type="button" onclick={onclose}>Go to the desk</button>
+        {/if}
+      </div>
+    </div>
+
+    <p class="wizard-foot mono">step {step} of 3</p>
+  </div>
+</div>
+
+<style>
+  .wizard-scrim {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    display: grid;
+    place-items: center;
+    padding: 1rem;
+    background: rgba(0, 0, 0, 0.55);
+    backdrop-filter: blur(2px);
+    opacity: 0;
+  }
+  .wizard-scrim.ready {
+    opacity: 1;
+    transition: opacity 220ms ease;
+  }
+
+  .wizard-dialog {
+    display: flex;
+    flex-direction: column;
+    width: min(40rem, 92vw);
+    max-height: 86vh;
+    overflow: hidden;
+    border: 1px solid var(--line);
+    border-radius: 0;
+    background: var(--surface);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.04),
+      0 1.5rem 5rem rgba(0, 0, 0, 0.5);
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  .wizard-dialog.ready {
+    opacity: 1;
+    transform: translateY(0);
+    transition:
+      opacity 260ms cubic-bezier(0.23, 1, 0.32, 1),
+      transform 260ms cubic-bezier(0.23, 1, 0.32, 1);
+  }
+
+  .wizard-scroll {
+    overflow-y: auto;
+    overflow-x: hidden;
+    display: grid;
+    gap: 0.85rem;
+    padding: 1rem;
+  }
+
+  .wizard-spine {
+    display: flex;
+    gap: 0.6rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+  .spine-seg {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding-bottom: 0.3rem;
+    color: var(--faint);
+    font-size: 0.76rem;
+    border-bottom: 2px solid transparent;
+  }
+  .spine-seg.active {
+    color: var(--ink);
+    border-bottom-color: var(--accent);
+  }
+  .spine-seg.done {
+    color: var(--up);
+  }
+  .spine-num {
+    font-weight: 700;
+  }
+  .spine-check {
+    color: var(--up);
+    font-weight: 700;
+  }
+
+  .step-body {
+    opacity: 0;
+    transform: translateX(8px);
+  }
+  .step-body.ready {
+    opacity: 1;
+    transform: translateX(0);
+    transition:
+      opacity 240ms cubic-bezier(0.23, 1, 0.32, 1),
+      transform 240ms cubic-bezier(0.23, 1, 0.32, 1);
+  }
+
+  .step-title {
+    margin: 0;
+    font-size: 0.92rem;
+    font-weight: 700;
+  }
+  .step-copy {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.82rem;
+    line-height: 1.45;
+  }
+  .step-hint {
+    margin: 0;
+    color: var(--faint);
+    font-size: 0.76rem;
+    line-height: 1.4;
+  }
+
+  .address-copy {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem;
+    width: 100%;
+    border: 1px solid var(--line);
+    border-radius: 0;
+    background: var(--surface-2);
+    color: var(--ink);
+    padding: 0.55rem 0.65rem;
+    font: inherit;
+    cursor: pointer;
+  }
+  .address-copy:hover {
+    border-color: var(--accent);
+  }
+  .address-copy .mono {
+    overflow-wrap: anywhere;
+    font-size: 0.74rem;
+  }
+  .copy-hint {
+    flex: 0 0 auto;
+    color: var(--muted);
+    font-size: 0.74rem;
+  }
+
+  .wizard-foot {
+    margin: 0;
+    padding: 0.55rem 0.9rem;
+    border-top: 1px solid var(--line-soft);
+    color: var(--faint);
+    font-size: 0.72rem;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .wizard-scrim,
+    .wizard-dialog,
+    .step-body {
+      opacity: 1 !important;
+      transform: none !important;
+      transition: none !important;
+    }
+  }
+</style>

--- a/apps/portal/src/routes/terminal/components/WelcomeStrip.svelte
+++ b/apps/portal/src/routes/terminal/components/WelcomeStrip.svelte
@@ -3,45 +3,48 @@
     address,
     funded,
     traded,
-    onfund,
+    onopen,
     ondismiss,
   }: {
     /** shortened wallet address, e.g. "3Qw1…9xKe" */
     address: string;
     funded: boolean;
     traded: boolean;
-    onfund: () => void;
+    /** opens the funding wizard — the strip is the wizard's re-entry point. */
+    onopen: () => void;
     ondismiss: () => void;
   } = $props();
 </script>
 
 <div class="welcome-strip" role="status">
-  <span class="step step-done">
-    <span class="check">✓</span> Wallet ready
-    <span class="mono">{address}</span>
-    <span class="hint">self-custodial via Privy</span>
-  </span>
-
-  {#if funded}
+  <button class="strip-open" type="button" aria-label="Open funding wizard" onclick={onopen}>
     <span class="step step-done">
-      <span class="check">✓</span> Funded
+      <span class="check">✓</span> Wallet ready
+      <span class="mono">{address}</span>
+      <span class="hint">self-custodial via Privy</span>
     </span>
-  {:else}
-    <span class="step">
-      <button class="step-action" onclick={onfund}>2. Fund it</button>
-      <span class="hint">USDC to trade · keep ~0.04 SOL for rent + fees</span>
-    </span>
-  {/if}
 
-  {#if traded}
-    <span class="step step-done">
-      <span class="check">✓</span> First trade placed
-    </span>
-  {:else}
-    <span class="step">
-      <span class="hint">3. Place your first trade — start small</span>
-    </span>
-  {/if}
+    {#if funded}
+      <span class="step step-done">
+        <span class="check">✓</span> Funded
+      </span>
+    {:else}
+      <span class="step">
+        <span class="step-action">2. Fund it</span>
+        <span class="hint">USDC to trade · keep ~0.04 SOL for rent + fees</span>
+      </span>
+    {/if}
+
+    {#if traded}
+      <span class="step step-done">
+        <span class="check">✓</span> First trade placed
+      </span>
+    {:else}
+      <span class="step">
+        <span class="hint">3. Place your first trade — start small</span>
+      </span>
+    {/if}
+  </button>
 
   <button class="strip-dismiss" aria-label="Dismiss welcome" onclick={ondismiss}
     >×</button
@@ -58,6 +61,23 @@
     background: var(--surface-2);
     color: var(--muted);
     font-size: 0.74rem;
+  }
+  .strip-open {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex: 1;
+    min-width: 0;
+    border: none;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+    padding: 0;
+    cursor: pointer;
+  }
+  .strip-open:hover {
+    color: var(--ink);
   }
   .step {
     display: inline-flex;
@@ -97,6 +117,10 @@
   }
   @media (max-width: 720px) {
     .welcome-strip {
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+    .strip-open {
       flex-wrap: wrap;
       gap: 0.5rem;
     }


### PR DESCRIPTION
Closes #512 · Part of PRD #510 · **DO NOT MERGE — awaiting Guillaume's preview QA**

## Summary

- `FundingWizard.svelte`: full-screen guided modal — desk recognizable behind `rgba(0,0,0,.55)` + 2px blur scrim; dialog `min(40rem, 92vw)`; kicker/title/step-indicator/footer per order. Step derives from **real state only**: no funds → Receive, funds w/o Phoenix collateral → Activate, collateral → Trade.
- Focus trap (AckModal pattern), Escape/scrim/× close, `role=dialog aria-modal`; transitions are transform+opacity, 220–260ms strong ease-out, dead under `prefers-reduced-motion`.
- Welcome strip = the wizard's minimized form: steps region is now the open button (delegate correctly avoided nested-button HTML), auto-open **once per wallet** (`wizard-auto/v1` + test matrix), dismiss unchanged.
- Step bodies are minimal-but-real (copy full address; "Open funding" → existing modal; "Go to the desk") — W3/W4/W5 replace them; shell, nav, animation, state plumbing are final.

## Validation

typecheck 0/0 · lint clean · 16 ui + 241 portal tests (7 new) · build, unused-css = 0 · real-Chrome probe (forced open, reverted): dialog renders with exact copy, **0 focus escapes in 12 Tabs**, Escape closes, desk visible through scrim. Screenshot in session log.

## QA notes for preview

Fresh wallet: wizard auto-opens after auth (once — reload won't repeat; strip click reopens). Your onboarded wallet: no strip, no wizard, zero change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)