### PR TITLE
Charts Week: structure levels, click-to-trade, draggable TP/SL, rays + measure

### DIFF
--- a/apps/portal/src/lib/terminal/autocomplete.test.ts
+++ b/apps/portal/src/lib/terminal/autocomplete.test.ts
@@ -1,0 +1,429 @@
+import { describe, expect, test } from "bun:test";
+import type { JournalEntry } from "$lib/journal";
+import type { MarketPoint } from "$lib/phoenix-market-data";
+import {
+  detectSwings,
+  GHOST_DEFAULTS,
+  ghostSizing,
+  ghostStop,
+  ghostTakeProfit,
+  structureLevels,
+} from "./autocomplete";
+
+const DAY_MS = 86_400_000;
+const HOUR_MS = 3_600_000;
+
+function candle(ts: number, high: number, low: number): MarketPoint {
+  const close = (high + low) / 2;
+  return { ts, price: close, open: close, high, low, close };
+}
+
+/** Flat highs (100), lows shaped so window=2 swing lows sit at exactly
+ * 90 (ts 2) and 95 (ts 7). Highs all equal → ties → no swing highs. */
+const SWING_LOW_CANDLES: MarketPoint[] = [
+  candle(0, 100, 97),
+  candle(1, 100, 94),
+  candle(2, 100, 90),
+  candle(3, 100, 94),
+  candle(4, 100, 97),
+  candle(5, 100, 98),
+  candle(6, 100, 96),
+  candle(7, 100, 95),
+  candle(8, 100, 96.5),
+  candle(9, 100, 97),
+];
+
+/** Flat lows (100), highs shaped so window=2 swing highs sit at exactly
+ * 110 (ts 2) and 105 (ts 7). */
+const SWING_HIGH_CANDLES: MarketPoint[] = [
+  candle(0, 103, 100),
+  candle(1, 106, 100),
+  candle(2, 110, 100),
+  candle(3, 106, 100),
+  candle(4, 103, 100),
+  candle(5, 102, 100),
+  candle(6, 104, 100),
+  candle(7, 105, 100),
+  candle(8, 103.5, 100),
+  candle(9, 103, 100),
+];
+
+describe("detectSwings", () => {
+  test("detects a known 5-bar (window=2) swing low", () => {
+    const candles = [
+      candle(0, 10, 5),
+      candle(1, 10, 4),
+      candle(2, 10, 3),
+      candle(3, 10, 4),
+      candle(4, 10, 5),
+    ];
+    expect(detectSwings(candles, 2)).toEqual([
+      { ts: 2, price: 3, kind: "low" },
+    ]);
+  });
+
+  test("detects a known 5-bar (window=2) swing high", () => {
+    const candles = [
+      candle(0, 10, 1),
+      candle(1, 11, 1),
+      candle(2, 12, 1),
+      candle(3, 11, 1),
+      candle(4, 10, 1),
+    ];
+    expect(detectSwings(candles, 2)).toEqual([
+      { ts: 2, price: 12, kind: "high" },
+    ]);
+  });
+
+  test("edge bars are never pivots even when extreme", () => {
+    // Strictly lowest low sits at index 1 — only one bar on its left, so
+    // it cannot qualify with window=2; nothing else qualifies either.
+    const candles = [
+      candle(0, 10, 5),
+      candle(1, 10, 1),
+      candle(2, 10, 3),
+      candle(3, 10, 4),
+      candle(4, 10, 5),
+      candle(5, 10, 6),
+      candle(6, 10, 7),
+    ];
+    expect(detectSwings(candles, 2)).toEqual([]);
+  });
+
+  test("equal lows (ties) are not pivots — strictness", () => {
+    const candles = [
+      candle(0, 10, 5),
+      candle(1, 10, 4),
+      candle(2, 10, 3),
+      candle(3, 10, 3),
+      candle(4, 10, 4),
+      candle(5, 10, 5),
+    ];
+    expect(detectSwings(candles, 2)).toEqual([]);
+  });
+
+  test("multiple pivots come back in chronological order", () => {
+    expect(detectSwings(SWING_LOW_CANDLES, 2)).toEqual([
+      { ts: 2, price: 90, kind: "low" },
+      { ts: 7, price: 95, kind: "low" },
+    ]);
+    expect(detectSwings(SWING_HIGH_CANDLES, 2)).toEqual([
+      { ts: 2, price: 110, kind: "high" },
+      { ts: 7, price: 105, kind: "high" },
+    ]);
+  });
+
+  test("empty and too-short arrays yield []", () => {
+    expect(detectSwings([], 2)).toEqual([]);
+    expect(detectSwings([candle(0, 10, 5)], 2)).toEqual([]);
+    expect(
+      detectSwings(
+        [
+          candle(0, 10, 5),
+          candle(1, 10, 4),
+          candle(2, 10, 3),
+          candle(3, 10, 4),
+        ],
+        2,
+      ),
+    ).toEqual([]);
+  });
+
+  test("window below 1 yields []", () => {
+    expect(detectSwings(SWING_LOW_CANDLES, 0)).toEqual([]);
+  });
+});
+
+describe("ghostStop", () => {
+  const opts = {
+    window: 2,
+    bufferPct: 0.3,
+    prevDayHigh: null,
+    prevDayLow: null,
+  };
+
+  test("long picks the NEAREST swing low below entry, not the lowest", () => {
+    const result = ghostStop(SWING_LOW_CANDLES, "buy", 100, opts);
+    expect(result).toEqual({
+      value: 95 * (1 - 0.3 / 100),
+      provenance: "0.3% below swing low 95.00",
+      source: "swing",
+    });
+  });
+
+  test("long skips swing lows at or above entry", () => {
+    // Entry 94: swing low 95 is above entry, so 90 is the qualifying one.
+    const result = ghostStop(SWING_LOW_CANDLES, "buy", 94, opts);
+    expect(result).toEqual({
+      value: 90 * (1 - 0.3 / 100),
+      provenance: "0.3% below swing low 90.00",
+      source: "swing",
+    });
+  });
+
+  test("long falls back to prev-day low when all swings sit above entry", () => {
+    const result = ghostStop(SWING_LOW_CANDLES, "buy", 89, {
+      ...opts,
+      prevDayLow: 85,
+    });
+    expect(result).toEqual({
+      value: 85 * (1 - 0.3 / 100),
+      provenance: "prev-day low 85.00 − 0.3%",
+      source: "prev-day",
+    });
+  });
+
+  test("long returns null when the fallback is also absent", () => {
+    expect(ghostStop(SWING_LOW_CANDLES, "buy", 89, opts)).toBeNull();
+  });
+
+  test("long returns null when prev-day low is not below entry", () => {
+    expect(
+      ghostStop(SWING_LOW_CANDLES, "buy", 89, { ...opts, prevDayLow: 92 }),
+    ).toBeNull();
+  });
+
+  test("short picks the NEAREST swing high above entry, buffered above", () => {
+    const result = ghostStop(SWING_HIGH_CANDLES, "sell", 100, opts);
+    expect(result).toEqual({
+      value: 105 * (1 + 0.3 / 100),
+      provenance: "0.3% above swing high 105.00",
+      source: "swing",
+    });
+  });
+
+  test("short falls back to prev-day high when swings are all below entry", () => {
+    const result = ghostStop(SWING_HIGH_CANDLES, "sell", 111, {
+      ...opts,
+      prevDayHigh: 115,
+    });
+    expect(result).toEqual({
+      value: 115 * (1 + 0.3 / 100),
+      provenance: "prev-day high 115.00 + 0.3%",
+      source: "prev-day",
+    });
+  });
+
+  test("short returns null without qualifying swing or prev-day high", () => {
+    expect(ghostStop(SWING_HIGH_CANDLES, "sell", 111, opts)).toBeNull();
+  });
+});
+
+describe("ghostTakeProfit", () => {
+  const opts = { window: 2, rMultiple: 2 };
+
+  test("long picks the nearest swing high above entry, unbuffered", () => {
+    const result = ghostTakeProfit(SWING_HIGH_CANDLES, "buy", 100, null, opts);
+    expect(result).toEqual({
+      value: 105,
+      provenance: "nearest swing high 105.00",
+      source: "swing",
+    });
+  });
+
+  test("short picks the nearest swing low below entry", () => {
+    const result = ghostTakeProfit(SWING_LOW_CANDLES, "sell", 100, null, opts);
+    expect(result).toEqual({
+      value: 95,
+      provenance: "nearest swing low 95.00",
+      source: "swing",
+    });
+  });
+
+  test("r-multiple fallback uses the stop distance exactly (long)", () => {
+    const result = ghostTakeProfit([], "buy", 100, 95, opts);
+    expect(result).toEqual({
+      value: 110,
+      provenance: "2R from stop 95.00",
+      source: "r-multiple",
+    });
+  });
+
+  test("r-multiple fallback mirrors for shorts", () => {
+    const result = ghostTakeProfit([], "sell", 100, 105, opts);
+    expect(result).toEqual({
+      value: 90,
+      provenance: "2R from stop 105.00",
+      source: "r-multiple",
+    });
+  });
+
+  test("null without a swing and without a stop", () => {
+    expect(ghostTakeProfit([], "buy", 100, null, opts)).toBeNull();
+  });
+
+  test("null when the stop distance is zero", () => {
+    expect(ghostTakeProfit([], "buy", 100, 100, opts)).toBeNull();
+  });
+});
+
+describe("ghostSizing", () => {
+  function entry(overrides: Partial<JournalEntry> = {}): JournalEntry {
+    return {
+      ts: 1,
+      venue: "perp",
+      symbol: "SOL",
+      action: "long",
+      notionalUsd: 100,
+      price: 100,
+      leverage: 5,
+      signature: "sig",
+      ...overrides,
+    };
+  }
+
+  test("odd count: exact median notional and modal leverage", () => {
+    const entries = [
+      entry({ notionalUsd: 100, leverage: 5 }),
+      entry({ notionalUsd: 300, leverage: 10 }),
+      entry({ notionalUsd: 200, leverage: 5 }),
+    ];
+    expect(ghostSizing(entries, "SOL", 3)).toEqual({
+      notionalUsd: 200,
+      leverage: 5,
+      provenance: "median of your last 3 SOL trades",
+      sampleSize: 3,
+    });
+  });
+
+  test("even count: median is the mean of the two middles", () => {
+    const entries = [
+      entry({ notionalUsd: 400, leverage: 3 }),
+      entry({ notionalUsd: 100, leverage: 3 }),
+      entry({ notionalUsd: 300, leverage: 3 }),
+      entry({ notionalUsd: 200, leverage: 3 }),
+    ];
+    expect(ghostSizing(entries, "SOL", 4)).toEqual({
+      notionalUsd: 250,
+      leverage: 3,
+      provenance: "median of your last 4 SOL trades",
+      sampleSize: 4,
+    });
+  });
+
+  test("modal leverage tie breaks to the LOWER leverage", () => {
+    const entries = [
+      entry({ leverage: 10 }),
+      entry({ leverage: 10 }),
+      entry({ leverage: 5 }),
+      entry({ leverage: 5 }),
+    ];
+    const result = ghostSizing(entries, "SOL", 4);
+    expect(result?.leverage).toBe(5);
+  });
+
+  test("filters by symbol", () => {
+    const entries = [
+      entry({ symbol: "SOL", notionalUsd: 50 }),
+      entry({ symbol: "ETH", notionalUsd: 900 }),
+      entry({ symbol: "SOL", notionalUsd: 150 }),
+      entry({ symbol: "SOL", notionalUsd: 100 }),
+    ];
+    expect(ghostSizing(entries, "SOL", 3)).toEqual({
+      notionalUsd: 100,
+      leverage: 5,
+      provenance: "median of your last 3 SOL trades",
+      sampleSize: 3,
+    });
+  });
+
+  test("filters out spot-venue entries", () => {
+    const entries = [
+      entry({ venue: "spot", notionalUsd: 9_999 }),
+      entry({ notionalUsd: 100 }),
+      entry({ notionalUsd: 200 }),
+      entry({ notionalUsd: 300 }),
+    ];
+    expect(ghostSizing(entries, "SOL", 3)).toEqual({
+      notionalUsd: 200,
+      leverage: 5,
+      provenance: "median of your last 3 SOL trades",
+      sampleSize: 3,
+    });
+  });
+
+  test("entries missing notional or leverage do not count toward the sample", () => {
+    const entries = [
+      entry({ notionalUsd: null }),
+      entry({ leverage: null }),
+      entry(),
+      entry(),
+      entry(),
+    ];
+    expect(ghostSizing(entries, "SOL", 5)).toBeNull();
+  });
+
+  test("null under minSample — 2 trades are noise, not history", () => {
+    const entries = [entry(), entry()];
+    expect(ghostSizing(entries, "SOL", 5)).toBeNull();
+  });
+});
+
+describe("structureLevels", () => {
+  // Previous UTC day = [DAY_MS, 2 * DAY_MS); "now" is 1h into the next day.
+  const nowMs = 2 * DAY_MS + HOUR_MS;
+
+  test("candles spanning two UTC days yield the previous day's exact PDH/PDL", () => {
+    const candles = [
+      // Day before the previous day — extreme values prove exclusion.
+      candle(DAY_MS - HOUR_MS, 200, 1),
+      candle(DAY_MS, 105, 95),
+      candle(DAY_MS + 6 * HOUR_MS, 110, 96),
+      candle(DAY_MS + 12 * HOUR_MS, 108, 92),
+      // Current UTC day — extreme values prove exclusion.
+      candle(2 * DAY_MS, 300, 0.5),
+    ];
+    const result = structureLevels(candles, 2, nowMs);
+    expect(result.prevDayHigh).toBe(110);
+    expect(result.prevDayLow).toBe(92);
+  });
+
+  test("history ending inside the previous day yields nulls but still reports swings", () => {
+    // All candles inside the previous UTC day: its close is not covered,
+    // so no PDH/PDL — but swing math still runs on what is visible.
+    const candles = [
+      candle(DAY_MS, 10, 5),
+      candle(DAY_MS + HOUR_MS, 10, 4),
+      candle(DAY_MS + 2 * HOUR_MS, 10, 3),
+      candle(DAY_MS + 3 * HOUR_MS, 10, 4),
+      candle(DAY_MS + 4 * HOUR_MS, 10, 5),
+    ];
+    expect(structureLevels(candles, 2, nowMs)).toEqual({
+      prevDayHigh: null,
+      prevDayLow: null,
+      swings: [{ ts: DAY_MS + 2 * HOUR_MS, price: 3, kind: "low" }],
+    });
+  });
+
+  test("history starting after the previous day's open yields nulls", () => {
+    const candles = [
+      candle(DAY_MS + 6 * HOUR_MS, 110, 96),
+      candle(DAY_MS + 12 * HOUR_MS, 108, 92),
+      candle(2 * DAY_MS, 300, 0.5),
+    ];
+    expect(structureLevels(candles, 2, nowMs)).toEqual({
+      prevDayHigh: null,
+      prevDayLow: null,
+      swings: [],
+    });
+  });
+
+  test("empty candles yield nulls and no swings", () => {
+    expect(structureLevels([], 2, nowMs)).toEqual({
+      prevDayHigh: null,
+      prevDayLow: null,
+      swings: [],
+    });
+  });
+});
+
+describe("GHOST_DEFAULTS", () => {
+  test("exact default tuning", () => {
+    expect(GHOST_DEFAULTS).toEqual({
+      swingWindow: 5,
+      stopBufferPct: 0.3,
+      tpRMultiple: 2,
+      sizingMinSample: 5,
+    });
+  });
+});

