### PR TITLE
Discord funded-trader verification: /discord page, OAuth flow, role grant

### DIFF
--- a/apps/portal/src/lib/discord-verify.test.ts
+++ b/apps/portal/src/lib/discord-verify.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, test } from "bun:test";
+import { createHmac } from "node:crypto";
+import {
+  type DiscordStatePayload,
+  fundingDecision,
+  linkGuardDecision,
+  parseFundedMinUsd,
+  STATE_TTL_MS,
+  signState,
+  verifyState,
+} from "./discord-verify";
+
+const SECRET = "test-secret";
+const NOW = 1_750_000_000_000;
+
+function payload(
+  overrides: Partial<DiscordStatePayload> = {},
+): DiscordStatePayload {
+  return {
+    privyUserId: "did:privy:abc123",
+    wallet: "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+    iat: NOW,
+    ...overrides,
+  };
+}
+
+describe("signState / verifyState", () => {
+  test("round-trips a payload", () => {
+    const state = signState(payload(), SECRET);
+    expect(verifyState(state, SECRET, NOW)).toEqual(payload());
+  });
+
+  test("is deterministic for identical inputs", () => {
+    expect(signState(payload(), SECRET)).toBe(signState(payload(), SECRET));
+  });
+
+  test("rejects a tampered payload", () => {
+    const state = signState(payload(), SECRET);
+    const [, mac] = state.split(".");
+    const forgedBody = Buffer.from(
+      JSON.stringify(
+        payload({ wallet: "AttackerWallet1111111111111111111111111111" }),
+      ),
+    ).toString("base64url");
+    expect(verifyState(`${forgedBody}.${mac}`, SECRET, NOW)).toBeNull();
+  });
+
+  test("rejects a tampered mac", () => {
+    const state = signState(payload(), SECRET);
+    const [body, mac] = state.split(".");
+    const flipped = mac.slice(0, -1) + (mac.endsWith("A") ? "B" : "A");
+    expect(verifyState(`${body}.${flipped}`, SECRET, NOW)).toBeNull();
+  });
+
+  test("rejects the wrong secret", () => {
+    const state = signState(payload(), SECRET);
+    expect(verifyState(state, "other-secret", NOW)).toBeNull();
+  });
+
+  test("rejects a mac of the wrong length", () => {
+    const [body] = signState(payload(), SECRET).split(".");
+    expect(verifyState(`${body}.AAAA`, SECRET, NOW)).toBeNull();
+  });
+
+  test("accepts a state right at the 10-minute boundary", () => {
+    const state = signState(payload(), SECRET);
+    expect(verifyState(state, SECRET, NOW + STATE_TTL_MS)).not.toBeNull();
+  });
+
+  test("rejects an expired state", () => {
+    const state = signState(payload(), SECRET);
+    expect(verifyState(state, SECRET, NOW + STATE_TTL_MS + 1)).toBeNull();
+  });
+
+  test("rejects a state minted too far in the future", () => {
+    const state = signState(payload({ iat: NOW + 5 * 60 * 1000 }), SECRET);
+    expect(verifyState(state, SECRET, NOW)).toBeNull();
+  });
+
+  test("accepts small clock skew on iat", () => {
+    const state = signState(payload({ iat: NOW + 30_000 }), SECRET);
+    expect(verifyState(state, SECRET, NOW)).not.toBeNull();
+  });
+
+  test.each([
+    "",
+    "no-dot",
+    ".",
+    "a.",
+    ".b",
+    "a.b.c",
+  ])("rejects malformed state %j", (state) => {
+    expect(verifyState(state, SECRET, NOW)).toBeNull();
+  });
+
+  test("rejects a signed payload that is not an object", () => {
+    const body = Buffer.from(JSON.stringify("hello")).toString("base64url");
+    const mac = createHmac("sha256", SECRET).update(body).digest("base64url");
+    expect(verifyState(`${body}.${mac}`, SECRET, NOW)).toBeNull();
+  });
+
+  test.each([
+    [{ wallet: "w", iat: NOW }], // missing privyUserId
+    [{ privyUserId: "u", iat: NOW }], // missing wallet
+    [{ privyUserId: "u", wallet: "w" }], // missing iat
+    [{ privyUserId: "", wallet: "w", iat: NOW }],
+    [{ privyUserId: "u", wallet: "", iat: NOW }],
+    [{ privyUserId: "u", wallet: "w", iat: "now" }],
+    [{ privyUserId: 7, wallet: "w", iat: NOW }],
+  ])("rejects a signed payload with bad fields %j", (bad) => {
+    const body = Buffer.from(JSON.stringify(bad)).toString("base64url");
+    const mac = createHmac("sha256", SECRET).update(body).digest("base64url");
+    expect(verifyState(`${body}.${mac}`, SECRET, NOW)).toBeNull();
+  });
+});
+
+describe("fundingDecision", () => {
+  test("below threshold is not funded", () => {
+    expect(fundingDecision(4, 5.99, 10)).toEqual({
+      funded: false,
+      totalUsd: 9.99,
+    });
+  });
+
+  test("exactly at threshold is funded", () => {
+    expect(fundingDecision(6, 4, 10)).toEqual({ funded: true, totalUsd: 10 });
+  });
+
+  test("above threshold is funded", () => {
+    expect(fundingDecision(100, 0, 10)).toEqual({
+      funded: true,
+      totalUsd: 100,
+    });
+  });
+
+  test("zero balances are not funded", () => {
+    expect(fundingDecision(0, 0, 10)).toEqual({ funded: false, totalUsd: 0 });
+  });
+
+  test("either asset alone can cross the threshold", () => {
+    expect(fundingDecision(0, 12, 10).funded).toBe(true);
+    expect(fundingDecision(12, 0, 10).funded).toBe(true);
+  });
+});
+
+describe("parseFundedMinUsd", () => {
+  test("defaults when unset", () => {
+    expect(parseFundedMinUsd(undefined)).toBe(10);
+  });
+
+  test("parses a plain number", () => {
+    expect(parseFundedMinUsd("25")).toBe(25);
+  });
+
+  test("parses a decimal", () => {
+    expect(parseFundedMinUsd("10.5")).toBe(10.5);
+  });
+
+  test.each([
+    "",
+    "abc",
+    "-5",
+    "0",
+    "NaN",
+    "Infinity",
+  ])("falls back on invalid %j", (raw) => {
+    expect(parseFundedMinUsd(raw)).toBe(10);
+  });
+
+  test("honors a custom fallback", () => {
+    expect(parseFundedMinUsd(undefined, 42)).toBe(42);
+  });
+});
+
+describe("linkGuardDecision", () => {
+  const WALLET = "walletA";
+  const DISCORD = "111";
+
+  test("no existing links → allow", () => {
+    expect(linkGuardDecision(null, null, WALLET, DISCORD)).toBe("allow");
+  });
+
+  test("both links match the current pair → allow (idempotent re-verify)", () => {
+    const link = { wallet: WALLET, discordId: DISCORD };
+    expect(linkGuardDecision(link, link, WALLET, DISCORD)).toBe("allow");
+  });
+
+  test("wallet already linked to a different discord user → refuse", () => {
+    expect(
+      linkGuardDecision(
+        { wallet: WALLET, discordId: "999" },
+        null,
+        WALLET,
+        DISCORD,
+      ),
+    ).toBe("already-linked");
+  });
+
+  test("discord user already linked to a different wallet → refuse", () => {
+    expect(
+      linkGuardDecision(
+        null,
+        { wallet: "walletB", discordId: DISCORD },
+        WALLET,
+        DISCORD,
+      ),
+    ).toBe("already-linked");
+  });
+
+  test("partial write recovery: only the wallet record exists and matches → allow", () => {
+    expect(
+      linkGuardDecision(
+        { wallet: WALLET, discordId: DISCORD },
+        null,
+        WALLET,
+        DISCORD,
+      ),
+    ).toBe("allow");
+  });
+
+  test("partial write recovery: only the user record exists and matches → allow", () => {
+    expect(
+      linkGuardDecision(
+        null,
+        { wallet: WALLET, discordId: DISCORD },
+        WALLET,
+        DISCORD,
+      ),
+    ).toBe("allow");
+  });
+
+  test("both records exist and both point elsewhere → refuse", () => {
+    expect(
+      linkGuardDecision(
+        { wallet: WALLET, discordId: "999" },
+        { wallet: "walletB", discordId: DISCORD },
+        WALLET,
+        DISCORD,
+      ),
+    ).toBe("already-linked");
+  });
+});

