### PR TITLE
Chat model routing + Free/Pro tiering (PRD #571, PR1)

### DIFF
--- a/.factory/orders/chat-routing/wp1.md
+++ b/.factory/orders/chat-routing/wp1.md
@@ -1,0 +1,165 @@
+# WP1 — Chat model routing + Free/Pro tiering (PRD #571, PR1)
+
+Working in the WORKTREE `/Users/guillaume/Github/serious-trader-ralph-router`
+(branch codex/chat-routing). ALL paths below are inside that worktree —
+never touch other checkouts. Read AGENTS.md and .factory/PITFALLS.md first —
+every rule binds. Bun only. Git read-only for you; Claude commits.
+
+## Goal
+
+Replace the chat's hardcoded `deepseek-chat` call with a task-class model
+registry routed through the Vercel AI Gateway for the premium tier, add a
+flag-gated "Pro (open beta)" tier, and expose an "Auto"-default model picker
+in the panel. Pure, tested selection logic; the endpoint and UI are thin
+wiring. NO money path, NO change to grounding/rate-caps/tool-loop behavior.
+
+## Non-goals
+
+- No NL ticket edits, no slippage preview (later PRs).
+- No real billing/entitlement — the flag stands in.
+- Do not change the grounding validator, rate caps, tool loop, or system
+  prompt semantics. Do not touch paper-ledger or any signing path.
+
+## Files
+
+Create:
+- apps/portal/src/lib/chat-models.ts
+- apps/portal/src/lib/chat-models.test.ts
+
+Modify:
+- apps/portal/src/lib/chat-core.ts — export a task-class classifier (payload below)
+- apps/portal/src/lib/chat-core.test.ts — tests for the classifier
+- apps/portal/src/routes/api/chat/+server.ts — route via the registry; enforce tier server-side
+- apps/portal/src/lib/chat.ts — carry the chosen model tier in the request + state
+- apps/portal/src/routes/terminal/components/SidePanel.svelte — model picker (Auto default)
+
+Delete: none. Touch NOTHING outside these lists — STOP and report if it
+seems necessary.
+
+## Load-bearing payloads
+
+`chat-models.ts` — PURE, fully tested, no env/network:
+```ts
+export type ChatTier = "free" | "pro";
+export type TaskClass = "chat" | "analysis";
+export type ChatModelChoice = "auto" | "free" | "pro";
+
+export type ResolvedModel = {
+  tier: ChatTier;
+  /** AI Gateway "provider/model" string for pro; sentinel "deepseek-chat"
+   * for free (raw DeepSeek path the endpoint already owns). */
+  model: string;
+  /** true when a frontier/pro model was actually selected — drives the
+   * honest "Pro (open beta)" response label. */
+  proLabel: boolean;
+};
+
+export const FREE_MODEL = "deepseek-chat"; // raw DeepSeek path (existing)
+export const PRO_MODEL = "anthropic/claude-opus-4.8"; // AI Gateway provider/model; swap freely
+export const PRO_LABEL = "Pro (open beta)";
+
+/**
+ * Resolve the model for a request.
+ * - proAllowed = the server-side tier flag (PUBLIC_CHAT_PRO_OPEN on).
+ * - choice = the user's picker value.
+ * - taskClass = classifier output ("analysis" prefers pro under Auto).
+ * Rules: choice "pro" AND proAllowed → pro. choice "free" → free.
+ * choice "auto" → pro when proAllowed AND taskClass==="analysis", else free.
+ * When proAllowed is false, pro is NEVER selected regardless of choice
+ * (server is the authority — a client asking for pro without the flag gets
+ * free). proLabel === (tier === "pro").
+ */
+export function resolveModel(
+  choice: ChatModelChoice,
+  taskClass: TaskClass,
+  proAllowed: boolean,
+): ResolvedModel;
+```
+
+`chat-core.ts` add:
+```ts
+/** Cheap keyword classifier for Auto routing. "analysis" for asks that want
+ * reasoning over the book/macro/portfolio (why/analy[sz]e/compare/should/
+ * risk/regime/scenario/explain-in-depth); "chat" otherwise. Deterministic,
+ * lower-cased substring match — no model call. */
+export function classifyTaskClass(latestUserMessage: string): TaskClass;
+```
+(Import the `TaskClass` type from `./chat-models`.)
+
+`+server.ts` wiring:
+- Read the tier flag from env: `PUBLIC_CHAT_PRO_OPEN === "1"` → proAllowed.
+  (PUBLIC_ prefix so build exposes it; the SERVER still enforces it — the
+  client cannot force pro when the flag is off.)
+- Parse an optional `modelChoice: "auto"|"free"|"pro"` from the body
+  (default "auto"; validate, bad → 400 same as other fields).
+- `classifyTaskClass(lastUserContent)` → `resolveModel(choice, taskClass, proAllowed)`.
+- If `resolved.tier === "free"`: keep the EXISTING raw DeepSeek path
+  (`DEEPSEEK_URL`, `model: "deepseek-chat"`) unchanged.
+- If `resolved.tier === "pro"`: call the **AI Gateway OpenAI-compatible
+  endpoint via raw fetch** — NO new dependency, NO `ai` import. It is the
+  SAME OpenAI request shape the free DeepSeek path already builds; only the
+  constants differ:
+  - URL: `https://ai-gateway.vercel.sh/v1/chat/completions`
+  - Header: `Authorization: Bearer ${process.env.AI_GATEWAY_API_KEY}`
+  - Body `model`: `resolved.model` (e.g. `anthropic/claude-opus-4.8`)
+  - identical `messages`, `tools`, `temperature`, and the SAME 3-round tool
+    loop + grounding as the free path.
+  Refactor the existing DeepSeek call into a small shared
+  `callChatModel({ url, apiKey, model, messages, tools })` helper so free
+  and pro share one code path with different constants (keeps the tool loop
+  DRY). If `AI_GATEWAY_API_KEY` is missing or the pro call throws, FALL BACK
+  to the free DeepSeek path (never fail the request for a routing reason)
+  and set tier=free/proLabel=false in the response.
+- Response JSON gains `model: resolved.model` and `proLabel: resolved.proLabel`.
+  When proLabel, the reply is prefixed with a single quiet line
+  `${PRO_LABEL} · ` is NOT added to content — instead return proLabel in the
+  payload and let the client render the badge (provenance in data, chrome
+  minimal — constitution). Grounding still runs on the model's raw text.
+
+`chat.ts`:
+- `chatState` gains `modelChoice: ChatModelChoice` (default "auto") and the
+  last reply's `proLabel`/`model` for display. `sendChatMessage` includes
+  `modelChoice` in the POST body. Add `setModelChoice(choice)` persisting to
+  the existing `harness.chat.v1` localStorage key (extend the persisted
+  shape; keep `open` working).
+
+`SidePanel.svelte` (Svelte 5 runes, match file style):
+- A small, quiet picker (Auto / Free / Pro) — text control matching the
+  panel's existing tokens; no icon-candy, no pulse. Bound to
+  `setModelChoice`. When a reply carried `proLabel`, show a subtle
+  "Pro (open beta)" tag on that assistant message (token-only color, no
+  fallback hex). Picker reflects current `modelChoice`.
+
+## Acceptance criteria
+
+- `resolveModel` + `classifyTaskClass` fully unit-tested incl.: auto+analysis+flag→pro,
+  auto+chat→free, auto+analysis+flag OFF→free, choice pro+flag OFF→free
+  (server authority), choice free always free, proLabel mirrors tier.
+- Free tier path byte-identical to today's behavior (regression: existing
+  chat-core tests still pass).
+- Endpoint compiles; no `any`, no non-null assertions.
+- Panel picker renders, persists, and a Pro-labeled reply shows the tag.
+- No new deps beyond `ai` (already present).
+
+## Validation (run all from worktree root, paste FULL output)
+
+```bash
+bun run typecheck
+bun run lint
+bun run test
+cd apps/portal && bun test && cd ../..
+bun run build
+```
+Also grep the build output for `unused css selector` — must be 0.
+
+## Report format
+
+1. Summary per file. 2. Full validation output verbatim. 3. The exact
+`resolveModel` truth table you implemented. 4. Anything skipped/unsure.
+5. No success claim without validation output.
+
+## Rules (non-negotiable)
+
+- Git READ-ONLY (`status`/`diff`/`log`). Never commit/push/stash/reset.
+- Stay inside the file lists. Worktree paths only. Kill any dev server.
+- All `.factory/PITFALLS.md` rules apply.

