### PR TITLE
Beta cap: dynamic 150-user gate on Privy signups (existing users unaffected)

### DIFF
--- a/apps/portal/src/lib/beta-cap.test.ts
+++ b/apps/portal/src/lib/beta-cap.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_BETA_USER_CAP,
+  parseBetaCap,
+  resolveBetaEligibility,
+} from "./beta-cap";
+
+describe("resolveBetaEligibility", () => {
+  test("fails open when the server is unconfigured", () => {
+    expect(
+      resolveBetaEligibility({
+        configured: false,
+        existing: null,
+        count: null,
+        cap: 150,
+      }),
+    ).toEqual({ allowed: true, reason: "unconfigured" });
+  });
+
+  test("existing users are always allowed, even at or past the cap", () => {
+    expect(
+      resolveBetaEligibility({
+        configured: true,
+        existing: true,
+        count: 150,
+        cap: 150,
+      }),
+    ).toEqual({ allowed: true, reason: "existing" });
+    expect(
+      resolveBetaEligibility({
+        configured: true,
+        existing: true,
+        count: null,
+        cap: 150,
+      }),
+    ).toEqual({ allowed: true, reason: "existing" });
+  });
+
+  test("fails open when the email lookup errored", () => {
+    expect(
+      resolveBetaEligibility({
+        configured: true,
+        existing: null,
+        count: 200,
+        cap: 150,
+      }),
+    ).toEqual({ allowed: true, reason: "unavailable" });
+  });
+
+  test("fails open when the user count errored", () => {
+    expect(
+      resolveBetaEligibility({
+        configured: true,
+        existing: false,
+        count: null,
+        cap: 150,
+      }),
+    ).toEqual({ allowed: true, reason: "unavailable" });
+  });
+
+  test("blocks a new user exactly at the cap boundary", () => {
+    expect(
+      resolveBetaEligibility({
+        configured: true,
+        existing: false,
+        count: 150,
+        cap: 150,
+      }),
+    ).toEqual({ allowed: false, reason: "beta-full" });
+  });
+
+  test("blocks a new user past the cap", () => {
+    expect(
+      resolveBetaEligibility({
+        configured: true,
+        existing: false,
+        count: 151,
+        cap: 150,
+      }),
+    ).toEqual({ allowed: false, reason: "beta-full" });
+  });
+
+  test("allows a new user one below the cap", () => {
+    expect(
+      resolveBetaEligibility({
+        configured: true,
+        existing: false,
+        count: 149,
+        cap: 150,
+      }),
+    ).toEqual({ allowed: true, reason: "open" });
+  });
+
+  test("cap of zero closes the beta to all new users", () => {
+    expect(
+      resolveBetaEligibility({
+        configured: true,
+        existing: false,
+        count: 0,
+        cap: 0,
+      }),
+    ).toEqual({ allowed: false, reason: "beta-full" });
+  });
+});
+
+describe("parseBetaCap", () => {
+  test("defaults to 150", () => {
+    expect(DEFAULT_BETA_USER_CAP).toBe(150);
+    expect(parseBetaCap(undefined)).toBe(150);
+    expect(parseBetaCap("")).toBe(150);
+    expect(parseBetaCap("   ")).toBe(150);
+  });
+
+  test("parses a valid integer", () => {
+    expect(parseBetaCap("200")).toBe(200);
+    expect(parseBetaCap(" 75 ")).toBe(75);
+    expect(parseBetaCap("0")).toBe(0);
+  });
+
+  test("rejects garbage and negatives", () => {
+    expect(parseBetaCap("abc")).toBe(150);
+    expect(parseBetaCap("-5")).toBe(150);
+    expect(parseBetaCap("NaN")).toBe(150);
+  });
+});

