### PR TITLE
Marketing OG cards: live flagship strip on home, terminal card + scraper-visible meta

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,8 @@
 ## Environment and Domains
 
 - Production branch: `main`.
-- Production domain: `trader-ralph.com` and `www.trader-ralph.com`.
+- Production domain: `traderralph.com`; `trader-ralph.com` and
+  `www.trader-ralph.com` redirect to it.
 - Lower environment: `dev` branch -> `dev.trader-ralph.com`.
 - There is no frontend requirement for `api.trader-ralph.com` in the current
   repo shape.

--- a/apps/portal/src/hooks.server.ts
+++ b/apps/portal/src/hooks.server.ts
@@ -1,0 +1,29 @@
+// Server hooks. The terminal is a pure client app (`ssr = false` in
+// src/routes/terminal/+layout.ts), so its <svelte:head> never runs on the
+// server and scrapers only see the bare app shell. Inject the /terminal
+// OG/meta tags into the served HTML here instead.
+
+import type { Handle } from "@sveltejs/kit";
+
+const TERMINAL_HEAD = [
+  "<title>Trader Ralph Terminal — perps &amp; spot on Solana</title>",
+  '<meta property="og:title" content="Trader Ralph Terminal — perps &amp; spot on Solana" />',
+  '<meta property="og:description" content="Phoenix perps and Jupiter spot from one USDC account. Email login, no seed phrase." />',
+  '<meta property="og:image" content="https://traderralph.com/og/terminal.png" />',
+  '<meta name="twitter:card" content="summary_large_image" />',
+].join("\n    ");
+
+export const handle: Handle = async ({ event, resolve }) => {
+  if (event.url.pathname !== "/terminal") return resolve(event);
+
+  // Anchor choice: `</head>` from src/app.html. With SSR disabled the shell
+  // is the rendered template, where `</head>` appears exactly once and is a
+  // stable literal (unlike %sveltekit.head%, which is substituted away
+  // before transformPageChunk runs). String#replace only touches the first
+  // occurrence, and the pathname guard above keeps every other route
+  // untouched — no double injection.
+  return resolve(event, {
+    transformPageChunk: ({ html }) =>
+      html.replace("</head>", `${TERMINAL_HEAD}\n  </head>`),
+  });
+};

--- a/apps/portal/src/routes/og/home.png/+server.ts
+++ b/apps/portal/src/routes/og/home.png/+server.ts
@@ -1,144 +1,113 @@
-// Static OG card for the landing, hubs and /news — same satori pipeline as
-// the spotlight cards.
+// Landing OG card: brand statement plus a LIVE strip of curated flagships.
+// Same honest-data rule as the hub cards: catalog failure is a 503, never
+// placeholder numbers.
 
-import { Resvg } from "@resvg/resvg-js";
-import satori from "satori";
-import { read } from "$app/server";
-import interBold from "$lib/server/fonts/Inter-Bold.ttf";
-import interRegular from "$lib/server/fonts/Inter-Regular.ttf";
-import { brandMark, C } from "$lib/server/og";
+import { error } from "@sveltejs/kit";
+import {
+  brandRow,
+  C,
+  el,
+  fmtPct,
+  fmtPrice,
+  frame,
+  renderOgPng,
+  text,
+  utcStamp,
+} from "$lib/server/og";
+import { type CatalogAsset, getCatalog } from "$lib/server/tokensxyz";
 import type { RequestHandler } from "./$types";
 
