### PR TITLE
Telemetry blobs write private (store moved to private-only access)

### DIFF
--- a/apps/portal/src/routes/api/events/+server.ts
+++ b/apps/portal/src/routes/api/events/+server.ts
@@ -40,8 +40,11 @@ export const POST: RequestHandler = async ({ request }) => {
     .toString(36)
     .slice(2, 8)}.ndjson`;
   try {
+    // Private on purpose, twice over: event payloads can carry wallet
+    // addresses, and the connected store (ralph-private) only accepts
+    // private writes — a "public" put throws and silently drops the batch.
     await put(name, `${lines}\n`, {
-      access: "public",
+      access: "private",
       contentType: "application/x-ndjson",
       token,
     });


### PR DESCRIPTION
Small plumbing fix, part of the Discord-ops rollout (#526 follow-through).

The project's connected blob store is now `ralph-private` (private-only) — the Discord link guard and cron state need private writes, and Vercel stores are single-access-mode. The events sink still wrote `access: "public"`, which now throws inside its silent catch → every telemetry batch dropped. Flipped to private, which is also simply correct for payloads that can carry wallet addresses.

Validation: typecheck 0/0 · lint clean. One-word behavior change inside the existing try/catch; the 202-always contract is untouched. Verified the store rejects public and accepts private writes via SDK probe before this change.

The old public store (`ralph-links`, disconnected) still holds today's earlier events as an archive — nothing references it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)