### PR TITLE
Fix: trader view drifted — orders + PnL/liq enrichment restored, per-subaccount queries

### DIFF
--- a/apps/portal/src/lib/phoenix-trade.test.ts
+++ b/apps/portal/src/lib/phoenix-trade.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, test } from "bun:test";
+import {
+  mergeTraderView,
+  type PhoenixTraderState,
+  parseTraderStatePayload,
+} from "./phoenix-trade";
+
+// Lot decimals mirror the live /exchange config for the fixture symbols
+// (ANSEM baseLotsDecimals=0 → 1 lot = 1 unit; AAPL=3 → 1 lot = 0.001).
+const LOT_DECIMALS: Record<string, number> = { ANSEM: 0, AAPL: 3 };
+const lotDecimalsFor = (symbol: string): number => LOT_DECIMALS[symbol] ?? 0;
+
+// Trimmed from the live /v1/trader/state payload of an authority holding a
+// cross AAPL position on the parent (sub 0) and an isolated ANSEM long on a
+// child (sub 16) — the exact shape observed 2026-07-18. Isolated positions
+// arrive inside snapshot.subaccounts like cross ones; only the index and
+// per-child collateral differ.
+const FIXTURE: Record<string, unknown> = {
+  authority: "BJsbrDPdpxvzP35TYJ7gmrcumqxVSqwDeEb4Gg3aV4Ax",
+  traderPdaIndex: 0,
+  slot: 433760158,
+  slotIndex: 1157,
+  snapshot: {
+    version: 1,
+    subaccounts: [
+      {
+        subaccountIndex: 0,
+        sequence: 0,
+        collateral: "5244530886",
+        positions: [
+          {
+            symbol: "AAPL",
+            positionSequenceNumber: "52",
+            basePositionLots: "8",
+            entryPriceTicks: "33286",
+            entryPriceUsd: "332.86",
+            virtualQuotePositionLots: "-2662880",
+            takeProfitTriggers: [],
+            stopLossTriggers: [],
+          },
+        ],
+      },
+      // Registered-but-flat isolated child: no positions key at all.
+      { subaccountIndex: 7, sequence: 0, collateral: "0" },
+      {
+        subaccountIndex: 16,
+        sequence: 0,
+        collateral: "76679932",
+        positions: [
+          {
+            symbol: "ANSEM",
+            positionSequenceNumber: "31",
+            basePositionLots: "5",
+            entryPriceTicks: "18005",
+            entryPriceUsd: "0.18005",
+            virtualQuotePositionLots: "-900250",
+            takeProfitTriggers: [],
+            stopLossTriggers: [{ triggerPriceUsd: 0.171 }],
+          },
+        ],
+      },
+    ],
+  },
+};
+
+describe("parseTraderStatePayload", () => {
+  test("no snapshot → null (unregistered wallet)", () => {
+    expect(parseTraderStatePayload({}, lotDecimalsFor)).toBeNull();
+    expect(
+      parseTraderStatePayload({ error: "Trader not found" }, lotDecimalsFor),
+    ).toBeNull();
+  });
+
+  test("isolated-subaccount position surfaces with its true indices", () => {
+    const parsed = parseTraderStatePayload(FIXTURE, lotDecimalsFor);
+    expect(parsed).not.toBeNull();
+    if (!parsed) return;
+    expect(parsed.traderPdaIndex).toBe(0);
+    // Every registered subaccount is reported, positions or not — the view
+    // merge must query flat children too (resting isolated orders).
+    expect(parsed.subaccountIndexes).toEqual([0, 7, 16]);
+    expect(parsed.state.registered).toBe(true);
+    expect(parsed.state.apiSlot).toBe(433760158);
+    // Free cross collateral = parent only; total = every subaccount.
+    expect(parsed.state.collateralUsd).toBe(5244.530886);
+    expect(parsed.state.totalCollateralUsd).toBe(5244.530886 + 0 + 76.679932);
+    expect(parsed.state.positions).toEqual([
+      {
+        symbol: "AAPL",
+        size: 0.008,
+        entryPrice: 332.86,
+        liquidationPrice: null,
+        unrealizedPnl: null,
+        positionValue: 2.66288,
+        takeProfitPrice: null,
+        stopLossPrice: null,
+        traderPdaIndex: 0,
+        subaccountIndex: 0,
+        marginUsd: 5244.530886,
+      },
+      {
+        symbol: "ANSEM",
+        size: 5,
+        entryPrice: 0.18005,
+        liquidationPrice: null,
+        unrealizedPnl: null,
+        positionValue: 0.90025,
+        takeProfitPrice: null,
+        stopLossPrice: 0.171,
+        traderPdaIndex: 0,
+        subaccountIndex: 16,
+        marginUsd: 76.679932,
+      },
+    ]);
+    expect(parsed.state.orders).toEqual([]);
+  });
+
+  test("zero-lot entries are dropped, not rendered as phantom rows", () => {
+    const parsed = parseTraderStatePayload(
+      {
+        traderPdaIndex: 0,
+        snapshot: {
+          subaccounts: [
+            {
+              subaccountIndex: 0,
+              collateral: "1000000",
+              positions: [
+                { symbol: "AAPL", basePositionLots: "0" },
+                { symbol: "AAPL", basePositionLots: "not-a-number" },
+              ],
+            },
+          ],
+        },
+      },
+      lotDecimalsFor,
+    );
+    expect(parsed?.state.positions).toEqual([]);
+  });
+});
+
+describe("mergeTraderView", () => {
+  function parsedState(): PhoenixTraderState {
+    const parsed = parseTraderStatePayload(FIXTURE, lotDecimalsFor);
+    if (!parsed) throw new Error("fixture must parse");
+    return parsed.state;
+  }
+
+  test("orders are tagged with the owning subaccount", () => {
+    const state = parsedState();
+    mergeTraderView(
+      state,
+      {
+        limitOrders: {
+          ANSEM: [
+            {
+              side: "bid",
+              price: { ui: "0.15", value: 150000, decimals: 6 },
+              tradeSizeRemaining: { ui: "10", value: 10, decimals: 0 },
+              orderSequenceNumber: "12345",
+              isStopLoss: false,
+            },
+          ],
+        },
+      },
+      0,
+      16,
+    );
+    expect(state.orders).toEqual([
+      {
+        symbol: "ANSEM",
+        side: "bid",
+        price: 0.15,
+        remaining: 10,
+        orderSequenceNumber: "12345",
+        isStopLoss: false,
+        isStopLossDirection: false,
+        traderPdaIndex: 0,
+        subaccountIndex: 16,
+      },
+    ]);
+  });
+
+  test("position enrichment stays within its subaccount on symbol collision", () => {
+    const state = parsedState();
+    // Same symbol as the parent's cross AAPL, but reported by the child-16
+    // view — must NOT enrich the parent's row.
+    mergeTraderView(
+      state,
+      {
+        positions: [
+          {
+            symbol: "AAPL",
+            unrealizedPnl: { ui: "9.99", value: 9990000, decimals: 6 },
+          },
+        ],
+      },
+      0,
+      16,
+    );
+    const parent = state.positions.find(
+      (position) =>
+        position.symbol === "AAPL" && position.subaccountIndex === 0,
+    );
+    expect(parent?.unrealizedPnl).toBeNull();
+    // The matching subaccount does enrich.
+    mergeTraderView(
+      state,
+      {
+        positions: [
+          {
+            symbol: "AAPL",
+            unrealizedPnl: { ui: "9.99", value: 9990000, decimals: 6 },
+          },
+        ],
+      },
+      0,
+      0,
+    );
+    expect(parent?.unrealizedPnl).toBe(9.99);
+  });
+
+  test("risk tier comes from the parent view only", () => {
+    const state = parsedState();
+    mergeTraderView(state, { riskTier: "danger" }, 0, 16);
+    expect(state.riskTier).toBeNull();
+    mergeTraderView(state, { riskTier: "safe" }, 0, 0);
+    expect(state.riskTier).toBe("safe");
+  });
+});