--- a/apps/portal/src/lib/terminal/autocomplete.ts
+++ b/apps/portal/src/lib/terminal/autocomplete.ts
@@ -1,0 +1,261 @@
+// Ghost suggestions for the perp ticket, derived from honest sources only:
+// TP/SL prices from visible chart structure (fractal swing pivots,
+// previous-UTC-day high/low) and size/leverage from the user's own local
+// journal history. Pure module — no DOM, no network, no Date.now(); callers
+// inject candles, journal entries, and the clock. Every suggestion carries
+// a provenance string a human can verify against the chart.
+
+import type { JournalEntry } from "$lib/journal";
+import type { MarketPoint } from "$lib/phoenix-market-data";
+import { fmtTriggerPrice } from "./trade-math";
+
+const DAY_MS = 86_400_000;
+
+export type SwingPoint = { ts: number; price: number; kind: "high" | "low" };
+
+/** N-bar fractal pivots: a bar whose low is strictly the lowest of the
+ * `window` bars on each side is a swing low (mirror for highs). Returns
+ * chronological order. Incomplete edges (fewer than `window` bars on a
+ * side) are never pivots. */
+export function detectSwings(
+  candles: MarketPoint[],
+  window: number,
+): SwingPoint[] {
+  if (!Number.isInteger(window) || window < 1) return [];
+  const swings: SwingPoint[] = [];
+  for (let i = window; i < candles.length - window; i++) {
+    const bar = candles[i];
+    let isHigh = true;
+    let isLow = true;
+    for (let j = i - window; j <= i + window; j++) {
+      if (j === i) continue;
+      const other = candles[j];
+      if (other.high >= bar.high) isHigh = false;
+      if (other.low <= bar.low) isLow = false;
+      if (!isHigh && !isLow) break;
+    }
+    if (isHigh) swings.push({ ts: bar.ts, price: bar.high, kind: "high" });
+    if (isLow) swings.push({ ts: bar.ts, price: bar.low, kind: "low" });
+  }
+  return swings;
+}
+
+export type GhostValue = {
+  value: number;
+  /** Human-verifiable one-liner, e.g. "0.3% below swing low 76.42" or
+   * "prev-day low 75.10 − 0.3%". */
+  provenance: string;
+  /** Which rule produced it — telemetry dimension. */
+  source: "swing" | "prev-day" | "r-multiple" | "journal";
+};
+
+/** Ghost stop for a prospective entry. Long: nearest swing low BELOW entry,
+ * buffered `bufferPct` further below; short: mirrored above. Falls back to
+ * previous-day low/high (same buffer) when no qualifying swing exists.
+ * Returns null when neither source exists — never invent. */
+export function ghostStop(
+  candles: MarketPoint[],
+  side: "buy" | "sell",
+  entryPrice: number,
+  opts: {
+    window: number;
+    bufferPct: number;
+    prevDayHigh: number | null;
+    prevDayLow: number | null;
+  },
+): GhostValue | null {
+  const swings = detectSwings(candles, opts.window);
+  const long = side === "buy";
+  const kind = long ? "low" : "high";
+  let nearest: SwingPoint | null = null;
+  for (const swing of swings) {
+    if (swing.kind !== kind) continue;
+    if (long ? swing.price >= entryPrice : swing.price <= entryPrice) continue;
+    if (
+      nearest === null ||
+      (long ? swing.price > nearest.price : swing.price < nearest.price)
+    ) {
+      nearest = swing;
+    }
+  }
+  if (nearest !== null) {
+    return {
+      value: bufferedStop(nearest.price, long, opts.bufferPct),
+      provenance: long
+        ? `${opts.bufferPct}% below swing low ${fmtTriggerPrice(nearest.price)}`
+        : `${opts.bufferPct}% above swing high ${fmtTriggerPrice(nearest.price)}`,
+      source: "swing",
+    };
+  }
+  const prevDayLevel = long ? opts.prevDayLow : opts.prevDayHigh;
+  if (
+    prevDayLevel !== null &&
+    (long ? prevDayLevel < entryPrice : prevDayLevel > entryPrice)
+  ) {
+    return {
+      value: bufferedStop(prevDayLevel, long, opts.bufferPct),
+      provenance: long
+        ? `prev-day low ${fmtTriggerPrice(prevDayLevel)} − ${opts.bufferPct}%`
+        : `prev-day high ${fmtTriggerPrice(prevDayLevel)} + ${opts.bufferPct}%`,
+      source: "prev-day",
+    };
+  }
+  return null;
+}
+
+function bufferedStop(level: number, long: boolean, bufferPct: number): number {
+  return long ? level * (1 - bufferPct / 100) : level * (1 + bufferPct / 100);
+}
+
+/** Ghost take-profit. Primary: nearest opposing swing beyond entry (swing
+ * high above for longs, swing low below for shorts). Fallback: `rMultiple`
+ * × the stop distance when a stop value is provided. Null when neither
+ * applies. */
+export function ghostTakeProfit(
+  candles: MarketPoint[],
+  side: "buy" | "sell",
+  entryPrice: number,
+  stopPrice: number | null,
+  opts: { window: number; rMultiple: number },
+): GhostValue | null {
+  const swings = detectSwings(candles, opts.window);
+  const long = side === "buy";
+  const kind = long ? "high" : "low";
+  let nearest: SwingPoint | null = null;
+  for (const swing of swings) {
+    if (swing.kind !== kind) continue;
+    if (long ? swing.price <= entryPrice : swing.price >= entryPrice) continue;
+    if (
+      nearest === null ||
+      (long ? swing.price < nearest.price : swing.price > nearest.price)
+    ) {
+      nearest = swing;
+    }
+  }
+  if (nearest !== null) {
+    return {
+      value: nearest.price,
+      provenance: `nearest swing ${kind} ${fmtTriggerPrice(nearest.price)}`,
+      source: "swing",
+    };
+  }
+  if (stopPrice !== null) {
+    const stopDistance = Math.abs(entryPrice - stopPrice);
+    if (stopDistance > 0) {
+      const value = long
+        ? entryPrice + opts.rMultiple * stopDistance
+        : entryPrice - opts.rMultiple * stopDistance;
+      if (value > 0) {
+        return {
+          value,
+          provenance: `${opts.rMultiple}R from stop ${fmtTriggerPrice(stopPrice)}`,
+          source: "r-multiple",
+        };
+      }
+    }
+  }
+  return null;
+}
+
+export type GhostSizing = {
+  notionalUsd: number;
+  leverage: number;
+  provenance: string; // e.g. "median of your last 12 SOL-PERP trades"
+  sampleSize: number;
+};
+
+/** Median notional + modal leverage from the user's own journal entries for
+ * `symbol` (perp/Phoenix venue entries only). Requires >= minSample entries;
+ * null below that — a ghost from 2 trades is noise, not history. */
+export function ghostSizing(
+  entries: JournalEntry[],
+  symbol: string,
+  minSample: number,
+): GhostSizing | null {
+  const notionals: number[] = [];
+  const leverages: number[] = [];
+  for (const entry of entries) {
+    if (entry.venue !== "perp" || entry.symbol !== symbol) continue;
+    const { notionalUsd, leverage } = entry;
+    if (notionalUsd === null || !Number.isFinite(notionalUsd)) continue;
+    if (notionalUsd <= 0) continue;
+    if (leverage === null || !Number.isFinite(leverage)) continue;
+    notionals.push(notionalUsd);
+    leverages.push(leverage);
+  }
+  const sampleSize = notionals.length;
+  if (sampleSize < Math.max(1, minSample)) return null;
+
+  const sorted = [...notionals].sort((a, b) => a - b);
+  const mid = Math.floor(sampleSize / 2);
+  const notionalUsd =
+    sampleSize % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+
+  const counts = new Map<number, number>();
+  for (const value of leverages) {
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  let leverage = leverages[0];
+  let bestCount = 0;
+  for (const [value, count] of counts) {
+    // Ties break to the higher frequency, then the LOWER leverage.
+    if (count > bestCount || (count === bestCount && value < leverage)) {
+      leverage = value;
+      bestCount = count;
+    }
+  }
+
+  return {
+    notionalUsd,
+    leverage,
+    provenance: `median of your last ${sampleSize} ${symbol} trades`,
+    sampleSize,
+  };
+}
+
+export type StructureLevels = {
+  prevDayHigh: number | null;
+  prevDayLow: number | null;
+  swings: SwingPoint[];
+};
+
+/** Previous-UTC-day high/low from candles (null when the loaded history
+ * does not cover the full previous UTC day — honest absence, never a
+ * partial-day value passed off as PDH/PDL) plus detectSwings output.
+ * `nowMs` injected for determinism. Coverage means the history reaches
+ * back to (or before) the previous day's UTC open AND forward into the
+ * current UTC day. */
+export function structureLevels(
+  candles: MarketPoint[],
+  window: number,
+  nowMs: number,
+): StructureLevels {
+  const swings = detectSwings(candles, window);
+  if (candles.length === 0) {
+    return { prevDayHigh: null, prevDayLow: null, swings };
+  }
+  const todayStartMs = Math.floor(nowMs / DAY_MS) * DAY_MS;
+  const prevStartMs = todayStartMs - DAY_MS;
+  let minTs = Number.POSITIVE_INFINITY;
+  let maxTs = Number.NEGATIVE_INFINITY;
+  let high: number | null = null;
+  let low: number | null = null;
+  for (const candle of candles) {
+    if (candle.ts < minTs) minTs = candle.ts;
+    if (candle.ts > maxTs) maxTs = candle.ts;
+    if (candle.ts >= prevStartMs && candle.ts < todayStartMs) {
+      if (high === null || candle.high > high) high = candle.high;
+      if (low === null || candle.low < low) low = candle.low;
+    }
+  }
+  const covered = minTs <= prevStartMs && maxTs >= todayStartMs;
+  if (!covered) return { prevDayHigh: null, prevDayLow: null, swings };
+  return { prevDayHigh: high, prevDayLow: low, swings };
+}
+
+export const GHOST_DEFAULTS = {
+  swingWindow: 5,
+  stopBufferPct: 0.3,
+  tpRMultiple: 2,
+  sizingMinSample: 5,
+} as const;

--- a/apps/portal/src/lib/terminal/chart-lines.test.ts
+++ b/apps/portal/src/lib/terminal/chart-lines.test.ts
@@ -3,7 +3,12 @@ import { colors } from "@trader-ralph/ui/tokens";
 import type { PhoenixOpenOrder, PhoenixPosition } from "$lib/phoenix-trade";
 import type { Alert } from "./alerts";
 import type { SwingPoint } from "./autocomplete";
-import { buildChartLineSpecs, buildStructureLineSpecs } from "./chart-lines";
+import {
+  buildChartLineSpecs,
+  buildStructureLineSpecs,
+  clickTradeLabel,
+  clickTradeSide,
+} from "./chart-lines";
 
 const PREFS_ALL = { pos: true, tpsl: true, orders: true, alerts: true };
 
@@ -284,5 +289,36 @@ describe("buildStructureLineSpecs", () => {
       "swing",
     ]);
     expect(specs.map((spec) => spec.price)).toEqual([160, 140, 155, 145]);
+  });
+});
+
+describe("clickTradeSide", () => {
+  test("hover below mark → long", () => {
+    expect(clickTradeSide(75, 77.2)).toBe("long");
+  });
+
+  test("hover above mark → short", () => {
+    expect(clickTradeSide(80, 77.2)).toBe("short");
+  });
+
+  test("boundary: exactly at mark counts as long (buying at mark)", () => {
+    expect(clickTradeSide(77.2, 77.2)).toBe("long");
+  });
+});
+
+describe("clickTradeLabel", () => {
+  test("formats with the limit field's precision: two decimals ≥10", () => {
+    expect(clickTradeLabel(77.2, 100)).toBe("77.20 · limit long");
+  });
+
+  test("short side above mark", () => {
+    expect(clickTradeLabel(120.456, 100)).toBe("120.46 · limit short");
+  });
+
+  test("sub-cent meme price keeps significant digits", () => {
+    // fmtTriggerPrice keeps 4 significant digits for sub-cent prices.
+    expect(clickTradeLabel(0.00004821, 0.00005)).toBe(
+      "0.00004821 · limit long",
+    );
   });
 });

--- a/apps/portal/src/lib/terminal/chart-lines.test.ts
+++ b/apps/portal/src/lib/terminal/chart-lines.test.ts
@@ -8,7 +8,12 @@ import {
   buildStructureLineSpecs,
   clickTradeLabel,
   clickTradeSide,
+  measureParts,
+  measureReadout,
+  nearestRay,
   positionLineSpecs,
+  RAY_TOLERANCE_PCT,
+  rayLineSpec,
 } from "./chart-lines";
 
 const PREFS_ALL = { pos: true, tpsl: true, orders: true, alerts: true };