-const W = 1200;
-const H = 630;
-
-let fontsPromise: Promise<{ regular: ArrayBuffer; bold: ArrayBuffer }> | null =
-  null;
-function loadFonts() {
-  fontsPromise ??= (async () => {
-    const [regular, bold] = await Promise.all([
-      read(interRegular).arrayBuffer(),
-      read(interBold).arrayBuffer(),
-    ]);
-    return { regular, bold };
-  })();
-  return fontsPromise;
+function moverCell(asset: CatalogAsset): Record<string, unknown> {
+  const up = (asset.change24hPct ?? 0) >= 0;
+  return el(
+    "div",
+    {
+      flexDirection: "column",
+      flexGrow: 1,
+      flexBasis: 0,
+      border: `1px solid ${C.line}`,
+      borderRadius: "0",
+      backgroundColor: C.surface,
+      padding: "18px 24px",
+      gap: "6px",
+    },
+    [
+      text(asset.symbol, {
+        fontSize: "22px",
+        fontWeight: 700,
+        letterSpacing: "2px",
+        color: C.ink,
+      }),
+      text(fmtPrice(asset.price), {
+        fontSize: "30px",
+        fontWeight: 700,
+        color: C.muted,
+      }),
+      text(fmtPct(asset.change24hPct), {
+        fontSize: "22px",
+        fontWeight: 700,
+        color: up ? C.up : C.down,
+      }),
+    ],
+  );
 }
 
 export const GET: RequestHandler = async ({ setHeaders }) => {
-  const fonts = await loadFonts();
-
-  const tree = {
-    type: "div",
-    props: {
-      style: {
-        width: `${W}px`,
-        height: `${H}px`,
-        display: "flex",
-        flexDirection: "column",
-        backgroundColor: C.paper,
-        padding: "64px 80px",
-        fontFamily: "Inter",
-        color: C.ink,
-      },
-      children: [
-        {
-          type: "div",
-          props: {
-            style: {
-              display: "flex",
-              alignItems: "center",
-              fontSize: "26px",
-              fontWeight: 700,
-              letterSpacing: "4px",
-            },
-            children: [
-              brandMark(34),
-              {
-                type: "span",
-                props: { style: { marginLeft: "14px" }, children: "RALPH" },
-              },
-              {
-                type: "span",
-                props: { style: { color: C.accent }, children: "·TERMINAL" },
-              },
-            ],
-          },
-        },
-        {
-          type: "div",
-          props: {
-            style: {
-              display: "flex",
-              flexDirection: "column",
-              fontSize: "86px",
-              fontWeight: 700,
-              lineHeight: 1.05,
-              letterSpacing: "-2px",
-              marginTop: "96px",
-            },
-            children: [
-              {
-                type: "div",
-                props: {
-                  style: { display: "flex" },
-                  children: "SOL to SPACEX.",
-                },
-              },
-              {
-                type: "div",
-                props: {
-                  style: { display: "flex", color: C.accent },
-                  children: "One account.",
-                },
-              },
-            ],
-          },
-        },
-        {
-          type: "div",
-          props: {
-            style: {
-              display: "flex",
-              fontSize: "30px",
-              color: C.muted,
-              marginTop: "40px",
-            },
-            children: "Spot and perps on 300+ Solana markets, settled in USDC",
-          },
-        },
-        {
-          type: "div",
-          props: {
-            style: {
-              display: "flex",
-              marginTop: "auto",
-              fontSize: "24px",
-              color: C.muted,
-            },
-            children:
-              "Spot by Jupiter · perps on Phoenix · email login, no seed phrase",
-          },
-        },
-      ],
-    },
-  };
-
-  const svg = await satori(tree as Parameters<typeof satori>[0], {
-    width: W,
-    height: H,
-    fonts: [
-      { name: "Inter", data: fonts.regular, weight: 400, style: "normal" },
-      { name: "Inter", data: fonts.bold, weight: 700, style: "normal" },
-    ],
+  const assets = await getCatalog().catch(() => {
+    error(503, "Catalog unavailable");
   });
 
-  const png = new Resvg(svg, { fitTo: { mode: "width", value: W } })
-    .render()
-    .asPng();
+  // Curated flagship lineup — this is a marketing card, so it delivers the
+  // hero tagline ("SOL to SPACEX. One account."): SOL, BTC, NVDA, SpaceX.
+  // Top-mover selection was tried and surfaced crash-outliers and sub-penny
+  // unknowns (extreme tokens.xyz prints are often data artifacts) — never
+  // lead an acquisition card with those. Real prices only: any of the four
+  // that is missing or unpriced is honestly omitted, never faked.
+  const FLAGSHIP_ASSET_IDS = ["solana", "bitcoin", "nvidia", "spacex"];
+  const movers = FLAGSHIP_ASSET_IDS.map(
+    (id) =>
+      assets.find((asset) => asset.assetId === id && asset.price !== null) ??
+      null,
+  ).filter((asset): asset is CatalogAsset => asset !== null);
+  if (movers.length === 0) error(503, "Market data unavailable");
+
+  const tree = frame([
+    brandRow(`LIVE ${utcStamp()}`),
+
+    // Hero — the brand statement.
+    el(
+      "div",
+      {
+        flexDirection: "column",
+        fontSize: "84px",
+        fontWeight: 700,
+        lineHeight: 1.05,
+        letterSpacing: "-2px",
+        marginTop: "52px",
+      },
+      [
+        text("SOL to SPACEX.", { color: C.ink }),
+        text("One account.", { color: C.accent }),
+      ],
+    ),
+
+    // Live movers strip.
+    el(
+      "div",
+      { gap: "16px", width: "100%", marginTop: "48px" },
+      movers.map((asset) => moverCell(asset)),
+    ),
+
+    text("Spot and perps on Solana — settled in USDC · traderralph.com", {
+      marginTop: "auto",
+      fontSize: "24px",
+      color: C.muted,
+    }),
+  ]);
+
   setHeaders({
     "content-type": "image/png",
-    "cache-control": "public, s-maxage=604800, stale-while-revalidate=86400",
+    "cache-control": "public, s-maxage=900, stale-while-revalidate=3600",
   });
-  return new Response(new Uint8Array(png));
+  return new Response(await renderOgPng(tree));
 };

--- a/apps/portal/src/routes/og/terminal.png/+server.ts
+++ b/apps/portal/src/routes/og/terminal.png/+server.ts
@@ -1,6 +1,7 @@
 // Terminal OG card: the trading desk at a glance — brand bar, live SOL
 // price with 24h badge, and a real 7-day sparkline in a chart panel.
-// Every number comes from tokens.xyz; any fetch failure is a 503.
+// Every number comes from tokens.xyz; any fetch failure — or a bundle
+// without enough candles to draw the chart — is a 503.
 
 import { error } from "@sveltejs/kit";
 import {
@@ -41,20 +42,20 @@ export const GET: RequestHandler = async ({ setHeaders }) => {
   const trendColor = up ? C.up : C.down;
 
   // Sparkline — same idiom as the spotlight card, sized as a wide band.
+  // The panel advertises "SOL / USDC · 7 DAYS"; without a drawable line the
+  // card is a silent bad-data render (and cacheable), so 503 instead.
   const closes = bundle.candles.map((candle) => candle.close);
-  let sparkPoints = "";
-  if (closes.length > 1) {
-    const min = Math.min(...closes);
-    const max = Math.max(...closes);
-    const span = max - min || 1;
-    sparkPoints = closes
-      .map((close, index) => {
-        const x = (index / (closes.length - 1)) * SPARK_W;
-        const y = SPARK_H - 12 - ((close - min) / span) * (SPARK_H - 24);
-        return `${x.toFixed(1)},${y.toFixed(1)}`;
-      })
-      .join(" ");
-  }
+  if (closes.length < 2) error(503, "SOL market data unavailable");
+  const min = Math.min(...closes);
+  const max = Math.max(...closes);
+  const span = max - min || 1;
+  const sparkPoints = closes
+    .map((close, index) => {
+      const x = (index / (closes.length - 1)) * SPARK_W;
+      const y = SPARK_H - 12 - ((close - min) / span) * (SPARK_H - 24);
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
 
   const tree = frame([
     // Top bar: mark + desk label left, live chip right.
@@ -156,36 +157,34 @@ export const GET: RequestHandler = async ({ setHeaders }) => {
             text(utcStamp(), { fontSize: "18px", color: C.faint }),
           ],
         ),
-        sparkPoints
-          ? {
-              type: "svg",
-              props: {
-                width: SPARK_W,
-                height: SPARK_H,
-                viewBox: `0 0 ${SPARK_W} ${SPARK_H}`,
-                style: { margin: "8px 24px", display: "flex" },
-                children: [
-                  {
-                    type: "polyline",
-                    props: {
-                      points: sparkPoints,
-                      fill: "none",
-                      stroke: trendColor,
-                      "stroke-width": 4,
-                    },
-                  },
-                  {
-                    type: "polygon",
-                    props: {
-                      points: `0,${SPARK_H} ${sparkPoints} ${SPARK_W},${SPARK_H}`,
-                      fill: trendColor,
-                      opacity: 0.08,
-                    },
-                  },
-                ],
+        {
+          type: "svg",
+          props: {
+            width: SPARK_W,
+            height: SPARK_H,
+            viewBox: `0 0 ${SPARK_W} ${SPARK_H}`,
+            style: { margin: "8px 24px", display: "flex" },
+            children: [
+              {
+                type: "polyline",
+                props: {
+                  points: sparkPoints,
+                  fill: "none",
+                  stroke: trendColor,
+                  "stroke-width": 4,
+                },
               },
-            }
-          : el("div", { height: `${SPARK_H}px` }),
+              {
+                type: "polygon",
+                props: {
+                  points: `0,${SPARK_H} ${sparkPoints} ${SPARK_W},${SPARK_H}`,
+                  fill: trendColor,
+                  opacity: 0.08,
+                },
+              },
+            ],
+          },
+        },
       ],
     ),
 

--- a/apps/portal/src/routes/og/terminal.png/+server.ts
+++ b/apps/portal/src/routes/og/terminal.png/+server.ts
@@ -1,0 +1,220 @@
+// Terminal OG card: the trading desk at a glance — brand bar, live SOL
+// price with 24h badge, and a real 7-day sparkline in a chart panel.
+// Every number comes from tokens.xyz; any fetch failure is a 503.
+
+import { error } from "@sveltejs/kit";
+import {
+  brandMark,
+  C,
+  chip,
+  el,
+  fmtPct,
+  fmtPrice,
+  frame,
+  renderOgPng,
+  text,
+  utcStamp,
+} from "$lib/server/og";
+import { getCatalog, getSpotlightBundle } from "$lib/server/tokensxyz";
+import type { RequestHandler } from "./$types";
+
+// Frame inner width (1200 − 2×72 padding); panel chart sits inside borders.
+const PANEL_W = 1056;
+const SPARK_W = 1004;
+const SPARK_H = 168;
+
+export const GET: RequestHandler = async ({ setHeaders }) => {
+  const assets = await getCatalog().catch(() => {
+    error(503, "Catalog unavailable");
+  });
+  const sol = assets.find(
+    (asset) => asset.symbol.toUpperCase() === "SOL" && asset.price !== null,
+  );
+  if (!sol) error(503, "SOL market data unavailable");
+
+  const bundle = await getSpotlightBundle(sol).catch(() => {
+    error(503, "SOL market data unavailable");
+  });
+
+  const change = sol.change24hPct;
+  const up = (change ?? 0) >= 0;
+  const trendColor = up ? C.up : C.down;
+
+  // Sparkline — same idiom as the spotlight card, sized as a wide band.
+  const closes = bundle.candles.map((candle) => candle.close);
+  let sparkPoints = "";
+  if (closes.length > 1) {
+    const min = Math.min(...closes);
+    const max = Math.max(...closes);
+    const span = max - min || 1;
+    sparkPoints = closes
+      .map((close, index) => {
+        const x = (index / (closes.length - 1)) * SPARK_W;
+        const y = SPARK_H - 12 - ((close - min) / span) * (SPARK_H - 24);
+        return `${x.toFixed(1)},${y.toFixed(1)}`;
+      })
+      .join(" ");
+  }
+
+  const tree = frame([
+    // Top bar: mark + desk label left, live chip right.
+    el(
+      "div",
+      { justifyContent: "space-between", alignItems: "center", width: "100%" },
+      [
+        el("div", { alignItems: "center", gap: "14px" }, [
+          brandMark(30),
+          text("TRADER RALPH — TERMINAL", {
+            fontSize: "22px",
+            fontWeight: 700,
+            letterSpacing: "4px",
+            color: C.muted,
+          }),
+        ]),
+        chip("LIVE ON SOLANA", C.accent),
+      ],
+    ),
+
+    // Hero row: SOL, live price, 24h badge.
+    el(
+      "div",
+      {
+        alignItems: "flex-end",
+        justifyContent: "space-between",
+        marginTop: "40px",
+        width: "100%",
+      },
+      [
+        el("div", { alignItems: "baseline", gap: "28px" }, [
+          text("SOL", {
+            fontSize: "68px",
+            fontWeight: 700,
+            letterSpacing: "-1px",
+          }),
+          text(fmtPrice(sol.price), {
+            fontSize: "92px",
+            fontWeight: 700,
+            letterSpacing: "-3px",
+          }),
+        ]),
+        el(
+          "div",
+          {
+            backgroundColor: up
+              ? "rgba(44,233,127,0.12)"
+              : "rgba(255,90,106,0.12)",
+            border: `2px solid ${trendColor}`,
+            borderRadius: "0",
+            padding: "12px 24px",
+            flexDirection: "column",
+            alignItems: "flex-end",
+          },
+          [
+            text(fmtPct(change), {
+              fontSize: "44px",
+              fontWeight: 700,
+              color: trendColor,
+            }),
+            text("24 HOURS", {
+              fontSize: "16px",
+              color: C.muted,
+              letterSpacing: "2px",
+            }),
+          ],
+        ),
+      ],
+    ),
+
+    // Chart panel: thin-bordered surface, header strip, wide sparkline band.
+    el(
+      "div",
+      {
+        flexDirection: "column",
+        width: `${PANEL_W}px`,
+        marginTop: "32px",
+        border: `1px solid ${C.line}`,
+        borderRadius: "0",
+        backgroundColor: C.surface,
+      },
+      [
+        el(
+          "div",
+          {
+            justifyContent: "space-between",
+            alignItems: "center",
+            width: "100%",
+            padding: "14px 24px",
+            borderBottom: `1px solid ${C.line}`,
+          },
+          [
+            text("SOL / USDC · 7 DAYS", {
+              fontSize: "18px",
+              fontWeight: 700,
+              letterSpacing: "3px",
+              color: C.muted,
+            }),
+            text(utcStamp(), { fontSize: "18px", color: C.faint }),
+          ],
+        ),
+        sparkPoints
+          ? {
+              type: "svg",
+              props: {
+                width: SPARK_W,
+                height: SPARK_H,
+                viewBox: `0 0 ${SPARK_W} ${SPARK_H}`,
+                style: { margin: "8px 24px", display: "flex" },
+                children: [
+                  {
+                    type: "polyline",
+                    props: {
+                      points: sparkPoints,
+                      fill: "none",
+                      stroke: trendColor,
+                      "stroke-width": 4,
+                    },
+                  },
+                  {
+                    type: "polygon",
+                    props: {
+                      points: `0,${SPARK_H} ${sparkPoints} ${SPARK_W},${SPARK_H}`,
+                      fill: trendColor,
+                      opacity: 0.08,
+                    },
+                  },
+                ],
+              },
+            }
+          : el("div", { height: `${SPARK_H}px` }),
+      ],
+    ),
+
+    // Footer: venue facts + destination.
+    el(
+      "div",
+      {
+        marginTop: "auto",
+        justifyContent: "space-between",
+        alignItems: "center",
+        width: "100%",
+      },
+      [
+        text("Perps on Phoenix · Spot by Jupiter · one USDC account", {
+          fontSize: "22px",
+          color: C.muted,
+        }),
+        text("traderralph.com/terminal", {
+          fontSize: "22px",
+          fontWeight: 700,
+          color: C.ink,
+        }),
+      ],
+    ),
+  ]);
+
+  setHeaders({
+    "content-type": "image/png",
+    "cache-control": "public, s-maxage=900, stale-while-revalidate=3600",
+  });
+  return new Response(await renderOgPng(tree));
+};


### PR DESCRIPTION
**DO NOT MERGE — awaiting Guillaume's preview QA**

## Summary

Marketing/user-acquisition OG images for the two front doors:

- **`/og/home.png` reworked (same URL — landing/news/hub fallbacks keep working):** brand statement ("SOL to SPACEX. One account.") + a LIVE curated flagship strip — SOL, BTC, NVDA, SPCX — real prices and 24h moves, 15-min ISR cache like the hub cards. Selection is curated by assetId, not top-mover: top-mover was tried first and surfaced VT −87.68% and a $0.04 asset — crash-outliers and probable tokens.xyz data artifacts, wrong lead for an acquisition card. The strip now literally delivers the tagline lineup.
- **`/og/terminal.png` (new):** desk-look card — real SOL price, up/down 24h badge, real 7-day sparkline in a bordered chart panel, "Perps on Phoenix · Spot by Jupiter" footer, traderralph.com/terminal sign-off.
- **`/terminal` finally has scraper-visible meta:** the route is `ssr = false`, so its head never reached crawlers. New `hooks.server.ts` injects title/og/twitter tags into the served shell for that exact pathname only (anchor: the single `</head>` literal; injection verified exactly once on /terminal, zero on other routes).

Honest-data rule holds everywhere: catalog/bundle failure → 503 (no placeholder numbers); a missing/unpriced flagship is omitted, never faked.

## Validation

typecheck 0/0 (ui + portal) · lint clean · 16 ui + 257 portal tests · build green, unused-css = 0, both endpoints present in build output.

## Proof artifacts (rendered from dev with real tokens.xyz data)

- home: SOL $77.62 +3.96% · BTC $64,879 +4.49% · NVDA $211.51 +4.12% · SPCX $168.68 −0.62%
- terminal: SOL $77.65, +3.97% badge, real 7-day sparkline
- `curl /terminal | grep og:image` → exactly one tag; `/` → zero (no leak)

## QA notes for preview

Open directly on the preview:
- `https://preview.trader-ralph.com/og/home.png`
- `https://preview.trader-ralph.com/og/terminal.png`
- `view-source:https://preview.trader-ralph.com/terminal` → og:image/twitter meta present in the raw HTML.

Note: the injected og:image URL points at production `traderralph.com/og/terminal.png` (same convention as every existing page), so external link-preview debuggers will only show the terminal card after merge.

## Risk notes

- home.png cache drops from 7-day static to 15-min ISR — more function invocations, matches the hub cards' existing profile.
- SPCX is the asset's real catalog symbol (assetId `spacex`); the cell renders the venue symbol as everywhere else on the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)