--- a/apps/portal/src/lib/beta-cap.ts
+++ b/apps/portal/src/lib/beta-cap.ts
@@ -1,0 +1,49 @@
+// Beta user-cap decision logic (PRD: dynamic 150-user beta cap on Privy
+// login). Pure and shared: the server eligibility endpoint imports it and
+// the adjacent test exercises it in isolation. Policy: existing users
+// always get in; every failure mode fails OPEN with an explicit reason —
+// a new user is only refused when Privy confirmably reports the cap
+// reached. Privy's own dashboard user cap is the hard backstop.
+
+export const DEFAULT_BETA_USER_CAP = 150;
+
+export type BetaEligibilityReason =
+  | "unconfigured"
+  | "existing"
+  | "unavailable"
+  | "beta-full"
+  | "open";
+
+export type BetaEligibility = {
+  allowed: boolean;
+  reason: BetaEligibilityReason;
+};
+
+export type BetaEligibilityInput = {
+  /** Server has both a Privy app id and app secret. */
+  configured: boolean;
+  /** Privy lookup for this email: found / not found, null on API failure. */
+  existing: boolean | null;
+  /** Privy user count (scan stops at the cap), null on API failure. */
+  count: number | null;
+  cap: number;
+};
+
+export function resolveBetaEligibility(
+  input: BetaEligibilityInput,
+): BetaEligibility {
+  if (!input.configured) return { allowed: true, reason: "unconfigured" };
+  if (input.existing === true) return { allowed: true, reason: "existing" };
+  if (input.existing === null) return { allowed: true, reason: "unavailable" };
+  if (input.count === null) return { allowed: true, reason: "unavailable" };
+  if (input.count >= input.cap) return { allowed: false, reason: "beta-full" };
+  return { allowed: true, reason: "open" };
+}
+
+/** BETA_USER_CAP env parser: non-negative integer or the 150 default. */
+export function parseBetaCap(raw: string | undefined): number {
+  const parsed = Number.parseInt(String(raw ?? "").trim(), 10);
+  return Number.isInteger(parsed) && parsed >= 0
+    ? parsed
+    : DEFAULT_BETA_USER_CAP;
+}