@@ -378,5 +383,77 @@ describe("clickTradeLabel", () => {
     expect(clickTradeLabel(0.00004821, 0.00005)).toBe(
       "0.00004821 · limit long",
     );
+  });
+});
+
+describe("rayLineSpec", () => {
+  test("solid 1px muted@60% line, no title, axis label on — exact fields", () => {
+    expect(rayLineSpec(150.25)).toEqual({
+      price: 150.25,
+      color: `${colors.muted}99`, // #8c95a499 — 0x99 ≈ 60% alpha
+      lineWidth: 1,
+      lineStyle: 0,
+      axisLabelVisible: true,
+      title: "",
+    });
+  });
+});
+
+describe("nearestRay", () => {
+  test("none within tolerance → null", () => {
+    expect(nearestRay([100, 110], 105, RAY_TOLERANCE_PCT)).toBeNull();
+    expect(nearestRay([], 105, RAY_TOLERANCE_PCT)).toBeNull();
+  });
+
+  test("exact hit and boundary: tolerance is a % of the clicked price", () => {
+    // ±0.5% of 100 = ±0.5 — 100.5 is exactly on the boundary (inclusive).
+    expect(nearestRay([100.5], 100, RAY_TOLERANCE_PCT)).toBe(100.5);
+    expect(nearestRay([100.51], 100, RAY_TOLERANCE_PCT)).toBeNull();
+    expect(nearestRay([100], 100, RAY_TOLERANCE_PCT)).toBe(100);
+  });
+
+  test("nearest wins when several qualify", () => {
+    expect(nearestRay([100.4, 99.9, 100.3], 100, RAY_TOLERANCE_PCT)).toBe(99.9);
+  });
+
+  test("exact distance ties keep the earliest-placed ray", () => {
+    expect(nearestRay([100.2, 99.8], 100, RAY_TOLERANCE_PCT)).toBe(100.2);
+  });
+});
+
+describe("measureReadout", () => {
+  test("upward drag: exact chip string with signed % and bar count", () => {
+    expect(measureReadout(100, 101.45, 14)).toBe("Δ $1.45 · +1.45% · 14 bars");
+  });
+
+  test("downward drag: Δ stays absolute, % carries the minus sign", () => {
+    expect(measureReadout(100, 98.55, 6)).toBe("Δ $1.45 · -1.45% · 6 bars");
+  });
+
+  test("single bar reads singular", () => {
+    expect(measureReadout(200, 201, 1)).toBe("Δ $1.00 · +0.50% · 1 bar");
+  });
+
+  test("no movement is honest zeros, not a fake reading", () => {
+    expect(measureReadout(100, 100, 0)).toBe("Δ $0 · 0.00% · 0 bars");
+  });
+
+  test("negative bar delta counts as bars (drag direction agnostic)", () => {
+    expect(measureReadout(100, 101.45, -14)).toBe("Δ $1.45 · +1.45% · 14 bars");
+  });
+});
+
+describe("measureParts", () => {
+  test("direction follows the drag; parts compose the readout exactly", () => {
+    const up = measureParts(100, 101.45, 14);
+    expect(up.direction).toBe("up");
+    expect(`${up.delta} · ${up.pct} · ${up.bars}`).toBe(
+      measureReadout(100, 101.45, 14),
+    );
+    expect(measureParts(100, 98.55, 6).direction).toBe("down");
+  });
+
+  test("start-at-or-below-zero renders an honest -- percent", () => {
+    expect(measureParts(0, 5, 2).pct).toBe("--");
   });
 });

--- a/apps/portal/src/lib/terminal/chart-lines.test.ts
+++ b/apps/portal/src/lib/terminal/chart-lines.test.ts
@@ -8,6 +8,7 @@ import {
   buildStructureLineSpecs,
   clickTradeLabel,
   clickTradeSide,
+  positionLineSpecs,
 } from "./chart-lines";
 
 const PREFS_ALL = { pos: true, tpsl: true, orders: true, alerts: true };
@@ -64,7 +65,7 @@ describe("buildChartLineSpecs", () => {
     ).toEqual([]);
   });
 
-  test("full long position renders entry/LIQ/TP/SL with exact fields", () => {
+  test("position renders only the liq estimate — entry/TP/SL belong to the draggable overlay", () => {
     const specs = buildChartLineSpecs(
       [position()],
       [],
@@ -73,41 +74,29 @@ describe("buildChartLineSpecs", () => {
       "SOL",
       "perps",
     );
-    expect(specs).toHaveLength(4);
-    const [entry, liq, tp, sl] = specs;
-    expect(entry.price).toBe(100);
-    expect(entry.color).toBe(colors.up);
-    expect(entry.lineWidth).toBe(2);
-    expect(entry.lineStyle).toBe(0);
-    expect(entry.title).toContain("LONG");
-    expect(entry.title).toContain("+$12.35"); // signed uPnL in the label
-    expect(liq.title).toBe("LIQ est");
-    expect(liq.lineStyle).toBe(2);
-    expect(tp.title).toBe("TP · +$60.00"); // |130-100| × 2
-    expect(tp.color).toBe(colors.up);
-    expect(sl.title).toBe("SL · -$20.00"); // |90-100| × 2
-    expect(sl.color).toBe(colors.down);
+    expect(specs).toEqual([
+      {
+        price: 80,
+        color: colors.down,
+        lineWidth: 1,
+        lineStyle: 2,
+        axisLabelVisible: true,
+        title: "LIQ est",
+      },
+    ]);
   });
 
-  test("short position gets down-colored solid entry with SHORT label", () => {
-    const specs = buildChartLineSpecs(
-      [
-        position({
-          size: -2,
-          takeProfitPrice: null,
-          stopLossPrice: null,
-          liquidationPrice: null,
-        }),
-      ],
-      [],
-      [],
-      PREFS_ALL,
-      "SOL",
-      "perps",
-    );
-    expect(specs).toHaveLength(1);
-    expect(specs[0].color).toBe(colors.down);
-    expect(specs[0].title).toContain("SHORT");
+  test("position without a liq estimate renders nothing here", () => {
+    expect(
+      buildChartLineSpecs(
+        [position({ liquidationPrice: null })],
+        [],
+        [],
+        PREFS_ALL,
+        "SOL",
+        "perps",
+      ),
+    ).toEqual([]);
   });
 
   test("pref groups gate independently", () => {
@@ -119,10 +108,7 @@ describe("buildChartLineSpecs", () => {
       "SOL",
       "perps",
     );
-    expect(posOnly.map((s) => s.title)).toEqual([
-      expect.stringContaining("LONG"),
-      "LIQ est",
-    ]);
+    expect(posOnly.map((s) => s.title)).toEqual(["LIQ est"]);
     const ordersOnly = buildChartLineSpecs(
       [position()],
       [order()],
@@ -173,6 +159,78 @@ describe("buildChartLineSpecs", () => {
       "perps",
     );
     expect(specs[0].title).toBe("ASK");
+  });
+});
+
+describe("positionLineSpecs", () => {
+  test("position with both triggers → entry/tp/sl with exact fields", () => {
+    expect(positionLineSpecs(position())).toEqual([
+      {
+        kind: "entry",
+        price: 100,
+        color: colors.muted,
+        lineWidth: 1,
+        lineStyle: 0,
+        axisLabelVisible: true,
+        title: "entry",
+      },
+      {
+        kind: "tp",
+        price: 130,
+        color: colors.up,
+        lineWidth: 1,
+        lineStyle: 0,
+        axisLabelVisible: true,
+        title: "",
+      },
+      {
+        kind: "sl",
+        price: 90,
+        color: colors.down,
+        lineWidth: 1,
+        lineStyle: 0,
+        axisLabelVisible: true,
+        title: "",
+      },
+    ]);
+  });
+
+  test("missing TP → no tp line at all (drag edits existing triggers only)", () => {
+    expect(
+      positionLineSpecs(position({ takeProfitPrice: null })).map(
+        (spec) => spec.kind,
+      ),
+    ).toEqual(["entry", "sl"]);
+  });
+
+  test("missing SL → no sl line at all", () => {
+    expect(
+      positionLineSpecs(position({ stopLossPrice: null })).map(
+        (spec) => spec.kind,
+      ),
+    ).toEqual(["entry", "tp"]);
+  });
+
+  test("no triggers → entry only", () => {
+    expect(
+      positionLineSpecs(
+        position({ takeProfitPrice: null, stopLossPrice: null }),
+      ).map((spec) => spec.kind),
+    ).toEqual(["entry"]);
+  });
+
+  test("null entry price → triggers still render without an entry anchor", () => {
+    expect(
+      positionLineSpecs(position({ entryPrice: null })).map(
+        (spec) => spec.kind,
+      ),
+    ).toEqual(["tp", "sl"]);
+  });
+
+  test("entry stays muted regardless of position direction", () => {
+    const short = positionLineSpecs(position({ size: -2 }));
+    expect(short[0].color).toBe(colors.muted);
+    expect(short[0].title).toBe("entry");
   });
 });
 

--- a/apps/portal/src/lib/terminal/chart-lines.test.ts
+++ b/apps/portal/src/lib/terminal/chart-lines.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from "bun:test";
 import { colors } from "@trader-ralph/ui/tokens";
 import type { PhoenixOpenOrder, PhoenixPosition } from "$lib/phoenix-trade";
 import type { Alert } from "./alerts";
-import { buildChartLineSpecs } from "./chart-lines";
+import type { SwingPoint } from "./autocomplete";
+import { buildChartLineSpecs, buildStructureLineSpecs } from "./chart-lines";
 
 const PREFS_ALL = { pos: true, tpsl: true, orders: true, alerts: true };
 
@@ -167,5 +168,121 @@ describe("buildChartLineSpecs", () => {
       "perps",
     );
     expect(specs[0].title).toBe("ASK");
+  });
+});
+
+function swing(ts: number, price: number, kind: "high" | "low"): SwingPoint {
+  return { ts, price, kind };
+}
+
+describe("buildStructureLineSpecs", () => {
+  test("empty levels → no lines at all", () => {
+    expect(
+      buildStructureLineSpecs({
+        prevDayHigh: null,
+        prevDayLow: null,
+        swings: [],
+      }),
+    ).toEqual([]);
+  });
+
+  test("PDH/PDL render as dashed faint axis-labeled lines, exact fields", () => {
+    expect(
+      buildStructureLineSpecs({
+        prevDayHigh: 152.4,
+        prevDayLow: 147.1,
+        swings: [],
+      }),
+    ).toEqual([
+      {
+        price: 152.4,
+        color: colors.faint,
+        lineWidth: 1,
+        lineStyle: 2,
+        axisLabelVisible: true,
+        title: "PDH",
+      },
+      {
+        price: 147.1,
+        color: colors.faint,
+        lineWidth: 1,
+        lineStyle: 2,
+        axisLabelVisible: true,
+        title: "PDL",
+      },
+    ]);
+  });
+
+  test("null PDH with present PDL renders only the PDL line", () => {
+    const specs = buildStructureLineSpecs({
+      prevDayHigh: null,
+      prevDayLow: 147.1,
+      swings: [],
+    });
+    expect(specs.map((spec) => spec.title)).toEqual(["PDL"]);
+  });
+
+  test("swings render dotted faint specs without axis labels", () => {
+    expect(
+      buildStructureLineSpecs({
+        prevDayHigh: null,
+        prevDayLow: null,
+        swings: [swing(1_000, 150, "high"), swing(2_000, 140, "low")],
+      }),
+    ).toEqual([
+      {
+        price: 150,
+        color: colors.faint,
+        lineWidth: 1,
+        lineStyle: 1,
+        axisLabelVisible: false,
+        title: "swing",
+      },
+      {
+        price: 140,
+        color: colors.faint,
+        lineWidth: 1,
+        lineStyle: 1,
+        axisLabelVisible: false,
+        title: "swing",
+      },
+    ]);
+  });
+
+  test("caps at the 3 MOST RECENT swings per kind (chronological tail)", () => {
+    const specs = buildStructureLineSpecs({
+      prevDayHigh: null,
+      prevDayLow: null,
+      swings: [
+        swing(1_000, 101, "high"),
+        swing(2_000, 102, "high"),
+        swing(3_000, 103, "high"),
+        swing(4_000, 104, "high"),
+        swing(5_000, 91, "low"),
+        swing(6_000, 92, "low"),
+        swing(7_000, 93, "low"),
+        swing(8_000, 94, "low"),
+      ],
+    });
+    // 3 highs then 3 lows — the oldest of each kind (101, 91) dropped.
+    expect(specs.map((spec) => spec.price)).toEqual([
+      102, 103, 104, 92, 93, 94,
+    ]);
+    expect(specs.every((spec) => spec.title === "swing")).toBe(true);
+  });
+
+  test("PDH/PDL and swings compose in order: PDH, PDL, highs, lows", () => {
+    const specs = buildStructureLineSpecs({
+      prevDayHigh: 160,
+      prevDayLow: 140,
+      swings: [swing(1_000, 155, "high"), swing(2_000, 145, "low")],
+    });
+    expect(specs.map((spec) => spec.title)).toEqual([
+      "PDH",
+      "PDL",
+      "swing",
+      "swing",
+    ]);
+    expect(specs.map((spec) => spec.price)).toEqual([160, 140, 155, 145]);
   });
 });

--- a/apps/portal/src/lib/terminal/chart-lines.ts
+++ b/apps/portal/src/lib/terminal/chart-lines.ts
@@ -10,6 +10,7 @@ import type { PhoenixOpenOrder, PhoenixPosition } from "$lib/phoenix-trade";
 import { formatNumber, formatPrice } from "$lib/utils";
 import type { Alert } from "./alerts";
 import type { StructureLevels } from "./autocomplete";
+import { fmtTriggerPrice } from "./trade-math";
 
 export type PriceLineSpec = {
   price: number;
@@ -180,4 +181,25 @@ export function buildStructureLineSpecs(
     }
   }
   return specs;
+}
+
+/**
+ * Click-to-trade side preview: hovering below the mark reads as a resting
+ * long (buying under the market), above as a resting short. Exactly-at-mark
+ * counts as long — a limit buy at mark is the natural "buy here" intent.
+ */
+export function clickTradeSide(
+  hoverPrice: number,
+  markPrice: number,
+): "long" | "short" {
+  return hoverPrice <= markPrice ? "long" : "short";
+}
+
+/**
+ * Pill label for the armed crosshair line: "77.20 · limit long". Price is
+ * rendered with fmtTriggerPrice — the same precision dialect the ticket's
+ * limit field uses, so what the pill shows is exactly what a click fills.
+ */
+export function clickTradeLabel(hoverPrice: number, markPrice: number): string {
+  return `${fmtTriggerPrice(hoverPrice)} · limit ${clickTradeSide(hoverPrice, markPrice)}`;
 }

--- a/apps/portal/src/lib/terminal/chart-lines.ts
+++ b/apps/portal/src/lib/terminal/chart-lines.ts
@@ -9,6 +9,7 @@ import type { ChartLinePrefs } from "$lib/phoenix-cache";
 import type { PhoenixOpenOrder, PhoenixPosition } from "$lib/phoenix-trade";
 import { formatNumber, formatPrice } from "$lib/utils";
 import type { Alert } from "./alerts";
+import type { StructureLevels } from "./autocomplete";
 
 export type PriceLineSpec = {
   price: number;
@@ -117,6 +118,64 @@ export function buildChartLineSpecs(
         lineStyle: 1,
         axisLabelVisible: true,
         title: `ALERT ${alert.op === "above" ? "↑" : "↓"}`,
+      });
+    }
+  }
+  return specs;
+}
+
+/** How many of the most recent swing highs — and, separately, lows — get a
+ * line each. */
+export const STRUCTURE_SWING_CAP = 3;
+
+/**
+ * Structure-level lines: previous-day high/low as dashed `--faint` lines
+ * with axis labels, plus the STRUCTURE_SWING_CAP most recent swing highs
+ * and lows as dotted whispers. Swings also use `--faint` — `--line`
+ * (#272b34) was tried first and is indistinguishable from the chart grid
+ * on the real canvas — so their subordination comes from style instead:
+ * dotted (lighter per pixel than the PDH/PDL dashes) and no axis label
+ * (six identical "swing" tags would clutter the scale; the pane title
+ * still names the line). Null PDH/PDL and missing swings simply don't
+ * render: honest absence, never a placeholder line.
+ */
+export function buildStructureLineSpecs(
+  levels: StructureLevels,
+): PriceLineSpec[] {
+  const specs: PriceLineSpec[] = [];
+  if (levels.prevDayHigh !== null) {
+    specs.push({
+      price: levels.prevDayHigh,
+      color: colors.faint,
+      lineWidth: 1,
+      lineStyle: 2, // dashed
+      axisLabelVisible: true,
+      title: "PDH",
+    });
+  }
+  if (levels.prevDayLow !== null) {
+    specs.push({
+      price: levels.prevDayLow,
+      color: colors.faint,
+      lineWidth: 1,
+      lineStyle: 2, // dashed
+      axisLabelVisible: true,
+      title: "PDL",
+    });
+  }
+  for (const kind of ["high", "low"] as const) {
+    // detectSwings returns chronological order — the tail is most recent.
+    const recent = levels.swings
+      .filter((swing) => swing.kind === kind)
+      .slice(-STRUCTURE_SWING_CAP);
+    for (const swing of recent) {
+      specs.push({
+        price: swing.price,
+        color: colors.faint,
+        lineWidth: 1,
+        lineStyle: 1, // dotted
+        axisLabelVisible: false,
+        title: "swing",
       });
     }
   }

--- a/apps/portal/src/lib/terminal/chart-lines.ts
+++ b/apps/portal/src/lib/terminal/chart-lines.ts
@@ -7,7 +7,7 @@
 import { colors } from "@trader-ralph/ui/tokens";
 import type { ChartLinePrefs } from "$lib/phoenix-cache";
 import type { PhoenixOpenOrder, PhoenixPosition } from "$lib/phoenix-trade";
-import { formatNumber } from "$lib/utils";
+import { formatNumber, formatPercent, formatPrice } from "$lib/utils";
 import type { Alert } from "./alerts";
 import type { StructureLevels } from "./autocomplete";
 import { fmtTriggerPrice } from "./trade-math";
@@ -211,4 +211,85 @@ export function clickTradeSide(
  */
 export function clickTradeLabel(hoverPrice: number, markPrice: number): string {
   return `${fmtTriggerPrice(hoverPrice)} · limit ${clickTradeSide(hoverPrice, markPrice)}`;
+}
+
+/** Armed-ray removal: a click lands "on" a ray within this % of the
+ * clicked price. */
+export const RAY_TOLERANCE_PCT = 0.5;
+
+/**
+ * A user-placed horizontal ray: solid 1px in `--muted` at 60% alpha
+ * (lightweight-charts feeds colors straight to canvas strokeStyle, which
+ * takes 8-digit hex — 0x99 ≈ 60%; the string stays derived from the token
+ * so the palette drift guard still owns the base hex). No pane title; axis
+ * label on, so the level reads off the scale.
+ */
+export function rayLineSpec(price: number): PriceLineSpec {
+  return {
+    price,
+    color: `${colors.muted}99`,
+    lineWidth: 1,
+    lineStyle: 0, // solid
+    axisLabelVisible: true,
+    title: "",
+  };
+}
+
+/**
+ * The ray an armed click should remove: nearest to the clicked price within
+ * ±tolerancePct (percent of the CLICKED price). Null when none qualifies —
+ * the click places a new ray instead. Exact distance ties keep the
+ * earliest-placed ray (stable FIFO order).
+ */
+export function nearestRay(
+  prices: number[],
+  clickPrice: number,
+  tolerancePct: number,
+): number | null {
+  const tolerance = Math.abs(clickPrice) * (tolerancePct / 100);
+  let best: number | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (const price of prices) {
+    const distance = Math.abs(price - clickPrice);
+    if (distance <= tolerance && distance < bestDistance) {
+      best = price;
+      bestDistance = distance;
+    }
+  }
+  return best;
+}
+
+export type MeasureParts = {
+  delta: string; // "Δ $1.45"
+  pct: string; // "+1.45%" — sign carries the direction
+  bars: string; // "14 bars"
+  direction: "up" | "down";
+};
+
+/**
+ * Measure-chip pieces: Δ is the absolute price move in the terminal price
+ * dialect, % is signed at 2dp (formatPercent — the app has no other pct
+ * convention; chart-format.ts checked), bars is the |logical-index| delta.
+ * Split so the page can color the % segment by direction without
+ * re-deriving any string.
+ */
+export function measureParts(
+  p1: number,
+  p2: number,
+  bars: number,
+): MeasureParts {
+  const pct = p1 > 0 ? ((p2 - p1) / p1) * 100 : null; // p1 ≤ 0 → honest "--"
+  const count = Math.abs(Math.round(bars));
+  return {
+    delta: `Δ $${formatPrice(Math.abs(p2 - p1))}`,
+    pct: formatPercent(pct),
+    bars: `${count} bar${count === 1 ? "" : "s"}`,
+    direction: p2 >= p1 ? "up" : "down",
+  };
+}
+
+/** The exact chip string: "Δ $1.45 · +1.45% · 14 bars". */
+export function measureReadout(p1: number, p2: number, bars: number): string {
+  const parts = measureParts(p1, p2, bars);
+  return `${parts.delta} · ${parts.pct} · ${parts.bars}`;
 }

--- a/apps/portal/src/lib/terminal/chart-lines.ts
+++ b/apps/portal/src/lib/terminal/chart-lines.ts
@@ -7,7 +7,7 @@
 import { colors } from "@trader-ralph/ui/tokens";
 import type { ChartLinePrefs } from "$lib/phoenix-cache";
 import type { PhoenixOpenOrder, PhoenixPosition } from "$lib/phoenix-trade";
-import { formatNumber, formatPrice } from "$lib/utils";
+import { formatNumber } from "$lib/utils";
 import type { Alert } from "./alerts";
 import type { StructureLevels } from "./autocomplete";
 import { fmtTriggerPrice } from "./trade-math";
@@ -34,22 +34,10 @@ export function buildChartLineSpecs(
 
   for (const position of positions) {
     if (position.symbol !== symbol) continue;
-    const side = position.size > 0 ? "LONG" : "SHORT";
-    const sideColor = position.size > 0 ? colors.up : colors.down;
-    if (prefs.pos && position.entryPrice !== null) {
-      const upnl =
-        position.unrealizedPnl !== null
-          ? ` · ${position.unrealizedPnl >= 0 ? "+" : "-"}$${formatNumber(Math.abs(position.unrealizedPnl), 2)}`
-          : "";
-      specs.push({
-        price: position.entryPrice,
-        color: sideColor,
-        lineWidth: 2,
-        lineStyle: 0, // solid
-        axisLabelVisible: true,
-        title: `${side} ${formatNumber(Math.abs(position.size), 4)} @ ${formatPrice(position.entryPrice)}${upnl}`,
-      });
-    }
+    // Entry/TP/SL for the charted position moved to the draggable overlay
+    // (positionLineSpecs + the page's DOM grab handles) — only the liq
+    // estimate still renders from this builder, so the two layers never
+    // draw duplicate lines at the same price.
     if (prefs.pos && position.liquidationPrice !== null) {
       specs.push({
         price: position.liquidationPrice,
@@ -58,40 +46,6 @@ export function buildChartLineSpecs(
         lineStyle: 2, // dashed
         axisLabelVisible: true,
         title: "LIQ est",
-      });
-    }
-    if (
-      prefs.tpsl &&
-      position.takeProfitPrice !== null &&
-      position.entryPrice !== null
-    ) {
-      const gain =
-        Math.abs(position.takeProfitPrice - position.entryPrice) *
-        Math.abs(position.size);
-      specs.push({
-        price: position.takeProfitPrice,
-        color: colors.up,
-        lineWidth: 1,
-        lineStyle: 2,
-        axisLabelVisible: true,
-        title: `TP · +$${formatNumber(gain, 2)}`,
-      });
-    }
-    if (
-      prefs.tpsl &&
-      position.stopLossPrice !== null &&
-      position.entryPrice !== null
-    ) {
-      const loss =
-        Math.abs(position.stopLossPrice - position.entryPrice) *
-        Math.abs(position.size);
-      specs.push({
-        price: position.stopLossPrice,
-        color: colors.down,
-        lineWidth: 1,
-        lineStyle: 2,
-        axisLabelVisible: true,
-        title: `SL · -$${formatNumber(loss, 2)}`,
       });
     }
   }
@@ -121,6 +75,61 @@ export function buildChartLineSpecs(
         title: `ALERT ${alert.op === "above" ? "↑" : "↓"}`,
       });
     }
+  }
+  return specs;
+}
+
+export type PositionLineKind = "entry" | "tp" | "sl";
+
+export type PositionLineSpec = PriceLineSpec & { kind: PositionLineKind };
+
+/**
+ * The charted position's own lines — the draggable TP/SL overlay's pure
+ * half. Entry is a muted always-there anchor (whenever the position has an
+ * entry price), never draggable; TP/SL render ONLY when the position has
+ * that trigger set on-chain. A position without a TP (or SL) gets no line
+ * for it: dragging edits existing triggers, adding new triggers by drag is
+ * out of scope (the ticket sets them at order time). TP/SL carry no pane
+ * title — the price text lives in the DOM grab handle the page attaches at
+ * the right edge — but keep the axis label so the trigger stays readable
+ * when the handle sits off-scale.
+ */
+export function positionLineSpecs(
+  position: PhoenixPosition,
+): PositionLineSpec[] {
+  const specs: PositionLineSpec[] = [];
+  if (position.entryPrice !== null) {
+    specs.push({
+      kind: "entry",
+      price: position.entryPrice,
+      color: colors.muted,
+      lineWidth: 1,
+      lineStyle: 0, // solid
+      axisLabelVisible: true,
+      title: "entry",
+    });
+  }
+  if (position.takeProfitPrice !== null) {
+    specs.push({
+      kind: "tp",
+      price: position.takeProfitPrice,
+      color: colors.up,
+      lineWidth: 1,
+      lineStyle: 0, // solid
+      axisLabelVisible: true,
+      title: "",
+    });
+  }
+  if (position.stopLossPrice !== null) {
+    specs.push({
+      kind: "sl",
+      price: position.stopLossPrice,
+      color: colors.down,
+      lineWidth: 1,
+      lineStyle: 0, // solid
+      axisLabelVisible: true,
+      title: "",
+    });
   }
   return specs;
 }

