### PR TITLE
funding-wizard W3: real receive step — QR, live polling, arrival beat

### DIFF
--- a/.factory/orders/funding-wizard/wp3-receive.md
+++ b/.factory/orders/funding-wizard/wp3-receive.md
@@ -1,0 +1,152 @@
+# WP3 — Wizard step 1: real receive screen with live auto-advance
+
+You are implementing one scoped work package in the `serious-trader-ralph`
+repo (ticket #513, PRD #510). Follow this order exactly. Read `AGENTS.md`
+and `.factory/PITFALLS.md` before touching anything — every rule is binding.
+
+## Goal
+
+Replace the wizard's step-1 placeholder with the real receive screen: a QR
+code of the wallet address, tighter balance polling while the wizard sits
+on step 1, and a funds-detected beat — a brief celebratory pulse when the
+balance flips, then the existing state-derived step advance (W2's `step`
+derivation already flips 1→2 when `funded` becomes true; you are adding
+the polish around it, not new navigation).
+
+## Non-goals
+
+- No Ultra/gasless execution (W4). No starter ticket (W5).
+- No changes to FundsModal, the strip, or step 2/3 bodies.
+- No new dependencies — the `qrcode` package is already in the portal
+  (FundsModal lazy-imports it).
+
+## Files
+
+Modify:
+- /Users/guillaume/Github/serious-trader-ralph/apps/portal/src/routes/terminal/components/FundingWizard.svelte
+  — step-1 body + QR + funds-detected beat (payload 1).
+- /Users/guillaume/Github/serious-trader-ralph/apps/portal/src/routes/terminal/+page.svelte
+  — ONLY payload 2 (fast-poll while wizard open on step 1).
+
+Create/Delete: none
+
+## Load-bearing payloads
+
+1. `FundingWizard.svelte` changes (runes file):
+
+a. QR: lazy-import exactly like FundsModal (keep `qrcode` out of the
+entry chunk):
+```ts
+let qrSvg = $state<string | null>(null);
+$effect(() => {
+  if (!address) return;
+  let cancelled = false;
+  void import("qrcode").then(async ({ default: QRCode }) => {
+    const svg = await QRCode.toString(address, {
+      type: "svg",
+      margin: 0,
+      color: { dark: "#e8e8ef", light: "#00000000" },
+    });
+    if (!cancelled) qrSvg = svg;
+  });
+  return () => {
+    cancelled = true;
+  };
+});
+```
+Match FundsModal's actual QRCode.toString options if they differ — check
+that file first and mirror its colors/options verbatim; the payload above
+yields to the existing convention on conflict.
+
+b. Step-1 body becomes: QR block (10rem square, centered,
+`{@html qrSvg}` inside a bordered tile; while `qrSvg` is null show an
+empty tile with `aria-hidden` skeleton) + the existing address row with
+COPY + the existing hint line. Keep all existing copy.
+
+c. Funds-detected beat: track the previous `funded` value; when it flips
+false→true while the wizard is open, set `fundsJustArrived = true` for
+1400ms. While true, render a `.funds-beat` row replacing the hint line:
+`✓ Funds received` (var(--up), 0.8rem) with a one-time scale pulse:
+
+```css
+.funds-beat {
+  color: var(--up);
+  animation: funds-pulse 480ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+@keyframes funds-pulse {
+  0% { transform: scale(0.94); opacity: 0; }
+  100% { transform: scale(1); opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .funds-beat { animation: none; }
+}
+```
+The step indicator advances on its own via the `step` derivation — do NOT
+delay or fake it; the beat overlaps the transition (implement the flip
+detection with `$effect` watching `funded`).
+
+2. `+page.svelte` — faster funds detection while the user watches step 1.
+Near the wizard state block, add (legacy `$:` style):
+
+```ts
+// While the wizard is open and the wallet is unfunded, poll balances
+// every 5s so "this screen will advance on its own" is actually prompt —
+// the ambient 30s cadence stays for everything else.
+let wizardPollTimer: ReturnType<typeof setInterval> | null = null;
+$: {
+  const wantFast = wizardOpen && !welcomeFunded && Boolean(walletBalanceAddress);
+  if (wantFast && wizardPollTimer === null) {
+    wizardPollTimer = setInterval(() => {
+      if (walletBalanceAddress) {
+        void refreshWalletBalance(walletBalanceAddress, { quiet: true });
+      }
+    }, 5_000);
+  } else if (!wantFast && wizardPollTimer !== null) {
+    clearInterval(wizardPollTimer);
+    wizardPollTimer = null;
+  }
+}
+```
+Also clear the timer in the page's existing onDestroy/cleanup return
+(find where the `timers` array is cleared and add
+`if (wizardPollTimer !== null) window.clearInterval(wizardPollTimer);`).
+
+## Acceptance criteria
+
+- Step 1 shows a scannable QR of the FULL address; QR chunk stays lazy
+  (verify `qrcode` is not in the entry bundle — same as before this WP).
+- Funding the wallet while on step 1: balance flip detected within ~5s,
+  "✓ Funds received" pulse renders, step indicator advances to 2 via the
+  existing derivation; reduced-motion gets no animation.
+- Closing the wizard (or funding completing) stops the fast poll timer —
+  no leaked intervals (verify via the reactive teardown).
+- Zero change for onboarded wallets or signed-out visitors.
+- Token-only CSS except the QR svg colors (mirroring FundsModal's
+  existing QR convention); zero new `unused css selector` warnings.
+
+## Validation (run all, paste FULL output)
+
+```bash
+bun run typecheck
+bun run lint
+bun run test
+cd apps/portal && bun test
+bun run build
+```
+
+Also grep the build output for `unused css selector` — must be 0 occurrences.
+
+## Report format
+
+1. Summary of what changed, per file.
+2. Full validation output (verbatim, no truncation).
+3. Anything you could not do, skipped, or are unsure about — say so plainly.
+4. NO claims of success without validation output to back them.
+
+## Rules (non-negotiable)
+
+- Git is READ-ONLY for you: `status` / `diff` / `log` only. Never commit,
+  push, stash, restore, reset, or clean.
+- Stay inside the file lists above; in +page.svelte touch only the anchors.
+- Kill any dev server you start.
+- All pitfalls in `.factory/PITFALLS.md` apply.

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -634,6 +634,23 @@
     recordWizardAutoOpened($privyAuth.walletAddress);
     wizardOpen = true;
   }