--- a/apps/portal/src/lib/server/privy.ts
+++ b/apps/portal/src/lib/server/privy.ts
@@ -1,0 +1,123 @@
+// Server-only Privy REST client for the beta user cap. Endpoint shapes
+// verified against docs.privy.io/api-reference (users/get-by-email-address,
+// users/get-all): Basic auth `app_id:app_secret` plus a `privy-app-id`
+// header. Every function fails soft — callers receive null on any failure
+// and decide policy (the eligibility endpoint fails open).
+
+import { env as privateEnv } from "$env/dynamic/private";
+import { env as publicEnv } from "$env/dynamic/public";
+
+const PRIVY_API = "https://api.privy.io/v1";
+const COUNT_TTL_MS = 60_000;
+// ~150 users is 2 pages at limit=100; the guard only exists so a
+// pathological cursor loop can never spin forever.
+const MAX_COUNT_PAGES = 20;
+
+// Module-level 60s cache (same idiom as /api/desk/[slug]). A cached count
+// is only reusable when its scan went at least as deep as the caller needs.
+let countCache: { count: number; max: number; at: number } | null = null;
+
+type PrivyCredentials = { appId: string; appSecret: string };
+
+export function isConfigured(): boolean {
+  return readCredentials() !== null;
+}
+
+/** true/false = Privy answered; null = not configured or API failure. */
+export async function findUserByEmail(email: string): Promise<boolean | null> {
+  const creds = readCredentials();
+  if (!creds) return null;
+  try {
+    const response = await fetch(`${PRIVY_API}/users/email/address`, {
+      method: "POST",
+      headers: {
+        ...privyHeaders(creds),
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ address: email }),
+    });
+    // Privy returns 404 when no user exists for the address.
+    if (response.status === 404) return false;
+    if (!response.ok) return null;
+    const data = (await response.json()) as { id?: unknown };
+    return typeof data.id === "string" && data.id.length > 0 ? true : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Count users via GET /v1/users, following next_cursor pages but stopping
+ * as soon as the count reaches `max` — exact totals beyond the cap are
+ * never needed. null = not configured or API failure.
+ */
+export async function countUsers(max: number): Promise<number | null> {
+  const creds = readCredentials();
+  if (!creds) return null;
+
+  const cached = countCache;
+  if (
+    cached &&
+    Date.now() - cached.at < COUNT_TTL_MS &&
+    (cached.max >= max || cached.count >= max)
+  ) {
+    return cached.count;
+  }
+
+  try {
+    let count = 0;
+    let cursor: string | null = null;
+    for (let page = 0; page < MAX_COUNT_PAGES; page += 1) {
+      const url = new URL(`${PRIVY_API}/users`);
+      url.searchParams.set("limit", "100");
+      if (cursor) url.searchParams.set("cursor", cursor);
+      const response = await fetch(url, { headers: privyHeaders(creds) });
+      if (!response.ok) return null;
+      const data = (await response.json()) as {
+        data?: unknown[];
+        next_cursor?: unknown;
+      };
+      if (!Array.isArray(data.data)) return null;
+      count += data.data.length;
+      cursor =
+        typeof data.next_cursor === "string" && data.next_cursor.length > 0
+          ? data.next_cursor
+          : null;
+      if (count >= max || !cursor) break;
+    }
+    countCache = { count, max, at: Date.now() };
+    return count;
+  } catch {
+    return null;
+  }
+}
+
+function readCredentials(): PrivyCredentials | null {
+  // Same app-id names the client reads (privy-auth.ts readPrivyConfig);
+  // PUBLIC_-prefixed vars live in the public env, the rest in private.
+  const appId = cleanEnv(
+    publicEnv.PUBLIC_PRIVY_APP_ID ??
+      privateEnv.VITE_PRIVY_APP_ID ??
+      privateEnv.NEXT_PUBLIC_PRIVY_APP_ID,
+  );
+  const appSecret = cleanEnv(privateEnv.PRIVY_APP_SECRET);
+  if (!appId || !appSecret) return null;
+  return { appId, appSecret };
+}
+
+function privyHeaders(creds: PrivyCredentials): Record<string, string> {
+  const basic = Buffer.from(`${creds.appId}:${creds.appSecret}`).toString(
+    "base64",
+  );
+  return {
+    authorization: `Basic ${basic}`,
+    "privy-app-id": creds.appId,
+  };
+}
+
+function cleanEnv(value: string | undefined): string {
+  return String(value ?? "")
+    .trim()
+    .replace(/^"+|"+$/g, "")
+    .replace(/\\n$/, "");
+}

--- a/apps/portal/src/lib/server/privy.ts
+++ b/apps/portal/src/lib/server/privy.ts
@@ -13,9 +13,13 @@ const COUNT_TTL_MS = 60_000;
 // pathological cursor loop can never spin forever.
 const MAX_COUNT_PAGES = 20;
 
-// Module-level 60s cache (same idiom as /api/desk/[slug]). A cached count
-// is only reusable when its scan went at least as deep as the caller needs.
-let countCache: { count: number; max: number; at: number } | null = null;
+// Module-level 60s cache (same idiom as /api/desk/[slug]). Reuse is
+// asymmetric on purpose: an at-cap result (count >= the cap being asked
+// about) only gets MORE true as users sign up, so it holds for the TTL.
+// A below-cap result is the dangerous one to reuse — serving a stale
+// under-cap count would keep admitting signups after the last seat fills —
+// so anything short of the requested cap always triggers a fresh scan.
+let countCache: { count: number; at: number } | null = null;
 
 type PrivyCredentials = { appId: string; appSecret: string };
 
@@ -55,12 +59,11 @@ export async function countUsers(max: number): Promise<number | null> {
   const creds = readCredentials();
   if (!creds) return null;
 
+  // Only serve the cache when the counted value already reached the cap
+  // being asked about — a count of 200 proves "at least 200 exist", which
+  // answers any max <= 200 regardless of how deep that scan went.
   const cached = countCache;
-  if (
-    cached &&
-    Date.now() - cached.at < COUNT_TTL_MS &&
-    (cached.max >= max || cached.count >= max)
-  ) {
+  if (cached && Date.now() - cached.at < COUNT_TTL_MS && cached.count >= max) {
     return cached.count;
   }
 
@@ -85,7 +88,7 @@ export async function countUsers(max: number): Promise<number | null> {
           : null;
       if (count >= max || !cursor) break;
     }
-    countCache = { count, max, at: Date.now() };
+    countCache = { count, at: Date.now() };
     return count;
   } catch {
     return null;

--- a/apps/portal/src/routes/api/beta/eligibility/+server.ts
+++ b/apps/portal/src/routes/api/beta/eligibility/+server.ts
@@ -1,0 +1,64 @@
+// Beta-cap eligibility gate for Privy signup (dynamic user cap, default
+// 150). Fail-open everywhere, matching the gates.ts convention: an
+// unconfigured secret or a Privy API failure must never lock anyone out —
+// Privy's own dashboard user cap is the hard backstop.
+//
+// Account-enumeration note: for the submitted email only, `allowed` lets a
+// caller infer whether that email already has an account (only new users
+// can be refused). Acknowledged and acceptable for the beta; the response
+// never echoes existence directly.
+
+import { json } from "@sveltejs/kit";
+import { env } from "$env/dynamic/private";
+import { parseBetaCap, resolveBetaEligibility } from "$lib/beta-cap";
+import { countUsers, findUserByEmail, isConfigured } from "$lib/server/privy";
+import type { RequestHandler } from "./$types";
+
+const MAX_EMAIL_LENGTH = 320;
+
+export const POST: RequestHandler = async ({ request, setHeaders }) => {
+  setHeaders({ "cache-control": "no-store" });
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: "invalid-body" }, { status: 400 });
+  }
+  const email = readEmail(body);
+  if (!email) return json({ error: "invalid-email" }, { status: 400 });
+
+  const cap = parseBetaCap(env.BETA_USER_CAP);
+  if (!isConfigured()) {
+    return json(
+      resolveBetaEligibility({
+        configured: false,
+        existing: null,
+        count: null,
+        cap,
+      }),
+    );
+  }
+
+  const existing = await findUserByEmail(email);
+  // Only a confirmed-new user needs the count; the scan stops at the cap.
+  const count = existing === false ? await countUsers(cap) : null;
+  return json(
+    resolveBetaEligibility({ configured: true, existing, count, cap }),
+  );
+};
+
+function readEmail(body: unknown): string | null {
+  if (typeof body !== "object" || body === null) return null;
+  const email = (body as Record<string, unknown>).email;
+  if (typeof email !== "string") return null;
+  const trimmed = email.trim();
+  if (
+    trimmed.length < 3 ||
+    trimmed.length > MAX_EMAIL_LENGTH ||
+    !trimmed.includes("@")
+  ) {
+    return null;
+  }
+  return trimmed;
+}