--- a/apps/portal/src/lib/terminal/prefs.test.ts
+++ b/apps/portal/src/lib/terminal/prefs.test.ts
@@ -134,3 +134,21 @@ describe("dock + drawer prefs", () => {
     ).toBeUndefined();
   });
 });
+
+describe("structure levels pref", () => {
+  test("showLevels round-trips both booleans", () => {
+    expect(parsePrefs(JSON.stringify({ showLevels: false })).showLevels).toBe(
+      false,
+    );
+    expect(parsePrefs(JSON.stringify({ showLevels: true })).showLevels).toBe(
+      true,
+    );
+  });
+
+  test("showLevels rejects non-booleans — absent keeps the ON default", () => {
+    expect(
+      parsePrefs(JSON.stringify({ showLevels: "on" })).showLevels,
+    ).toBeUndefined();
+    expect(parsePrefs(JSON.stringify({})).showLevels).toBeUndefined();
+  });
+});

--- a/apps/portal/src/lib/terminal/prefs.test.ts
+++ b/apps/portal/src/lib/terminal/prefs.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { DEFAULT_PANEL_ORDER, mergeLayout, parsePrefs } from "./prefs";
+import {
+  DEFAULT_PANEL_ORDER,
+  mergeLayout,
+  parsePrefs,
+  parseRays,
+  RAYS_PER_SYMBOL_CAP,
+} from "./prefs";
 
 describe("parsePrefs", () => {
   test("null/malformed/non-object → empty", () => {
@@ -150,5 +156,44 @@ describe("structure levels pref", () => {
       parsePrefs(JSON.stringify({ showLevels: "on" })).showLevels,
     ).toBeUndefined();
     expect(parsePrefs(JSON.stringify({})).showLevels).toBeUndefined();
+  });
+});
+
+describe("rays pref", () => {
+  test("valid payload round-trips per symbol", () => {
+    const prefs = parsePrefs(
+      JSON.stringify({ rays: { SOL: [150.5, 148.2], BTC: [65000] } }),
+    );
+    expect(prefs.rays).toEqual({ SOL: [150.5, 148.2], BTC: [65000] });
+  });
+
+  test("absent key stays undefined — page default {} applies", () => {
+    expect(parsePrefs(JSON.stringify({})).rays).toBeUndefined();
+  });
+
+  test("garbage payloads collapse to {}", () => {
+    expect(parseRays("junk")).toEqual({});
+    expect(parseRays(42)).toEqual({});
+    expect(parseRays(null)).toEqual({});
+    expect(parseRays([150, 160])).toEqual({});
+    expect(parsePrefs(JSON.stringify({ rays: "junk" })).rays).toEqual({});
+  });
+
+  test("filters non-finite/non-positive/non-number prices, drops emptied symbols", () => {
+    expect(
+      parseRays({
+        SOL: [150, "160", Number.NaN, -5, 0, 149.9],
+        BTC: [null, false],
+        ETH: "not-an-array",
+      }),
+    ).toEqual({ SOL: [150, 149.9] });
+  });
+
+  test("caps at 12 per symbol keeping the newest tail (FIFO)", () => {
+    const prices = Array.from({ length: 15 }, (_, i) => i + 1);
+    const parsed = parseRays({ SOL: prices });
+    expect(parsed.SOL).toHaveLength(RAYS_PER_SYMBOL_CAP);
+    expect(parsed.SOL[0]).toBe(4); // oldest three evicted
+    expect(parsed.SOL.at(-1)).toBe(15);
   });
 });

--- a/apps/portal/src/lib/terminal/prefs.ts
+++ b/apps/portal/src/lib/terminal/prefs.ts
@@ -64,7 +64,35 @@ export type TerminalPrefs = {
   macroOpen: boolean;
   /** Structure-level chart lines (PDH/PDL + swing pivots) — default ON. */
   showLevels: boolean;
+  /** User-drawn horizontal rays per symbol (array order = placement order). */
+  rays: Record<string, number[]>;
 };
+
+/** Rays per symbol — placing a 13th evicts the oldest (FIFO). */
+export const RAYS_PER_SYMBOL_CAP = 12;
+
+/**
+ * Validate a persisted rays payload: prices must be finite positive numbers,
+ * capped at RAYS_PER_SYMBOL_CAP per symbol (keeping the newest tail — the
+ * same end FIFO eviction preserves), symbols left with no valid price are
+ * dropped, any non-object garbage collapses to {}.
+ */
+export function parseRays(value: unknown): Record<string, number[]> {
+  const rays: Record<string, number[]> = {};
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return rays;
+  }
+  for (const [symbol, prices] of Object.entries(value)) {
+    if (!Array.isArray(prices)) continue;
+    const valid = prices.filter(
+      (price): price is number =>
+        typeof price === "number" && Number.isFinite(price) && price > 0,
+    );
+    if (valid.length === 0) continue;
+    rays[symbol] = valid.slice(-RAYS_PER_SYMBOL_CAP);
+  }
+  return rays;
+}
 
 /**
  * Validate a raw localStorage prefs payload into the subset of fields that
@@ -148,6 +176,7 @@ export function parsePrefs(raw: string | null): Partial<TerminalPrefs> {
   }
   if (typeof data.macroOpen === "boolean") prefs.macroOpen = data.macroOpen;
   if (typeof data.showLevels === "boolean") prefs.showLevels = data.showLevels;
+  if (data.rays !== undefined) prefs.rays = parseRays(data.rays);
   return prefs;
 }
 
@@ -184,6 +213,7 @@ export function persistPrefs(
   _dockTab: "desk" | "journal" | "alerts",
   _macroOpen: boolean,
   _showLevels: boolean,
+  _rays: Record<string, number[]>,
 ): void {
   if (typeof window === "undefined") return;
   try {
@@ -208,6 +238,7 @@ export function persistPrefs(
         dockTab: _dockTab,
         macroOpen: _macroOpen,
         showLevels: _showLevels,
+        rays: _rays,
       }),
     );
   } catch {

--- a/apps/portal/src/lib/terminal/prefs.ts
+++ b/apps/portal/src/lib/terminal/prefs.ts
@@ -62,6 +62,8 @@ export type TerminalPrefs = {
   tradeLeverage: number;
   dockTab: "desk" | "journal" | "alerts";
   macroOpen: boolean;
+  /** Structure-level chart lines (PDH/PDL + swing pivots) — default ON. */
+  showLevels: boolean;
 };
 
 /**
@@ -145,6 +147,7 @@ export function parsePrefs(raw: string | null): Partial<TerminalPrefs> {
     prefs.dockTab = data.dockTab;
   }
   if (typeof data.macroOpen === "boolean") prefs.macroOpen = data.macroOpen;
+  if (typeof data.showLevels === "boolean") prefs.showLevels = data.showLevels;
   return prefs;
 }
 
@@ -180,6 +183,7 @@ export function persistPrefs(
   _tradeLeverage: number,
   _dockTab: "desk" | "journal" | "alerts",
   _macroOpen: boolean,
+  _showLevels: boolean,
 ): void {
   if (typeof window === "undefined") return;
   try {
@@ -203,6 +207,7 @@ export function persistPrefs(
         tradeLeverage: _tradeLeverage,
         dockTab: _dockTab,
         macroOpen: _macroOpen,
+        showLevels: _showLevels,
       }),
     );
   } catch {

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -51,7 +51,13 @@
   } from "$lib/terminal/welcome";
   import { type Alert, alertsStore } from "$lib/terminal/alerts";
   import {
+    GHOST_DEFAULTS,
+    type StructureLevels,
+    structureLevels,
+  } from "$lib/terminal/autocomplete";
+  import {
     buildChartLineSpecs,
+    buildStructureLineSpecs,
     type PriceLineSpec,
   } from "$lib/terminal/chart-lines";
   import { parseTerminalDeepLink } from "$lib/terminal/deep-link";
@@ -550,6 +556,17 @@
   let chartLineFullSig: string | null = null;
   let chartLineStructSig: string | null = null;
   let chartLineTick = -1;
+  // Structure levels (PDH/PDL + swing pivots) drawn quietly on the chart.
+  // Full data loads recompute immediately (renderChartSeries); websocket
+  // candle ticks only arm the trailing 2 s debounce — never per tick.
+  let showLevels = true;
+  let structLevels: StructureLevels = {
+    prevDayHigh: null,
+    prevDayLow: null,
+    swings: [],
+  };
+  let structureLines: IPriceLine[] = [];
+  let structureTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Intel feeds (Crucix-inspired): event radar, news ticker, sanctions, ideas.
   let news: NewsItem[] = [];
@@ -1137,6 +1154,7 @@
       $tradeLeverage,
       dockTab,
       macroOpen,
+      showLevels,
     );
 
   onMount(() => {
@@ -1232,6 +1250,7 @@
       if (copyResetTimer) clearTimeout(copyResetTimer);
       spotTicket.dispose();
       if (spotChartTimer) clearInterval(spotChartTimer);
+      if (structureTimer !== null) clearTimeout(structureTimer);
       lwChart?.remove();
       lwChart = null;
       candleSeries = null;
@@ -1387,6 +1406,8 @@
     if (tradeMode === "perps") {
       candleSeries?.setData([]);
       volumeSeries?.setData([]);
+      // No candles → no levels; the old market's lines must not linger.
+      recomputeStructureLevels([]);
     }
     legendCandle = null;
     bids = [];
@@ -3376,6 +3397,9 @@
     if (!candleSeries || !volumeSeries) return;
     candleSeries.setData(points.map((point) => toCandle(point, priceMode)));
     volumeSeries.setData(points.map(toVolume));
+    // Full loads are the immediate structure path — every symbol/timeframe
+    // switch, boot paint, gap heal, and spot swap funnels through here.
+    recomputeStructureLevels(points);
   }
 
   function setChartData(): void {
@@ -3391,6 +3415,8 @@
     if (!candleSeries || !volumeSeries) return;
     candleSeries.update(toCandle(point, priceMode));
     volumeSeries.update(toVolume(point));
+    // Debounced — this is the per-tick hot path; see the scheduler.
+    scheduleStructureRecompute();
   }
 
   function applyPriceScaleMode(mode: PriceScaleMode): void {
@@ -3721,6 +3747,46 @@
     return sig;
   }
 
+  // ── Structure levels: PDH/PDL + swing pivots, drawn quietly ─────────
+  const STRUCTURE_DEBOUNCE_MS = 2_000;
+
+  // Immediate path: full data loads only (symbol/timeframe switch, boot,
+  // gap heal, spot swaps) plus the footer toggle — infrequent by nature.
+  function recomputeStructureLevels(points: MarketPoint[]): void {
+    structLevels = structureLevels(
+      points,
+      GHOST_DEFAULTS.swingWindow,
+      Date.now(),
+    );
+    applyStructureLines();
+  }
+
+  // Tick path: the websocket can update the live candle many times a
+  // second, but swing pivots and PDH/PDL barely move within a bar — arm a
+  // single trailing 2 s timer and recompute once when it fires. Never
+  // recompute per tick.
+  function scheduleStructureRecompute(): void {
+    if (structureTimer !== null) return; // already armed — coalesce
+    structureTimer = setTimeout(() => {
+      structureTimer = null;
+      recomputeStructureLevels(
+        tradeMode === "spot" ? spotChartPoints : chartPoints,
+      );
+    }, STRUCTURE_DEBOUNCE_MS);
+  }
+
+  function applyStructureLines(): void {
+    const series = candleSeries;
+    if (!series) return;
+    // Remove before re-adding — stale handles must never leak duplicates.
+    for (const line of structureLines) series.removePriceLine(line);
+    structureLines = [];
+    if (!showLevels) return;
+    for (const spec of buildStructureLineSpecs(structLevels)) {
+      structureLines.push(series.createPriceLine(spec));
+    }
+  }
+
   // ── Journal ────────────────────────────────────────────────────────
   function noteTrade(entry: JournalEntry): void {
     journalEntries = recordTrade(entry);
@@ -3909,6 +3975,7 @@
     if (prefs.tradeLeverage !== undefined) $tradeLeverage = prefs.tradeLeverage;
     if (prefs.dockTab !== undefined) dockTab = prefs.dockTab;
     if (prefs.macroOpen !== undefined) macroOpen = prefs.macroOpen;
+    if (prefs.showLevels !== undefined) showLevels = prefs.showLevels;
   }
 
   function loadOpenBetaBanner(): void {
@@ -4423,6 +4490,22 @@
           }}
         >
           log
+        </button>
+        <button
+          class:active={showLevels}
+          type="button"
+          aria-pressed={showLevels}
+          title="Toggle structure levels (PDH/PDL, swings)"
+          onclick={() => {
+            showLevels = !showLevels;
+            // OFF removes every structure line immediately; ON recomputes
+            // fresh from the candles currently on the chart.
+            recomputeStructureLevels(
+              tradeMode === "spot" ? spotChartPoints : chartPoints,
+            );
+          }}
+        >
+          levels
         </button>
         <button
           class:active={autoFollow}

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -58,6 +58,8 @@
   import {
     buildChartLineSpecs,
     buildStructureLineSpecs,
+    clickTradeLabel,
+    clickTradeSide,
     type PriceLineSpec,
   } from "$lib/terminal/chart-lines";
   import { parseTerminalDeepLink } from "$lib/terminal/deep-link";
@@ -567,6 +569,15 @@
   };
   let structureLines: IPriceLine[] = [];
   let structureTimer: ReturnType<typeof setTimeout> | null = null;
+  // Click-to-trade: armed per-session only (never persisted — arming is an
+  // intent, not a preference; defaults OFF every load). While armed, ONE
+  // reusable price line follows the crosshair and a click prefills the perp
+  // ticket then disarms. Zero overhead when off: the crosshair/click
+  // subscriptions exist only while armed.
+  let clickTradeArmed = false;
+  let clickTradeLine: IPriceLine | null = null;
+  let clickTradeHover: { y: number; right: number; label: string } | null =
+    null;
 
   // Intel feeds (Crucix-inspired): event radar, news ticker, sanctions, ideas.
   let news: NewsItem[] = [];
@@ -2090,6 +2101,9 @@
     }
     if (mode === "spot") {
       bookTab = "trade";
+      // Click-to-trade is perp-only — the armed crosshair must not survive
+      // onto the spot surface.
+      disarmClickTrade();
       // Take ownership of the chart surface immediately — never leave the
       // perp series sitting under a spot label while candles load.
       spotChartPoints = [];
@@ -3334,7 +3348,8 @@
     // FIT or a double-click on the price axis re-arms auto-fit.
     let pressPoint: { x: number; y: number } | null = null;
     container.addEventListener("mousedown", (event) => {
-      container.style.cursor = "grabbing";
+      // While click-to-trade is armed the crosshair cursor wins throughout.
+      container.style.cursor = clickTradeArmed ? "crosshair" : "grabbing";
       pressPoint = { x: event.clientX, y: event.clientY };
     });
     container.addEventListener("mousemove", (event) => {
@@ -3347,11 +3362,11 @@
       }
     });
     container.addEventListener("mouseup", () => {
-      container.style.cursor = "grab";
+      container.style.cursor = clickTradeArmed ? "crosshair" : "grab";
       pressPoint = null;
     });
     container.addEventListener("mouseleave", () => {
-      container.style.cursor = "grab";
+      container.style.cursor = clickTradeArmed ? "crosshair" : "grab";
       pressPoint = null;
     });
     // Alt+click sets a price alert at the cursor — drag infra's cousin.
@@ -3787,6 +3802,86 @@
     }
   }
 
+  // ── Click-to-trade: armed crosshair → one-shot limit prefill ────────
+  // Perp-only. Subscribe on arm, unsubscribe on disarm — the unarmed path
+  // registers nothing. The follow line is ONE reusable price-line handle
+  // (created on first hover, applyOptions per move, removed on disarm) —
+  // never created/removed per crosshair move.
+  function armClickTrade(): void {
+    if (clickTradeArmed || tradeMode !== "perps" || !lwChart) return;
+    clickTradeArmed = true;
+    lwChart.subscribeCrosshairMove(onClickTradeCrosshair);
+    lwChart.subscribeClick(onClickTradeClick);
+    if (chartContainer) chartContainer.style.cursor = "crosshair";
+  }
+
+  function disarmClickTrade(): void {
+    if (!clickTradeArmed) return;
+    clickTradeArmed = false;
+    lwChart?.unsubscribeCrosshairMove(onClickTradeCrosshair);
+    lwChart?.unsubscribeClick(onClickTradeClick);
+    removeClickTradeLine();
+    if (chartContainer) chartContainer.style.cursor = "grab";
+  }
+
+  function removeClickTradeLine(): void {
+    if (clickTradeLine && candleSeries) {
+      candleSeries.removePriceLine(clickTradeLine);
+    }
+    clickTradeLine = null;
+    clickTradeHover = null;
+  }
+
+  // Hovered PRICE from the crosshair's y coordinate — valid only over the
+  // plot area with a live mark to preview the side against.
+  function clickTradeHoverPrice(param: MouseEventParams): number | null {
+    if (!param.point || !candleSeries || latestPrice === null) return null;
+    const price = Number(candleSeries.coordinateToPrice(param.point.y));
+    return Number.isFinite(price) && price > 0 ? price : null;
+  }
+
+  function onClickTradeCrosshair(param: MouseEventParams): void {
+    const price = clickTradeHoverPrice(param);
+    if (price === null || latestPrice === null || !param.point) {
+      // Left the plot (or no mark yet): hide the preview, keep armed.
+      removeClickTradeLine();
+      return;
+    }
+    if (clickTradeLine) {
+      clickTradeLine.applyOptions({ price });
+    } else if (candleSeries) {
+      clickTradeLine = candleSeries.createPriceLine({
+        price,
+        color: colors.muted,
+        lineWidth: 1,
+        lineStyle: LineStyle.Solid,
+        axisLabelVisible: true,
+        title: "",
+      });
+    }
+    clickTradeHover = {
+      y: param.point.y,
+      right: (lwChart?.priceScale("right").width() ?? 0) + 6,
+      label: clickTradeLabel(price, latestPrice),
+    };
+  }
+
+  function onClickTradeClick(param: MouseEventParams): void {
+    // Alt+click stays the set-alert gesture even while armed.
+    if (param.sourceEvent?.altKey) return;
+    const mark = latestPrice;
+    const price = clickTradeHoverPrice(param);
+    if (price === null || mark === null || tradeMode !== "perps") return;
+    // One-shot fill: limit ticket at the hovered price, side per the
+    // long-at-or-below / short-above rule. NOTHING submits — the trader
+    // lands on the size input with the order staged.
+    $tradeType = "limit";
+    $tradeLimitPrice = fmtTriggerPrice(price);
+    $tradeSide = clickTradeSide(price, mark) === "long" ? "buy" : "sell";
+    disarmClickTrade();
+    focusTicketSize();
+  }
+
   // ── Journal ────────────────────────────────────────────────────────
   function noteTrade(entry: JournalEntry): void {
     journalEntries = recordTrade(entry);
@@ -4062,6 +4157,14 @@
   }
 
   function onGlobalKeydown(event: KeyboardEvent): void {
+    // Armed click-to-trade owns Escape: disarm only, swallowed before the
+    // modal-close block below so one Escape never doubles as modal-close
+    // (same key-swallowing posture as the funding wizard).
+    if (event.key === "Escape" && clickTradeArmed) {
+      event.stopPropagation();
+      disarmClickTrade();
+      return;
+    }
     if (event.key === "Escape") {
       if (tradeOpen) tradeOpen = false;
       if (authOpen) authOpen = false;
@@ -4417,6 +4520,15 @@
           {/if}
 
           <div class="chart-canvas" bind:this={chartContainer}></div>
+
+          {#if clickTradeArmed && clickTradeHover}
+            <div
+              class="click-trade-pill"
+              style="top: {clickTradeHover.y}px; right: {clickTradeHover.right}px;"
+            >
+              {clickTradeHover.label}
+            </div>
+          {/if}
         </div>
       </div>
 
@@ -4506,6 +4618,18 @@
           }}
         >
           levels
+        </button>
+        <button
+          class:active={clickTradeArmed}
+          type="button"
+          aria-pressed={clickTradeArmed}
+          disabled={tradeMode === "spot"}
+          title={tradeMode === "spot"
+            ? "perps only for now"
+            : "Arm click-to-trade — click the chart to stage a limit order"}
+          onclick={() => (clickTradeArmed ? disarmClickTrade() : armClickTrade())}
+        >
+          trade
         </button>
         <button
           class:active={autoFollow}
@@ -5370,6 +5494,14 @@
     border-color: rgba(255, 77, 151, 0.7);
   }
 
+  /* Honest gating: the trade toggle stays visible but inert on Spot. */
+  .chart-footer button:disabled {
+    color: var(--faint);
+    cursor: not-allowed;
+    transform: none;
+    border-color: transparent;
+  }
+
   .chart-market-tools {
     flex: 1;
     justify-content: center;
@@ -5544,6 +5676,22 @@
   .chart-canvas {
     position: absolute;
     inset: 0;
+  }
+
+  /* Armed click-to-trade: side/price preview pill riding the crosshair
+     line at the right edge of the plot (just left of the price scale). */
+  .click-trade-pill {
+    position: absolute;
+    z-index: 4;
+    transform: translateY(-50%);
+    padding: 0.1rem 0.4rem;
+    border: 1px solid var(--line);
+    background: var(--surface);
+    color: var(--ink);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px;
+    white-space: nowrap;
+    pointer-events: none;
   }
 
   .chart-empty {

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -60,6 +60,8 @@
     buildStructureLineSpecs,
     clickTradeLabel,
     clickTradeSide,
+    type PositionLineKind,
+    positionLineSpecs,
     type PriceLineSpec,
   } from "$lib/terminal/chart-lines";
   import { parseTerminalDeepLink } from "$lib/terminal/deep-link";
@@ -578,6 +580,48 @@
   let clickTradeLine: IPriceLine | null = null;
   let clickTradeHover: { y: number; right: number; label: string } | null =
     null;
+  // Draggable TP/SL overlay: the charted position's entry/TP/SL price lines
+  // plus DOM grab handles on the TP/SL lines. Line handles are reusable
+  // (applyOptions on change, guarded by a price memo — never re-created per
+  // WS event); the drag itself is transform/option-update only. tpslPending
+  // holds a just-submitted trigger at the dragged price until the lagging
+  // indexer confirms it (or 25s pass) — the position ROW keeps rendering
+  // chain state throughout; only these chart lines preview.
+  type TpSlKind = Exclude<PositionLineKind, "entry">;
+  let posOverlayLines: Record<PositionLineKind, IPriceLine | null> = {
+    entry: null,
+    tp: null,
+    sl: null,
+  };
+  let posOverlayPrices: Record<PositionLineKind, number | null> = {
+    entry: null,
+    tp: null,
+    sl: null,
+  };
+  let tpHandleEl: HTMLButtonElement | null = null;
+  let slHandleEl: HTMLButtonElement | null = null;
+  let tpslHandleCache: Record<
+    TpSlKind,
+    { el: HTMLButtonElement | null; y: number | null; right: number | null }
+  > = {
+    tp: { el: null, y: null, right: null },
+    sl: { el: null, y: null, right: null },
+  };
+  let tpslDrag: {
+    kind: TpSlKind;
+    pointerId: number;
+    startPrice: number;
+    price: number;
+    chartTop: number;
+    moved: boolean;
+  } | null = null;
+  let tpslPending: {
+    kind: TpSlKind;
+    price: number;
+    from: number;
+    until: number;
+  } | null = null;
+  let tpslFrame: number | null = null;
 
   // Intel feeds (Crucix-inspired): event radar, news ticker, sanctions, ideas.
   let news: NewsItem[] = [];
@@ -1262,6 +1306,10 @@
       spotTicket.dispose();
       if (spotChartTimer) clearInterval(spotChartTimer);
       if (structureTimer !== null) clearTimeout(structureTimer);
+      if (tpslFrame !== null) cancelAnimationFrame(tpslFrame);
+      tpslFrame = null;
+      posOverlayLines = { entry: null, tp: null, sl: null };
+      posOverlayPrices = { entry: null, tp: null, sl: null };
       lwChart?.remove();
       lwChart = null;
       candleSeries = null;
@@ -3397,6 +3445,17 @@
     liqLines = [];
     chartLineFullSig = null;
     chartLineStructSig = null;
+    // The draggable TP/SL overlay's lines died with the old series too —
+    // drop the stale handles and redraw against the fresh series.
+    posOverlayLines = { entry: null, tp: null, sl: null };
+    posOverlayPrices = { entry: null, tp: null, sl: null };
+    syncPositionOverlay(
+      selectedPosition,
+      entryLinePrice,
+      tpHandlePrice,
+      slHandlePrice,
+      tradeMode,
+    );
     refreshChartLines(
       enrichedPositions,
       perpOpenOrders,
@@ -3882,6 +3941,347 @@
     focusTicketSize();
   }
 
+  // ── Draggable TP/SL overlay: the open position drawn on the chart ───
+  // Entry line (muted, not draggable) whenever the charted perp position
+  // exists; TP/SL lines with DOM grab handles ONLY when the position has
+  // that trigger set on-chain — dragging EDITS existing triggers, adding
+  // new ones by drag is out of scope (the ticket sets them at order time).
+  // Footer prefs keep their meaning: POS gates entry, TP/SL gates triggers.
+  // No position on the charted symbol → zero lines, zero rAF, zero
+  // subscriptions (the handles are the only event surface).
+
+  // Line/handle price per trigger: live drag preview wins, then an
+  // in-flight (submitted, indexer-lagging) edit, then chain state.
+  function tpslOverlayPrice(
+    kind: TpSlKind,
+    drag: typeof tpslDrag,
+    pending: typeof tpslPending,
+    position: PhoenixPosition | null,
+    mode: "perps" | "spot",
+    enabled: boolean,
+  ): number | null {
+    if (mode !== "perps" || !enabled || !position) return null;
+    const trigger =
+      kind === "tp" ? position.takeProfitPrice : position.stopLossPrice;
+    if (trigger === null) return null; // no trigger → no line, no handle
+    if (drag?.kind === kind) return drag.price;
+    if (pending?.kind === kind) return pending.price;
+    return trigger;
+  }
+
+  $: entryLinePrice =
+    tradeMode === "perps" && $chartLinePrefs.pos && selectedPosition
+      ? selectedPosition.entryPrice
+      : null;
+  $: tpHandlePrice = tpslOverlayPrice(
+    "tp",
+    tpslDrag,
+    tpslPending,
+    selectedPosition,
+    tradeMode,
+    $chartLinePrefs.tpsl,
+  );
+  $: slHandlePrice = tpslOverlayPrice(
+    "sl",
+    tpslDrag,
+    tpslPending,
+    selectedPosition,
+    tradeMode,
+    $chartLinePrefs.tpsl,
+  );
+  $: syncPositionOverlay(
+    selectedPosition,
+    entryLinePrice,
+    tpHandlePrice,
+    slHandlePrice,
+    tradeMode,
+  );
+
+  // An in-flight edit's preview clears the moment the indexer reports a
+  // trigger different from the pre-drag one (fmtTriggerPrice equality — the
+  // chain quantizes to tick size, exact float match would never clear), the
+  // trigger disappears, or the 25 s horizon passes. Only then does chain
+  // state own the line again.
+  $: if (tpslPending) {
+    const confirmed = selectedPosition
+      ? tpslPending.kind === "tp"
+        ? selectedPosition.takeProfitPrice
+        : selectedPosition.stopLossPrice
+      : null;
+    if (
+      nowMs >= tpslPending.until ||
+      confirmed === null ||
+      fmtTriggerPrice(confirmed) !== fmtTriggerPrice(tpslPending.from)
+    ) {
+      tpslPending = null;
+    }
+  }
+
+  function syncPositionOverlay(
+    position: PhoenixPosition | null,
+    entryPrice: number | null,
+    tpPrice: number | null,
+    slPrice: number | null,
+    mode: "perps" | "spot",
+  ): void {
+    const series = candleSeries;
+    if (!series) return;
+    const specs =
+      mode === "perps" && position ? positionLineSpecs(position) : [];
+    const prices: Record<PositionLineKind, number | null> = {
+      entry: entryPrice,
+      tp: tpPrice,
+      sl: slPrice,
+    };
+    for (const kind of ["entry", "tp", "sl"] as const) {
+      const spec = specs.find((candidate) => candidate.kind === kind);
+      const price = spec ? prices[kind] : null;
+      const held = posOverlayLines[kind];
+      if (spec === undefined || price === null) {
+        if (held) {
+          series.removePriceLine(held);
+          posOverlayLines[kind] = null;
+          posOverlayPrices[kind] = null;
+        }
+        // Position/trigger vanished mid-drag (closed, symbol or mode
+        // switch) — drop the drag rather than edit a ghost.
+        if (tpslDrag?.kind === kind) tpslDrag = null;
+        continue;
+      }
+      if (held) {
+        // Option-update only (styles are static per kind); the price memo
+        // keeps WS-rate reruns from repainting an unchanged line.
+        if (posOverlayPrices[kind] !== price) {
+          held.applyOptions({ price });
+          posOverlayPrices[kind] = price;
+        }
+      } else {
+        posOverlayLines[kind] = series.createPriceLine({
+          price,
+          color: spec.color,
+          lineWidth: spec.lineWidth,
+          lineStyle: spec.lineStyle,
+          axisLabelVisible: spec.axisLabelVisible,
+          title: spec.title,
+        });
+        posOverlayPrices[kind] = price;
+      }
+    }
+    // The reposition loop exists ONLY while a draggable handle is on
+    // screen; it dies with the last TP/SL line.
+    const needsFrame =
+      posOverlayLines.tp !== null || posOverlayLines.sl !== null;
+    if (needsFrame && tpslFrame === null) {
+      tpslFrame = requestAnimationFrame(tpslFrameTick);
+    } else if (!needsFrame && tpslFrame !== null) {
+      cancelAnimationFrame(tpslFrame);
+      tpslFrame = null;
+    }
+  }
+
+  // Handle repositioning mechanism: lightweight-charts v5 exposes NO
+  // price-scale change hook (typings checked — only timeScale
+  // visible-range/size and series dataChanged; a manual price-axis rescale
+  // or an autoscale shift from a live tick fires none of them), so a rAF
+  // loop owns handle geometry while handles exist. Cost: ≤2
+  // priceToCoordinate calls (pure math, no layout read) and ≤2 memoized
+  // transform writes per frame — and syncPositionOverlay cancels the loop
+  // the moment the charted position loses its triggers.
+  function tpslFrameTick(): void {
+    tpslFrame = requestAnimationFrame(tpslFrameTick);
+    placeTpSlHandle("tp", tpHandleEl, tpHandlePrice);
+    placeTpSlHandle("sl", slHandleEl, slHandlePrice);
+  }
+
+  function placeTpSlHandle(
+    kind: TpSlKind,
+    el: HTMLButtonElement | null,
+    price: number | null,
+  ): void {
+    if (tpslHandleCache[kind].el !== el) {
+      // Fresh (re)mount: forget cached geometry so the new element gets
+      // positioned before its CSS visibility:hidden lifts.
+      tpslHandleCache[kind] = { el, y: null, right: null };
+    }
+    if (!el || price === null || !candleSeries || !lwChart) return;
+    const cache = tpslHandleCache[kind];
+    const y = candleSeries.priceToCoordinate(price);
+    // Null = scale not ready; out-of-pane coordinates (the library returns
+    // them for prices beyond the visible range, it does NOT null them) would
+    // float the handle over the chart header — hide in both cases.
+    if (y === null || y < 0 || y > lwChart.paneSize().height) {
+      if (cache.y !== null) {
+        el.style.visibility = "hidden";
+        cache.y = null;
+      }
+      return;
+    }
+    const snapped = Math.round(y * 2) / 2;
+    if (cache.y !== snapped) {
+      // Transform-only write — translates, never triggers layout.
+      el.style.transform = `translate(0, ${snapped}px) translateY(-50%)`;
+      el.style.visibility = "visible";
+      cache.y = snapped;
+    }
+    const right = Math.round(lwChart.priceScale("right").width()) + 4;
+    if (right !== cache.right) {
+      // `right` is a layout write, but the price-scale width changes only
+      // when the axis re-measures — effectively never per frame.
+      el.style.right = `${right}px`;
+      cache.right = right;
+    }
+  }
+
+  function tpslBusyKey(position: PhoenixPosition): string {
+    return `tpsl:${position.symbol}:${position.subaccountIndex}`;
+  }
+
+  function onTpSlHandleDown(event: PointerEvent, kind: TpSlKind): void {
+    const position = selectedPosition;
+    if (!position || !chartContainer || tpslDrag || tpslPending) return;
+    if (phoenixBusyKeys.has(tpslBusyKey(position))) return;
+    const trigger =
+      kind === "tp" ? position.takeProfitPrice : position.stopLossPrice;
+    if (trigger === null) return;
+    event.preventDefault();
+    (kind === "tp" ? tpHandleEl : slHandleEl)?.setPointerCapture(
+      event.pointerId,
+    );
+    tpslDrag = {
+      kind,
+      pointerId: event.pointerId,
+      startPrice: trigger,
+      price: trigger,
+      // Cached once — the chart doesn't move mid-drag, so pointermove
+      // never needs a layout read.
+      chartTop: chartContainer.getBoundingClientRect().top,
+      moved: false,
+    };
+  }
+
+  function onTpSlHandleMove(event: PointerEvent): void {
+    if (!tpslDrag || event.pointerId !== tpslDrag.pointerId || !candleSeries) {
+      return;
+    }
+    const price = Number(
+      candleSeries.coordinateToPrice(event.clientY - tpslDrag.chartTop),
+    );
+    if (!Number.isFinite(price) || price <= 0) return;
+    // Reassign, never mutate: line price and handle label derive from this.
+    tpslDrag = { ...tpslDrag, price, moved: true };
+  }
+
+  // ESC mid-drag and pointercancel land here: dropping the drag state
+  // snaps line + label back to the position's real trigger.
+  function cancelTpSlDrag(): void {
+    tpslDrag = null;
+  }
+
+  function onTpSlHandleUp(event: PointerEvent): void {
+    const drag = tpslDrag;
+    if (!drag || event.pointerId !== drag.pointerId) return;
+    tpslDrag = null;
+    const position = selectedPosition;
+    if (!drag.moved || !position) return;
+    const current =
+      drag.kind === "tp" ? position.takeProfitPrice : position.stopLossPrice;
+    if (current === null) return; // trigger vanished mid-drag
+    // Unchanged at the trigger dialect's own precision → a grab, not an edit.
+    if (fmtTriggerPrice(drag.price) === fmtTriggerPrice(current)) return;
+    // Same side-validity the ticket enforces at order time, against the
+    // mark: a wrong-side trigger would fire the moment it lands on-chain.
+    const mark =
+      marketMids[position.symbol] ??
+      (position.symbol === selectedSymbol ? latestPrice : null);
+    const long = position.size > 0;
+    if (mark !== null) {
+      const valid =
+        drag.kind === "tp"
+          ? long
+            ? drag.price > mark
+            : drag.price < mark
+          : long
+            ? drag.price < mark
+            : drag.price > mark;
+      if (!valid) {
+        phoenixActionError =
+          drag.kind === "tp"
+            ? `Take profit must be ${long ? "above" : "below"} the mark — trigger unchanged`
+            : `Stop loss must be ${long ? "below" : "above"} the mark — trigger unchanged`;
+        phoenixActionErrorDetail = "";
+        phoenixActionRetry = null;
+        return; // snap back — the drag state is already cleared
+      }
+    }
+    void submitTpSlDrag(position, drag.kind, drag.price, current);
+  }
+
+  // Release path: the position row has NO TP/SL editor today —
+  // buildSetPositionTpSlIxs (phoenix-trade.ts) is the app's only TP/SL
+  // edit machinery, and simulate→auto-sign (ratified 2026-07-02) its only
+  // confirmation posture, exactly how Close/Margin+ submit from the row.
+  // A completed drag therefore submits through that same existing pipeline
+  // (no new transaction code, no new confirm UI). The drag is pointer-only
+  // by design: keyboard/AT users keep the position row as the accessible
+  // TP/SL surface (read-only there today — a follow-up row editor should
+  // reuse submitTpSlDrag's body).
+  async function submitTpSlDrag(
+    position: PhoenixPosition,
+    kind: TpSlKind,
+    price: number,
+    fromPrice: number,
+  ): Promise<void> {
+    const busyKey = tpslBusyKey(position);
+    if (!phoenixAuthority || phoenixBusyKeys.has(busyKey)) return;
+    setPhoenixBusy(busyKey, true);
+    phoenixActionError = "";
+    phoenixActionErrorDetail = "";
+    phoenixActionRetry = null;
+    // Hold the line at the dragged price while the tx flies and the lagging
+    // indexer catches up; the position ROW keeps rendering chain state the
+    // whole time — only the chart line previews.
+    tpslPending = { kind, price, from: fromPrice, until: Date.now() + 25_000 };
+    const preFingerprint = snapshotFingerprint();
+    const label = kind === "tp" ? "take profit" : "stop loss";
+    try {
+      const instructions = await (await tradeModule()).buildSetPositionTpSlIxs(
+        phoenixAuthority,
+        position,
+        kind === "tp" ? { takeProfitPrice: price } : { stopLossPrice: price },
+      );
+      lastTradeSignature = await signAndSendPhoenixIxs(
+        instructions,
+        {
+          title: `Move ${label} · ${position.symbol}-PERP`,
+          details: [
+            "Venue: Phoenix Perps",
+            `${kind === "tp" ? "Take profit" : "Stop loss"}: ${formatPrice(fromPrice)} → ${formatPrice(price)}`,
+          ],
+        },
+        busyKey,
+      );
+      track("tpsl_dragged", {
+        ...marketContext(),
+        trigger: kind,
+        fromPrice,
+        toPrice: price,
+        signature: lastTradeSignature,
+      });
+      void burstRefreshPhoenix(preFingerprint);
+    } catch (error) {
+      tpslPending = null; // snap back to the position's real trigger
+      const human = humanizeTradeError(error);
+      phoenixActionError = human.text;
+      phoenixActionErrorDetail = human.detail;
+      phoenixActionRetry = null; // re-dragging is the natural retry gesture
+      if (human.confirmUncertain) void burstRefreshPhoenix(preFingerprint);
+      markLastTxFailed(busyKey);
+    } finally {
+      setPhoenixBusy(busyKey, false);
+      clearTxStage(busyKey);
+    }
+  }
+
   // ── Journal ────────────────────────────────────────────────────────
   function noteTrade(entry: JournalEntry): void {
     journalEntries = recordTrade(entry);
@@ -4157,6 +4557,13 @@
   }
 
   function onGlobalKeydown(event: KeyboardEvent): void {
+    // A live TP/SL drag owns Escape ahead of everything: cancel the drag
+    // (snap back) and swallow — one Escape never doubles as anything else.
+    if (event.key === "Escape" && tpslDrag) {
+      event.stopPropagation();
+      cancelTpSlDrag();
+      return;
+    }
     // Armed click-to-trade owns Escape: disarm only, swallowed before the
     // modal-close block below so one Escape never doubles as modal-close
     // (same key-swallowing posture as the funding wizard).
@@ -4528,6 +4935,44 @@
             >
               {clickTradeHover.label}
             </div>
+          {/if}
+
+          <!-- Draggable TP/SL grab handles. Geometry (transform/right) is
+               written imperatively by the rAF loop — never through Svelte
+               attributes, so a re-render can't clobber a mid-drag position.
+               Pointer-only affordance: the accessible TP/SL surface stays
+               the position row, not these handles. -->
+          {#if tpHandlePrice !== null}
+            <button
+              class="tpsl-handle tpsl-handle-tp"
+              class:pending={tpslPending?.kind === "tp"}
+              type="button"
+              aria-label="Drag to move the take-profit trigger"
+              bind:this={tpHandleEl}
+              onpointerdown={(event) => onTpSlHandleDown(event, "tp")}
+              onpointermove={onTpSlHandleMove}
+              onpointerup={onTpSlHandleUp}
+              onpointercancel={cancelTpSlDrag}
+            >
+              <span>TP {fmtTriggerPrice(tpHandlePrice)}</span>
+              <i aria-hidden="true">⋮⋮</i>
+            </button>
+          {/if}
+          {#if slHandlePrice !== null}
+            <button
+              class="tpsl-handle tpsl-handle-sl"
+              class:pending={tpslPending?.kind === "sl"}
+              type="button"
+              aria-label="Drag to move the stop-loss trigger"
+              bind:this={slHandleEl}
+              onpointerdown={(event) => onTpSlHandleDown(event, "sl")}
+              onpointermove={onTpSlHandleMove}
+              onpointerup={onTpSlHandleUp}
+              onpointercancel={cancelTpSlDrag}
+            >
+              <span>SL {fmtTriggerPrice(slHandlePrice)}</span>
+              <i aria-hidden="true">⋮⋮</i>
+            </button>
           {/if}
         </div>
       </div>
@@ -5676,6 +6121,51 @@
   .chart-canvas {
     position: absolute;
     inset: 0;
+  }
+
+  /* Draggable TP/SL grab handles: bordered pills riding their price lines
+     at the plot's right edge (just left of the price scale). Vertical
+     position + right offset are written imperatively by the rAF loop —
+     keep transforms out of this rule. Hidden until first placement so a
+     fresh mount never flashes at the top-left corner. */
+  .tpsl-handle {
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 5;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    min-width: 24px;
+    height: 14px;
+    margin: 0;
+    padding: 0 0.3rem;
+    border: 1px solid var(--up);
+    background: var(--surface);
+    color: var(--up);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 10px;
+    line-height: 1;
+    white-space: nowrap;
+    cursor: ns-resize;
+    touch-action: none;
+    visibility: hidden;
+  }
+
+  .tpsl-handle-sl {
+    border-color: var(--down);
+    color: var(--down);
+  }
+
+  /* In-flight edit: inert until the chain answers. */
+  .tpsl-handle.pending {
+    cursor: progress;
+    opacity: 0.6;
+  }
+
+  .tpsl-handle i {
+    font-style: normal;
+    letter-spacing: -2px;
   }
 
   /* Armed click-to-trade: side/price preview pill riding the crosshair

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -60,9 +60,13 @@
     buildStructureLineSpecs,
     clickTradeLabel,
     clickTradeSide,
+    measureParts,
+    nearestRay,
     type PositionLineKind,
     positionLineSpecs,
     type PriceLineSpec,
+    RAY_TOLERANCE_PCT,
+    rayLineSpec,
   } from "$lib/terminal/chart-lines";
   import { parseTerminalDeepLink } from "$lib/terminal/deep-link";
   import {
@@ -97,6 +101,7 @@
     parsePrefs,
     persistPrefs,
     PREFS_STORAGE_KEY,
+    RAYS_PER_SYMBOL_CAP,
   } from "$lib/terminal/prefs";
   import {
     disconnectedPanel,
@@ -580,6 +585,31 @@
   let clickTradeLine: IPriceLine | null = null;
   let clickTradeHover: { y: number; right: number; label: string } | null =
     null;
+  // Horizontal rays — user-drawn price lines persisted per symbol in prefs
+  // (max 12, FIFO eviction). Arming is one-shot like click-to-trade: the
+  // armed click places a ray, or removes the nearest existing ray within
+  // ±0.5% instead. Zero overhead unarmed with no rays for the symbol: no
+  // subscriptions, no lines.
+  let rays: Record<string, number[]> = {};
+  let rayArmed = false;
+  let rayLines: IPriceLine[] = [];
+  // Measure tool — armed pointer drag between two points shows a Δ/%/bars
+  // chip near the cursor; ephemeral by design (never persisted). The chip
+  // lingers 2 s after release; ESC cancels. Pointer listeners exist only
+  // while armed.
+  let measureArmed = false;
+  let measure: {
+    pointerId: number;
+    p1: number;
+    p2: number;
+    startLogical: number;
+    bars: number;
+    x: number;
+    y: number;
+    moved: boolean;
+    done: boolean;
+  } | null = null;
+  let measureLingerTimer: ReturnType<typeof setTimeout> | null = null;
   // Draggable TP/SL overlay: the charted position's entry/TP/SL price lines
   // plus DOM grab handles on the TP/SL lines. Line handles are reusable
   // (applyOptions on change, guarded by a price memo — never re-created per
@@ -1210,6 +1240,7 @@
       dockTab,
       macroOpen,
       showLevels,
+      rays,
     );
 
   onMount(() => {
@@ -1306,6 +1337,7 @@
       spotTicket.dispose();
       if (spotChartTimer) clearInterval(spotChartTimer);
       if (structureTimer !== null) clearTimeout(structureTimer);
+      if (measureLingerTimer !== null) clearTimeout(measureLingerTimer);
       if (tpslFrame !== null) cancelAnimationFrame(tpslFrame);
       tpslFrame = null;
       posOverlayLines = { entry: null, tp: null, sl: null };
@@ -3396,9 +3428,12 @@
     // FIT or a double-click on the price axis re-arms auto-fit.
     let pressPoint: { x: number; y: number } | null = null;
     container.addEventListener("mousedown", (event) => {
-      // While click-to-trade is armed the crosshair cursor wins throughout.
-      container.style.cursor = clickTradeArmed ? "crosshair" : "grabbing";
-      pressPoint = { x: event.clientX, y: event.clientY };
+      // While an armed chart tool owns the pointer the crosshair cursor
+      // wins throughout (click-to-trade, ray placement, measure).
+      container.style.cursor = chartToolArmed() ? "crosshair" : "grabbing";
+      // An armed measure drag must never double as the vertical-pan
+      // autoscale-off gesture.
+      pressPoint = measureArmed ? null : { x: event.clientX, y: event.clientY };
     });
     container.addEventListener("mousemove", (event) => {
       if (!pressPoint || event.buttons !== 1) return;
@@ -3410,11 +3445,11 @@
       }
     });
     container.addEventListener("mouseup", () => {
-      container.style.cursor = clickTradeArmed ? "crosshair" : "grab";
+      container.style.cursor = chartToolArmed() ? "crosshair" : "grab";
       pressPoint = null;
     });
     container.addEventListener("mouseleave", () => {
-      container.style.cursor = clickTradeArmed ? "crosshair" : "grab";
+      container.style.cursor = chartToolArmed() ? "crosshair" : "grab";
       pressPoint = null;
     });
     // Alt+click sets a price alert at the cursor — drag infra's cousin.
@@ -3445,6 +3480,9 @@
     liqLines = [];
     chartLineFullSig = null;
     chartLineStructSig = null;
+    // Ray line handles died with the old series too — redraw from prefs.
+    rayLines = [];
+    applyRayLines(chartedRaySymbol, rays);
     // The draggable TP/SL overlay's lines died with the old series too —
     // drop the stale handles and redraw against the fresh series.
     posOverlayLines = { entry: null, tp: null, sl: null };
@@ -3939,6 +3977,191 @@
     $tradeSide = clickTradeSide(price, mark) === "long" ? "buy" : "sell";
     disarmClickTrade();
     focusTicketSize();
+  }
+
+  // Any armed chart tool → the crosshair cursor owns the plot.
+  function chartToolArmed(): boolean {
+    return clickTradeArmed || rayArmed || measureArmed;
+  }
+
+  // ── Horizontal rays: armed click places/removes a persisted line ────
+  // Venue-agnostic drawings keyed by the CHARTED symbol (perp market or
+  // spot asset). One-shot arming; the click subscription exists only while
+  // armed, and the line set is empty for symbols without rays.
+  $: chartedRaySymbol =
+    tradeMode === "spot"
+      ? (spotAsset?.symbol.toUpperCase() ?? null)
+      : selectedSymbol;
+  // Reapply on symbol/mode switches and every rays mutation. Timeframe
+  // switches setData on the same series, so the lines simply survive.
+  $: applyRayLines(chartedRaySymbol, rays);
+
+  function applyRayLines(
+    symbol: string | null,
+    bySymbol: Record<string, number[]>,
+  ): void {
+    const series = candleSeries;
+    if (!series) return;
+    // Remove before re-adding — stale handles must never leak duplicates.
+    for (const line of rayLines) series.removePriceLine(line);
+    rayLines = [];
+    const prices = symbol ? (bySymbol[symbol] ?? []) : [];
+    for (const price of prices) {
+      rayLines.push(series.createPriceLine(rayLineSpec(price)));
+    }
+  }
+
+  function armRay(): void {
+    if (rayArmed || !lwChart || !chartedRaySymbol) return;
+    // Armed chart tools are mutually exclusive — one crosshair, one intent.
+    disarmClickTrade();
+    disarmMeasure();
+    rayArmed = true;
+    lwChart.subscribeClick(onRayClick);
+    if (chartContainer) chartContainer.style.cursor = "crosshair";
+  }
+
+  function disarmRay(): void {
+    if (!rayArmed) return;
+    rayArmed = false;
+    lwChart?.unsubscribeClick(onRayClick);
+    if (chartContainer) chartContainer.style.cursor = "grab";
+  }
+
+  function onRayClick(param: MouseEventParams): void {
+    // Alt+click stays the set-alert gesture even while armed.
+    if (param.sourceEvent?.altKey) return;
+    const symbol = chartedRaySymbol;
+    if (!param.point || !candleSeries || !symbol) return;
+    const price = Number(candleSeries.coordinateToPrice(param.point.y));
+    if (!Number.isFinite(price) || price <= 0) return;
+    const existing = rays[symbol] ?? [];
+    const hit = nearestRay(existing, price, RAY_TOLERANCE_PCT);
+    const next = { ...rays };
+    if (hit !== null) {
+      // Click landed on an existing ray (nearest within ±0.5%): remove
+      // that one occurrence instead of stacking a near-duplicate.
+      const index = existing.indexOf(hit);
+      const remaining = existing.filter((_, i) => i !== index);
+      if (remaining.length > 0) next[symbol] = remaining;
+      else delete next[symbol];
+    } else {
+      // Append newest-last; the slice evicts the oldest at the cap (FIFO).
+      next[symbol] = [...existing, price].slice(-RAYS_PER_SYMBOL_CAP);
+    }
+    rays = next; // reactive: reapplies lines + persists via prefs
+    disarmRay(); // one-shot — place/remove, then back to normal
+  }
+
+  // ── Measure tool: armed drag → Δ/%/bars chip near the cursor ────────
+  // Chart scroll is suspended while armed so the drag measures instead of
+  // panning; bars come from the time scale's logical indices
+  // (coordinateToLogical), so the delta IS the bar count.
+  const MEASURE_LINGER_MS = 2_000;
+
+  $: measureChip = measure
+    ? measureParts(measure.p1, measure.p2, measure.bars)
+    : null;
+
+  function armMeasure(): void {
+    if (measureArmed || !lwChart || !chartContainer) return;
+    disarmClickTrade();
+    disarmRay();
+    measureArmed = true;
+    lwChart.applyOptions({ handleScroll: false });
+    chartContainer.addEventListener("pointerdown", onMeasureDown);
+    chartContainer.addEventListener("pointermove", onMeasureMove);
+    chartContainer.addEventListener("pointerup", onMeasureUp);
+    chartContainer.addEventListener("pointercancel", onMeasureCancel);
+    chartContainer.style.cursor = "crosshair";
+  }
+
+  function disarmMeasure(): void {
+    clearMeasure();
+    if (!measureArmed) return;
+    measureArmed = false;
+    lwChart?.applyOptions({ handleScroll: true });
+    if (chartContainer) {
+      chartContainer.removeEventListener("pointerdown", onMeasureDown);
+      chartContainer.removeEventListener("pointermove", onMeasureMove);
+      chartContainer.removeEventListener("pointerup", onMeasureUp);
+      chartContainer.removeEventListener("pointercancel", onMeasureCancel);
+      chartContainer.style.cursor = "grab";
+    }
+  }
+
+  function clearMeasure(): void {
+    if (measureLingerTimer !== null) {
+      clearTimeout(measureLingerTimer);
+      measureLingerTimer = null;
+    }
+    measure = null;
+  }
+
+  function onMeasureDown(event: PointerEvent): void {
+    // Alt+click stays the set-alert gesture even while armed.
+    if (event.altKey || !candleSeries || !lwChart || !chartContainer) return;
+    const rect = chartContainer.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    const price = Number(candleSeries.coordinateToPrice(y));
+    const logical = lwChart.timeScale().coordinateToLogical(x);
+    if (!Number.isFinite(price) || price <= 0 || logical === null) return;
+    clearMeasure(); // a fresh press replaces any lingering chip
+    event.preventDefault();
+    chartContainer.setPointerCapture(event.pointerId);
+    measure = {
+      pointerId: event.pointerId,
+      p1: price,
+      p2: price,
+      startLogical: logical,
+      bars: 0,
+      x,
+      y,
+      moved: false,
+      done: false,
+    };
+  }
+
+  function onMeasureMove(event: PointerEvent): void {
+    const active = measure;
+    if (!active || active.done || event.pointerId !== active.pointerId) return;
+    if (!candleSeries || !lwChart || !chartContainer) return;
+    const rect = chartContainer.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    const price = Number(candleSeries.coordinateToPrice(y));
+    const logical = lwChart.timeScale().coordinateToLogical(x);
+    if (!Number.isFinite(price) || price <= 0 || logical === null) return;
+    // Reassign, never mutate: the chip derives from this state.
+    measure = {
+      ...active,
+      p2: price,
+      bars: Math.abs(Math.round(logical - active.startLogical)),
+      x,
+      y,
+      moved: true,
+    };
+  }
+
+  function onMeasureUp(event: PointerEvent): void {
+    const active = measure;
+    if (!active || active.done || event.pointerId !== active.pointerId) return;
+    if (!active.moved) {
+      clearMeasure(); // a click, not a drag — nothing measured, no chip
+      return;
+    }
+    measure = { ...active, done: true };
+    measureLingerTimer = setTimeout(() => {
+      measureLingerTimer = null;
+      measure = null;
+    }, MEASURE_LINGER_MS);
+  }
+
+  function onMeasureCancel(event: PointerEvent): void {
+    if (measure && !measure.done && event.pointerId === measure.pointerId) {
+      clearMeasure();
+    }
   }
 
   // ── Draggable TP/SL overlay: the open position drawn on the chart ───
@@ -4471,6 +4694,7 @@
     if (prefs.dockTab !== undefined) dockTab = prefs.dockTab;
     if (prefs.macroOpen !== undefined) macroOpen = prefs.macroOpen;
     if (prefs.showLevels !== undefined) showLevels = prefs.showLevels;
+    if (prefs.rays !== undefined) rays = prefs.rays;
   }
 
   function loadOpenBetaBanner(): void {
@@ -4570,6 +4794,19 @@
     if (event.key === "Escape" && clickTradeArmed) {
       event.stopPropagation();
       disarmClickTrade();
+      return;
+    }
+    // Armed measure (mid-drag or lingering chip) owns Escape the same way:
+    // cancel the measurement and disarm, swallowed before modal-close.
+    if (event.key === "Escape" && (measureArmed || measure !== null)) {
+      event.stopPropagation();
+      disarmMeasure();
+      return;
+    }
+    // Armed ray placement owns Escape: disarm without placing.
+    if (event.key === "Escape" && rayArmed) {
+      event.stopPropagation();
+      disarmRay();
       return;
     }
     if (event.key === "Escape") {
@@ -4937,6 +5174,20 @@
             </div>
           {/if}
 
+          {#if measure && measureChip}
+            <div
+              class="measure-chip"
+              style="left: {measure.x + 14}px; top: {measure.y + 14}px;"
+            >
+              {measureChip.delta} ·
+              <span
+                class:up={measureChip.direction === "up"}
+                class:down={measureChip.direction === "down"}
+              >{measureChip.pct}</span>
+              · {measureChip.bars}
+            </div>
+          {/if}
+
           <!-- Draggable TP/SL grab handles. Geometry (transform/right) is
                written imperatively by the rAF loop — never through Svelte
                attributes, so a re-render can't clobber a mid-drag position.
@@ -5075,6 +5326,25 @@
           onclick={() => (clickTradeArmed ? disarmClickTrade() : armClickTrade())}
         >
           trade
+        </button>
+        <button
+          class:active={rayArmed}
+          type="button"
+          aria-pressed={rayArmed}
+          disabled={chartedRaySymbol === null}
+          title="Arm ray — click the chart to place a horizontal ray (or click an existing ray to remove it)"
+          onclick={() => (rayArmed ? disarmRay() : armRay())}
+        >
+          ray
+        </button>
+        <button
+          class:active={measureArmed}
+          type="button"
+          aria-pressed={measureArmed}
+          title="Arm measure — drag on the chart to read Δ / % / bars"
+          onclick={() => (measureArmed ? disarmMeasure() : armMeasure())}
+        >
+          measure
         </button>
         <button
           class:active={autoFollow}
@@ -6182,6 +6452,29 @@
     font-size: 11px;
     white-space: nowrap;
     pointer-events: none;
+  }
+
+  /* Armed measure: Δ/%/bars readout chip trailing the drag cursor. Only
+     the % segment carries direction color — the sign already says it. */
+  .measure-chip {
+    position: absolute;
+    z-index: 4;
+    padding: 0.1rem 0.4rem;
+    border: 1px solid var(--line);
+    background: var(--surface);
+    color: var(--ink);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px;
+    white-space: nowrap;
+    pointer-events: none;
+  }
+
+  .measure-chip .up {
+    color: var(--up);
+  }
+
+  .measure-chip .down {
+    color: var(--down);
   }
 
   .chart-empty {

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -3338,6 +3338,16 @@
     setChartData();
   }
 
+  // Creation-time scroll behavior, named so the measure tool's disarm can
+  // restore EXACTLY this (a blanket `handleScroll: true` would silently
+  // re-enable vertTouchDrag and let the chart hijack page scrolling).
+  const CHART_SCROLL_OPTIONS = {
+    mouseWheel: true,
+    pressedMouseMove: true,
+    horzTouchDrag: true,
+    vertTouchDrag: false,
+  };
+
   function createChartInstance(): void {
     if (!chartContainer || lwChart) return;
     lwChart = createChart(chartContainer, {
@@ -3347,12 +3357,7 @@
       // it, double-click an axis to reset. Vertical touch-drag stays off so
       // the chart never hijacks page scrolling; kinetic momentum is
       // touch-only (mouse panning should stop where you stop).
-      handleScroll: {
-        mouseWheel: true,
-        pressedMouseMove: true,
-        horzTouchDrag: true,
-        vertTouchDrag: false,
-      },
+      handleScroll: CHART_SCROLL_OPTIONS,
       handleScale: {
         mouseWheel: true,
         pinch: true,
@@ -3906,6 +3911,7 @@
   // never created/removed per crosshair move.
   function armClickTrade(): void {
     if (clickTradeArmed || tradeMode !== "perps" || !lwChart) return;
+    disarmChartTools();
     clickTradeArmed = true;
     lwChart.subscribeCrosshairMove(onClickTradeCrosshair);
     lwChart.subscribeClick(onClickTradeClick);
@@ -3984,6 +3990,15 @@
     return clickTradeArmed || rayArmed || measureArmed;
   }
 
+  // Armed chart tools are mutually exclusive — one crosshair, one intent.
+  // Every arm path disarms the others through here; each disarm is a no-op
+  // when its tool is not armed (including the caller's own, still unarmed).
+  function disarmChartTools(): void {
+    disarmClickTrade();
+    disarmRay();
+    disarmMeasure();
+  }
+
   // ── Horizontal rays: armed click places/removes a persisted line ────
   // Venue-agnostic drawings keyed by the CHARTED symbol (perp market or
   // spot asset). One-shot arming; the click subscription exists only while
@@ -4013,9 +4028,7 @@
 
   function armRay(): void {
     if (rayArmed || !lwChart || !chartedRaySymbol) return;
-    // Armed chart tools are mutually exclusive — one crosshair, one intent.
-    disarmClickTrade();
-    disarmMeasure();
+    disarmChartTools();
     rayArmed = true;
     lwChart.subscribeClick(onRayClick);
     if (chartContainer) chartContainer.style.cursor = "crosshair";
@@ -4065,8 +4078,7 @@
 
   function armMeasure(): void {
     if (measureArmed || !lwChart || !chartContainer) return;
-    disarmClickTrade();
-    disarmRay();
+    disarmChartTools();
     measureArmed = true;
     lwChart.applyOptions({ handleScroll: false });
     chartContainer.addEventListener("pointerdown", onMeasureDown);
@@ -4080,7 +4092,7 @@
     clearMeasure();
     if (!measureArmed) return;
     measureArmed = false;
-    lwChart?.applyOptions({ handleScroll: true });
+    lwChart?.applyOptions({ handleScroll: CHART_SCROLL_OPTIONS });
     if (chartContainer) {
       chartContainer.removeEventListener("pointerdown", onMeasureDown);
       chartContainer.removeEventListener("pointermove", onMeasureMove);


### PR DESCRIPTION
**DO NOT MERGE — awaiting Guillaume's preview QA**

## Summary — roadmap #528, Week 1 (Days 1–5), one commit per day

- **Day 1 — Structure levels** (`bd8b4a1`+`0c58241`): pure swing/PDH/PDL lib (33 exact-output tests; also feeds Week 3's ticket ghosts) + chart overlay — PDH/PDL dashed faint with axis tags, 3 most-recent swings per side dotted; footer "levels" toggle, persisted, default ON; recompute funnels through renderChartSeries with a coalescing 2s timer (never per WS tick); honest absence without a full previous UTC day.
- **Day 2 — Click-to-trade** (`b2e967b`): session-only "trade" arm; crosshair-follow line + pill ("75.81 · limit short"); click fills type/limit/side via the ticket's own precision dialect, one-shot disarms, focuses size; Escape disarms ahead of modal-close; alt+click stays set-alert; Spot disables the toggle honestly; zero subscriptions while disarmed.
- **Days 3–4 — Draggable TP/SL** (`a127ebd`): entry/TP/SL lines with grab handles (rAF repositioning only while trigger lines exist); pointer-capture drag, ESC/pointercancel snap-back, no-move no-op, side-validity guarded; release submits via the EXISTING simulate→auto-sign pipeline (there was no TP/SL edit UI anywhere — the row is read-only; discovery documented in-code). Mid-drag prices live only on the chart; row/ticket stay chain-true. buildChartLineSpecs cedes entry/TP/SL to the overlay (keeps LIQ) — the old rich entry label retires.
- **Day 5 — Rays + measure** (`3af7927`): armed ray placement (60%-muted token-derived lines, per-symbol persistence, cap 12 FIFO, click-near removes), measure drag chip ("Δ $0.30 · +0.40% · 41 bars") with scroll suppressed mid-gesture, 2s linger, ephemeral.

## Validation (reproduced at every commit)

typecheck 0/0 · lint clean · 16 ui + **452 portal tests** (**+70 this branch**) · build green, unused-css 0 at all five gates.

## Browser proof (real Chrome, per-day smokes)

Levels on/off, click-to-trade hover+fill, drag render/mid-drag/pipeline-invocation (runtime-stubbed position, zero code stubs, git-status-verified), rays place/persist/remove, measure mid-gesture — screenshots in the session log; key ones re-verified by Claude directly.

## Risk notes — read before QA

1. **Drag-release is a money action**: consistent with the ratified simulate→auto-sign posture (a deliberate drag = the consent gesture; ESC cancels, no-move no-ops, side-validity guards) — but QA it consciously with a real position.
2. Two orders exceeded the ~400-line guidance (Days 3–4: 646; Day 5: 534, ~130 tests) — flagged at commit, accepted as cohesive features.
3. The chart's old rich entry label ("LONG 2.0 @ … · +$x") is retired in favor of the design's muted entry line — uPnL remains in the summary strip + row.
4. Success-path TP/SL drag couldn't be chain-confirmed in smoke (no funded dev session) — it rides the identical burst-refresh path as Close/Margin+; QA covers it.

## QA notes (preview)

1. Levels: toggle on/off, switch timeframes/symbols, confirm PDH/PDL sanity vs yesterday.
2. Click-to-trade: arm, hover (side flips at mark), click → ticket filled, disarmed; Escape; Spot disabled.
3. **With your real position**: drag TP a little → release → sign → row updates to the new trigger; drag + ESC → snaps back, nothing signed.
4. Rays: place two, reload, remove one; measure a swing; check nothing fights the alt+click alert gesture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)