+  // While the wizard is open and the wallet is unfunded, poll balances
+  // every 5s so "this screen will advance on its own" is actually prompt —
+  // the ambient 30s cadence stays for everything else.
+  let wizardPollTimer: ReturnType<typeof setInterval> | null = null;
+  $: {
+    const wantFast = wizardOpen && !welcomeFunded && Boolean(walletBalanceAddress);
+    if (wantFast && wizardPollTimer === null) {
+      wizardPollTimer = setInterval(() => {
+        if (walletBalanceAddress) {
+          void refreshWalletBalance(walletBalanceAddress, { quiet: true });
+        }
+      }, 5_000);
+    } else if (!wantFast && wizardPollTimer !== null) {
+      clearInterval(wizardPollTimer);
+      wizardPollTimer = null;
+    }
+  }
   // Bottom dock (desk / journal / alerts) + macro drawer — day-trading grid.
   let dockTab: "desk" | "journal" | "alerts" = "desk";
   let macroOpen = false;
@@ -1211,6 +1228,7 @@
       stackMq.removeEventListener("change", onStackMq);
       for (const timer of timers) window.clearInterval(timer);
       if (fundsPollTimer !== null) window.clearInterval(fundsPollTimer);
+      if (wizardPollTimer !== null) window.clearInterval(wizardPollTimer);
       if (copyResetTimer) clearTimeout(copyResetTimer);
       spotTicket.dispose();
       if (spotChartTimer) clearInterval(spotChartTimer);

--- a/apps/portal/src/routes/terminal/components/FundingWizard.svelte
+++ b/apps/portal/src/routes/terminal/components/FundingWizard.svelte
@@ -35,8 +35,9 @@
   // stays out of the entry chunk (same pattern as FundsModal).
   let qrSvg = $state<string | null>(null);
   // Funds-detected beat: a brief celebratory pulse when the balance flips
-  // to funded while the wizard watches step 1. The step itself advances via
-  // the `step` derivation below — the beat only overlaps that transition.
+  // to funded while the wizard is open. It renders as an overlay outside the
+  // step branches — the same flip advances `step` past 1, so a beat rendered
+  // inside step 1 would unmount before it was ever visible.
   let fundsJustArrived = $state(false);
   let fundsBeatTimer: ReturnType<typeof setTimeout> | null = null;
   // Previous `funded` value across effect runs; starts undefined so the first