--- a/apps/portal/src/lib/discord-verify.test.ts
+++ b/apps/portal/src/lib/discord-verify.test.ts
@@ -116,30 +116,53 @@ describe("signState / verifyState", () => {
 
 describe("fundingDecision", () => {
   test("below threshold is not funded", () => {
-    expect(fundingDecision(4, 5.99, 10)).toEqual({
+    expect(fundingDecision(4, 5.99, 0, 10)).toEqual({
       funded: false,
       totalUsd: 9.99,
     });
   });
 
   test("exactly at threshold is funded", () => {
-    expect(fundingDecision(6, 4, 10)).toEqual({ funded: true, totalUsd: 10 });
+    expect(fundingDecision(6, 4, 0, 10)).toEqual({
+      funded: true,
+      totalUsd: 10,
+    });
   });
 
   test("above threshold is funded", () => {
-    expect(fundingDecision(100, 0, 10)).toEqual({
+    expect(fundingDecision(100, 0, 0, 10)).toEqual({
       funded: true,
       totalUsd: 100,
     });
   });
 
   test("zero balances are not funded", () => {
-    expect(fundingDecision(0, 0, 10)).toEqual({ funded: false, totalUsd: 0 });
+    expect(fundingDecision(0, 0, 0, 10)).toEqual({
+      funded: false,
+      totalUsd: 0,
+    });
   });
 
-  test("either asset alone can cross the threshold", () => {
-    expect(fundingDecision(0, 12, 10).funded).toBe(true);
-    expect(fundingDecision(12, 0, 10).funded).toBe(true);
+  test("any asset alone can cross the threshold", () => {
+    expect(fundingDecision(0, 12, 0, 10).funded).toBe(true);
+    expect(fundingDecision(12, 0, 0, 10).funded).toBe(true);
+    expect(fundingDecision(0, 0, 12, 10).funded).toBe(true);
+  });
+
+  test("phoenix collateral counts toward the threshold (QA case)", () => {
+    // $1.11 wallet USDC + ~$1.50 of SOL + $62.83 in Phoenix margin.
+    expect(fundingDecision(1.11, 1.5, 62.83, 10)).toEqual({
+      funded: true,
+      totalUsd: 65.44,
+    });
+  });
+
+  test("all three legs sum across the threshold together", () => {
+    expect(fundingDecision(4, 3, 3, 10)).toEqual({
+      funded: true,
+      totalUsd: 10,
+    });
+    expect(fundingDecision(4, 3, 2.99, 10).funded).toBe(false);
   });
 });
 

--- a/apps/portal/src/lib/discord-verify.ts
+++ b/apps/portal/src/lib/discord-verify.ts
@@ -89,13 +89,18 @@ export type FundingDecision = {
   totalUsd: number;
 };
 
-/** `>=` on purpose: holding exactly the threshold counts as funded. */
+/**
+ * `>=` on purpose: holding exactly the threshold counts as funded. All
+ * three legs count — wallet USDC, wallet SOL (priced), and Phoenix margin
+ * collateral; funds parked in the margin account are still the trader's.
+ */
 export function fundingDecision(
   usdcUsd: number,
   solUsd: number,
+  phoenixUsd: number,
   thresholdUsd: number,
 ): FundingDecision {
-  const totalUsd = usdcUsd + solUsd;
+  const totalUsd = usdcUsd + solUsd + phoenixUsd;
   return { funded: totalUsd >= thresholdUsd, totalUsd };
 }
 

--- a/apps/portal/src/lib/discord-verify.ts
+++ b/apps/portal/src/lib/discord-verify.ts
@@ -1,0 +1,136 @@
+// Pure decision logic for the Discord funded-trader verification flow
+// (/discord + /api/discord/*). Same convention as beta-cap.ts: the server
+// endpoints import these helpers and the adjacent test exercises them in
+// isolation — no env reads, no network, and no Date.now() inside any
+// function (callers inject the clock so every branch is deterministic).
+//
+// node:crypto keeps this module server-side by construction: only
+// lib/server/discord.ts and the /api/discord endpoints import it, never
+// client code.
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+// ── OAuth state: HMAC-signed, self-expiring ───────────────────────────
+// The `state` round-trips through Discord's authorize page, so it must be
+// tamper-proof: it carries which Privy user/wallet passed the funding
+// check. base64url(JSON payload) + "." + base64url(HMAC-SHA256).
+
+export type DiscordStatePayload = {
+  privyUserId: string;
+  wallet: string;
+  /** Mint time, ms since epoch. */
+  iat: number;
+};
+
+export const STATE_TTL_MS = 10 * 60 * 1000;
+// Tolerance for a state that appears minted "in the future" — we mint and
+// verify on our own servers, so anything beyond small skew is forgery.
+const STATE_FUTURE_SKEW_MS = 60 * 1000;
+
+export function signState(
+  payload: DiscordStatePayload,
+  secret: string,
+): string {
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const mac = createHmac("sha256", secret).update(body).digest("base64url");
+  return `${body}.${mac}`;
+}
+
+/**
+ * Verify signature + shape + freshness. Returns the payload or null —
+ * never throws, and the MAC comparison is constant-time.
+ */
+export function verifyState(
+  state: string,
+  secret: string,
+  nowMs: number,
+): DiscordStatePayload | null {
+  const parts = state.split(".");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+  const [body, mac] = parts;
+
+  const expected = createHmac("sha256", secret).update(body).digest();
+  let given: Buffer;
+  try {
+    given = Buffer.from(mac, "base64url");
+  } catch {
+    return null;
+  }
+  // Length check first: timingSafeEqual throws on mismatched lengths, and
+  // leaking the MAC length reveals nothing (it is a public constant).
+  if (given.length !== expected.length) return null;
+  if (!timingSafeEqual(given, expected)) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const record = parsed as Record<string, unknown>;
+  const privyUserId = record.privyUserId;
+  const wallet = record.wallet;
+  const iat = record.iat;
+  if (typeof privyUserId !== "string" || privyUserId.length === 0) return null;
+  if (typeof wallet !== "string" || wallet.length === 0) return null;
+  if (typeof iat !== "number" || !Number.isFinite(iat)) return null;
+  if (nowMs - iat > STATE_TTL_MS) return null;
+  if (iat - nowMs > STATE_FUTURE_SKEW_MS) return null;
+  return { privyUserId, wallet, iat };
+}
+
+// ── Funding threshold ────────────────────────────────────────────────
+
+export const DEFAULT_FUNDED_MIN_USD = 10;
+
+export type FundingDecision = {
+  funded: boolean;
+  totalUsd: number;
+};
+
+/** `>=` on purpose: holding exactly the threshold counts as funded. */
+export function fundingDecision(
+  usdcUsd: number,
+  solUsd: number,
+  thresholdUsd: number,
+): FundingDecision {
+  const totalUsd = usdcUsd + solUsd;
+  return { funded: totalUsd >= thresholdUsd, totalUsd };
+}
+
+/** Parse DISCORD_FUNDED_MIN_USD; anything non-positive or non-numeric falls back. */
+export function parseFundedMinUsd(
+  raw: string | undefined,
+  fallback = DEFAULT_FUNDED_MIN_USD,
+): number {
+  const value = Number(String(raw ?? "").trim());
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+// ── 1:1 link guard ───────────────────────────────────────────────────
+// One wallet ↔ one Discord account. Storage keeps two records per link
+// (keyed by wallet and by Discord id); the pair is only allowed when
+// neither record points at a DIFFERENT counterpart. Records that match
+// the current pair are fine — re-verifying is idempotent, and a partial
+// write (one record present, the other lost) must not brick the user.
+
+export type LinkRecord = {
+  wallet: string;
+  discordId: string;
+};
+
+export type LinkGuardDecision = "allow" | "already-linked";
+
+export function linkGuardDecision(
+  walletLink: LinkRecord | null,
+  userLink: LinkRecord | null,
+  wallet: string,
+  discordId: string,
+): LinkGuardDecision {
+  if (walletLink && walletLink.discordId !== discordId) {
+    return "already-linked";
+  }
+  if (userLink && userLink.wallet !== wallet) return "already-linked";
+  return "allow";
+}

--- a/apps/portal/src/lib/server/discord.ts
+++ b/apps/portal/src/lib/server/discord.ts
@@ -13,7 +13,7 @@
 // Same never-throw idiom as lib/server/privy.ts: every function fails soft
 // (null / false / "unavailable") and callers decide policy.
 
-import { get, put } from "@vercel/blob";
+import { BlobError, del, get, put } from "@vercel/blob";
 import { env } from "$env/dynamic/private";
 import {
   type DiscordStatePayload,
@@ -187,8 +187,80 @@ export async function checkLinkGuard(
   return linkGuardDecision(walletLink, userLink, wallet, discordId);
 }
 
-/** Persist both link records. Call only after the role grant succeeded. */
-export async function writeLinks(
+/**
+ * Atomically reserve the wallet-side link record BEFORE granting anything.
+ * checkLinkGuard alone is check-then-act: two concurrent callbacks for the
+ * same wallet both read "no record" and both grant. Blob's
+ * `allowOverwrite: false` is the compare-and-swap that closes that window —
+ * exactly one concurrent put creates the record; the loser's put rejects.
+ *
+ * - "reserved":       we created the record, or it already held this exact
+ *                     wallet↔discordId pair (idempotent re-verify).
+ * - "already-linked": the wallet's record points at a different Discord id.
+ * - "unavailable":    Blob outage/unconfigured — fail-open, matching the
+ *                     module convention above: verification is gated on
+ *                     funding + email, not on our own storage being up.
+ */
+export async function reserveWalletLink(
+  wallet: string,
+  discordId: string,
+): Promise<"reserved" | "already-linked" | "unavailable"> {
+  const token = env.BLOB_READ_WRITE_TOKEN;
+  if (!token) return "unavailable";
+  const record = JSON.stringify({ wallet, discordId } satisfies LinkRecord);
+  try {
+    await put(walletLinkPath(wallet), record, {
+      access: "private",
+      contentType: "application/json",
+      addRandomSuffix: false,
+      allowOverwrite: false,
+      token,
+    });
+    return "reserved";
+  } catch (error) {
+    // @vercel/blob v2 has no dedicated "already exists" error class: the
+    // API answers `bad_request` with an "…already exists, use
+    // allowOverwrite…" message, which the SDK surfaces as the base
+    // BlobError (non-retryable; only unknown/service_unavailable retry).
+    // Anything else — outage, auth, rate limit — is "unavailable".
+    if (!isBlobAlreadyExists(error)) return "unavailable";
+    // The path is taken. Read it to see by whom: the winning writer's
+    // record is durably there by the time our put was refused.
+    const existing = await readLink(walletLinkPath(wallet));
+    if (existing === "error" || existing === null) return "unavailable";
+    return existing.discordId === discordId ? "reserved" : "already-linked";
+  }
+}
+
+function isBlobAlreadyExists(error: unknown): boolean {
+  return (
+    error instanceof BlobError && /already exists/i.test(error.message ?? "")
+  );
+}
+
+/**
+ * Best-effort compensation when the grant fails after a reservation. This
+ * is NOT transactional: if the delete itself fails, the orphaned
+ * reservation blocks nothing — a retry by the same wallet+Discord pair is
+ * idempotent through reserveWalletLink, and a different Discord account is
+ * exactly what the reservation exists to refuse.
+ */
+export async function releaseWalletLink(wallet: string): Promise<void> {
+  const token = env.BLOB_READ_WRITE_TOKEN;
+  if (!token) return;
+  try {
+    await del(walletLinkPath(wallet), { token });
+  } catch {
+    // Swallowed on purpose — see docblock.
+  }
+}
+
+/**
+ * Persist the user-side (Discord-id-keyed) record. Call only after the
+ * role grant succeeded; the wallet-side record was already written by
+ * reserveWalletLink.
+ */
+export async function writeUserLink(
   wallet: string,
   discordId: string,
 ): Promise<boolean> {
@@ -196,22 +268,13 @@ export async function writeLinks(
   if (!token) return false;
   const record = JSON.stringify({ wallet, discordId } satisfies LinkRecord);
   try {
-    await Promise.all([
-      put(walletLinkPath(wallet), record, {
-        access: "private",
-        contentType: "application/json",
-        addRandomSuffix: false,
-        allowOverwrite: true,
-        token,
-      }),
-      put(userLinkPath(discordId), record, {
-        access: "private",
-        contentType: "application/json",
-        addRandomSuffix: false,
-        allowOverwrite: true,
-        token,
-      }),
-    ]);
+    await put(userLinkPath(discordId), record, {
+      access: "private",
+      contentType: "application/json",
+      addRandomSuffix: false,
+      allowOverwrite: true,
+      token,
+    });
     return true;
   } catch {
     return false;

--- a/apps/portal/src/lib/server/discord.ts
+++ b/apps/portal/src/lib/server/discord.ts
@@ -1,0 +1,264 @@
+// Server-only Discord client for the funded-trader verification flow.
+// Endpoint shapes verified against docs.discord.com/developers:
+// - authorize: https://discord.com/oauth2/authorize with response_type=code,
+//   client_id, scope ("identify guilds.join"), redirect_uri, state
+// - token exchange: POST https://discord.com/api/oauth2/token,
+//   application/x-www-form-urlencoded body + Basic client_id:client_secret
+// - GET /users/@me with the user's Bearer token (identify scope)
+// - PUT /guilds/{guild}/members/{user} — bot token, JSON { access_token }
+//   from the guilds.join grant; 201 = added, 204 = already a member
+// - PUT /guilds/{guild}/members/{user}/roles/{role} — bot token with
+//   Manage Roles; 204 on success
+//
+// Same never-throw idiom as lib/server/privy.ts: every function fails soft
+// (null / false / "unavailable") and callers decide policy.
+
+import { get, put } from "@vercel/blob";
+import { env } from "$env/dynamic/private";
+import {
+  type DiscordStatePayload,
+  type LinkGuardDecision,
+  type LinkRecord,
+  linkGuardDecision,
+  signState,
+  verifyState,
+} from "$lib/discord-verify";
+
+const DISCORD_AUTHORIZE = "https://discord.com/oauth2/authorize";
+const DISCORD_TOKEN = "https://discord.com/api/oauth2/token";
+const DISCORD_API = "https://discord.com/api/v10";
+const OAUTH_SCOPES = "identify guilds.join";
+
+type DiscordConfig = {
+  clientId: string;
+  clientSecret: string;
+  botToken: string;
+  guildId: string;
+  roleId: string;
+  stateSecret: string;
+};
+
+export function isConfigured(): boolean {
+  return readConfig() !== null;
+}
+
+export function buildAuthorizeUrl(
+  payload: DiscordStatePayload,
+  redirectUri: string,
+): string | null {
+  const config = readConfig();
+  if (!config) return null;
+  const url = new URL(DISCORD_AUTHORIZE);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", config.clientId);
+  url.searchParams.set("scope", OAUTH_SCOPES);
+  url.searchParams.set("redirect_uri", redirectUri);
+  url.searchParams.set("state", signState(payload, config.stateSecret));
+  return url.toString();
+}
+
+export function verifyStateParam(
+  state: string,
+  nowMs: number,
+): DiscordStatePayload | null {
+  const config = readConfig();
+  if (!config) return null;
+  return verifyState(state, config.stateSecret, nowMs);
+}
+
+/** Exchange the authorization code for the user's access token. */
+export async function exchangeCode(
+  code: string,
+  redirectUri: string,
+): Promise<string | null> {
+  const config = readConfig();
+  if (!config) return null;
+  try {
+    const basic = Buffer.from(
+      `${config.clientId}:${config.clientSecret}`,
+    ).toString("base64");
+    const response = await fetch(DISCORD_TOKEN, {
+      method: "POST",
+      headers: {
+        authorization: `Basic ${basic}`,
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: redirectUri,
+      }),
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { access_token?: unknown };
+    return typeof data.access_token === "string" && data.access_token
+      ? data.access_token
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchDiscordUser(
+  accessToken: string,
+): Promise<{ id: string; username: string } | null> {
+  try {
+    const response = await fetch(`${DISCORD_API}/users/@me`, {
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as {
+      id?: unknown;
+      username?: unknown;
+    };
+    if (typeof data.id !== "string" || !data.id) return null;
+    return { id: data.id, username: String(data.username ?? "") };
+  } catch {
+    return null;
+  }
+}
+
+/** Add the user to the guild. 201 = added, 204 = already a member. */
+export async function joinGuild(
+  discordUserId: string,
+  userAccessToken: string,
+): Promise<boolean> {
+  const config = readConfig();
+  if (!config) return false;
+  try {
+    const response = await fetch(
+      `${DISCORD_API}/guilds/${config.guildId}/members/${discordUserId}`,
+      {
+        method: "PUT",
+        headers: {
+          authorization: `Bot ${config.botToken}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ access_token: userAccessToken }),
+      },
+    );
+    return response.status === 201 || response.status === 204;
+  } catch {
+    return false;
+  }
+}
+
+/** Grant the funded-trader role. Bot needs Manage Roles; 204 on success. */
+export async function grantRole(discordUserId: string): Promise<boolean> {
+  const config = readConfig();
+  if (!config) return false;
+  try {
+    const response = await fetch(
+      `${DISCORD_API}/guilds/${config.guildId}/members/${discordUserId}/roles/${config.roleId}`,
+      {
+        method: "PUT",
+        headers: { authorization: `Bot ${config.botToken}` },
+      },
+    );
+    return response.status === 204;
+  } catch {
+    return false;
+  }
+}
+
+// ── 1:1 wallet ↔ Discord linkage (Vercel Blob) ───────────────────────
+// Tiny JSON records at deterministic private paths. Fail-open by design:
+// verification is gated on funding + email, not on our own storage — if
+// Blob is down or unconfigured we proceed without the guard and report
+// linkGuard "unavailable" rather than blocking a legitimate user.
+
+function walletLinkPath(wallet: string): string {
+  return `discord-links/wallet/${wallet}.json`;
+}
+
+function userLinkPath(discordId: string): string {
+  return `discord-links/user/${discordId}.json`;
+}
+
+export async function checkLinkGuard(
+  wallet: string,
+  discordId: string,
+): Promise<LinkGuardDecision | "unavailable"> {
+  const [walletLink, userLink] = await Promise.all([
+    readLink(walletLinkPath(wallet)),
+    readLink(userLinkPath(discordId)),
+  ]);
+  if (walletLink === "error" || userLink === "error") return "unavailable";
+  return linkGuardDecision(walletLink, userLink, wallet, discordId);
+}
+
+/** Persist both link records. Call only after the role grant succeeded. */
+export async function writeLinks(
+  wallet: string,
+  discordId: string,
+): Promise<boolean> {
+  const token = env.BLOB_READ_WRITE_TOKEN;
+  if (!token) return false;
+  const record = JSON.stringify({ wallet, discordId } satisfies LinkRecord);
+  try {
+    await Promise.all([
+      put(walletLinkPath(wallet), record, {
+        access: "private",
+        contentType: "application/json",
+        addRandomSuffix: false,
+        allowOverwrite: true,
+        token,
+      }),
+      put(userLinkPath(discordId), record, {
+        access: "private",
+        contentType: "application/json",
+        addRandomSuffix: false,
+        allowOverwrite: true,
+        token,
+      }),
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** null = no record; "error" = storage unavailable (distinct on purpose). */
+async function readLink(
+  pathname: string,
+): Promise<LinkRecord | null | "error"> {
+  const token = env.BLOB_READ_WRITE_TOKEN;
+  if (!token) return "error";
+  try {
+    const result = await get(pathname, { access: "private", token });
+    if (result === null) return null; // no such blob — never linked
+    if (result.statusCode !== 200 || !result.stream) return "error";
+    const text = await new Response(result.stream).text();
+    const data = JSON.parse(text) as { wallet?: unknown; discordId?: unknown };
+    if (typeof data.wallet !== "string" || typeof data.discordId !== "string") {
+      return "error";
+    }
+    return { wallet: data.wallet, discordId: data.discordId };
+  } catch {
+    return "error";
+  }
+}
+
+function readConfig(): DiscordConfig | null {
+  const clientId = clean(env.DISCORD_CLIENT_ID);
+  const clientSecret = clean(env.DISCORD_CLIENT_SECRET);
+  const botToken = clean(env.DISCORD_BOT_TOKEN);
+  const guildId = clean(env.DISCORD_GUILD_ID);
+  const roleId = clean(env.DISCORD_FUNDED_ROLE_ID);
+  const stateSecret = clean(env.DISCORD_STATE_SECRET);
+  if (
+    !clientId ||
+    !clientSecret ||
+    !botToken ||
+    !guildId ||
+    !roleId ||
+    !stateSecret
+  ) {
+    return null;
+  }
+  return { clientId, clientSecret, botToken, guildId, roleId, stateSecret };
+}
+
+function clean(value: string | undefined): string {
+  return String(value ?? "").trim();
+}

--- a/apps/portal/src/lib/server/funding-check.ts
+++ b/apps/portal/src/lib/server/funding-check.ts
@@ -10,9 +10,7 @@ import { decodeTrader, getTraderAddresses } from "@ellipsis-labs/rise";
 import { env as privateEnv } from "$env/dynamic/private";
 import { env as publicEnv } from "$env/dynamic/public";
 import { fundingDecision, parseFundedMinUsd } from "$lib/discord-verify";
-// funding.ts is server-safe: it imports only $lib/utils (pure helpers, no
-// browser modules, no @solana/web3.js).
-import { fetchUsdcBalance } from "$lib/funding";
+import { USDC_MINT } from "$lib/funding";
 import { getCatalog } from "./tokensxyz";
 
 const SOLANA_MAINNET_RPC = "https://api.mainnet-beta.solana.com";
@@ -38,11 +36,14 @@ export async function checkFunding(
   try {
     const url = rpcUrl();
     const [usdc, lamports, solPrice, phoenixUsd] = await Promise.all([
-      fetchUsdcBalance(url, wallet),
+      fetchUsdcUsd(url, wallet),
       fetchLamports(url, wallet),
       fetchSolPriceUsd(),
       fetchPhoenixCollateralUsd(url, wallet),
     ]);
+    // A failed USDC read is "unknown", never "$0 of USDC" — a zero here
+    // would flow straight into a not-funded refusal.
+    if (usdc === null) return null;
     // No SOL price means the SOL leg is unknowable — the whole check is
     // "unknown", not "SOL is worth $0".
     if (solPrice === null) return null;
@@ -101,6 +102,67 @@ async function fetchLamports(url: string, owner: string): Promise<number> {
     throw new Error("solana-balance-missing");
   }
   return Math.max(0, value);
+}
+
+// Gate-specific USDC read. The display helper ($lib/funding fetchUsdcBalance)
+// deliberately shrugs at soft failures — an HTTP 200 carrying a JSON-RPC
+// `error` envelope falls through to an empty account list and returns 0,
+// which is fine for a balance widget (worst case it briefly shows $0) but
+// poison for a refusal gate: that 0 would flow into fundingDecision and
+// refuse a funded user as "not-funded" instead of the honest
+// "unknown → error". So this gate inspects the JSON-RPC envelope itself and
+// returns:
+//   number — total USDC (0 ONLY when the response legitimately lists no
+//            token accounts, or lists accounts holding nothing);
+//   null   — unknown (HTTP failure, JSON-RPC `error`, malformed shape).
+async function fetchUsdcUsd(
+  url: string,
+  owner: string,
+): Promise<number | null> {
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "trader-ralph-discord-usdc",
+        method: "getTokenAccountsByOwner",
+        // "confirmed" for the same reason as fetchLamports above.
+        params: [
+          owner,
+          { mint: USDC_MINT },
+          { encoding: "jsonParsed", commitment: "confirmed" },
+        ],
+      }),
+    });
+    if (!response.ok) return null;
+    const payload = (await response.json()) as {
+      result?: { value?: unknown };
+      error?: unknown;
+    };
+    if (payload.error) return null;
+    const value = payload.result?.value;
+    if (!Array.isArray(value)) return null;
+    let total = 0;
+    for (const account of value) {
+      const ui = (
+        account as {
+          account?: {
+            data?: {
+              parsed?: { info?: { tokenAmount?: { uiAmount?: unknown } } };
+            };
+          };
+        }
+      )?.account?.data?.parsed?.info?.tokenAmount?.uiAmount;
+      // An account we cannot read is an unknown balance, not a $0 one —
+      // the display helper skips these; the gate must not undercount.
+      if (typeof ui !== "number" || !Number.isFinite(ui)) return null;
+      total += ui;
+    }
+    return total;
+  } catch {
+    return null;
+  }
 }
 
 // Phoenix margin collateral, chain-first: the chain is truth, the Phoenix

--- a/apps/portal/src/lib/server/funding-check.ts
+++ b/apps/portal/src/lib/server/funding-check.ts
@@ -1,9 +1,12 @@
 // Server-side wallet funding check for Discord verification: USD value of
-// the wallet's USDC + SOL, priced off the same tokens.xyz catalog the OG
-// cards use. Honest-data rule: any failed read (RPC, price) returns null —
-// "unknown" — never a zero that would read as "unfunded". Callers must
-// treat null and { funded: false } differently.
+// the wallet's USDC + SOL (priced off the same tokens.xyz catalog the OG
+// cards use) plus Phoenix margin collateral. Honest-data rule: any failed
+// read (RPC, price, decode) returns null — "unknown" — never a zero that
+// would read as "unfunded". Callers must treat null and { funded: false }
+// differently.
 
+// Plain-JS SDK helpers (no @solana/web3.js) — server-safe.
+import { decodeTrader, getTraderAddresses } from "@ellipsis-labs/rise";
 import { env as privateEnv } from "$env/dynamic/private";
 import { env as publicEnv } from "$env/dynamic/public";
 import { fundingDecision, parseFundedMinUsd } from "$lib/discord-verify";
@@ -14,12 +17,17 @@ import { getCatalog } from "./tokensxyz";
 
 const SOLANA_MAINNET_RPC = "https://api.mainnet-beta.solana.com";
 const LAMPORTS_PER_SOL = 1_000_000_000;
+const USDC_DECIMALS = 6;
+const PHOENIX_API = "https://perp-api.phoenix.trade";
 
 export type FundingCheck = {
   funded: boolean;
   totalUsd: number;
   usdcUsd: number;
   solUsd: number;
+  /** Phoenix margin collateral; null = the read was indeterminate (the
+   * wallet still cleared the threshold on wallet assets alone). */
+  phoenixUsd: number | null;
 };
 
 /** Funding snapshot for a wallet, or null when any read failed (unknown). */
@@ -29,17 +37,29 @@ export async function checkFunding(
   const threshold = parseFundedMinUsd(privateEnv.DISCORD_FUNDED_MIN_USD);
   try {
     const url = rpcUrl();
-    const [usdc, lamports, solPrice] = await Promise.all([
+    const [usdc, lamports, solPrice, phoenixUsd] = await Promise.all([
       fetchUsdcBalance(url, wallet),
       fetchLamports(url, wallet),
       fetchSolPriceUsd(),
+      fetchPhoenixCollateralUsd(url, wallet),
     ]);
     // No SOL price means the SOL leg is unknowable — the whole check is
     // "unknown", not "SOL is worth $0".
     if (solPrice === null) return null;
     const solUsd = (lamports / LAMPORTS_PER_SOL) * solPrice;
-    const decision = fundingDecision(usdc, solUsd, threshold);
-    return { ...decision, usdcUsd: usdc, solUsd };
+    // Asymmetric on purpose: a wallet that clears the threshold on
+    // USDC + SOL alone is funded even when the Phoenix read is
+    // indeterminate — the old wallet-only check would have passed it, and
+    // a flaky Phoenix leg must never refuse (or error) someone it can only
+    // help. Only when the wallet alone is below the bar does an unknown
+    // Phoenix read make the whole check unknown.
+    if (phoenixUsd === null) {
+      const walletOnly = fundingDecision(usdc, solUsd, 0, threshold);
+      if (!walletOnly.funded) return null;
+      return { ...walletOnly, usdcUsd: usdc, solUsd, phoenixUsd: null };
+    }
+    const decision = fundingDecision(usdc, solUsd, phoenixUsd, threshold);
+    return { ...decision, usdcUsd: usdc, solUsd, phoenixUsd };
   } catch {
     return null;
   }
@@ -81,6 +101,91 @@ async function fetchLamports(url: string, owner: string): Promise<number> {
     throw new Error("solana-balance-missing");
   }
   return Math.max(0, value);
+}
+
+// Phoenix margin collateral, chain-first: the chain is truth, the Phoenix
+// API indexer is a lagging hint — so collateral comes from the trader PDA
+// via RPC, never the REST trader endpoint. This mirrors the client's
+// fetchOnChainCollateralUsd (lib/phoenix-trade.ts) with the same SDK
+// helpers; only the exchange config (the canonical mint that keys the PDA)
+// comes from the Phoenix REST API. Returns:
+//   number — collateral in USD (0 when the wallet never registered);
+//   null   — indeterminate (config/RPC/decode failure), never coerced to 0.
+async function fetchPhoenixCollateralUsd(
+  url: string,
+  wallet: string,
+): Promise<number | null> {
+  try {
+    const mint = await fetchPhoenixCanonicalMint();
+    const addresses = await getTraderAddresses(
+      wallet as never,
+      mint as never,
+      0,
+      0,
+    );
+    const data = await fetchAccountData(url, String(addresses.traderAccount));
+    // Account not found = the wallet never registered with Phoenix, which
+    // is honestly $0 of collateral there — NOT an unknown.
+    if (data === null) return 0;
+    const trader = decodeTrader(data);
+    // Quote lots are USDC atoms (QUOTE_LOTS_DECIMALS = 6 in the SDK).
+    const usd = Number(trader.state.quoteLotCollateral) / 10 ** USDC_DECIMALS;
+    return Number.isFinite(usd) && usd >= 0 && usd < 1e9 ? usd : null;
+  } catch {
+    // RPC error, config fetch failure, or decode throw — unknown, never 0.
+    return null;
+  }
+}
+
+// Same fetch-and-cache pattern as the client's fetchExchangeConfig, trimmed
+// to the one key this check needs.
+let phoenixCanonicalMintCache: string | null = null;
+
+async function fetchPhoenixCanonicalMint(): Promise<string> {
+  if (phoenixCanonicalMintCache) return phoenixCanonicalMintCache;
+  const response = await fetch(`${PHOENIX_API}/exchange`);
+  if (!response.ok) throw new Error(`phoenix-exchange-${response.status}`);
+  const data = (await response.json()) as {
+    keys?: { canonicalMint?: unknown };
+  };
+  const mint = data.keys?.canonicalMint;
+  if (typeof mint !== "string" || mint.length === 0) {
+    throw new Error("phoenix-exchange-mint-missing");
+  }
+  phoenixCanonicalMintCache = mint;
+  return mint;
+}
+
+/** getAccountInfo (base64). Missing account → null; malformed reply throws. */
+async function fetchAccountData(
+  url: string,
+  address: string,
+): Promise<Uint8Array | null> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: "trader-ralph-discord-phoenix",
+      method: "getAccountInfo",
+      // "confirmed" for the same reason as fetchLamports above.
+      params: [address, { commitment: "confirmed", encoding: "base64" }],
+    }),
+  });
+  if (!response.ok) throw new Error(`solana-rpc-http-${response.status}`);
+  const payload = (await response.json()) as {
+    result?: { value?: { data?: unknown } | null };
+    error?: unknown;
+  };
+  if (payload.error) throw new Error("solana-rpc-error");
+  if (!payload.result || !("value" in payload.result)) {
+    throw new Error("solana-account-info-missing");
+  }
+  if (payload.result.value === null) return null;
+  const data = payload.result.value?.data;
+  const base64 = Array.isArray(data) ? data[0] : data;
+  if (typeof base64 !== "string") throw new Error("solana-account-data-shape");
+  return Uint8Array.from(Buffer.from(base64, "base64"));
 }
 
 // SOL priced from the tokens.xyz catalog — the same source the OG cards

--- a/apps/portal/src/lib/server/funding-check.ts
+++ b/apps/portal/src/lib/server/funding-check.ts
@@ -1,0 +1,105 @@
+// Server-side wallet funding check for Discord verification: USD value of
+// the wallet's USDC + SOL, priced off the same tokens.xyz catalog the OG
+// cards use. Honest-data rule: any failed read (RPC, price) returns null —
+// "unknown" — never a zero that would read as "unfunded". Callers must
+// treat null and { funded: false } differently.
+
+import { env as privateEnv } from "$env/dynamic/private";
+import { env as publicEnv } from "$env/dynamic/public";
+import { fundingDecision, parseFundedMinUsd } from "$lib/discord-verify";
+// funding.ts is server-safe: it imports only $lib/utils (pure helpers, no
+// browser modules, no @solana/web3.js).
+import { fetchUsdcBalance } from "$lib/funding";
+import { getCatalog } from "./tokensxyz";
+
+const SOLANA_MAINNET_RPC = "https://api.mainnet-beta.solana.com";
+const LAMPORTS_PER_SOL = 1_000_000_000;
+
+export type FundingCheck = {
+  funded: boolean;
+  totalUsd: number;
+  usdcUsd: number;
+  solUsd: number;
+};
+
+/** Funding snapshot for a wallet, or null when any read failed (unknown). */
+export async function checkFunding(
+  wallet: string,
+): Promise<FundingCheck | null> {
+  const threshold = parseFundedMinUsd(privateEnv.DISCORD_FUNDED_MIN_USD);
+  try {
+    const url = rpcUrl();
+    const [usdc, lamports, solPrice] = await Promise.all([
+      fetchUsdcBalance(url, wallet),
+      fetchLamports(url, wallet),
+      fetchSolPriceUsd(),
+    ]);
+    // No SOL price means the SOL leg is unknowable — the whole check is
+    // "unknown", not "SOL is worth $0".
+    if (solPrice === null) return null;
+    const solUsd = (lamports / LAMPORTS_PER_SOL) * solPrice;
+    const decision = fundingDecision(usdc, solUsd, threshold);
+    return { ...decision, usdcUsd: usdc, solUsd };
+  } catch {
+    return null;
+  }
+}
+
+// Same env names the client's solanaRpcUrl() resolves, read through the
+// server-side dynamic env (import.meta.env is a client/vite concept).
+function rpcUrl(): string {
+  const configured = cleanEnv(
+    publicEnv.PUBLIC_SOLANA_RPC_URL ??
+      privateEnv.VITE_SOLANA_RPC_URL ??
+      privateEnv.NEXT_PUBLIC_SOLANA_RPC_URL,
+  );
+  return configured || SOLANA_MAINNET_RPC;
+}
+
+async function fetchLamports(url: string, owner: string): Promise<number> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: "trader-ralph-discord-funding",
+      method: "getBalance",
+      // "confirmed" over "processed": this gates a role grant, so a
+      // rolled-back slot briefly overstating the balance is not worth the
+      // faster read the display paths use.
+      params: [owner, { commitment: "confirmed" }],
+    }),
+  });
+  if (!response.ok) throw new Error(`solana-rpc-http-${response.status}`);
+  const payload = (await response.json()) as {
+    result?: { value?: unknown };
+    error?: unknown;
+  };
+  if (payload.error) throw new Error("solana-rpc-error");
+  const value = payload.result?.value;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error("solana-balance-missing");
+  }
+  return Math.max(0, value);
+}
+
+// SOL priced from the tokens.xyz catalog — the same source the OG cards
+// read (routes/og/terminal.png finds SOL the same way).
+async function fetchSolPriceUsd(): Promise<number | null> {
+  try {
+    const assets = await getCatalog();
+    const sol = assets.find(
+      (asset) => asset.symbol.toUpperCase() === "SOL" && asset.price !== null,
+    );
+    return sol?.price ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function cleanEnv(value: string | undefined): string {
+  return String(value ?? "")
+    .trim()
+    .replace(/^"+|"+$/g, "")
+    .replace(/\\n$/, "");
+}

--- a/apps/portal/src/lib/server/privy.ts
+++ b/apps/portal/src/lib/server/privy.ts
@@ -95,6 +95,159 @@ export async function countUsers(max: number): Promise<number | null> {
   }
 }
 
+export type PrivyUserProfile = {
+  id: string;
+  email: string | null;
+  solanaWallet: string | null;
+};
+
+/**
+ * Fetch a user by Privy DID via GET /v1/users/{user_id} (verified against
+ * docs.privy.io/api-reference/users/get: Basic auth + privy-app-id header)
+ * and extract the email + embedded Solana wallet from linked_accounts.
+ * null = not configured or API failure.
+ */
+export async function getUserById(
+  userId: string,
+): Promise<PrivyUserProfile | null> {
+  const creds = readCredentials();
+  if (!creds) return null;
+  try {
+    const response = await fetch(
+      `${PRIVY_API}/users/${encodeURIComponent(userId)}`,
+      { headers: privyHeaders(creds) },
+    );
+    if (!response.ok) return null;
+    const data = (await response.json()) as {
+      id?: unknown;
+      linked_accounts?: unknown;
+    };
+    const id = typeof data.id === "string" && data.id ? data.id : null;
+    if (!id) return null;
+
+    let email: string | null = null;
+    let solanaWallet: string | null = null;
+    const accounts = Array.isArray(data.linked_accounts)
+      ? data.linked_accounts
+      : [];
+    for (const account of accounts) {
+      if (typeof account !== "object" || account === null) continue;
+      const record = account as Record<string, unknown>;
+      const type = String(record.type ?? "").toLowerCase();
+      const address = String(record.address ?? "").trim();
+      if (!address) continue;
+      if (!email && type === "email") email = address;
+      const chainType = String(record.chain_type ?? "").toLowerCase();
+      if (!solanaWallet && type === "wallet" && chainType === "solana") {
+        solanaWallet = address;
+      }
+    }
+    return { id, email, solanaWallet };
+  } catch {
+    return null;
+  }
+}
+
+// ── Access-token verification ─────────────────────────────────────────
+// Privy access tokens are ES256 JWTs with iss "privy.io", aud = app id and
+// sub = the user's DID (docs.privy.io authentication/access-tokens). The
+// app's public keys are served as a JWKS at
+// https://auth.privy.io/api/v1/apps/{appId}/jwks.json (P-256, kid-keyed) —
+// verified live. Signatures check out against those keys via WebCrypto
+// (JWS ES256 signatures are raw r||s, which is exactly what WebCrypto's
+// ECDSA verify expects).
+
+const JWKS_TTL_MS = 10 * 60_000;
+type PrivyJwk = JsonWebKey & { kid?: string };
+let jwksCache: { keys: PrivyJwk[]; at: number } | null = null;
+
+/** Verify a Privy access token. Returns the user's DID (sub) or null. */
+export async function verifyPrivyAccessToken(
+  token: string,
+): Promise<string | null> {
+  const creds = readCredentials();
+  if (!creds) return null;
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3) return null;
+    const [headerB64, payloadB64, signatureB64] = parts;
+
+    const header = JSON.parse(
+      Buffer.from(headerB64, "base64url").toString("utf8"),
+    ) as { alg?: unknown; kid?: unknown };
+    if (header.alg !== "ES256") return null;
+
+    const payload = JSON.parse(
+      Buffer.from(payloadB64, "base64url").toString("utf8"),
+    ) as { iss?: unknown; aud?: unknown; exp?: unknown; sub?: unknown };
+    if (payload.iss !== "privy.io") return null;
+    const audOk = Array.isArray(payload.aud)
+      ? payload.aud.includes(creds.appId)
+      : payload.aud === creds.appId;
+    if (!audOk) return null;
+    if (typeof payload.exp !== "number" || payload.exp * 1000 <= Date.now()) {
+      return null;
+    }
+    if (typeof payload.sub !== "string" || !payload.sub) return null;
+
+    const keys = await fetchJwks(creds.appId);
+    if (!keys || keys.length === 0) return null;
+    // Prefer the kid match; fall back to trying every key so a rotation
+    // between our cache refreshes cannot reject a valid token.
+    const kid = typeof header.kid === "string" ? header.kid : null;
+    const candidates = kid
+      ? [
+          ...keys.filter((key) => key.kid === kid),
+          ...keys.filter((key) => key.kid !== kid),
+        ]
+      : keys;
+
+    const signature = Buffer.from(signatureB64, "base64url");
+    const message = Buffer.from(`${headerB64}.${payloadB64}`);
+    for (const jwk of candidates) {
+      const key = await crypto.subtle.importKey(
+        "jwk",
+        jwk,
+        { name: "ECDSA", namedCurve: "P-256" },
+        false,
+        ["verify"],
+      );
+      const valid = await crypto.subtle.verify(
+        { name: "ECDSA", hash: "SHA-256" },
+        key,
+        signature,
+        message,
+      );
+      if (valid) return payload.sub;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchJwks(appId: string): Promise<PrivyJwk[] | null> {
+  const cached = jwksCache;
+  if (cached && Date.now() - cached.at < JWKS_TTL_MS) return cached.keys;
+  try {
+    const response = await fetch(
+      `https://auth.privy.io/api/v1/apps/${encodeURIComponent(appId)}/jwks.json`,
+    );
+    if (!response.ok) return cached ? cached.keys : null;
+    const data = (await response.json()) as { keys?: unknown };
+    const keys = Array.isArray(data.keys)
+      ? (data.keys.filter(
+          (key) => typeof key === "object" && key !== null,
+        ) as PrivyJwk[])
+      : [];
+    if (keys.length === 0) return cached ? cached.keys : null;
+    jwksCache = { keys, at: Date.now() };
+    return keys;
+  } catch {
+    return cached ? cached.keys : null; // stale-on-error
+  }
+}
+
 function readCredentials(): PrivyCredentials | null {
   // Same app-id names the client reads (privy-auth.ts readPrivyConfig);
   // PUBLIC_-prefixed vars live in the public env, the rest in private.

--- a/apps/portal/src/routes/api/discord/callback/+server.ts
+++ b/apps/portal/src/routes/api/discord/callback/+server.ts
@@ -1,0 +1,53 @@
+// Discord OAuth callback: verify the signed state, re-check funding
+// server-side (the state could be minted and the funds moved before the
+// user finishes the OAuth dance — the re-check is cheap), enforce the 1:1
+// wallet ↔ Discord linkage, then join the guild and grant the role. This
+// is a browser navigation, so every outcome redirects back to /discord
+// with a status — no JSON dead-ends.
+
+import { redirect } from "@sveltejs/kit";
+import * as discord from "$lib/server/discord";
+import { checkFunding } from "$lib/server/funding-check";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async ({ url, setHeaders }) => {
+  setHeaders({ "cache-control": "no-store" });
+
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  if (!code || !state) redirect(302, "/discord?status=error");
+  if (!discord.isConfigured()) redirect(302, "/discord?status=error");
+
+  const payload = discord.verifyStateParam(state, Date.now());
+  if (!payload) redirect(302, "/discord?status=expired");
+
+  const funding = await checkFunding(payload.wallet);
+  // Unknown (null) maps to error, not not-funded: a failed read must never
+  // be reported to the user as "you don't hold enough".
+  if (funding === null) redirect(302, "/discord?status=error");
+  if (!funding.funded) redirect(302, "/discord?status=not-funded");
+
+  const redirectUri = `${url.origin}/api/discord/callback`;
+  const accessToken = await discord.exchangeCode(code, redirectUri);
+  if (!accessToken) redirect(302, "/discord?status=error");
+
+  const discordUser = await discord.fetchDiscordUser(accessToken);
+  if (!discordUser) redirect(302, "/discord?status=error");
+
+  const guard = await discord.checkLinkGuard(payload.wallet, discordUser.id);
+  if (guard === "already-linked") {
+    redirect(302, "/discord?status=already-linked");
+  }
+  // guard "unavailable" proceeds: verification is gated on funding + email,
+  // not on our own storage being up (see lib/server/discord.ts).
+
+  const joined = await discord.joinGuild(discordUser.id, accessToken);
+  if (!joined) redirect(302, "/discord?status=error");
+  const granted = await discord.grantRole(discordUser.id);
+  if (!granted) redirect(302, "/discord?status=error");
+
+  // Only record the linkage once the role actually landed — a failed grant
+  // must not burn the wallet's one link.
+  await discord.writeLinks(payload.wallet, discordUser.id);
+  redirect(302, "/discord?status=success");
+};

--- a/apps/portal/src/routes/api/discord/callback/+server.ts
+++ b/apps/portal/src/routes/api/discord/callback/+server.ts
@@ -34,6 +34,9 @@ export const GET: RequestHandler = async ({ url, setHeaders }) => {
   const discordUser = await discord.fetchDiscordUser(accessToken);
   if (!discordUser) redirect(302, "/discord?status=error");
 
+  // Fast pre-check. Still load-bearing for the user-side record: the
+  // reservation below only guards the wallet-side path, so a Discord
+  // account already linked to a DIFFERENT wallet is caught here.
   const guard = await discord.checkLinkGuard(payload.wallet, discordUser.id);
   if (guard === "already-linked") {
     redirect(302, "/discord?status=already-linked");
@@ -41,13 +44,44 @@ export const GET: RequestHandler = async ({ url, setHeaders }) => {
   // guard "unavailable" proceeds: verification is gated on funding + email,
   // not on our own storage being up (see lib/server/discord.ts).
 
-  const joined = await discord.joinGuild(discordUser.id, accessToken);
-  if (!joined) redirect(302, "/discord?status=error");
-  const granted = await discord.grantRole(discordUser.id);
-  if (!granted) redirect(302, "/discord?status=error");
+  // Atomic wallet-side reservation BEFORE anything is granted. The
+  // pre-check above is check-then-act; without this, two concurrent
+  // callbacks for the same wallet (different Discord accounts) both pass
+  // the guard and both get the role.
+  const reservation = await discord.reserveWalletLink(
+    payload.wallet,
+    discordUser.id,
+  );
+  if (reservation === "already-linked") {
+    redirect(302, "/discord?status=already-linked");
+  }
+  // "unavailable" proceeds — same fail-open convention as the guard.
 
-  // Only record the linkage once the role actually landed — a failed grant
-  // must not burn the wallet's one link.
-  await discord.writeLinks(payload.wallet, discordUser.id);
+  const joined = await discord.joinGuild(discordUser.id, accessToken);
+  if (!joined) {
+    // Compensation, not a transaction: a failed grant must not burn the
+    // wallet's one link. If this delete fails too, nothing is bricked —
+    // re-verifying the same wallet+Discord pair reserves idempotently.
+    if (reservation === "reserved") {
+      await discord.releaseWalletLink(payload.wallet);
+    }
+    redirect(302, "/discord?status=error");
+  }
+  const granted = await discord.grantRole(discordUser.id);
+  if (!granted) {
+    if (reservation === "reserved") {
+      await discord.releaseWalletLink(payload.wallet);
+    }
+    redirect(302, "/discord?status=error");
+  }
+
+  // Role landed: persist the user-side record (the wallet-side one was
+  // already written by the reservation). If the reservation was skipped by
+  // the outage fail-open, best-effort re-attempt the wallet-side record now
+  // — the CAS is idempotent, so this can't clobber a concurrent winner.
+  if (reservation === "unavailable") {
+    await discord.reserveWalletLink(payload.wallet, discordUser.id);
+  }
+  await discord.writeUserLink(payload.wallet, discordUser.id);
   redirect(302, "/discord?status=success");
 };

--- a/apps/portal/src/routes/api/discord/start/+server.ts
+++ b/apps/portal/src/routes/api/discord/start/+server.ts
@@ -1,0 +1,63 @@
+// Start Discord funded-trader verification: prove the caller is a Privy
+// user (email confirmed) with a funded wallet, then hand back the Discord
+// authorize URL carrying an HMAC-signed state. Honest failure states:
+// 503 = we could not know (unconfigured / upstream down), 403 = we know
+// and the answer is no (with the real reason and numbers).
+
+import { json } from "@sveltejs/kit";
+import * as discord from "$lib/server/discord";
+import { checkFunding } from "$lib/server/funding-check";
+import { getUserById, verifyPrivyAccessToken } from "$lib/server/privy";
+import type { RequestHandler } from "./$types";
+
+export const POST: RequestHandler = async ({ request, setHeaders, url }) => {
+  setHeaders({ "cache-control": "no-store" });
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ reason: "invalid-body" }, { status: 400 });
+  }
+  const privyToken =
+    typeof body === "object" && body !== null
+      ? (body as Record<string, unknown>).privyToken
+      : null;
+  if (typeof privyToken !== "string" || !privyToken) {
+    return json({ reason: "invalid-body" }, { status: 400 });
+  }
+
+  if (!discord.isConfigured()) {
+    return json({ reason: "unconfigured" }, { status: 503 });
+  }
+
+  const privyUserId = await verifyPrivyAccessToken(privyToken);
+  if (!privyUserId) return json({ reason: "invalid-token" }, { status: 401 });
+
+  const user = await getUserById(privyUserId);
+  if (!user) return json({ reason: "privy-unavailable" }, { status: 503 });
+  if (!user.email) return json({ reason: "email-required" }, { status: 403 });
+  if (!user.solanaWallet) {
+    return json({ reason: "wallet-required" }, { status: 403 });
+  }
+
+  const funding = await checkFunding(user.solanaWallet);
+  // null = we could not read the balance or price — that is "unknown",
+  // never "unfunded", so it is a 503, not a refusal.
+  if (funding === null) {
+    return json({ reason: "funding-unknown" }, { status: 503 });
+  }
+  if (!funding.funded) {
+    return json(
+      { reason: "not-funded", totalUsd: funding.totalUsd },
+      { status: 403 },
+    );
+  }
+
+  const authorizeUrl = discord.buildAuthorizeUrl(
+    { privyUserId, wallet: user.solanaWallet, iat: Date.now() },
+    `${url.origin}/api/discord/callback`,
+  );
+  if (!authorizeUrl) return json({ reason: "unconfigured" }, { status: 503 });
+  return json({ url: authorizeUrl });
+};

--- a/apps/portal/src/routes/discord/+page.svelte
+++ b/apps/portal/src/routes/discord/+page.svelte
@@ -1,0 +1,564 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { BrandMark, Button } from "@trader-ralph/ui";
+  import { page } from "$app/state";
+  import {
+    getPrivyAccessToken,
+    initializePrivyAuth,
+    loginPrivyWithCode,
+    privyAuth,
+    sendPrivyEmailCode,
+  } from "$lib/privy-auth";
+
+  const status = $derived(page.url.searchParams.get("status"));
+
+  // Inline Privy email login (same flow as the terminal's auth modal,
+  // rebuilt here so the terminal components stay untouched).
+  let email = $state("");
+  let code = $state("");
+  let step = $state<"email" | "code">("email");
+  let authBusy = $state(false);
+  let authNote = $state("");
+
+  // Verification kickoff state.
+  let verifyBusy = $state(false);
+  let refusal = $state<{ reason: string; totalUsd?: number } | null>(null);
+
+  onMount(() => {
+    void initializePrivyAuth();
+  });
+
+  // Beta-cap check before the OTP fires — same fail-open policy as the
+  // terminal: only an explicit { allowed: false } blocks the send.
+  async function checkBetaEligibility(address: string): Promise<boolean> {
+    try {
+      const response = await fetch("/api/beta/eligibility", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: address }),
+      });
+      if (!response.ok) return true;
+      const data = (await response.json()) as { allowed?: boolean };
+      return data.allowed !== false;
+    } catch {
+      return true;
+    }
+  }
+
+  async function submitEmail(event: SubmitEvent): Promise<void> {
+    event.preventDefault();
+    authBusy = true;
+    authNote = "";
+    try {
+      if (!(await checkBetaEligibility(email))) {
+        authNote = "The beta is full right now — check back soon.";
+        return;
+      }
+      await sendPrivyEmailCode(email);
+      step = "code";
+      authNote = "Code sent.";
+    } catch {
+      authNote = "Could not send the code. Check the address and try again.";
+    } finally {
+      authBusy = false;
+    }
+  }
+
+  async function submitCode(event: SubmitEvent): Promise<void> {
+    event.preventDefault();
+    authBusy = true;
+    authNote = "";
+    try {
+      await loginPrivyWithCode(email, code);
+      code = "";
+    } catch {
+      authNote = "That code didn't work. Try again or resend.";
+    } finally {
+      authBusy = false;
+    }
+  }
+
+  async function startVerification(): Promise<void> {
+    verifyBusy = true;
+    refusal = null;
+    try {
+      const token = await getPrivyAccessToken();
+      if (!token) {
+        refusal = { reason: "error" };
+        return;
+      }
+      const response = await fetch("/api/discord/start", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ privyToken: token }),
+      });
+      const data = (await response.json().catch(() => ({}))) as {
+        url?: unknown;
+        reason?: unknown;
+        totalUsd?: unknown;
+      };
+      if (response.ok && typeof data.url === "string") {
+        window.location.href = data.url;
+        return;
+      }
+      refusal = {
+        reason: typeof data.reason === "string" ? data.reason : "error",
+        totalUsd: typeof data.totalUsd === "number" ? data.totalUsd : undefined,
+      };
+    } catch {
+      refusal = { reason: "error" };
+    } finally {
+      verifyBusy = false;
+    }
+  }
+
+  const fmtUsd = (value: number) =>
+    `$${value.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+</script>
+
+<svelte:head>
+  <title>Trader Ralph Discord — verified funded traders</title>
+  <meta
+    name="description"
+    content="Join the Trader Ralph Discord as a verified funded trader: confirm your email and hold at least $10 of USDC + SOL in your trading wallet."
+  />
+  <link rel="canonical" href="https://traderralph.com/discord" />
+  <meta property="og:title" content="Trader Ralph Discord — verified funded traders" />
+  <meta
+    property="og:description"
+    content="A Discord role for traders with skin in the game: email-confirmed account, at least $10 of USDC + SOL in the wallet."
+  />
+  <meta property="og:image" content="https://traderralph.com/og/home.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+</svelte:head>
+
+<div class="site">
+  <header class="navbar">
+    <div class="nav">
+      <a class="brand" href="/">
+        <span class="brand-mark"><BrandMark /></span>
+        RALPH<span>·TERMINAL</span>
+      </a>
+      <Button href="/terminal">Open terminal</Button>
+    </div>
+  </header>
+
+  <main class="wrap">
+    <p class="eyebrow">DISCORD_VERIFY</p>
+    <h1>Funded traders only.</h1>
+    <p class="lead">
+      The Trader Ralph Discord grants the <b>Funded Trader</b> role to
+      accounts with skin in the game. Two requirements, checked on-chain:
+    </p>
+
+    <ol class="reqs">
+      <li>
+        <span class="n">1</span>
+        <div>
+          <h2>Email-confirmed account</h2>
+          <p>Log in with the email you use for the terminal. No seed phrase, no wallet extension.</p>
+        </div>
+      </li>
+      <li>
+        <span class="n">2</span>
+        <div>
+          <h2>At least $10 in the wallet</h2>
+          <p>USDC + SOL in your trading wallet, valued at current prices when you verify.</p>
+        </div>
+      </li>
+    </ol>
+
+    {#if status === "success"}
+      <div class="callout ok">
+        <strong>You're verified.</strong>
+        <span>The Funded Trader role is on your account and you've been added to the server.</span>
+        <div class="callout-cta">
+          <Button href="https://discord.com/app">Open Discord</Button>
+        </div>
+      </div>
+    {:else if status === "already-linked"}
+      <div class="callout warn">
+        <strong>Already linked.</strong>
+        <span>
+          This wallet or Discord account is already tied to a different
+          verification. One wallet, one Discord account — no re-use.
+        </span>
+      </div>
+    {:else if status === "expired"}
+      <div class="callout warn">
+        <strong>That link expired.</strong>
+        <span>Verification links are valid for 10 minutes. Start again below.</span>
+      </div>
+    {:else if status === "not-funded"}
+      <div class="callout warn">
+        <strong>Wallet below the threshold.</strong>
+        <span>
+          Your balance was re-checked during verification and came in under
+          $10 of USDC + SOL.
+          <a href="/terminal">Fund your wallet in the terminal</a> and try again.
+        </span>
+      </div>
+    {:else if status === "error"}
+      <div class="callout err">
+        <strong>Verification failed.</strong>
+        <span>Something went wrong talking to Discord. Try again below.</span>
+      </div>
+    {/if}
+
+    {#if status !== "success"}
+      <section class="action">
+        {#if !$privyAuth.configured}
+          <div class="callout err">
+            <strong>Login is not configured.</strong>
+            <span>This deployment has no Privy app id set, so verification is unavailable.</span>
+          </div>
+        {:else if $privyAuth.authenticated}
+          <p class="signed-in">
+            Signed in as <b>{$privyAuth.email ?? "your account"}</b>
+          </p>
+          <Button onclick={startVerification} disabled={verifyBusy}>
+            {verifyBusy ? "Checking your wallet…" : "Verify & join Discord"}
+          </Button>
+
+          {#if refusal}
+            {#if refusal.reason === "not-funded"}
+              <div class="callout warn">
+                <strong>Wallet below the threshold.</strong>
+                <span>
+                  Your wallet holds
+                  {refusal.totalUsd !== undefined ? fmtUsd(refusal.totalUsd) : "less than $10"}
+                  of USDC + SOL — the role needs at least $10.
+                  <a href="/terminal">Fund your wallet in the terminal</a> and try again.
+                </span>
+              </div>
+            {:else if refusal.reason === "email-required"}
+              <div class="callout warn">
+                <strong>Email confirmation required.</strong>
+                <span>
+                  Your account has no confirmed email. Log in to the
+                  <a href="/terminal">terminal</a> with an email code first, then verify here.
+                </span>
+              </div>
+            {:else if refusal.reason === "wallet-required"}
+              <div class="callout warn">
+                <strong>No trading wallet yet.</strong>
+                <span>
+                  Open the <a href="/terminal">terminal</a> once so your wallet is
+                  created, then come back.
+                </span>
+              </div>
+            {:else if refusal.reason === "funding-unknown"}
+              <div class="callout err">
+                <strong>Could not read your balance.</strong>
+                <span>
+                  The balance check is temporarily unavailable — your funding
+                  status is unknown, not rejected. Try again in a minute.
+                </span>
+              </div>
+            {:else if refusal.reason === "unconfigured"}
+              <div class="callout err">
+                <strong>Verification is not configured.</strong>
+                <span>This deployment has no Discord credentials set.</span>
+              </div>
+            {:else}
+              <div class="callout err">
+                <strong>Verification failed.</strong>
+                <span>Something went wrong. Try again in a minute.</span>
+              </div>
+            {/if}
+          {/if}
+        {:else}
+          <p class="signed-in">Log in with your terminal email to start.</p>
+          {#if step === "email"}
+            <form class="auth-form" onsubmit={submitEmail}>
+              <label>
+                Email address
+                <input
+                  bind:value={email}
+                  autocomplete="email"
+                  inputmode="email"
+                  placeholder="you@example.com"
+                  required
+                  type="email"
+                />
+              </label>
+              <Button disabled={authBusy || !$privyAuth.ready}>
+                {authBusy ? "Sending code…" : !$privyAuth.ready ? "Preparing…" : "Send code"}
+              </Button>
+            </form>
+          {:else}
+            <form class="auth-form" onsubmit={submitCode}>
+              <label>
+                Code sent to {email}
+                <input
+                  class="code-input"
+                  bind:value={code}
+                  autocomplete="one-time-code"
+                  inputmode="numeric"
+                  maxlength="6"
+                  placeholder="123456"
+                  required
+                />
+              </label>
+              <Button disabled={authBusy || !code.trim()}>
+                {authBusy ? "Verifying…" : "Log in"}
+              </Button>
+              <button
+                class="linklike"
+                type="button"
+                disabled={authBusy}
+                onclick={() => {
+                  step = "email";
+                  code = "";
+                  authNote = "";
+                }}
+              >
+                Use another email
+              </button>
+            </form>
+          {/if}
+          {#if authNote}
+            <p class="auth-note">{authNote}</p>
+          {/if}
+        {/if}
+      </section>
+    {/if}
+
+    <p class="fine">
+      Verification links a wallet to one Discord account. Balances are read
+      from the Solana chain at verification time; the role is not revoked if
+      you later move funds.
+    </p>
+  </main>
+</div>
+
+<style>
+  .site {
+    min-height: 100vh;
+    background: var(--paper);
+    color: var(--ink);
+  }
+
+  a {
+    text-decoration: none;
+  }
+
+  .navbar {
+    border-bottom: 1px solid var(--line-soft);
+  }
+
+  .nav {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    max-width: 72rem;
+    margin: 0 auto;
+    padding: 1.1rem 1.5rem;
+  }
+
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-weight: 800;
+    letter-spacing: 0.12em;
+    font-size: 0.95rem;
+    color: var(--ink);
+  }
+
+  .brand span.brand-mark {
+    display: flex;
+    width: 1.15rem;
+    height: 1.15rem;
+    color: var(--ink);
+  }
+
+  .brand span {
+    color: var(--accent);
+  }
+
+  .wrap {
+    max-width: 36rem;
+    margin: 0 auto;
+    padding: 4rem 1.5rem 5rem;
+  }
+
+  .eyebrow {
+    margin: 0 0 0.8rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.7rem;
+    letter-spacing: 0.14em;
+    color: var(--accent);
+    font-weight: 800;
+  }
+
+  h1 {
+    margin: 0 0 1rem;
+    font-size: clamp(2rem, 5vw, 3rem);
+    line-height: 1.05;
+    letter-spacing: -0.03em;
+  }
+
+  .lead {
+    color: var(--muted);
+    font-size: 1rem;
+    line-height: 1.6;
+    margin: 0 0 2rem;
+  }
+
+  .reqs {
+    list-style: none;
+    margin: 0 0 2.2rem;
+    padding: 0;
+  }
+
+  .reqs li {
+    display: grid;
+    grid-template-columns: 2.4rem minmax(0, 1fr);
+    gap: 1rem;
+    padding: 1.1rem 0;
+    border-bottom: 1px solid var(--line-soft);
+  }
+
+  .reqs li:first-child {
+    border-top: 1px solid var(--line-soft);
+  }
+
+  .reqs .n {
+    font-family: ui-monospace, monospace;
+    font-size: 0.8rem;
+    color: var(--accent);
+    font-weight: 700;
+    padding-top: 0.15rem;
+  }
+
+  .reqs h2 {
+    margin: 0 0 0.3rem;
+    font-size: 1rem;
+  }
+
+  .reqs p {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.88rem;
+    line-height: 1.55;
+  }
+
+  .action {
+    display: grid;
+    gap: 0.9rem;
+    justify-items: start;
+    margin-bottom: 2rem;
+  }
+
+  .signed-in {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.88rem;
+  }
+
+  .auth-form {
+    display: grid;
+    gap: 0.7rem;
+    width: 100%;
+    max-width: 22rem;
+    justify-items: start;
+  }
+
+  .auth-form label {
+    display: grid;
+    gap: 0.35rem;
+    width: 100%;
+    color: var(--muted);
+    font-size: 0.78rem;
+  }
+
+  .auth-form input {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    color: var(--ink);
+    padding: 0.55rem 0.7rem;
+    font-size: 0.9rem;
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .code-input {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 1.2rem;
+    letter-spacing: 0.4rem;
+  }
+
+  .linklike {
+    border: 0;
+    background: transparent;
+    color: var(--muted);
+    font-size: 0.76rem;
+    padding: 0;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    cursor: pointer;
+  }
+
+  .linklike:hover:not(:disabled) {
+    color: var(--ink);
+  }
+
+  .auth-note {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.8rem;
+  }
+
+  .callout {
+    display: grid;
+    gap: 0.35rem;
+    padding: 0.9rem 1rem;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    font-size: 0.85rem;
+    line-height: 1.5;
+    margin-bottom: 1.4rem;
+    max-width: 100%;
+  }
+
+  .callout strong {
+    color: var(--ink);
+  }
+
+  .callout span {
+    color: var(--muted);
+  }
+
+  .callout span a {
+    color: var(--accent);
+    font-weight: 600;
+  }
+
+  .callout.ok {
+    border-color: var(--up);
+  }
+
+  .callout.warn {
+    border-color: var(--amber);
+  }
+
+  .callout.err {
+    border-color: var(--down);
+  }
+
+  .callout-cta {
+    margin-top: 0.5rem;
+  }
+
+  .fine {
+    color: var(--faint);
+    font-size: 0.74rem;
+    line-height: 1.6;
+    border-top: 1px solid var(--line-soft);
+    padding-top: 1.2rem;
+    margin: 0;
+  }
+</style>

--- a/apps/portal/src/routes/discord/+page.svelte
+++ b/apps/portal/src/routes/discord/+page.svelte
@@ -117,13 +117,13 @@
 </script>
 
 <svelte:head>
-  <title>Trader Ralph Discord — verified funded traders</title>
+  <title>Trader Ralph Discord — verified active traders</title>
   <meta
     name="description"
-    content="Join the Trader Ralph Discord as a verified funded trader: confirm your email and hold at least $10 of USDC + SOL in your trading wallet."
+    content="Join the Trader Ralph Discord as a verified active trader: confirm your email and hold at least $10 of USDC + SOL in your trading wallet."
   />
   <link rel="canonical" href="https://traderralph.com/discord" />
-  <meta property="og:title" content="Trader Ralph Discord — verified funded traders" />
+  <meta property="og:title" content="Trader Ralph Discord — verified active traders" />
   <meta
     property="og:description"
     content="A Discord role for traders with skin in the game: email-confirmed account, at least $10 of USDC + SOL in the wallet."
@@ -145,9 +145,9 @@
 
   <main class="wrap">
     <p class="eyebrow">DISCORD_VERIFY</p>
-    <h1>Funded traders only.</h1>
+    <h1>Active traders only.</h1>
     <p class="lead">
-      The Trader Ralph Discord grants the <b>Funded Trader</b> role to
+      The Trader Ralph Discord grants the <b>Active Trader</b> role to
       accounts with skin in the game. Two requirements, checked on-chain:
     </p>
 
@@ -171,7 +171,7 @@
     {#if status === "success"}
       <div class="callout ok">
         <strong>You're verified.</strong>
-        <span>The Funded Trader role is on your account and you've been added to the server.</span>
+        <span>The Active Trader role is on your account and you've been added to the server.</span>
         <div class="callout-cta">
           <Button href="https://discord.com/app">Open Discord</Button>
         </div>

--- a/apps/portal/src/routes/discord/+page.svelte
+++ b/apps/portal/src/routes/discord/+page.svelte
@@ -120,13 +120,13 @@
   <title>Trader Ralph Discord — verified active traders</title>
   <meta
     name="description"
-    content="Join the Trader Ralph Discord as a verified active trader: confirm your email and hold at least $10 of USDC + SOL in your trading wallet."
+    content="Join the Trader Ralph Discord as a verified active trader: confirm your email and hold at least $10 of USDC + SOL in your trading wallet or Phoenix margin balance."
   />
   <link rel="canonical" href="https://traderralph.com/discord" />
   <meta property="og:title" content="Trader Ralph Discord — verified active traders" />
   <meta
     property="og:description"
-    content="A Discord role for traders with skin in the game: email-confirmed account, at least $10 of USDC + SOL in the wallet."
+    content="A Discord role for traders with skin in the game: email-confirmed account, at least $10 of USDC + SOL on the platform."
   />
   <meta property="og:image" content="https://traderralph.com/og/home.png" />
   <meta name="twitter:card" content="summary_large_image" />
@@ -162,8 +162,8 @@
       <li>
         <span class="n">2</span>
         <div>
-          <h2>At least $10 in the wallet</h2>
-          <p>USDC + SOL in your trading wallet, valued at current prices when you verify.</p>
+          <h2>At least $10 on the platform</h2>
+          <p>USDC + SOL in your wallet or Phoenix margin balance, valued at current prices when you verify.</p>
         </div>
       </li>
     </ol>
@@ -194,7 +194,7 @@
         <strong>Wallet below the threshold.</strong>
         <span>
           Your balance was re-checked during verification and came in under
-          $10 of USDC + SOL.
+          $10 of USDC + SOL, wallet and Phoenix margin combined.
           <a href="/terminal">Fund your wallet in the terminal</a> and try again.
         </span>
       </div>
@@ -225,9 +225,10 @@
               <div class="callout warn">
                 <strong>Wallet below the threshold.</strong>
                 <span>
-                  Your wallet holds
+                  You hold
                   {refusal.totalUsd !== undefined ? fmtUsd(refusal.totalUsd) : "less than $10"}
-                  of USDC + SOL — the role needs at least $10.
+                  of USDC + SOL across your wallet and Phoenix margin — the
+                  role needs at least $10.
                   <a href="/terminal">Fund your wallet in the terminal</a> and try again.
                 </span>
               </div>


### PR DESCRIPTION
**DO NOT MERGE — awaiting Guillaume's preview QA (needs DISCORD_* env vars from the server setup first)**

## Summary

Self-hosted Collab.Land-style verifier for the Trader Ralph Discord:

- **`/discord` page**: marketing-clean, landing-token styling. Privy email OTP login (the OTP *is* the email confirmation), then "Verify & join" → OAuth → status states rendered honestly (`not-funded` shows the wallet's real $ total + a link to fund; `funding-unknown` is an error, never a refusal).
- **`POST /api/discord/start`**: verifies the Privy access token against the live JWKS (ES256 via WebCrypto — zero new deps; JWKS endpoint verified live against our app id), fetches the user server-side (email + embedded wallet from Privy, not client claims), runs the funding check, returns a Discord authorize URL with HMAC-signed self-expiring state (10-min TTL, constant-time compare, injected clock).
- **`GET /api/discord/callback`**: re-verifies state, **re-runs the funding check** (funds could move mid-OAuth), exchanges the code, enforces **1:1 wallet↔Discord linkage** (private Vercel Blob records, written only after the role grant succeeds; storage outage degrades to no-guard rather than blocking verification), joins the guild + grants the role. Browser navigation → every outcome is a redirect, no JSON dead-ends.
- **Funding = wallet USDC + SOL ≥ $10** (`DISCORD_FUNDED_MIN_USD`, default 10): chain-read at `confirmed` commitment, SOL priced via tokens.xyz; any failed read returns null (honest unknown, never a fake zero).
- 41 new pure unit tests (state sign/verify incl. tamper/expiry/future-skew, threshold boundary, link-guard matrix).

## Validation

typecheck 0/0 · lint clean · 16 ui + 314 portal tests (41 new) · build green, unused-css 0 · smoke: unconfigured start → clean 503, garbage → 400, callback without params → 302 error state, /discord renders all status states.

## QA notes for preview (after env vars land)

1. Env needed (Preview + Production): `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, `DISCORD_BOT_TOKEN`, `DISCORD_GUILD_ID`, `DISCORD_FUNDED_ROLE_ID`, `DISCORD_STATE_SECRET`. Also register **both** redirect URIs in the Discord app: `https://traderralph.com/api/discord/callback` AND `https://preview.trader-ralph.com/api/discord/callback`.
2. On preview `/discord`: log in with your funded wallet → Verify & join → you should land in the guild with the Funded Trader role.
3. Re-run it → `already-linked`-free idempotent success (same pair re-verifies fine); a *different* Discord account with the same wallet → `already-linked`.
4. A wallet under $10 → the not-funded state with the real total.

## Risk notes

- Bot role must sit ABOVE "Funded Trader" in the Discord role list or grants 403 (classic silent Discord failure — surfaced as status=error).
- Blob link records are `access: "private"` (wallet↔Discord mappings at deterministic paths must not be world-readable).
- Repo is public: nothing in this diff assumes secrecy of the flow, only of the env values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)