### PR TITLE
Factory notes: preview.sh mandatory before QA handoff (stale-alias retro)

### DIFF
--- a/.claude/skills/factory-ship/SKILL.md
+++ b/.claude/skills/factory-ship/SKILL.md
@@ -34,11 +34,18 @@ bundle: change summary, validation commands + results, local URL used for
 UI verification, browser artifacts (screenshots) for UI changes, risk
 notes / deferred items. Reference the ticket (`Closes #N`).
 
-## 3. Preview URL (approval lane)
+## 3. Preview URL (approval lane) — NEVER skip the script
 
 ```bash
 scripts/factory/preview.sh <pr-number>
 ```
+
+This step is what moves the `preview.trader-ralph.com` alias. The domain
+is NOT automatic: until the script runs for this PR it silently serves
+whatever PR was QA'd last, and Guillaume tests stale code with no visible
+error (happened on #520 — the "fixed" bug reproduced because the alias
+still pointed at #519's build). Only post the QA link AFTER the script
+prints the `(auth-enabled alias)` line.
 
 Post PR link + preview URL + concrete QA notes ("what to check") to
 Guillaume. Wait. Do not gate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,12 @@ pick up without further human context.
    with build log grepped for `unused css selector` = 0.
 3. PR against `main` with the WORKFLOW.md proof bundle (summary, validation
    output, local URL, browser artifacts for UI, risk notes).
+   **Approval-lane QA handoff: run `scripts/factory/preview.sh <PR>` BEFORE
+   posting the QA link.** `preview.trader-ralph.com` is a manually-moved
+   alias — until the script runs for THIS PR it silently serves the
+   previous PR's build, and Guillaume QAs stale code (burned a QA round on
+   #520). This also means: don't hand-roll the ship flow from memory — the
+   `/factory-ship` skill already encodes this step; use it.
 4. Gate (background): poll `mergeStateStatus == CLEAN`, fail-fast on any
    check failure, merge, then verify — never walk away before this is green.
 5. Verify main CI for the exact merge sha, then the Vercel production


### PR DESCRIPTION
Auto lane — docs/factory-internal only.

## Summary
Retro from #520's burned QA round: `preview.trader-ralph.com` is a manually-moved alias; until `scripts/factory/preview.sh <PR>` runs for the PR under QA, the domain silently serves the previous PR's build. Recorded in the CLAUDE.md ship pipeline (step 3) and the factory-ship skill (step 3, "NEVER skip the script"), including the root-cause lesson: use /factory-ship instead of hand-rolling the flow.

## Validation
Docs-only (CLAUDE.md + .claude/skills/factory-ship/SKILL.md); no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)