--- a/apps/portal/src/lib/chat-core.test.ts
+++ b/apps/portal/src/lib/chat-core.test.ts
@@ -8,6 +8,7 @@ import {
   CHAT_TOOLS,
   type ChatMessage,
   capHistory,
+  classifyTaskClass,
   DAILY_MESSAGE_CAP,
   dailyAllowed,
   groundedOrNull,
@@ -16,6 +17,24 @@ import {
 } from "./chat-core";
 
 const NOW = Date.UTC(2026, 6, 19, 14, 2, 0);
+
+describe("classifyTaskClass", () => {
+  test("classifies analysis asks by deterministic lower-cased keyword match", () => {
+    expect(classifyTaskClass("WHY did risk regime change?")).toBe("analysis");
+    expect(classifyTaskClass("Can you analyse my portfolio scenario?")).toBe(
+      "analysis",
+    );
+    expect(classifyTaskClass("compare BTC and SOL funding")).toBe("analysis");
+    expect(classifyTaskClass("explain-in-depth what happened")).toBe(
+      "analysis",
+    );
+  });
+
+  test("classifies ordinary desk chat without analysis keywords as chat", () => {
+    expect(classifyTaskClass("show latest BTC price")).toBe("chat");
+    expect(classifyTaskClass("hello desk")).toBe("chat");
+  });
+});
 
 describe("CHAT_SYSTEM_PROMPT", () => {
   test("requires explicit simulation language and forbids live confirmation claims in paper mode", () => {

--- a/apps/portal/src/lib/chat-core.ts
+++ b/apps/portal/src/lib/chat-core.ts
@@ -1,3 +1,5 @@
+import type { TaskClass } from "./chat-models";
+
 export type ChatRole = "user" | "assistant" | "tool";
 export type ChatMessage = { role: ChatRole; content: string };
 export type DeskContext = unknown;
@@ -15,12 +17,34 @@ export const DAILY_MESSAGE_CAP = 200;
 export const BURST_WINDOW_MS = 60_000;
 export const BURST_CAP = 10;
 
+const ANALYSIS_KEYWORDS = [
+  "why",
+  "analy",
+  "compare",
+  "should",
+  "risk",
+  "regime",
+  "scenario",
+  "explain-in-depth",
+];
+
 const HISTORY_MESSAGE_CAP = 12;
 const HISTORY_CONTENT_CAP = 2_000;
 const CONTEXT_CONTENT_CAP = 12_000;
 const CONTEXT_TRUNCATED_SUFFIX = "\n[context truncated]";
 const NUMBER_RE = /\d[\d,]*\.?\d*/g;
 const ALLOWED_UNGROUNDED_NUMBERS = new Set(["24", "7", "30"]);
+
+/** Cheap keyword classifier for Auto routing. "analysis" for asks that want
+ * reasoning over the book/macro/portfolio (why/analy[sz]e/compare/should/
+ * risk/regime/scenario/explain-in-depth); "chat" otherwise. Deterministic,
+ * lower-cased substring match — no model call. */
+export function classifyTaskClass(latestUserMessage: string): TaskClass {
+  const normalized = latestUserMessage.toLowerCase();
+  return ANALYSIS_KEYWORDS.some((keyword) => normalized.includes(keyword))
+    ? "analysis"
+    : "chat";
+}
 
 /** Pure burst decision over injected timestamps (endpoint keeps the array). */
 export function burstAllowed(

--- a/apps/portal/src/lib/chat-models.test.ts
+++ b/apps/portal/src/lib/chat-models.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type ChatModelChoice,
+  FREE_MODEL,
+  PRO_MODEL,
+  resolveModel,
+  type TaskClass,
+} from "./chat-models";
+
+describe("resolveModel", () => {
+  const cases: {
+    choice: ChatModelChoice;
+    taskClass: TaskClass;
+    proAllowed: boolean;
+    tier: "free" | "pro";
+    model: string;
+    proLabel: boolean;
+  }[] = [
+    {
+      choice: "auto",
+      taskClass: "analysis",
+      proAllowed: true,
+      tier: "pro",
+      model: PRO_MODEL,
+      proLabel: true,
+    },
+    {
+      choice: "auto",
+      taskClass: "chat",
+      proAllowed: true,
+      tier: "free",
+      model: FREE_MODEL,
+      proLabel: false,
+    },
+    {
+      choice: "auto",
+      taskClass: "analysis",
+      proAllowed: false,
+      tier: "free",
+      model: FREE_MODEL,
+      proLabel: false,
+    },
+    {
+      choice: "pro",
+      taskClass: "analysis",
+      proAllowed: false,
+      tier: "free",
+      model: FREE_MODEL,
+      proLabel: false,
+    },
+    {
+      choice: "pro",
+      taskClass: "chat",
+      proAllowed: true,
+      tier: "pro",
+      model: PRO_MODEL,
+      proLabel: true,
+    },
+    {
+      choice: "free",
+      taskClass: "analysis",
+      proAllowed: true,
+      tier: "free",
+      model: FREE_MODEL,
+      proLabel: false,
+    },
+    {
+      choice: "free",
+      taskClass: "chat",
+      proAllowed: false,
+      tier: "free",
+      model: FREE_MODEL,
+      proLabel: false,
+    },
+  ];
+
+  test.each(cases)("$choice + $taskClass + proAllowed=$proAllowed -> $tier", ({
+    choice,
+    taskClass,
+    proAllowed,
+    tier,
+    model,
+    proLabel,
+  }) => {
+    expect(resolveModel(choice, taskClass, proAllowed)).toEqual({
+      tier,
+      model,
+      proLabel,
+    });
+  });
+
+  test.each(
+    cases,
+  )("proLabel mirrors tier for $choice + $taskClass + proAllowed=$proAllowed", ({
+    choice,
+    taskClass,
+    proAllowed,
+  }) => {
+    const resolved = resolveModel(choice, taskClass, proAllowed);
+
+    expect(resolved.proLabel).toBe(resolved.tier === "pro");
+  });
+});

--- a/apps/portal/src/lib/chat-models.ts
+++ b/apps/portal/src/lib/chat-models.ts
@@ -1,0 +1,46 @@
+export type ChatTier = "free" | "pro";
+export type TaskClass = "chat" | "analysis";
+export type ChatModelChoice = "auto" | "free" | "pro";
+
+export type ResolvedModel = {
+  tier: ChatTier;
+  /** AI Gateway "provider/model" string for pro; sentinel "deepseek-chat"
+   * for free (raw DeepSeek path the endpoint already owns). */
+  model: string;
+  /** true when a frontier/pro model was actually selected — drives the
+   * honest "Pro (open beta)" response label. */
+  proLabel: boolean;
+};
+
+export const FREE_MODEL = "deepseek-chat";
+export const PRO_MODEL = "anthropic/claude-opus-4.8";
+export const PRO_LABEL = "Pro (open beta)";
+
+/**
+ * Resolve the model for a request.
+ * - proAllowed = the server-side tier flag (PUBLIC_CHAT_PRO_OPEN on).
+ * - choice = the user's picker value.
+ * - taskClass = classifier output ("analysis" prefers pro under Auto).
+ * Rules: choice "pro" AND proAllowed → pro. choice "free" → free.
+ * choice "auto" → pro when proAllowed AND taskClass==="analysis", else free.
+ * When proAllowed is false, pro is NEVER selected regardless of choice
+ * (server is the authority — a client asking for pro without the flag gets
+ * free). proLabel === (tier === "pro").
+ */
+export function resolveModel(
+  choice: ChatModelChoice,
+  taskClass: TaskClass,
+  proAllowed: boolean,
+): ResolvedModel {
+  const tier: ChatTier =
+    proAllowed &&
+    (choice === "pro" || (choice === "auto" && taskClass === "analysis"))
+      ? "pro"
+      : "free";
+
+  return {
+    tier,
+    model: tier === "pro" ? PRO_MODEL : FREE_MODEL,
+    proLabel: tier === "pro",
+  };
+}

--- a/apps/portal/src/lib/chat.ts
+++ b/apps/portal/src/lib/chat.ts
@@ -13,32 +13,55 @@
 
 import { get, type Writable, writable } from "svelte/store";
 import type { ChatMessage } from "./chat-core";
+import type { ChatModelChoice } from "./chat-models";
 import { getPrivyAccessToken } from "./privy-auth";
 
 const CHAT_OPEN_KEY = "harness.chat.v1";
 const CHAT_ENDPOINT = "/api/chat";
 const UNGROUNDED_FALLBACK = "I can't ground that answer in the data I have.";
 
+export type ChatUiMessage = ChatMessage & {
+  model?: string;
+  proLabel?: boolean;
+};
+
 export type ChatState = {
   open: boolean;
   phase: "idle" | "waiting" | "error" | "limit" | "auth";
-  messages: ChatMessage[]; // user/assistant turns only
+  messages: ChatUiMessage[]; // user/assistant turns only
   error: string | null;
+  modelChoice: ChatModelChoice;
+  lastReplyModel: string | null;
+  lastReplyProLabel: boolean;
 };
 
+type PersistedChatState = {
+  open: boolean;
+  modelChoice: ChatModelChoice;
+};
+
+const persisted = readPersistedChatState();
+
 export const chatState: Writable<ChatState> = writable<ChatState>({
-  open: readPersistedOpen(),
+  open: persisted.open,
   phase: "idle",
   messages: [],
   error: null,
+  modelChoice: persisted.modelChoice,
+  lastReplyModel: null,
+  lastReplyProLabel: false,
 });
 
-// Persist ONLY the open/closed flag, lazily and SSR-safe. Best-effort: a
-// blocked quota / private mode is non-fatal — the store keeps working.
+// Persist ONLY the open/closed flag and model choice, lazily and SSR-safe.
+// Best-effort: a blocked quota / private mode is non-fatal — the store keeps
+// working. Legacy "1"/"0" payloads remain readable.
 if (typeof localStorage !== "undefined") {
   chatState.subscribe((state) => {
     try {
-      localStorage.setItem(CHAT_OPEN_KEY, state.open ? "1" : "0");
+      localStorage.setItem(
+        CHAT_OPEN_KEY,
+        JSON.stringify({ open: state.open, modelChoice: state.modelChoice }),
+      );
     } catch {
       // localStorage unavailable — persistence is best-effort.
     }
@@ -51,6 +74,10 @@ export function toggleChat(): void {
 
 export function closeChat(): void {
   chatState.update((state) => ({ ...state, open: false }));
+}
+
+export function setModelChoice(modelChoice: ChatModelChoice): void {
+  chatState.update((state) => ({ ...state, modelChoice }));
 }
 
 /** POST /api/chat. Attaches Authorization from getPrivyAccessToken() and the
@@ -76,10 +103,13 @@ export async function sendChatMessage(
 
   let response: Response;
   try {
+    const state = get(chatState);
     response = await fetch(CHAT_ENDPOINT, {
       method: "POST",
       headers: buildHeaders(token),
-      body: JSON.stringify(buildBody(token, get(chatState).messages, context)),
+      body: JSON.stringify(
+        buildBody(token, state.messages, context, state.modelChoice),
+      ),
     });
   } catch (error) {
     setError(networkErrorMessage(error));
@@ -99,26 +129,44 @@ export async function sendChatMessage(
     return;
   }
 
-  let payload: { reply?: string | null } = {};
+  let payload: { reply?: string | null; model?: unknown; proLabel?: unknown } =
+    {};
   try {
-    payload = (await response.json()) as { reply?: string | null };
+    payload = (await response.json()) as {
+      reply?: string | null;
+      model?: unknown;
+      proLabel?: unknown;
+    };
   } catch {
     setError("chat-bad-response");
     return;
   }
 
   const reply = typeof payload.reply === "string" ? payload.reply.trim() : "";
+  const model = typeof payload.model === "string" ? payload.model : null;
+  const proLabel = payload.proLabel === true;
   pushMessage({
     role: "assistant",
     content: reply.length > 0 ? reply : UNGROUNDED_FALLBACK,
+    ...(model ? { model } : {}),
+    proLabel,
   });
+  recordReplyMetadata(model, proLabel);
   setPhase("idle");
 }
 
-function pushMessage(message: ChatMessage): void {
+function pushMessage(message: ChatUiMessage): void {
   chatState.update((state) => ({
     ...state,
     messages: [...state.messages, message],
+  }));
+}
+
+function recordReplyMetadata(model: string | null, proLabel: boolean): void {
+  chatState.update((state) => ({
+    ...state,
+    lastReplyModel: model,
+    lastReplyProLabel: proLabel,
   }));
 }
 
@@ -142,10 +190,18 @@ function buildHeaders(token: string | null): Record<string, string> {
 
 function buildBody(
   token: string | null,
-  history: ChatMessage[],
+  history: ChatUiMessage[],
   context: Record<string, unknown>,
+  modelChoice: ChatModelChoice,
 ): Record<string, unknown> {
-  const body: Record<string, unknown> = { history, context };
+  const body: Record<string, unknown> = {
+    history: history.map((message) => ({
+      role: message.role,
+      content: message.content,
+    })),
+    context,
+    modelChoice,
+  };
   if (token) {
     body.edgeToken = token;
   }
@@ -159,11 +215,30 @@ function networkErrorMessage(error: unknown): string {
   return "chat-network-error";
 }
 
-function readPersistedOpen(): boolean {
-  if (typeof localStorage === "undefined") return false;
+function readPersistedChatState(): PersistedChatState {
+  const fallback: PersistedChatState = { open: false, modelChoice: "auto" };
+  if (typeof localStorage === "undefined") return fallback;
   try {
-    return localStorage.getItem(CHAT_OPEN_KEY) === "1";
+    const raw = localStorage.getItem(CHAT_OPEN_KEY);
+    if (raw === "1") return { ...fallback, open: true };
+    if (raw === "0" || raw === null) return fallback;
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isRecord(parsed)) return fallback;
+    return {
+      open: typeof parsed.open === "boolean" ? parsed.open : fallback.open,
+      modelChoice: isChatModelChoice(parsed.modelChoice)
+        ? parsed.modelChoice
+        : fallback.modelChoice,
+    };
   } catch {
-    return false;
+    return fallback;
   }
+}
+
+function isChatModelChoice(value: unknown): value is ChatModelChoice {
+  return value === "auto" || value === "free" || value === "pro";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/apps/portal/src/routes/api/chat/+server.ts
+++ b/apps/portal/src/routes/api/chat/+server.ts
@@ -1,5 +1,6 @@
 import { json } from "@sveltejs/kit";
-import { env } from "$env/dynamic/private";
+import { env as privateEnv } from "$env/dynamic/private";
+import { env as publicEnv } from "$env/dynamic/public";
 import {
   BURST_WINDOW_MS,
   buildMessages,
@@ -8,17 +9,30 @@ import {
   type ChatMessage,
   type ChatRole,
   capHistory,
+  classifyTaskClass,
   dailyAllowed,
   groundedOrNull,
   toolToEdgePath,
 } from "$lib/chat-core";
+import {
+  type ChatModelChoice,
+  FREE_MODEL,
+  type ResolvedModel,
+  resolveModel,
+} from "$lib/chat-models";
 import { verifyPrivyAccessToken } from "$lib/server/privy";
 import type { RequestHandler } from "./$types";
 
 const DEEPSEEK_URL = "https://api.deepseek.com/chat/completions";
+const AI_GATEWAY_URL = "https://ai-gateway.vercel.sh/v1/chat/completions";
 const TOOL_RESULT_CAP = 4_000;
 const MAX_TOOL_ROUNDS = 3;
 const TOOL_TIMEOUT_MS = 5_000;
+const FREE_RESOLVED_MODEL: ResolvedModel = {
+  tier: "free",
+  model: FREE_MODEL,
+  proLabel: false,
+};
 
 // V1 rate caps are intentionally in-memory and approximate across instances.
 // Fluid reuses instances enough for this side-panel chat guardrail.
@@ -29,6 +43,13 @@ type ChatRequestBody = {
   history: ChatMessage[];
   context: unknown;
   edgeToken?: string;
+  modelChoice: ChatModelChoice;
+};
+
+type ChatModelConfig = {
+  url: string;
+  apiKey: string;
+  model: string;
 };
 
 type DeepSeekMessage =
@@ -52,6 +73,12 @@ type DeepSeekResponse = {
 };
 
 type ToolResult = { message: DeepSeekMessage; facts: string };
+
+type GeneratedReply = {
+  reply: string | null;
+  toolFacts: string[];
+  resolved: ResolvedModel;
+};
 
 export const POST: RequestHandler = async ({ request, fetch, setHeaders }) => {
   setHeaders({ "cache-control": "no-store" });
@@ -89,14 +116,28 @@ export const POST: RequestHandler = async ({ request, fetch, setHeaders }) => {
   }
   burstByUser.set(userId, [...recent, nowMs]);
 
+  const taskClass = classifyTaskClass(latestUserContent(history));
+  const resolvedModel = resolveModel(
+    body.modelChoice,
+    taskClass,
+    publicEnv.PUBLIC_CHAT_PRO_OPEN === "1",
+  );
   const generated = await generateReply({
     context: body.context,
     edgeFetch: fetch,
     edgeToken: body.edgeToken,
     history,
     nowMs,
+    resolvedModel,
   });
-  if (!generated) return json({ reply: null, reason: "unavailable" });
+  if (!generated.reply) {
+    return json({
+      reply: null,
+      reason: "unavailable",
+      model: generated.resolved.model,
+      proLabel: generated.resolved.proLabel,
+    });
+  }
 
   // Grounding facts include the conversation itself: a number the user
   // typed is a given fact — echoing it back is not invention.
@@ -108,9 +149,21 @@ export const POST: RequestHandler = async ({ request, fetch, setHeaders }) => {
       ...generated.toolFacts,
     ].join("\n"),
   );
-  if (reply === null) return json({ reply: null, reason: "ungrounded" });
+  if (reply === null) {
+    return json({
+      reply: null,
+      reason: "ungrounded",
+      model: generated.resolved.model,
+      proLabel: generated.resolved.proLabel,
+    });
+  }
 
-  return json({ reply, asOf: Date.now() });
+  return json({
+    reply,
+    asOf: Date.now(),
+    model: generated.resolved.model,
+    proLabel: generated.resolved.proLabel,
+  });
 };
 
 async function readChatBody(request: Request): Promise<ChatRequestBody | null> {
@@ -126,10 +179,13 @@ async function readChatBody(request: Request): Promise<ChatRequestBody | null> {
   const history = parseHistory(body.history);
   if (!history) return null;
   if ("edgeToken" in body && typeof body.edgeToken !== "string") return null;
+  const modelChoice = parseModelChoice(body.modelChoice);
+  if (!modelChoice) return null;
   return {
     history,
     context: body.context,
     edgeToken: typeof body.edgeToken === "string" ? body.edgeToken : undefined,
+    modelChoice,
   };
 }
 
@@ -147,16 +203,60 @@ function isChatRole(value: unknown): value is ChatRole {
   return value === "user" || value === "assistant" || value === "tool";
 }
 
+function parseModelChoice(value: unknown): ChatModelChoice | null {
+  if (value === undefined) return "auto";
+  if (value === "auto" || value === "free" || value === "pro") return value;
+  return null;
+}
+
+function latestUserContent(history: ChatMessage[]): string {
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    const message = history[index];
+    if (message?.role === "user") return message.content;
+  }
+  return "";
+}
+
 async function generateReply(input: {
   context: unknown;
   edgeFetch: typeof fetch;
   edgeToken?: string;
   history: ChatMessage[];
   nowMs: number;
-}): Promise<{ reply: string; toolFacts: string[] } | null> {
-  const apiKey = env.DEEPSEEK_API_KEY;
-  if (!apiKey) return null;
+  resolvedModel: ResolvedModel;
+}): Promise<GeneratedReply> {
+  if (input.resolvedModel.tier === "pro") {
+    const proConfig = readProModelConfig(input.resolvedModel.model);
+    if (proConfig) {
+      try {
+        const proReply = await runToolLoop(input, proConfig);
+        if (proReply.reply) {
+          return { ...proReply, resolved: input.resolvedModel };
+        }
+      } catch {
+        // Pro routing failures fall back to the raw DeepSeek free lane.
+      }
+    }
+  }
 
+  const freeConfig = readFreeModelConfig();
+  if (!freeConfig) {
+    return { reply: null, toolFacts: [], resolved: FREE_RESOLVED_MODEL };
+  }
+  const freeReply = await runToolLoop(input, freeConfig);
+  return { ...freeReply, resolved: FREE_RESOLVED_MODEL };
+}
+
+async function runToolLoop(
+  input: {
+    context: unknown;
+    edgeFetch: typeof fetch;
+    edgeToken?: string;
+    history: ChatMessage[];
+    nowMs: number;
+  },
+  config: ChatModelConfig,
+): Promise<{ reply: string | null; toolFacts: string[] }> {
   const messages: DeepSeekMessage[] = buildMessages(
     input.context,
     input.history,
@@ -165,14 +265,20 @@ async function generateReply(input: {
   const toolFacts: string[] = [];
 
   for (let round = 0; round < MAX_TOOL_ROUNDS; round += 1) {
-    const response = await callDeepSeek(apiKey, messages);
-    if (!response) return null;
+    const response = await callChatModel({
+      url: config.url,
+      apiKey: config.apiKey,
+      model: config.model,
+      messages,
+      tools: CHAT_TOOLS,
+    });
+    if (!response) return { reply: null, toolFacts };
 
     const toolCalls = parseToolCalls(response.tool_calls);
     if (toolCalls.length === 0) {
       return response.content.trim()
         ? { reply: response.content.trim(), toolFacts }
-        : null;
+        : { reply: null, toolFacts };
     }
 
     messages.push({
@@ -191,25 +297,28 @@ async function generateReply(input: {
     }
   }
 
-  return null;
+  return { reply: null, toolFacts };
 }
 
-async function callDeepSeek(
-  apiKey: string,
-  messages: DeepSeekMessage[],
-): Promise<{ content: string; tool_calls: unknown } | null> {
-  const response = await globalThis.fetch(DEEPSEEK_URL, {
+async function callChatModel(input: {
+  url: string;
+  apiKey: string;
+  model: string;
+  messages: DeepSeekMessage[];
+  tools: typeof CHAT_TOOLS;
+}): Promise<{ content: string; tool_calls: unknown } | null> {
+  const response = await globalThis.fetch(input.url, {
     method: "POST",
     headers: {
       "content-type": "application/json",
-      authorization: `Bearer ${apiKey}`,
+      authorization: `Bearer ${input.apiKey}`,
     },
     body: JSON.stringify({
-      model: "deepseek-chat",
+      model: input.model,
       temperature: 0.2,
       max_tokens: 400,
-      messages,
-      tools: CHAT_TOOLS.map((tool) => ({
+      messages: input.messages,
+      tools: input.tools.map((tool) => ({
         type: "function",
         function: {
           name: tool.name,
@@ -228,6 +337,18 @@ async function callDeepSeek(
     content: typeof message.content === "string" ? message.content : "",
     tool_calls: message.tool_calls,
   };
+}
+
+function readFreeModelConfig(): ChatModelConfig | null {
+  const apiKey = privateEnv.DEEPSEEK_API_KEY;
+  if (!apiKey) return null;
+  return { url: DEEPSEEK_URL, apiKey, model: FREE_MODEL };
+}
+
+function readProModelConfig(model: string): ChatModelConfig | null {
+  const apiKey = privateEnv.AI_GATEWAY_API_KEY;
+  if (!apiKey) return null;
+  return { url: AI_GATEWAY_URL, apiKey, model };
 }
 
 function parseToolCalls(value: unknown): ToolCall[] {
@@ -269,10 +390,13 @@ async function resolveToolCall(
     const headers: HeadersInit = edgeToken
       ? { authorization: `Bearer ${edgeToken}` }
       : {};
-    const response = await edgeFetch(`${env.EDGE_API_BASE ?? ""}${path}`, {
-      headers,
-      signal: AbortSignal.timeout(TOOL_TIMEOUT_MS),
-    });
+    const response = await edgeFetch(
+      `${privateEnv.EDGE_API_BASE ?? ""}${path}`,
+      {
+        headers,
+        signal: AbortSignal.timeout(TOOL_TIMEOUT_MS),
+      },
+    );
     if (!response.ok) return unavailable();
     const content = (await response.text()).slice(0, TOOL_RESULT_CAP);
     return {

--- a/apps/portal/src/routes/terminal/components/SidePanel.svelte
+++ b/apps/portal/src/routes/terminal/components/SidePanel.svelte
@@ -8,7 +8,13 @@
   // state live in $lib/chat (WP2); this component is presentation only.
   //
   // Svelte 5 runes only (pitfall 5): $props/$state/$effect, no export let / $:.
-  import { chatState, closeChat, sendChatMessage } from "$lib/chat";
+  import {
+    chatState,
+    closeChat,
+    sendChatMessage,
+    setModelChoice,
+  } from "$lib/chat";
+  import { PRO_LABEL, type ChatModelChoice } from "$lib/chat-models";
 
   let {
     buildContext,
@@ -20,6 +26,12 @@
 
   let draft = $state("");
   let scrollEl: HTMLDivElement | null = $state(null);
+
+  const modelChoices: { value: ChatModelChoice; label: string }[] = [
+    { value: "auto", label: "Auto" },
+    { value: "free", label: "Free" },
+    { value: "pro", label: "Pro" },
+  ];
 
   // Pin the conversation to its newest turn whenever the list grows or the
   // phase flips to the waiting skeleton.
@@ -40,7 +52,21 @@
 
 <div class="desk-dock" role="complementary" aria-label="Desk chat">
   <header class="desk-head">
-    <span class="desk-title">Desk</span>
+    <div class="desk-title-row">
+      <span class="desk-title">Desk</span>
+      <div class="desk-model-picker" role="radiogroup" aria-label="Chat model">
+        {#each modelChoices as choice (choice.value)}
+          <button
+            class:active={$chatState.modelChoice === choice.value}
+            type="button"
+            aria-pressed={$chatState.modelChoice === choice.value}
+            onclick={() => setModelChoice(choice.value)}
+          >
+            {choice.label}
+          </button>
+        {/each}
+      </div>
+    </div>
     <button class="ghost" type="button" onclick={closeChat}>Close</button>
   </header>
 
@@ -50,7 +76,7 @@
     {/if}
 
     {#each $chatState.messages as message, index (index)}
-      <div class="desk-msg {message.role}">{message.content}</div>
+      <div class="desk-msg {message.role}">{#if message.role === "assistant" && message.proLabel}<span class="desk-pro-tag">{PRO_LABEL}</span>{/if}{message.content}</div>
     {/each}
 
     {#if $chatState.phase === "waiting"}
@@ -132,12 +158,48 @@
     border-bottom: 1px solid var(--line-soft);
   }
 
+  .desk-title-row {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    min-width: 0;
+  }
+
   .desk-title {
     color: var(--accent);
     font-size: 0.6rem;
     font-weight: 800;
     letter-spacing: 0.09em;
     text-transform: uppercase;
+  }
+
+  .desk-model-picker {
+    display: inline-flex;
+    border: 1px solid var(--line-soft);
+    background: var(--surface-2);
+  }
+
+  .desk-model-picker button {
+    color: var(--muted);
+    font: inherit;
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    padding: 0.22rem 0.35rem;
+    border: 0;
+    border-right: 1px solid var(--line-soft);
+    background: transparent;
+    cursor: pointer;
+  }
+
+  .desk-model-picker button:last-child {
+    border-right: 0;
+  }
+
+  .desk-model-picker button.active {
+    color: var(--accent);
+    background: var(--surface);
   }
 
   .desk-scroll {
@@ -165,6 +227,17 @@
     line-height: 1.45;
     white-space: pre-wrap;
     overflow-wrap: anywhere;
+  }
+
+  .desk-pro-tag {
+    display: block;
+    width: fit-content;
+    margin-bottom: 0.25rem;
+    color: var(--accent);
+    font-size: 0.58rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
   }
 
   .desk-msg.user {


### PR DESCRIPTION
## Summary

Lane A / PR 1 of side-panel completion (#571). Adds task-class model routing and a flag-gated Pro tier to the shipped desk chat. No money path.

- **Model registry** (`chat-models.ts`, pure + tested): `resolveModel(choice, taskClass, proAllowed)` — Auto routes `analysis` asks to Pro, else Free; explicit Free/Pro honored; **Pro never selected when the server flag is off** (server is the authority).
- **Pro via AI Gateway** (`anthropic/claude-opus-4.8`) through its OpenAI-compatible endpoint using the chat's existing raw-fetch shape — **no new dependency**; free + pro share one DRY tool-loop helper. Missing key / pro error → transparent fallback to free.
- **Tier flag** `PUBLIC_CHAT_PRO_OPEN` — open-beta gate (everyone gets Pro when on), honestly labeled "Pro (open beta)"; swap in real entitlement later behind the same check.
- Grounding validator, rate caps, tool loop unchanged for both tiers. `proLabel` reflects the model actually used (fallback never mislabels).
- Panel: quiet Auto/Free/Pro picker (persisted to `harness.chat.v1`) + Pro tag on pro replies.

## Validation
typecheck 0 · lint 0 · ui 16 + portal 443 tests green · build · `unused css selector` 0 · browser-proofed picker renders (Auto/Free/Pro).

## Config to set (prod)
- `PUBLIC_CHAT_PRO_OPEN=1` to open the Pro tier; `AI_GATEWAY_API_KEY` for the Gateway. Absent either → everyone stays on free, no errors.

Next in lane: PR2 NL ticket/position edits, PR3 depth-aware slippage. PRD #571.

🤖 Generated with [Claude Code](https://claude.com/claude-code)