@@ -215,6 +216,10 @@
         </li>
       </ol>
 
+      {#if fundsJustArrived}
+        <p class="funds-beat" role="status">✓ Funds received</p>
+      {/if}
+
       <div class="step-body" class:ready={stepBodyReady}>
         {#if step === 1}
           <h3 class="step-title">Send funds to your wallet</h3>
@@ -228,13 +233,9 @@
             <span class="mono">{address || "—"}</span>
             <span class="copy-hint">{copied ? "Copied" : "Copy"}</span>
           </button>
-          {#if fundsJustArrived}
-            <p class="funds-beat">✓ Funds received</p>
-          {:else}
-            <p class="step-hint">
-              Sends of $10+ unlock gasless setup. This screen will advance on its own when funds arrive.
-            </p>
-          {/if}
+          <p class="step-hint">
+            Sends of $10+ unlock gasless setup. This screen will advance on its own when funds arrive.
+          </p>
         {:else if step === 2}
           <h3 class="step-title">Make it tradable</h3>
           <p class="step-copy">
@@ -294,6 +295,7 @@
   }
 
   .wizard-scroll {
+    position: relative;
     overflow-y: auto;
     overflow-x: hidden;
     display: grid;
@@ -382,7 +384,12 @@
     height: 100%;
   }
 
+  /* Overlays top-right of the scroll area (out of flow) so its 1400ms
+     appearance never reflows the step body under it. */
   .funds-beat {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
     margin: 0;
     color: var(--up);
     font-size: 0.8rem;

--- a/apps/portal/src/routes/terminal/components/FundingWizard.svelte
+++ b/apps/portal/src/routes/terminal/components/FundingWizard.svelte
@@ -31,6 +31,18 @@
   let copied = $state(false);
   let stepBodyReady = $state(false);
   let copyTimer: ReturnType<typeof setTimeout> | null = null;
+  // QR of the wallet address, generated lazily so the `qrcode` package
+  // stays out of the entry chunk (same pattern as FundsModal).
+  let qrSvg = $state<string | null>(null);
+  // Funds-detected beat: a brief celebratory pulse when the balance flips
+  // to funded while the wizard watches step 1. The step itself advances via
+  // the `step` derivation below — the beat only overlaps that transition.
+  let fundsJustArrived = $state(false);
+  let fundsBeatTimer: ReturnType<typeof setTimeout> | null = null;
+  // Previous `funded` value across effect runs; starts undefined so the first
+  // run primes it without firing a spurious beat on mount. (Reading the
+  // reactive prop at init would only capture its initial value.)
+  let prevFunded: boolean | undefined;
 
   // Focus the dialog on open so keys originate here: terminal hotkeys are
   // swallowed below instead of flipping the ticket behind the overlay. The
@@ -59,8 +71,52 @@
     };
   });
 
