### PR TITLE
Paper trading: enable spot on the shared ledger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,8 @@
 - Do not add or restore Cloudflare Worker, x402, database, payment, React/Next,
   or live Solana execution behavior without another explicit scope change.
 - Paper trading is an allowed frontend-only simulation: local ledger on live
-  market data, no signing. Keep PAPER labeling obvious so it never looks live.
+  market data (perps + spot), no signing. Keep PAPER labeling obvious so it
+  never looks live.
 
 ## Design System (packages/ui)
 

--- a/apps/portal/src/lib/terminal/paper-ledger.test.ts
+++ b/apps/portal/src/lib/terminal/paper-ledger.test.ts
@@ -13,9 +13,9 @@ import {
   type PaperLedger,
   type PaperMark,
   type PaperPlaceOrderInput,
-  parsePaperLedger,
   paperSpotMarkUsd,
   paperTokenBalances,
+  parsePaperLedger,
   placePaperOrder,
   placePaperSpotLimit,
   resetPaperLedger,
@@ -1019,10 +1019,9 @@ describe("paper-ledger spot", () => {
       limitPrice: 40,
       amount: 80,
     }).ledger;
-    const cancelled = cancelPaperSpotLimit(
-      placed,
-      placed.spotOrders[0]!.orderKey,
-    );
+    const restingOrder = placed.spotOrders[0];
+    if (!restingOrder) throw new Error("expected a resting paper spot order");
+    const cancelled = cancelPaperSpotLimit(placed, restingOrder.orderKey);
     expect(cancelled.cashUsd).toBe(PAPER_STARTING_BALANCE);
     expect(cancelled.spotOrders).toHaveLength(0);
   });
@@ -1050,7 +1049,7 @@ describe("paper-ledger spot", () => {
       amount: 25,
       price: 78.34,
     }).ledger;