--- a/apps/portal/src/lib/phoenix-trade.ts
+++ b/apps/portal/src/lib/phoenix-trade.ts
@@ -80,6 +80,11 @@ export type PhoenixOpenOrder = {
    * above the trigger, per the SDK's StopLosses decoder) — picks which
    * StopLosses slot a single-order cancel targets. */
   isStopLossDirection: boolean;
+  /** Which subaccount the order rests under (isolated limit orders rest on
+   * the child trader account, not the parent) — cancels must target it.
+   * Optional so pre-existing fixtures/rows default to the parent (0/0). */
+  traderPdaIndex?: number;
+  subaccountIndex?: number;
 };
 
 export type PhoenixTraderState = {
@@ -186,48 +191,60 @@ function triggerPriceUsd(list: unknown): number | null {
   return null;
 }
 
-export async function fetchPhoenixTraderState(
-  authority: string,
-): Promise<PhoenixTraderState> {
-  const empty: PhoenixTraderState = {
-    registered: false,
-    apiSlot: null,
-    collateralUsd: null,
-    totalCollateralUsd: null,
-    effectiveCollateralUsd: null,
-    unrealizedPnlUsd: null,
-    riskTier: null,
-    positions: [],
-    orders: [],
-  };
-  const response = await fetch(
-    `${PHOENIX_API}/v1/trader/state/${encodeURIComponent(authority)}`,
-  );
-  if (response.status === 404) return empty;
-  if (!response.ok) throw new Error(`phoenix-trader-${response.status}`);
-  // Live schema (2026-07-03): { traderPdaIndex, snapshot: { subaccounts:
-  // [{ subaccountIndex, collateral: "<quote lots>", positions?: [{ symbol,
-  // basePositionLots, entryPriceUsd, virtualQuotePositionLots,
-  // takeProfitTriggers, stopLossTriggers }] }] } }. The previous
-  // { traders: [...] } shape is gone — parsing it silently reported every
-  // wallet as unregistered with no positions.
-  const data = (await response.json()) as Record<string, unknown>;
+const EMPTY_TRADER_STATE: PhoenixTraderState = {
+  registered: false,
+  apiSlot: null,
+  collateralUsd: null,
+  totalCollateralUsd: null,
+  effectiveCollateralUsd: null,
+  unrealizedPnlUsd: null,
+  riskTier: null,
+  positions: [],
+  orders: [],
+};
+
+export type ParsedTraderSnapshot = {
+  state: PhoenixTraderState;
+  traderPdaIndex: number;
+  /** Every registered subaccount in the snapshot (positions or not) — the
+   * view merge queries each one, since resting orders can sit on an
+   * isolated child that has no open position yet. */
+  subaccountIndexes: number[];
+};
+
+// Pure parser for the /v1/trader/state payload — exported so tests can feed
+// it fixture payloads (isolated-subaccount positions included) without
+// network. Live schema (2026-07-03): { traderPdaIndex, snapshot:
+// { subaccounts: [{ subaccountIndex, collateral: "<quote lots>",
+// positions?: [{ symbol, basePositionLots, entryPriceUsd,
+// virtualQuotePositionLots, takeProfitTriggers, stopLossTriggers }] }] } }.
+// The previous { traders: [...] } shape is gone — parsing it silently
+// reported every wallet as unregistered with no positions. Isolated
+// positions live on child subaccounts (subaccountIndex >= 1) of the same
+// PDA, one position per child, margin = the child's collateral.
+export function parseTraderStatePayload(
+  data: Record<string, unknown>,
+  lotDecimalsFor: (symbol: string) => number,
+): ParsedTraderSnapshot | null {
   const snapshot = isRecord(data.snapshot) ? data.snapshot : null;
-  if (!snapshot) return empty;
+  if (!snapshot) return null;
   const subaccounts = Array.isArray(snapshot.subaccounts)
     ? snapshot.subaccounts.filter(isRecord)
     : [];
   const pdaIndex = Number(data.traderPdaIndex ?? 0);
-  const markets =
-    (await fetchExchangeConfig().catch(() => null))?.markets ?? [];
-  const lotDecimalsFor = (symbol: string): number =>
-    markets.find((market) => market.symbol === symbol)?.baseLotsDecimals ?? 0;
 
-  const state: PhoenixTraderState = { ...empty, registered: true };
+  const state: PhoenixTraderState = {
+    ...EMPTY_TRADER_STATE,
+    registered: true,
+    positions: [],
+    orders: [],
+  };
   state.apiSlot = Number.isFinite(Number(data.slot)) ? Number(data.slot) : null;
+  const subaccountIndexes: number[] = [];
   let totalUsd = 0;
   for (const sub of subaccounts) {
     const subIndex = Number(sub.subaccountIndex ?? 0);
+    subaccountIndexes.push(subIndex);
     const collateral = lotsToUsd(sub.collateral);
     if (collateral !== null) totalUsd += collateral;
     // Parent (0/0) holds the free cross collateral that gates new orders.
@@ -261,54 +278,126 @@ export async function fetchPhoenixTraderState(
     }
   }
   state.totalCollateralUsd = totalUsd;
+  return { state, traderPdaIndex: pdaIndex, subaccountIndexes };
+}
+
+// Merges one subaccount's TraderView (open orders, risk tier, trigger/PnL
+// enrichment) into the parsed state. Orders are tagged with the owning
+// subaccount so cancels target the right trader account, and position
+// enrichment matches within the same subaccount only — the same symbol can
+// hold a cross position on the parent AND an isolated one on a child.
+// Exported for tests.
+export function mergeTraderView(
+  state: PhoenixTraderState,
+  view: Record<string, unknown>,
+  traderPdaIndex: number,
+  subaccountIndex: number,
+): void {
+  // Risk tier is an account-level readout — take the parent's.
+  if (
+    traderPdaIndex === 0 &&
+    subaccountIndex === 0 &&
+    typeof view.riskTier === "string"
+  ) {
+    state.riskTier = view.riskTier;
+  }
+  const orderMap = isRecord(view.limitOrders) ? view.limitOrders : {};
+  for (const [symbol, list] of Object.entries(orderMap)) {
+    if (!Array.isArray(list)) continue;
+    for (const order of list.filter(isRecord)) {
+      state.orders.push({
+        symbol,
+        side: Number(order.side) === 1 || order.side === "ask" ? "ask" : "bid",
+        price: tokenAmount(order.price),
+        remaining: tokenAmount(order.tradeSizeRemaining),
+        orderSequenceNumber: String(order.orderSequenceNumber ?? ""),
+        isStopLoss: order.isStopLoss === true,
+        isStopLossDirection: order.isStopLossDirection === true,
+        traderPdaIndex,
+        subaccountIndex,
+      });
+    }
+  }
+  // Trigger prices for open positions when the raw snapshot had none.
+  const viewPositions = Array.isArray(view.positions)
+    ? view.positions.filter(isRecord)
+    : [];
+  for (const viewPosition of viewPositions) {
+    const symbol = String(viewPosition.symbol ?? "");
+    const target = state.positions.find(
+      (position) =>
+        position.symbol === symbol &&
+        position.traderPdaIndex === traderPdaIndex &&
+        position.subaccountIndex === subaccountIndex,
+    );
+    if (!target) continue;
+    target.takeProfitPrice ??= tokenAmount(viewPosition.takeProfitPrice);
+    target.stopLossPrice ??= tokenAmount(viewPosition.stopLossPrice);
+    target.unrealizedPnl ??= tokenAmount(viewPosition.unrealizedPnl);
+    target.liquidationPrice ??= tokenAmount(viewPosition.liquidationPrice);
+  }
+}
+
+export async function fetchPhoenixTraderState(
+  authority: string,
+): Promise<PhoenixTraderState> {
+  const empty: PhoenixTraderState = {
+    ...EMPTY_TRADER_STATE,
+    positions: [],
+    orders: [],
+  };
+  const response = await fetch(
+    `${PHOENIX_API}/v1/trader/state/${encodeURIComponent(authority)}`,
+  );
+  if (response.status === 404) return empty;
+  if (!response.ok) throw new Error(`phoenix-trader-${response.status}`);
+  const data = (await response.json()) as Record<string, unknown>;
+  const exchange = await fetchExchangeConfig().catch(() => null);
+  const markets = exchange?.markets ?? [];
+  const lotDecimalsFor = (symbol: string): number =>
+    markets.find((market) => market.symbol === symbol)?.baseLotsDecimals ?? 0;
+  const parsed = parseTraderStatePayload(data, lotDecimalsFor);
+  if (!parsed) return empty;
+  const { state, traderPdaIndex, subaccountIndexes } = parsed;
 
   // The raw REST snapshot no longer carries open orders, but the SDK
-  // client's TraderView still does — merge orders (plus risk tier and any
-  // trigger prices the raw schema omitted) from it, fail-soft.
-  try {
-    const client = createPhoenixClient();
-    let view: unknown;
+  // client's TraderView still does. The view endpoint keys on the trader
+  // ACCOUNT pubkey (passing the authority 404s — schema drift, again), and
+  // each subaccount is its own trader account, so derive every key and
+  // query them in parallel. Fail-soft per subaccount and overall —
+  // positions/collateral above still stand without the merge.
+  if (exchange) {
     try {
-      view = await client.api.traders().getTrader(authority);
-    } finally {
-      client.dispose();
-    }
-    if (isRecord(view)) {
-      if (typeof view.riskTier === "string") state.riskTier = view.riskTier;
-      const orderMap = isRecord(view.limitOrders) ? view.limitOrders : {};
-      for (const [symbol, list] of Object.entries(orderMap)) {
-        if (!Array.isArray(list)) continue;
-        for (const order of list.filter(isRecord)) {
-          state.orders.push({
-            symbol,
-            side:
-              Number(order.side) === 1 || order.side === "ask" ? "ask" : "bid",
-            price: tokenAmount(order.price),
-            remaining: tokenAmount(order.tradeSizeRemaining),
-            orderSequenceNumber: String(order.orderSequenceNumber ?? ""),
-            isStopLoss: order.isStopLoss === true,
-            isStopLossDirection: order.isStopLossDirection === true,
-          });
-        }
-      }
-      // Trigger prices for open positions when the raw snapshot had none.
-      const viewPositions = Array.isArray(view.positions)
-        ? view.positions.filter(isRecord)
-        : [];
-      for (const viewPosition of viewPositions) {
-        const symbol = String(viewPosition.symbol ?? "");
-        const target = state.positions.find(
-          (position) => position.symbol === symbol,
+      const client = createPhoenixClient();
+      try {
+        const views = await Promise.all(
+          subaccountIndexes.map(async (subIndex) => {
+            try {
+              const addresses = await getTraderAddresses(
+                authority as never,
+                exchange.keys.canonicalMint as never,
+                traderPdaIndex,
+                subIndex,
+              );
+              const view: unknown = await client.api
+                .traders()
+                .getTrader(String(addresses.traderAccount));
+              return isRecord(view) ? { subIndex, view } : null;
+            } catch {
+              return null;
+            }
+          }),
         );
-        if (!target) continue;
-        target.takeProfitPrice ??= tokenAmount(viewPosition.takeProfitPrice);
-        target.stopLossPrice ??= tokenAmount(viewPosition.stopLossPrice);
-        target.unrealizedPnl ??= tokenAmount(viewPosition.unrealizedPnl);
-        target.liquidationPrice ??= tokenAmount(viewPosition.liquidationPrice);
+        for (const entry of views) {
+          if (!entry) continue;
+          mergeTraderView(state, entry.view, traderPdaIndex, entry.subIndex);
+        }
+      } finally {
+        client.dispose();
       }
+    } catch {
+      // view unavailable — positions/collateral above still stand
     }
-  } catch {
-    // view unavailable — positions/collateral above still stand
   }
   return state;
 }

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -2931,8 +2931,10 @@
         orderSequenceNumber: order.orderSequenceNumber,
         isStopLoss: order.isStopLoss,
         isStopLossDirection: order.isStopLossDirection,
-        traderPdaIndex: owner?.traderPdaIndex,
-        subaccountIndex: owner?.subaccountIndex,
+        // The order's own subaccount wins: isolated resting orders live on
+        // child accounts the owning-position lookup can't see.
+        traderPdaIndex: order.traderPdaIndex ?? owner?.traderPdaIndex,
+        subaccountIndex: order.subaccountIndex ?? owner?.subaccountIndex,
       });
       lastTradeSignature = await signAndSendPhoenixIxs(
         instructions,


### PR DESCRIPTION
**Awaiting Guillaume's preview QA**

## What was reported vs what was found

Reported: an ANSEM isolated long not showing in the Desk widget. **Chain truth: the position had been honestly closed by ExecuteStopLoss minutes before observation** (fill 0.18002, −$0.44) — the widget was right, and the isolated-subaccount parser was verified correct against a live third-party account holding an isolated ANSEM position.

**The real bug the diagnosis surfaced:** `/v1/view/trader/{x}` drifted to requiring the trader-account pubkey (authority now 404s — verified live). Our fail-soft catch has been silently swallowing that 404 since 07-03, meaning **open orders never rendered and riskTier/uPnL/liquidation enrichment was always null, for every user**.

## Fix

- View merge derives each registered subaccount's trader key (`getTraderAddresses`) and queries per subaccount in parallel, fail-soft per subaccount.
- Orders tagged with true `traderPdaIndex`/`subaccountIndex`; enrichment scoped to its own subaccount (same-symbol cross+isolated can no longer cross-attach); riskTier from parent view only.
- Cancel call site prefers the order's own indices (isolated resting orders live on child accounts).
- Parser extracted pure (`parseTraderStatePayload` / `mergeTraderView`) + 6 exact-output tests from a live-trimmed fixture (isolated ANSEM sub-16 incl. stop trigger, flat child).

## Validation

typecheck 0/0 · lint clean · **458 portal tests** (6 new) · build green, unused-css 0. Live proof through the fixed parser: a 52-position account surfaces all cross+isolated positions with restored riskTier/uPnL/liq; the reporter's account parses to exactly its chain state.

## QA notes (preview)

With your funded account: place a small resting limit order → it should appear under ORD (this was broken in prod for everyone); open an isolated position (ANSEM works) → position row shows with PnL/liq populated; cancel the resting order.

Cost note: one view request per registered subaccount per refresh (typical 1–2, parallel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)