+  // QR regenerates whenever the address changes (wallet switch). The lazy
+  // import keeps `qrcode` (+ dijkstrajs) out of the entry chunk; later opens
+  // hit the module cache. toString options mirror FundsModal verbatim.
+  $effect(() => {
+    if (!address) return;
+    let cancelled = false;
+    void import("qrcode")
+      .then(async ({ default: QRCode }) => {
+        const svg = await QRCode.toString(address, {
+          type: "svg",
+          margin: 1,
+          errorCorrectionLevel: "M",
+          color: { dark: "#f5eff7", light: "#00000000" },
+        });
+        if (!cancelled) qrSvg = svg;
+      })
+      .catch(() => {
+        /* generation failed — keep the skeleton tile */
+      });
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  // Funds-detected flip: funded going false→true fires the beat for 1400ms.
+  // The wizard only mounts while open, so "while the wizard is open" is
+  // implicit; opening onto an already-funded step (prevFunded starts true)
+  // does not fire it. The step indicator advances via the `step` derivation —
+  // the beat overlaps that transition, it never drives it.
+  $effect(() => {
+    const now = funded;
+    if (prevFunded === undefined) {
+      prevFunded = now;
+      return;
+    }
+    if (!prevFunded && now) {
+      fundsJustArrived = true;
+      if (fundsBeatTimer) clearTimeout(fundsBeatTimer);
+      fundsBeatTimer = setTimeout(() => (fundsJustArrived = false), 1400);
+    }
+    prevFunded = now;
+  });
+
   onDestroy(() => {
     if (copyTimer) clearTimeout(copyTimer);
+    if (fundsBeatTimer) clearTimeout(fundsBeatTimer);
   });
 
   // Real focus trap: Tab cycles within the dialog's controls, and if focus
@@ -163,13 +219,22 @@
         {#if step === 1}
           <h3 class="step-title">Send funds to your wallet</h3>
           <p class="step-copy">USDC or SOL on Solana. Your address:</p>
+          <div class="qr-wrap">
+            <div class="qr-tile" aria-hidden={qrSvg === null}>
+              {#if qrSvg}{@html qrSvg}{/if}
+            </div>
+          </div>
           <button class="address-copy" type="button" onclick={copyAddress}>
             <span class="mono">{address || "—"}</span>
             <span class="copy-hint">{copied ? "Copied" : "Copy"}</span>
           </button>
-          <p class="step-hint">
-            Sends of $10+ unlock gasless setup. This screen will advance on its own when funds arrive.
-          </p>
+          {#if fundsJustArrived}
+            <p class="funds-beat">✓ Funds received</p>
+          {:else}
+            <p class="step-hint">
+              Sends of $10+ unlock gasless setup. This screen will advance on its own when funds arrive.
+            </p>
+          {/if}
         {:else if step === 2}
           <h3 class="step-title">Make it tradable</h3>
           <p class="step-copy">
@@ -297,6 +362,43 @@
     line-height: 1.4;
   }
 
+  .qr-wrap {
+    display: flex;
+    justify-content: center;
+  }
+  .qr-tile {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 10rem;
+    height: 10rem;
+    padding: 0.6rem;
+    border: 1px solid var(--line-soft);
+    border-radius: 0;
+    background: rgba(255, 255, 255, 0.02);
+  }
+  .qr-tile :global(svg) {
+    width: 100%;
+    height: 100%;
+  }
+
+  .funds-beat {
+    margin: 0;
+    color: var(--up);
+    font-size: 0.8rem;
+    animation: funds-pulse 480ms cubic-bezier(0.23, 1, 0.32, 1);
+  }
+  @keyframes funds-pulse {
+    0% {
+      transform: scale(0.94);
+      opacity: 0;
+    }
+    100% {
+      transform: scale(1);
+      opacity: 1;
+    }
+  }
+
   .address-copy {
     display: flex;
     align-items: center;
@@ -339,6 +441,9 @@
       opacity: 1 !important;
       transform: none !important;
       transition: none !important;
+    }
+    .funds-beat {
+      animation: none;
     }
   }
 </style>


### PR DESCRIPTION
Closes #513 · Part of PRD #510 · **DO NOT MERGE — awaiting Guillaume's preview QA**

## Summary

- Step 1 is now the real receive screen: lazy-loaded QR (mirrors FundsModal's qrcode conventions; chunk verified absent from entry bundle), full address + COPY, honest $10-gasless hint.
- **5-second balance polling only while the wizard sits unfunded on step 1** — ambient 30s cadence untouched; timer reactively torn down when the wizard closes or funds arrive (+ page destroy cleanup).
- **"✓ Funds received" beat** on the balance flip (480ms ease-out pulse, `prefers-reduced-motion` → none); the step indicator advances via W2's existing state derivation — nothing faked, nothing delayed.
- Delegate disclosed 3 deviations, all correct: in-effect `prevFunded` priming (kills a `state_referenced_locally` warning), FundsModal QR options per the order's conflict rule, defensive `.catch` on the QR promise.

## Validation

typecheck 0/0 · lint clean · 16 ui + 254 portal tests · build, unused-css = 0 · `qrcode` confirmed lazy · real-Chrome probe (stubbed address, reverted): crisp scannable QR renders in the tile (screenshot in session log), no probe residue (verified by grep).

## QA notes for preview

Fresh wallet on https://preview.trader-ralph.com: wizard opens on Receive with your QR; **send $10+ USDC and watch it advance by itself within ~5s** with the arrival beat — that's the whole feature. Onboarded wallet: zero change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)