-    const have = paperTokenBalances(bought)[SOL_MINT]!;
+    const have = paperTokenBalances(bought)[SOL_MINT] ?? 0;
     const floored = Math.floor(have * 1e5) / 1e5;
     expect(floored).toBeLessThan(have);
     const { ledger } = executePaperSpotMarket(bought, {

--- a/apps/portal/src/lib/terminal/paper-ledger.test.ts
+++ b/apps/portal/src/lib/terminal/paper-ledger.test.ts
@@ -3,8 +3,10 @@ import type { PhoenixSide } from "../phoenix-trade";
 import {
   addPaperMargin,
   cancelPaperOrder,
+  cancelPaperSpotLimit,
   closePaperPosition,
   createEmptyLedger,
+  executePaperSpotMarket,
   ledgerToTraderState,
   PAPER_MARK_TTL_MS,
   PAPER_STARTING_BALANCE,
@@ -12,14 +14,19 @@ import {
   type PaperMark,
   type PaperPlaceOrderInput,
   parsePaperLedger,
+  paperSpotMarkUsd,
+  paperTokenBalances,
   placePaperOrder,
+  placePaperSpotLimit,
   resetPaperLedger,
   setPaperTpSl,
   tickPaperLedger,
+  tickPaperSpotOrders,
   topUpPaperCash,
 } from "./paper-ledger";
 
 const NOW_MS = 1_000_000;
+const SOL_MINT = "So11111111111111111111111111111111111111112";
 
 function firstSubaccount(ledger: PaperLedger): number {
   const index = ledger.positions[0]?.subaccountIndex;
@@ -945,5 +952,115 @@ describe("paper-ledger executable mark freshness", () => {
       expect(ticked.ledger).toBe(ledger);
       expect(ticked.ledger.positions).toHaveLength(1);
     }
+  });
+});
+
+describe("paper-ledger spot", () => {
+  test("spot market buy spends USDC and credits tokens", () => {
+    const { ledger, event } = executePaperSpotMarket(createEmptyLedger(), {
+      mint: SOL_MINT,
+      symbol: "SOL",
+      decimals: 9,
+      side: "buy",
+      amount: 100,
+      price: 50,
+    });
+    expect(event.kind).toBe("spot_buy");
+    expect(event.signature).toBe("paper-event-1");
+    expect(ledger.cashUsd).toBe(PAPER_STARTING_BALANCE - 100);
+    expect(paperTokenBalances(ledger)[SOL_MINT]).toBeCloseTo(2);
+    expect(paperSpotMarkUsd(ledger, { [SOL_MINT]: 50 })).toBeCloseTo(100);
+  });
+
+  test("spot market sell returns USDC", () => {
+    const bought = executePaperSpotMarket(createEmptyLedger(), {
+      mint: SOL_MINT,
+      symbol: "SOL",
+      decimals: 9,
+      side: "buy",
+      amount: 100,
+      price: 50,
+    }).ledger;
+    const { ledger } = executePaperSpotMarket(bought, {
+      mint: SOL_MINT,
+      symbol: "SOL",
+      decimals: 9,
+      side: "sell",
+      amount: 2,
+      price: 55,
+    });
+    expect(ledger.cashUsd).toBe(PAPER_STARTING_BALANCE + 10);
+    expect(paperTokenBalances(ledger)[SOL_MINT] ?? 0).toBe(0);
+  });
+
+  test("spot limit buy rests then fills below limit", () => {
+    const placed = placePaperSpotLimit(createEmptyLedger(), {
+      mint: SOL_MINT,
+      symbol: "SOL",
+      decimals: 9,
+      side: "buy",
+      limitPrice: 40,
+      amount: 80,
+    });
+    expect(placed.ledger.cashUsd).toBe(PAPER_STARTING_BALANCE - 80);
+    expect(placed.ledger.spotOrders).toHaveLength(1);
+    const filled = tickPaperSpotOrders(placed.ledger, { [SOL_MINT]: 39 });
+    expect(filled.events[0]?.kind).toBe("spot_limit_fill");
+    expect(filled.ledger.spotOrders).toHaveLength(0);
+    expect(paperTokenBalances(filled.ledger)[SOL_MINT]).toBeCloseTo(2);
+  });
+
+  test("cancel spot limit restores reserved USDC", () => {
+    const placed = placePaperSpotLimit(createEmptyLedger(), {
+      mint: SOL_MINT,
+      symbol: "SOL",
+      decimals: 9,
+      side: "buy",
+      limitPrice: 40,
+      amount: 80,
+    }).ledger;
+    const cancelled = cancelPaperSpotLimit(
+      placed,
+      placed.spotOrders[0]!.orderKey,
+    );
+    expect(cancelled.cashUsd).toBe(PAPER_STARTING_BALANCE);
+    expect(cancelled.spotOrders).toHaveLength(0);
+  });
+
+  test("parsePaperLedger migrates missing spot arrays", () => {
+    const parsed = parsePaperLedger({
+      version: 1,
+      cashUsd: PAPER_STARTING_BALANCE,
+      positions: [],
+      orders: [],
+      nextOrderId: 1,
+      nextSubaccount: 1,
+      nextEventId: 1,
+    });
+    expect(parsed.spotHoldings).toEqual([]);
+    expect(parsed.spotOrders).toEqual([]);
+  });
+
+  test("spot Max sell clears floored dust remainder", () => {
+    const bought = executePaperSpotMarket(createEmptyLedger(), {
+      mint: SOL_MINT,
+      symbol: "SOL",
+      decimals: 9,
+      side: "buy",
+      amount: 25,
+      price: 78.34,
+    }).ledger;
+    const have = paperTokenBalances(bought)[SOL_MINT]!;
+    const floored = Math.floor(have * 1e5) / 1e5;
+    expect(floored).toBeLessThan(have);
+    const { ledger } = executePaperSpotMarket(bought, {
+      mint: SOL_MINT,
+      symbol: "SOL",
+      decimals: 9,
+      side: "sell",
+      amount: floored,
+      price: 78.34,
+    });
+    expect(paperTokenBalances(ledger)[SOL_MINT] ?? 0).toBe(0);
   });
 });

--- a/apps/portal/src/lib/terminal/paper-ledger.ts
+++ b/apps/portal/src/lib/terminal/paper-ledger.ts
@@ -16,10 +16,10 @@ import type {
   PhoenixTraderState,
 } from "../phoenix-trade";
 import {
+  type TriggerOrder,
   tokenToAtoms,
   USDC_MINT,
   usdcToAtoms,
-  type TriggerOrder,
 } from "../spot";
 import { liquidationPriceEstimate } from "./trade-math";
 
@@ -204,7 +204,9 @@ function setSpotHolding(
 }
 
 /** Mint → available token qty for the spot ticket balance chip. */
-export function paperTokenBalances(ledger: PaperLedger): Record<string, number> {
+export function paperTokenBalances(
+  ledger: PaperLedger,
+): Record<string, number> {
   const out: Record<string, number> = {};
   for (const row of ledger.spotHoldings ?? []) out[row.mint] = row.amount;
   return out;
@@ -296,10 +298,10 @@ export function executePaperSpotMarket(
       leverage: null,
       realizedPnlUsd: 0,
     };
-    const { events, nextEventId } = stampEvents(ledger, [seed]);
+    const { event, nextEventId } = stampOne(ledger, seed);
     return {
       ledger: { ...nextLedger, nextEventId },
-      event: events[0]!,
+      event,
     };
   }
 
@@ -331,10 +333,10 @@ export function executePaperSpotMarket(
     leverage: null,
     realizedPnlUsd: 0,
   };
-  const { events, nextEventId } = stampEvents(ledger, [seed]);
+  const { event, nextEventId } = stampOne(ledger, seed);
   return {
     ledger: { ...nextLedger, nextEventId },
-    event: events[0]!,
+    event,
   };
 }
 
@@ -445,7 +447,9 @@ export function tickPaperSpotOrders(
 
     next = {
       ...next,
-      spotOrders: next.spotOrders.filter((row) => row.orderKey !== order.orderKey),
+      spotOrders: next.spotOrders.filter(
+        (row) => row.orderKey !== order.orderKey,
+      ),
     };
 
     if (order.side === "buy") {
@@ -535,6 +539,19 @@ function stampEvents(
     return { ...seed, signature };
   });
   return { events, nextEventId };
+}
+
+// Single-seed convenience: stamps exactly one event and hands back both the
+// event and the advanced counter — avoids `events[0]!` at the call sites.
+function stampOne(
+  ledger: PaperLedger,
+  seed: PaperEventSeed,
+): { event: PaperEvent; nextEventId: number } {
+  const nextEventId = ledger.nextEventId + 1;
+  return {
+    event: { ...seed, signature: `paper-event-${ledger.nextEventId}` },
+    nextEventId,
+  };
 }
 
 function signedSize(side: PhoenixSide, baseQty: number): number {
@@ -1603,7 +1620,10 @@ export function parsePaperLedger(value: unknown): PaperLedger {
   let spotHoldings: PaperSpotHolding[] = [];
   let spotOrders: PaperSpotLimitOrder[] = [];
   if (value.spotHoldings !== undefined || value.spotOrders !== undefined) {
-    if (!Array.isArray(value.spotHoldings) || !Array.isArray(value.spotOrders)) {
+    if (
+      !Array.isArray(value.spotHoldings) ||
+      !Array.isArray(value.spotOrders)
+    ) {
       return createEmptyLedger();
     }
     const parsedHoldings: PaperSpotHolding[] = [];

--- a/apps/portal/src/lib/terminal/paper-ledger.ts
+++ b/apps/portal/src/lib/terminal/paper-ledger.ts
@@ -1,6 +1,7 @@
-// Paper trading ledger — local simulated Phoenix account on live mids.
-// Frontend-only: no signing, no chain. Desk UI consumes the same
-// PhoenixTraderState shape via ledgerToTraderState().
+// Paper trading ledger — local simulated Phoenix account on live mids,
+// plus spot token balances / resting spot limits. Frontend-only: no
+// signing, no chain. Desk UI consumes the same PhoenixTraderState shape
+// via ledgerToTraderState(); spot ticket reads holdings + spotOrders.
 //
 // This module is PURE: every mutator returns a fresh next ledger + events
 // or throws WITHOUT touching the input ledger. No Date.now()/Math.random()
@@ -14,6 +15,12 @@ import type {
   PhoenixSide,
   PhoenixTraderState,
 } from "../phoenix-trade";
+import {
+  tokenToAtoms,
+  USDC_MINT,
+  usdcToAtoms,
+  type TriggerOrder,
+} from "../spot";
 import { liquidationPriceEstimate } from "./trade-math";
 
 export const PAPER_AUTHORITY = "paper";
@@ -27,6 +34,8 @@ const QTY_EPS = 1e-9;
 // Tolerance for the free-cash funding check so a sub-cent rounding gap on
 // an exact-fit order can't bounce a fundable fill.
 const CASH_EPS = 1e-9;
+// Spot Max-chip floor can leave up to ~1e-5 dust on sub-1 sizes.
+const SPOT_DUST_EPS = 1e-5;
 
 export type PaperMark = {
   price: number;
@@ -43,11 +52,32 @@ export type PaperRestingOrder = PhoenixOpenOrder & {
   reduceOnly: boolean;
 };
 
+export type PaperSpotHolding = {
+  mint: string;
+  symbol: string;
+  amount: number;
+  decimals: number;
+};
+
+/** Resting spot limit — buy reserves USDC from cash; sell reserves tokens. */
+export type PaperSpotLimitOrder = {
+  orderKey: string;
+  mint: string;
+  symbol: string;
+  decimals: number;
+  side: "buy" | "sell";
+  limitPrice: number;
+  /** Buy: USDC spend reserved. Sell: token qty reserved. */
+  amount: number;
+};
+
 export type PaperLedger = {
   version: 1;
   cashUsd: number;
   positions: PhoenixPosition[];
   orders: PaperRestingOrder[];
+  spotHoldings: PaperSpotHolding[];
+  spotOrders: PaperSpotLimitOrder[];
   nextOrderId: number;
   nextSubaccount: number;
   /** Monotonic source for deterministic paper-event-N event signatures. */
@@ -68,7 +98,16 @@ export type PaperPlaceOrderInput = {
 };
 
 export type PaperEvent = {
-  kind: "open" | "close" | "tp" | "sl" | "liq" | "limit_fill";
+  kind:
+    | "open"
+    | "close"
+    | "tp"
+    | "sl"
+    | "liq"
+    | "limit_fill"
+    | "spot_buy"
+    | "spot_sell"
+    | "spot_limit_fill";
   symbol: string;
   side: PhoenixSide;
   notionalUsd: number;
@@ -76,6 +115,29 @@ export type PaperEvent = {
   leverage: number | null;
   realizedPnlUsd: number;
   signature: string;
+};
+
+export type PaperSpotMarketInput = {
+  mint: string;
+  symbol: string;
+  decimals: number;
+  side: "buy" | "sell";
+  /** Buy: USDC to spend. Sell: tokens to sell. */
+  amount: number;
+  /** Fill price (token USD). */
+  price: number;
+  /** Optional quote out — preferred over amount/price math when set. */
+  outUi?: number;
+};
+
+export type PaperSpotLimitInput = {
+  mint: string;
+  symbol: string;
+  decimals: number;
+  side: "buy" | "sell";
+  limitPrice: number;
+  /** Buy: USDC to spend. Sell: tokens to sell. */
+  amount: number;
 };
 
 /** Event before its deterministic signature is stamped on. */
@@ -89,6 +151,8 @@ export function createEmptyLedger(
     cashUsd,
     positions: [],
     orders: [],
+    spotHoldings: [],
+    spotOrders: [],
     nextOrderId: 1,
     nextSubaccount: 1,
     nextEventId: 1,
@@ -105,6 +169,321 @@ export function topUpPaperCash(
 ): PaperLedger {
   if (!Number.isFinite(amount) || amount <= 0) return ledger;
   return { ...ledger, cashUsd: ledger.cashUsd + amount };
+}
+
+function ensureSpotFields(ledger: PaperLedger): PaperLedger {
+  if (Array.isArray(ledger.spotHoldings) && Array.isArray(ledger.spotOrders)) {
+    return ledger;
+  }
+  return {
+    ...ledger,
+    spotHoldings: Array.isArray(ledger.spotHoldings) ? ledger.spotHoldings : [],
+    spotOrders: Array.isArray(ledger.spotOrders) ? ledger.spotOrders : [],
+  };
+}
+
+function spotHoldingAmount(ledger: PaperLedger, mint: string): number {
+  return (
+    (ledger.spotHoldings ?? []).find((row) => row.mint === mint)?.amount ?? 0
+  );
+}
+
+function setSpotHolding(
+  ledger: PaperLedger,
+  mint: string,
+  symbol: string,
+  decimals: number,
+  amount: number,
+): PaperLedger {
+  const base = ensureSpotFields(ledger);
+  const holdings = base.spotHoldings.filter((row) => row.mint !== mint);
+  if (amount > SPOT_DUST_EPS) {
+    holdings.push({ mint, symbol, decimals, amount });
+  }
+  return { ...base, spotHoldings: holdings };
+}
+
+/** Mint → available token qty for the spot ticket balance chip. */
+export function paperTokenBalances(ledger: PaperLedger): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const row of ledger.spotHoldings ?? []) out[row.mint] = row.amount;
+  return out;
+}
+
+/** Mark-to-market value of free holdings + reserved sell tokens + reserved buy USDC. */
+export function paperSpotMarkUsd(
+  ledger: PaperLedger,
+  pricesByMint: Record<string, number>,
+): number {
+  let total = 0;
+  for (const row of ledger.spotHoldings ?? []) {
+    const px = pricesByMint[row.mint];
+    if (px && px > 0) total += row.amount * px;
+  }
+  for (const order of ledger.spotOrders ?? []) {
+    if (order.side === "buy") total += order.amount;
+    else {
+      const px = pricesByMint[order.mint];
+      if (px && px > 0) total += order.amount * px;
+    }
+  }
+  return total;
+}
+
+/** Shape paper resting spot limits like Jupiter TriggerOrder for the ticket list. */
+export function paperSpotOrdersToTriggers(ledger: PaperLedger): TriggerOrder[] {
+  return (ledger.spotOrders ?? []).map((order) => {
+    if (order.side === "buy") {
+      const tokens = order.limitPrice > 0 ? order.amount / order.limitPrice : 0;
+      return {
+        orderKey: order.orderKey,
+        inputMint: USDC_MINT,
+        outputMint: order.mint,
+        makingAmountAtoms: usdcToAtoms(order.amount),
+        takingAmountAtoms: tokenToAtoms(tokens, order.decimals),
+        createdAt: null,
+      };
+    }
+    return {
+      orderKey: order.orderKey,
+      inputMint: order.mint,
+      outputMint: USDC_MINT,
+      makingAmountAtoms: tokenToAtoms(order.amount, order.decimals),
+      takingAmountAtoms: usdcToAtoms(order.amount * order.limitPrice),
+      createdAt: null,
+    };
+  });
+}
+
+export function executePaperSpotMarket(
+  ledger: PaperLedger,
+  input: PaperSpotMarketInput,
+): { ledger: PaperLedger; event: PaperEvent } {
+  ledger = ensureSpotFields(ledger);
+  const amount = input.amount;
+  const price = input.price;
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new Error("Invalid spot amount");
+  }
+  if (!Number.isFinite(price) || price <= 0) {
+    throw new Error("Invalid spot price");
+  }
+
+  if (input.side === "buy") {
+    const usdcIn = amount;
+    if (ledger.cashUsd + CASH_EPS < usdcIn) {
+      throw new Error(
+        `Insufficient paper USDC — need $${usdcIn.toFixed(2)}, have $${ledger.cashUsd.toFixed(2)}`,
+      );
+    }
+    const tokenOut =
+      input.outUi != null && Number.isFinite(input.outUi) && input.outUi > 0
+        ? input.outUi
+        : usdcIn / price;
+    const nextLedger = setSpotHolding(
+      { ...ledger, cashUsd: ledger.cashUsd - usdcIn },
+      input.mint,
+      input.symbol,
+      input.decimals,
+      spotHoldingAmount(ledger, input.mint) + tokenOut,
+    );
+    const seed: PaperEventSeed = {
+      kind: "spot_buy",
+      symbol: input.symbol,
+      side: "bid",
+      notionalUsd: usdcIn,
+      price: tokenOut > 0 ? usdcIn / tokenOut : price,
+      leverage: null,
+      realizedPnlUsd: 0,
+    };
+    const { events, nextEventId } = stampEvents(ledger, [seed]);
+    return {
+      ledger: { ...nextLedger, nextEventId },
+      event: events[0]!,
+    };
+  }
+
+  const have = spotHoldingAmount(ledger, input.mint);
+  let sellAmount = amount;
+  if (have > 0 && have - sellAmount <= SPOT_DUST_EPS) sellAmount = have;
+  if (have + QTY_EPS < sellAmount) {
+    throw new Error(
+      `Insufficient paper ${input.symbol} — need ${amount}, have ${have}`,
+    );
+  }
+  const usdcOut =
+    input.outUi != null && Number.isFinite(input.outUi) && input.outUi > 0
+      ? input.outUi * (sellAmount / amount)
+      : sellAmount * price;
+  const nextLedger = setSpotHolding(
+    { ...ledger, cashUsd: ledger.cashUsd + usdcOut },
+    input.mint,
+    input.symbol,
+    input.decimals,
+    have - sellAmount,
+  );
+  const seed: PaperEventSeed = {
+    kind: "spot_sell",
+    symbol: input.symbol,
+    side: "ask",
+    notionalUsd: usdcOut,
+    price: sellAmount > 0 ? usdcOut / sellAmount : price,
+    leverage: null,
+    realizedPnlUsd: 0,
+  };
+  const { events, nextEventId } = stampEvents(ledger, [seed]);
+  return {
+    ledger: { ...nextLedger, nextEventId },
+    event: events[0]!,
+  };
+}
+
+export function placePaperSpotLimit(
+  ledger: PaperLedger,
+  input: PaperSpotLimitInput,
+): { ledger: PaperLedger; order: PaperSpotLimitOrder } {
+  ledger = ensureSpotFields(ledger);
+  const amount = input.amount;
+  const limitPrice = input.limitPrice;
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new Error("Invalid spot amount");
+  }
+  if (!Number.isFinite(limitPrice) || limitPrice <= 0) {
+    throw new Error("Invalid limit price");
+  }
+
+  const orderKey = `paper-spot-${ledger.nextOrderId}`;
+  const order: PaperSpotLimitOrder = {
+    orderKey,
+    mint: input.mint,
+    symbol: input.symbol,
+    decimals: input.decimals,
+    side: input.side,
+    limitPrice,
+    amount,
+  };
+
+  if (input.side === "buy") {
+    if (ledger.cashUsd + CASH_EPS < amount) {
+      throw new Error(
+        `Insufficient paper USDC — need $${amount.toFixed(2)}, have $${ledger.cashUsd.toFixed(2)}`,
+      );
+    }
+    return {
+      ledger: {
+        ...ledger,
+        cashUsd: ledger.cashUsd - amount,
+        spotOrders: [...ledger.spotOrders, order],
+        nextOrderId: ledger.nextOrderId + 1,
+      },
+      order,
+    };
+  }
+
+  const have = spotHoldingAmount(ledger, input.mint);
+  if (have + QTY_EPS < amount) {
+    throw new Error(
+      `Insufficient paper ${input.symbol} — need ${amount}, have ${have}`,
+    );
+  }
+  return {
+    ledger: {
+      ...setSpotHolding(
+        ledger,
+        input.mint,
+        input.symbol,
+        input.decimals,
+        have - amount,
+      ),
+      spotOrders: [...ledger.spotOrders, order],
+      nextOrderId: ledger.nextOrderId + 1,
+    },
+    order,
+  };
+}
+
+export function cancelPaperSpotLimit(
+  ledger: PaperLedger,
+  orderKey: string,
+): PaperLedger {
+  ledger = ensureSpotFields(ledger);
+  const order = ledger.spotOrders.find((row) => row.orderKey === orderKey);
+  if (!order) return ledger;
+  const without = {
+    ...ledger,
+    spotOrders: ledger.spotOrders.filter((row) => row.orderKey !== orderKey),
+  };
+  if (order.side === "buy") {
+    return { ...without, cashUsd: without.cashUsd + order.amount };
+  }
+  return setSpotHolding(
+    without,
+    order.mint,
+    order.symbol,
+    order.decimals,
+    spotHoldingAmount(without, order.mint) + order.amount,
+  );
+}
+
+/**
+ * Fill resting spot limits when catalog prices cross the limit.
+ * `pricesByMint` is mint → USD mark (no TTL — catalog mid).
+ */
+export function tickPaperSpotOrders(
+  ledger: PaperLedger,
+  pricesByMint: Record<string, number>,
+): { ledger: PaperLedger; events: PaperEvent[] } {
+  let next = ensureSpotFields(ledger);
+  const seeds: PaperEventSeed[] = [];
+
+  for (const order of [...next.spotOrders]) {
+    const mid = pricesByMint[order.mint];
+    if (!mid || mid <= 0) continue;
+    const crossed =
+      order.side === "buy" ? mid <= order.limitPrice : mid >= order.limitPrice;
+    if (!crossed) continue;
+
+    next = {
+      ...next,
+      spotOrders: next.spotOrders.filter((row) => row.orderKey !== order.orderKey),
+    };
+
+    if (order.side === "buy") {
+      const tokens = order.amount / order.limitPrice;
+      next = setSpotHolding(
+        next,
+        order.mint,
+        order.symbol,
+        order.decimals,
+        spotHoldingAmount(next, order.mint) + tokens,
+      );
+      seeds.push({
+        kind: "spot_limit_fill",
+        symbol: order.symbol,
+        side: "bid",
+        notionalUsd: order.amount,
+        price: order.limitPrice,
+        leverage: null,
+        realizedPnlUsd: 0,
+      });
+    } else {
+      const usdcOut = order.amount * order.limitPrice;
+      next = { ...next, cashUsd: next.cashUsd + usdcOut };
+      seeds.push({
+        kind: "spot_limit_fill",
+        symbol: order.symbol,
+        side: "ask",
+        notionalUsd: usdcOut,
+        price: order.limitPrice,
+        leverage: null,
+        realizedPnlUsd: 0,
+      });
+    }
+  }
+
+  if (seeds.length === 0) return { ledger: next, events: [] };
+  const { events, nextEventId } = stampEvents(ledger, seeds);
+  return { ledger: { ...next, nextEventId }, events };
 }
 
 export function ledgerToTraderState(ledger: PaperLedger): PhoenixTraderState {
@@ -1219,15 +1598,103 @@ export function parsePaperLedger(value: unknown): PaperLedger {
     return createEmptyLedger();
   }
 
+  // Spot fields are optional for pre-spot ledgers — default empty arrays.
+  // Present-but-invalid spot payloads reset wholesale (same honesty bar).
+  let spotHoldings: PaperSpotHolding[] = [];
+  let spotOrders: PaperSpotLimitOrder[] = [];
+  if (value.spotHoldings !== undefined || value.spotOrders !== undefined) {
+    if (!Array.isArray(value.spotHoldings) || !Array.isArray(value.spotOrders)) {
+      return createEmptyLedger();
+    }
+    const parsedHoldings: PaperSpotHolding[] = [];
+    const holdingMints = new Set<string>();
+    for (const item of value.spotHoldings) {
+      const holding = parsePaperSpotHolding(item);
+      if (!holding) return createEmptyLedger();
+      if (holdingMints.has(holding.mint)) return createEmptyLedger();
+      holdingMints.add(holding.mint);
+      parsedHoldings.push(holding);
+    }
+    const parsedOrders: PaperSpotLimitOrder[] = [];
+    const orderKeys = new Set<string>();
+    let maxSpotOrderId = 0;
+    for (const item of value.spotOrders) {
+      const order = parsePaperSpotOrder(item);
+      if (!order) return createEmptyLedger();
+      if (orderKeys.has(order.orderKey)) return createEmptyLedger();
+      orderKeys.add(order.orderKey);
+      const id = paperSpotOrderIdNumber(order.orderKey);
+      if (id !== null) maxSpotOrderId = Math.max(maxSpotOrderId, id);
+      parsedOrders.push(order);
+    }
+    if (value.nextOrderId <= maxSpotOrderId) return createEmptyLedger();
+    spotHoldings = parsedHoldings;
+    spotOrders = parsedOrders;
+  }
+
   return {
     version: 1,
     cashUsd: value.cashUsd,
     positions,
     orders,
+    spotHoldings,
+    spotOrders,
     nextOrderId: value.nextOrderId,
     nextSubaccount: value.nextSubaccount,
     nextEventId: value.nextEventId,
   };
+}
+
+function paperSpotOrderIdNumber(orderKey: string): number | null {
+  const match = /^paper-spot-(\d+)$/.exec(orderKey);
+  if (!match) return null;
+  const id = Number(match[1]);
+  return Number.isSafeInteger(id) && id > 0 ? id : null;
+}
+
+function parsePaperSpotHolding(value: unknown): PaperSpotHolding | null {
+  if (!isRecord(value)) return null;
+  const mint = value.mint;
+  const symbol = value.symbol;
+  const amount = value.amount;
+  const decimals = value.decimals;
+  if (
+    typeof mint !== "string" ||
+    mint.length === 0 ||
+    typeof symbol !== "string" ||
+    !isPaperSymbol(symbol) ||
+    !isPositiveNumber(amount) ||
+    !isNonNegativeSafeInteger(decimals)
+  ) {
+    return null;
+  }
+  return { mint, symbol, amount, decimals };
+}
+
+function parsePaperSpotOrder(value: unknown): PaperSpotLimitOrder | null {
+  if (!isRecord(value)) return null;
+  const orderKey = value.orderKey;
+  const mint = value.mint;
+  const symbol = value.symbol;
+  const decimals = value.decimals;
+  const side = value.side;
+  const limitPrice = value.limitPrice;
+  const amount = value.amount;
+  if (
+    typeof orderKey !== "string" ||
+    paperSpotOrderIdNumber(orderKey) === null ||
+    typeof mint !== "string" ||
+    mint.length === 0 ||
+    typeof symbol !== "string" ||
+    !isPaperSymbol(symbol) ||
+    !isNonNegativeSafeInteger(decimals) ||
+    (side !== "buy" && side !== "sell") ||
+    !isPositiveNumber(limitPrice) ||
+    !isPositiveNumber(amount)
+  ) {
+    return null;
+  }
+  return { orderKey, mint, symbol, decimals, side, limitPrice, amount };
 }
 
 export const paperLedger = persisted<PaperLedger>(

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -2599,7 +2599,7 @@
       const amount = Number($spotAmount);
       const price = asset.price;
       if (!Number.isFinite(amount) || amount <= 0) return;
-      if (!Number.isFinite(price) || price <= 0) {
+      if (price === null || !Number.isFinite(price) || price <= 0) {
         $spotQuoteStatus = "error";
         $spotQuoteError = "No mark price for this asset";
         return;

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -110,13 +110,20 @@
     addPaperMargin,
     cancelPaperOrder,
     cancelPaperOrdersOnSide,
+    cancelPaperSpotLimit,
     closePaperPosition,
+    executePaperSpotMarket,
     ledgerToTraderState,
     paperLedger,
+    paperSpotMarkUsd,
+    paperSpotOrdersToTriggers,
+    paperTokenBalances,
     placePaperOrder,
+    placePaperSpotLimit,
     resetPaperLedger,
     setPaperTpSl,
     tickPaperLedger,
+    tickPaperSpotOrders,
     topUpPaperCash,
     PAPER_MARK_TTL_MS,
     type PaperEvent,
@@ -602,7 +609,6 @@
     fundsOpen = false;
     pendingTradeMode = null;
     pendingSpotAssetId = null;
-    if (tradeMode !== "perps") setTradeMode("perps", false);
   }
 
   function exitPaperSafetyBoundary(): void {
@@ -1029,8 +1035,29 @@
   }
   $: if (!paperMode && phoenixAuthority)
     void ensurePhoenixOnboarding(phoenixAuthority, liveExecutionEpoch);
-  $: if (phoenixAuthority) void refreshTokenBalances(phoenixAuthority);
-  $: spotHolding = spotAsset ? tokenBalances[spotAsset.mint] ?? 0 : 0;
+  $: if (phoenixAuthority && !paperMode) void refreshTokenBalances(phoenixAuthority);
+  $: effectiveTokenBalances = paperMode
+    ? paperTokenBalances($paperLedger)
+    : tokenBalances;
+  $: spotHolding = spotAsset ? effectiveTokenBalances[spotAsset.mint] ?? 0 : 0;
+  $: spotUsdcBalanceValue = paperMode ? $paperLedger.cashUsd : usdcBalanceValue;
+  $: spotUsdcBalanceText = paperMode
+    ? `${$paperLedger.cashUsd.toLocaleString(undefined, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      })} USDC`
+    : usdcBalanceText;
+  $: spotTriggerOrders = paperMode
+    ? paperSpotOrdersToTriggers($paperLedger)
+    : triggerOrders;
+  $: paperSpotPricesByMint = Object.fromEntries(
+    spotAssets
+      .filter((asset) => Number.isFinite(asset.price) && (asset.price ?? 0) > 0)
+      .map((asset) => [asset.mint, asset.price as number]),
+  );
+  $: paperSpotEquityUsd = paperMode
+    ? paperSpotMarkUsd($paperLedger, paperSpotPricesByMint)
+    : 0;
   $: alertsStore.check(latestPrice, selectedSymbol);
   $: spread = asks[0] && bids[0] ? asks[0].price - bids[0].price : 0;
   $: spreadBps = latestPrice && latestPrice > 0 ? (spread / latestPrice) * 10_000 : 0;
@@ -1143,7 +1170,8 @@
     (sum, position) => sum + (position.unrealizedPnl ?? 0),
     0,
   );
-  $: accountEquityUsd = phoenixTotalCollateral + accountUpnlUsd;
+  $: accountEquityUsd =
+    phoenixTotalCollateral + accountUpnlUsd + (paperMode ? paperSpotEquityUsd : 0);
   $: marginInUseUsd = enrichedPositions.reduce(
     (sum, position) => sum + (position.marginUsd ?? 0),
     0,
@@ -1293,13 +1321,14 @@
     Boolean($tradePreview) &&
     (paperMode || !walletScreen.flagged);
   $: canSubmitSpot =
-    !paperMode &&
-    Boolean(phoenixAuthority) &&
+    (paperMode || Boolean(phoenixAuthority)) &&
     !spotBusy &&
-    !walletScreen.flagged &&
+    (paperMode || !walletScreen.flagged) &&
     ($spotOrderType === "limit"
       ? Number($spotLimitPrice) > 0 && Number($spotAmount) > 0
-      : $spotQuote !== null && $spotQuoteStatus === "quoted");
+      : paperMode
+        ? Number($spotAmount) > 0 && Boolean(spotAsset?.price)
+        : $spotQuote !== null && $spotQuoteStatus === "quoted");
 
   // ── Limit deviation gate ───────────────────────────────────────────
   // A dropped decimal (2450 instead of 245.0) would otherwise execute in
@@ -1469,8 +1498,8 @@
       visibleCandleCount,
       // Carry unapplied pendings through so a boot-time persist can't clobber
       // restored spot prefs before loadSpotAssets applies them.
-      paperMode ? "perps" : pendingTradeMode ?? tradeMode,
-      paperMode ? null : spotAsset?.assetId ?? pendingSpotAssetId,
+      pendingTradeMode ?? tradeMode,
+      spotAsset?.assetId ?? pendingSpotAssetId,
       watchlist,
       screenSort,
       screenHub,
@@ -2422,12 +2451,8 @@
       }
       if (pendingTradeMode === "spot") {
         pendingTradeMode = null;
-        if (paperMode) {
-          pendingSpotAssetId = null;
-        } else {
-          // Restored pref/deep-link — keep the restored asset, don't remap.
-          setTradeMode("spot", false);
-        }
+        // Restored pref/deep-link — keep the restored asset, don't remap.
+        setTradeMode("spot", false);
       }
     } catch {
       // catalog hiccup — keep last list
@@ -2435,14 +2460,6 @@
   }
 
   function setTradeMode(mode: "perps" | "spot", followAsset = true): void {
-    if (mode === "spot" && paperMode) {
-      pendingTradeMode = null;
-      pendingSpotAssetId = null;
-      spotSignature = "";
-      $spotQuoteStatus = "error";
-      $spotQuoteError = "Spot trading is disabled in PAPER mode.";
-      return;
-    }
     if (tradeMode === mode) return;
     track("venue_switched", { from: tradeMode, to: mode });
     // An explicit user choice overrides any not-yet-applied restored pref.
@@ -2501,14 +2518,6 @@
   }
 
   function selectSpotAsset(asset: SpotAsset): void {
-    if (paperMode) {
-      pendingTradeMode = null;
-      pendingSpotAssetId = null;
-      spotSignature = "";
-      $spotQuoteStatus = "error";
-      $spotQuoteError = "Spot trading is disabled in PAPER mode.";
-      return;
-    }
     const changed = spotAsset?.assetId !== asset.assetId;
     spotAsset = asset;
     $spotQuote = null;
@@ -2557,7 +2566,7 @@
   // balances that power the ticket preview. Max buy keeps the $0.01 dust
   // buffer the perp Max chip leaves. (The offered percentages live in
   // SpotTicketForm.svelte; the chip math stays here with the balances.)
-  $: spotChipBalance = $spotSide === "buy" ? (usdcBalanceValue ?? 0) : spotHolding;
+  $: spotChipBalance = $spotSide === "buy" ? (spotUsdcBalanceValue ?? 0) : spotHolding;
 
   function setSpotAmountChip(pct: number | "max"): void {
     const amount =
@@ -2583,15 +2592,62 @@
   }
 
   async function executeSpotSwap(): Promise<void> {
+    const asset = spotAsset;
+    if (!asset || spotBusy || (!paperMode && walletScreen.flagged)) return;
+
     if (paperMode) {
-      $spotQuoteStatus = "error";
-      $spotQuoteError = "Spot trading is disabled in PAPER mode.";
+      const amount = Number($spotAmount);
+      const price = asset.price;
+      if (!Number.isFinite(amount) || amount <= 0) return;
+      if (!Number.isFinite(price) || price <= 0) {
+        $spotQuoteStatus = "error";
+        $spotQuoteError = "No mark price for this asset";
+        return;
+      }
+      spotBusy = true;
+      $spotQuoteError = "";
+      try {
+        const filled = executePaperSpotMarket($paperLedger, {
+          mint: asset.mint,
+          symbol: asset.symbol,
+          decimals: asset.decimals,
+          side: $spotSide,
+          amount,
+          price,
+          outUi: $spotQuote?.outUi,
+        });
+        paperLedger.set(filled.ledger);
+        spotSignature = filled.event.signature;
+        noteTrade({
+          ts: Date.now(),
+          mode: "paper",
+          venue: "spot",
+          symbol: asset.symbol,
+          action: $spotSide,
+          notionalUsd:
+            $spotSide === "buy" ? amount : filled.event.notionalUsd,
+          price: filled.event.price,
+          leverage: null,
+          signature: filled.event.signature,
+        });
+        alertsStore.pushToast({
+          ts: Date.now(),
+          title: `Paper spot ${$spotSide}`,
+          body: `${asset.symbol} @ ${formatPrice(filled.event.price)}`,
+        });
+        spotTicket.invalidateQuote();
+      } catch (error) {
+        $spotQuoteStatus = "error";
+        $spotQuoteError = error instanceof Error ? error.message : "swap-failed";
+      } finally {
+        spotBusy = false;
+      }
       return;
     }
+
     const expectedLiveExecutionEpoch = captureLiveExecutionEpoch();
     const address = $privyAuth.walletAddress;
-    const asset = spotAsset;
-    if (!asset || !$spotQuote || !address || spotBusy || walletScreen.flagged) return;
+    if (!$spotQuote || !address) return;
     // Freshness gate: never execute a quote older than 30s — re-quote instead.
     if (Date.now() - spotTicket.quotedAtMs() > 30_000) {
       scheduleSpotQuote();
@@ -2861,13 +2917,27 @@
 
   function notePaperEvents(events: PaperEvent[]): void {
     for (const event of events) {
+      const isSpot =
+        event.kind === "spot_buy" ||
+        event.kind === "spot_sell" ||
+        event.kind === "spot_limit_fill";
       noteTrade({
         ts: Date.now(),
         mode: "paper",
-        venue: "perp",
+        venue: isSpot ? "spot" : "perp",
         symbol: event.symbol,
-        action:
-          event.kind === "close" || event.kind === "tp" || event.kind === "sl" || event.kind === "liq"
+        action: isSpot
+          ? event.side === "bid"
+            ? event.kind === "spot_limit_fill"
+              ? "limit-buy"
+              : "buy"
+            : event.kind === "spot_limit_fill"
+              ? "limit-sell"
+              : "sell"
+          : event.kind === "close" ||
+              event.kind === "tp" ||
+              event.kind === "sl" ||
+              event.kind === "liq"
             ? "close"
             : event.side === "bid"
               ? "long"
@@ -2888,20 +2958,34 @@
                 : "Paper liquidation",
           body: `${event.symbol} @ ${formatPrice(event.price)}`,
         });
+      } else if (event.kind === "spot_limit_fill") {
+        alertsStore.pushToast({
+          ts: Date.now(),
+          title: "Paper spot limit filled",
+          body: `${event.symbol} @ ${formatPrice(event.price)}`,
+        });
       }
     }
   }
 
   function applyPaperMids(): void {
     if (!paperMode) return;
-    const ticked = tickPaperLedger($paperLedger, paperExecutableMarks, nowMs);
-    if (ticked.events.length === 0 && ticked.ledger === $paperLedger) return;
-    paperLedger.set(ticked.ledger);
-    notePaperEvents(ticked.events);
+    let next = $paperLedger;
+    const events: PaperEvent[] = [];
+    const perpTick = tickPaperLedger(next, paperExecutableMarks, nowMs);
+    next = perpTick.ledger;
+    events.push(...perpTick.events);
+    const spotTick = tickPaperSpotOrders(next, paperSpotPricesByMint);
+    next = spotTick.ledger;
+    events.push(...spotTick.events);
+    if (events.length === 0 && next === $paperLedger) return;
+    paperLedger.set(next);
+    notePaperEvents(events);
   }
 
   $: if (paperMode) {
     paperExecutableMarks;
+    paperSpotPricesByMint;
     nowMs;
     applyPaperMids();
   }
@@ -5260,18 +5344,54 @@
   }
 
   async function submitSpotLimitOrder(): Promise<void> {
-    if (paperMode) {
-      $spotQuoteStatus = "error";
-      $spotQuoteError = "Spot trading is disabled in PAPER mode.";
-      return;
-    }
-    const expectedLiveExecutionEpoch = captureLiveExecutionEpoch();
-    const address = $privyAuth.walletAddress;
-    if (!spotAsset || !address || spotBusy || walletScreen.flagged) return;
+    if (!spotAsset || spotBusy || (!paperMode && walletScreen.flagged)) return;
     const limit = Number($spotLimitPrice);
     const amount = Number($spotAmount);
     if (!Number.isFinite(limit) || limit <= 0) return;
     if (!Number.isFinite(amount) || amount <= 0) return;
+
+    if (paperMode) {
+      spotBusy = true;
+      $spotQuoteError = "";
+      try {
+        const placed = placePaperSpotLimit($paperLedger, {
+          mint: spotAsset.mint,
+          symbol: spotAsset.symbol,
+          decimals: spotAsset.decimals,
+          side: $spotSide,
+          limitPrice: limit,
+          amount,
+        });
+        paperLedger.set(placed.ledger);
+        spotSignature = placed.order.orderKey;
+        noteTrade({
+          ts: Date.now(),
+          mode: "paper",
+          venue: "spot",
+          symbol: spotAsset.symbol,
+          action: `limit-${$spotSide}`,
+          notionalUsd: $spotSide === "buy" ? amount : amount * limit,
+          price: limit,
+          leverage: null,
+          signature: placed.order.orderKey,
+        });
+        alertsStore.pushToast({
+          ts: Date.now(),
+          title: "Paper spot limit placed",
+          body: `${$spotSide} ${spotAsset.symbol} @ ${formatPrice(limit)}`,
+        });
+      } catch (error) {
+        $spotQuoteStatus = "error";
+        $spotQuoteError = error instanceof Error ? error.message : "limit-failed";
+      } finally {
+        spotBusy = false;
+      }
+      return;
+    }
+
+    const expectedLiveExecutionEpoch = captureLiveExecutionEpoch();
+    const address = $privyAuth.walletAddress;
+    if (!address) return;
     spotBusy = true;
     $spotQuoteError = "";
     try {
@@ -5329,14 +5449,21 @@
   }
 
   async function cancelSpotLimitOrder(orderKey: string): Promise<void> {
+    if (triggerBusy) return;
+
     if (paperMode) {
-      $spotQuoteStatus = "error";
-      $spotQuoteError = "Spot trading is disabled in PAPER mode.";
+      triggerBusy = true;
+      try {
+        paperLedger.set(cancelPaperSpotLimit($paperLedger, orderKey));
+      } finally {
+        triggerBusy = false;
+      }
       return;
     }
+
     const expectedLiveExecutionEpoch = captureLiveExecutionEpoch();
     const address = $privyAuth.walletAddress;
-    if (!address || triggerBusy) return;
+    if (!address) return;
     triggerBusy = true;
     try {
       const transaction = await cancelTriggerOrder(address, orderKey);
@@ -5378,8 +5505,8 @@
     if (prefs.visibleCandleCount !== undefined) {
       visibleCandleCount = prefs.visibleCandleCount;
     }
-    if (prefs.tradeMode === "spot" && prefs.paperMode !== true) pendingTradeMode = "spot";
-    if (prefs.spotAssetId !== undefined && prefs.paperMode !== true) pendingSpotAssetId = prefs.spotAssetId;
+    if (prefs.tradeMode === "spot") pendingTradeMode = "spot";
+    if (prefs.spotAssetId !== undefined) pendingSpotAssetId = prefs.spotAssetId;
     if (prefs.watchlist !== undefined) watchlist = prefs.watchlist;
     if (prefs.screenSort !== undefined) screenSort = prefs.screenSort;
     if (prefs.screenHub !== undefined) screenHub = prefs.screenHub;
@@ -5395,11 +5522,6 @@
     // Without Privy, live trading is impossible — stay in paper regardless
     // of a previously saved LIVE preference.
     if (!readPrivyConfig().appId) paperMode = true;
-    if (paperMode) {
-      pendingTradeMode = null;
-      pendingSpotAssetId = null;
-      tradeMode = "perps";
-    }
   }
 
   function loadOpenBetaBanner(): void {
@@ -6583,17 +6705,17 @@
     {spotAsset}
     {spotAssets}
     {spotChipBalance}
-    {usdcBalanceText}
+    usdcBalanceText={spotUsdcBalanceText}
     {spotHolding}
-    {phoenixAuthority}
+    phoenixAuthority={paperMode ? PAPER_AUTHORITY : phoenixAuthority}
+    {paperMode}
     {spotBusy}
     {spotSignature}
-    {paperMode}
     canSubmit={canSubmitSpot}
     limitArmed={spotLimitArmed}
     limitBlocked={spotLimitBlocked}
     limitDeviationPct={spotLimitDeviationPct}
-    {triggerOrders}
+    triggerOrders={spotTriggerOrders}
     {triggerBusy}
     mintSafety={spotAsset ? (mintSafetyCache[spotAsset.mint] ?? null) : null}
     onswap={() => requireTradeAck(() => void executeSpotSwap())}

--- a/apps/portal/src/routes/terminal/components/PaperFundsModal.svelte
+++ b/apps/portal/src/routes/terminal/components/PaperFundsModal.svelte
@@ -140,7 +140,7 @@
       </div>
       <div class="modal-body">
         <p class="auth-lead">
-          Simulated USDC on live market data — nothing here is real money.
+          Simulated USDC on live market data (perps + spot) — nothing here is real money.
         </p>
         <div class="ticket-preview">
           <div class="preview-row">

--- a/apps/portal/src/routes/terminal/components/SpotTicketForm.svelte
+++ b/apps/portal/src/routes/terminal/components/SpotTicketForm.svelte
@@ -268,18 +268,18 @@
       {#if $spotQuoteStatus === "error"}
         {$spotQuoteError}
       {:else if spotSignature}
-        Swap submitted ·
-        <a class="news-domain" href={`https://solscan.io/tx/${spotSignature}`} target="_blank" rel="noopener noreferrer">view tx</a>
+        {#if paperMode}
+          Paper · simulated
+        {:else}
+          Swap submitted ·
+          <a class="news-domain" href={`https://solscan.io/tx/${spotSignature}`} target="_blank" rel="noopener noreferrer">view tx</a>
+        {/if}
       {:else}
         &nbsp;
       {/if}
     </p>
 
-    {#if paperMode}
-      <button class="primary wide" type="button" disabled>
-        Spot trading unavailable in PAPER
-      </button>
-    {:else if !phoenixAuthority}
+    {#if !phoenixAuthority}
       <button class="primary wide" type="button" onclick={onopenauth}>
         Connect account to trade
       </button>
@@ -293,12 +293,14 @@
       >
         {#if spotBusy}<span class="spinner" aria-hidden="true"></span>{/if}
         {spotBusy
-          ? "Signing…"
+          ? paperMode
+            ? "Filling…"
+            : "Signing…"
           : limitBlocked
             ? `Price ${formatNumber(Math.abs(limitDeviationPct ?? 0), 1)}% from mark — check decimals`
             : limitArmed
               ? `Confirm limit ${formatNumber(Math.abs(limitDeviationPct ?? 0), 1)}% from mark`
-              : `Limit ${$spotSide} ${spotAsset.symbol} @ ${$spotLimitPrice || "—"}`}
+              : `${paperMode ? "PAPER · " : ""}Limit ${$spotSide} ${spotAsset.symbol} @ ${$spotLimitPrice || "—"}`}
       </button>
     {:else}
       <button
@@ -309,8 +311,10 @@
       >
         {#if spotBusy}<span class="spinner" aria-hidden="true"></span>{/if}
         {spotBusy
-          ? "Signing…"
-          : `${$spotSide === "buy" ? "Buy" : "Sell"} ${spotAsset.symbol} · spot`}
+          ? paperMode
+            ? "Filling…"
+            : "Signing…"
+          : `${paperMode ? "PAPER · " : ""}${$spotSide === "buy" ? "Buy" : "Sell"} ${spotAsset.symbol} · spot`}
       </button>
     {/if}
   </div>
@@ -331,7 +335,7 @@
           <button
             class="row-action"
             type="button"
-            disabled={triggerBusy || paperMode}
+            disabled={triggerBusy}
             onclick={() => oncancelorder(order.orderKey)}
           >
             Cancel


### PR DESCRIPTION
## Summary
- Extends the hardened paper ledger with spot holdings and resting spot limits (deterministic \`paper-event-N\` refs, Max-sell dust handling, legacy ledger migration).
- Re-enables Spot in PAPER mode with labeled ticket UX, journal \`mode: paper\`, and equity that includes spot mark-to-market — live signing / epoch guards stay LIVE-only.
- Follow-up to #566: that PR intentionally blocked spot in PAPER for merge safety; this restores simulated spot only.

## Test plan
- [ ] \`bun test apps/portal/src/lib/terminal/paper-ledger.test.ts\`
- [ ] PAPER → Spot → market buy SOL → holdings + free USDC update; status shows Paper · simulated
- [ ] Max sell clears bag without dust / insufficient error
- [ ] Place spot limit below mark → cancels refund reserved USDC
- [ ] Toggle LIVE/PAPER does not force away from Spot; no wallet signature in PAPER
- [ ] Journal entries tagged paper + spot for fills

Made with [Cursor](https://cursor.com)