--- a/apps/portal/src/routes/terminal/components/AuthModal.svelte
+++ b/apps/portal/src/routes/terminal/components/AuthModal.svelte
@@ -28,6 +28,7 @@
   let authBusy = $state(false);
   let authStep: "email" | "code" = $state($privyAuth.otpSentTo ? "code" : "email");
   let authMessage = $state($privyAuth.error ?? "");
+  let betaClosed = $state(false);
 
   let authNote = $derived(humanizePrivyError(authMessage || $privyAuth.error));
   let authNoteIsError = $derived(
@@ -42,11 +43,33 @@
     if (event.key !== "Escape") event.stopPropagation();
   }
 
+  // Beta-cap check before the OTP fires. Fail-open: our own endpoint being
+  // down or slow must never strand a user — only an explicit
+  // `{ allowed: false }` blocks the send.
+  async function checkBetaEligibility(email: string): Promise<boolean> {
+    try {
+      const response = await fetch("/api/beta/eligibility", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      if (!response.ok) return true;
+      const data = (await response.json()) as { allowed?: boolean };
+      return data.allowed !== false;
+    } catch {
+      return true;
+    }
+  }
+
   async function submitAuthEmail(event: SubmitEvent): Promise<void> {
     event.preventDefault();
     authBusy = true;
     authMessage = "";
     try {
+      if (!(await checkBetaEligibility(authEmail))) {
+        betaClosed = true;
+        return;
+      }
       await sendPrivyEmailCode(authEmail);
       authStep = "code";
       authMessage = "Code sent.";
@@ -116,6 +139,16 @@
         <div class="auth-callout error">
           <strong>Auth is not configured</strong>
           <span>Set <code>PUBLIC_PRIVY_APP_ID</code> (or <code>VITE_PRIVY_APP_ID</code> / <code>NEXT_PUBLIC_PRIVY_APP_ID</code>) for this frontend, then reload.</span>
+        </div>
+      {:else if betaClosed}
+        <div class="beta-closed">
+          <div class="auth-callout notice">
+            <strong>The beta is full</strong>
+            <span>All beta seats are taken right now. We'll open more soon — check back.</span>
+          </div>
+          <button class="primary wide" type="button" onclick={() => (betaClosed = false)}>
+            Back
+          </button>
         </div>
       {:else if $privyAuth.authenticated}
         <div class="auth-success">
@@ -289,6 +322,16 @@
 
   .auth-callout.error {
     border-color: rgba(240, 107, 99, 0.35);
+  }
+
+  /* A state, not a failure — blue accent instead of the error red. */
+  .auth-callout.notice {
+    border-color: var(--blue);
+  }
+
+  .beta-closed {
+    display: grid;
+    gap: 0.7rem;
   }
 
   .auth-callout strong {


### PR DESCRIPTION
**DO NOT MERGE — awaiting Guillaume's preview QA (needs PRIVY_APP_SECRET in Vercel env first — see QA notes)**

## Summary

Small-beta gate driven live by Privy's own numbers:

- **`/api/beta/eligibility` (new):** POST an email → existing Privy user? always `allowed` (login untouched). Confirmed-new user and live user count ≥ `BETA_USER_CAP` (env, default 150) → `allowed: false, reason: "beta-full"`. Everything else fails OPEN with a reason (`unconfigured` / `unavailable`) — the gates.ts convention; Privy's dev-state 150 cap is the hard backstop, so fail-open can never oversell beyond what Privy itself allows.
- **`lib/server/privy.ts` (new):** by-email lookup + user count against `api.privy.io` (endpoint shapes verified against docs.privy.io, not memory; Basic auth `app_id:app_secret`). Count cached 60s, pagination stops at the cap (150 users = 2 requests), never throws.
- **AuthModal:** eligibility checked *before* the OTP send under the existing "Sending code…" busy state. Blocked → a blue-bordered notice (a state, not an error): "The beta is full — all beta seats are taken right now. We'll open more soon." with a Back affordance. Only an explicit `allowed: false` blocks; our own endpoint failing proceeds to OTP.
- **Pure decision logic** in `lib/beta-cap.ts` — 11 exhaustive unit tests incl. boundary `count === cap` and existing-user-past-cap.

## Validation

typecheck 0/0 · lint clean · 16 ui + 268 portal tests (11 new) · build green, unused-css 0 · smoke with no secret configured: `{"allowed":true,"reason":"unconfigured"}`, bad email → 400.

## QA notes for preview (requires two env vars first)

1. In Vercel: add `PRIVY_APP_SECRET` (Privy dashboard → App settings → API keys) to **Preview + Production**, and `BETA_USER_CAP=1` to **Preview only** (temporary, for this QA).
2. Redeploy the preview, then on preview.trader-ralph.com:
   - **New email** (never used with the app) → auth modal shows "The beta is full" instead of sending a code.
   - **Your existing email** → OTP arrives and login works exactly as before, even with cap=1.
3. Remove `BETA_USER_CAP=1` from Preview after QA (prod default is 150).

## Risk notes

- Privy's not-found response for the by-email lookup is under-documented (assumed 404); if the assumption is wrong the failure mode is fail-open — new users get in, nobody is locked out. Worth confirming during QA that the closed state actually triggers with cap=1.
- Eligibility endpoint is an account-enumeration surface (acknowledged in code comment) — acceptable for beta scale.
- Without `PRIVY_APP_SECRET` set, behavior is exactly today's (gate silently open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)