### PR TITLE
Paper funding UX: Top up needed + shortfall in funds modal

### DIFF
--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -6543,6 +6543,7 @@
       $paperLedger.orders.reduce((sum, o) => sum + o.marginUsd, 0)),
   )}
   openPositions={$paperLedger.positions.length}
+  requiredMarginUsd={$requiredMarginUsd}
   onclose={() => (paperFundsOpen = false)}
   ontopup={(amount) => {
     topUpPaperAccount(amount);

--- a/apps/portal/src/routes/terminal/components/PaperFundsModal.svelte
+++ b/apps/portal/src/routes/terminal/components/PaperFundsModal.svelte
@@ -8,6 +8,7 @@
     equityUsd,
     marginUsd,
     openPositions,
+    requiredMarginUsd = 0,
     onclose,
     ontopup,
     onreset,
@@ -17,10 +18,18 @@
     equityUsd: number;
     marginUsd: number;
     openPositions: number;
+    /** Margin the open ticket needs — shown when free cash is short. */
+    requiredMarginUsd?: number;
     onclose: () => void;
     ontopup: (amount: number) => void;
     onreset: () => void;
   } = $props();
+
+  const shortfallUsd = $derived(
+    requiredMarginUsd > 0 ? Math.max(0, requiredMarginUsd - freeUsd) : 0,
+  );
+  const hasTicketNeed = $derived(requiredMarginUsd > 0.01);
+  const canFundTicket = $derived(hasTicketNeed && shortfallUsd <= 0.01);
 
   let panel = $state<HTMLDivElement>();
   let previousFocus: HTMLElement | null = null;
@@ -159,7 +168,22 @@
             <span>Open positions</span>
             <b>{openPositions}</b>
           </div>
+          {#if hasTicketNeed}
+            <div class="preview-row">
+              <span>This ticket needs</span>
+              <b>${formatNumber(requiredMarginUsd, 2)}</b>
+            </div>
+          {/if}
         </div>
+        {#if hasTicketNeed && shortfallUsd > 0.01}
+          <p class="fund-note short">
+            Not enough free cash — short ${formatNumber(shortfallUsd, 2)}. Equity can look high while margin is locked in open positions.
+          </p>
+        {:else if canFundTicket}
+          <p class="fund-note ok">
+            Free cash covers this ticket — close this and press Long/Short.
+          </p>
+        {/if}
         <div class="ticket-grid-2">
           <button class="primary" type="button" onclick={() => ontopup(1_000)}>
             Top up +$1,000
@@ -175,3 +199,26 @@
     </div>
   </div>
 {/if}
+
+<style>
+  .fund-note {
+    margin: 0.65rem 0 0.85rem;
+    padding: 0.55rem 0.65rem;
+    border: 1px solid var(--line-soft);
+    font-size: 0.78rem;
+    line-height: 1.35;
+    color: var(--muted);
+  }
+
+  .fund-note.short {
+    border-color: rgba(255, 77, 151, 0.45);
+    color: var(--ink);
+    background: rgba(255, 77, 151, 0.08);
+  }
+
+  .fund-note.ok {
+    border-color: rgba(141, 236, 195, 0.35);
+    color: var(--muted);
+    background: rgba(141, 236, 195, 0.06);
+  }
+</style>

--- a/apps/portal/src/routes/terminal/components/TicketForm.svelte
+++ b/apps/portal/src/routes/terminal/components/TicketForm.svelte
@@ -473,7 +473,7 @@
     </button>
   {:else if $needsPhoenixFunding}
     <button class="primary wide" type="button" onclick={onopenfunds}>
-      {paperMode ? "Top up paper" : "Deposit first"} · ${formatNumber(Math.max(0, $requiredMarginUsd - phoenixCollateral), 2)}
+      {paperMode ? "Top up needed" : "Deposit first"}
     </button>
   {:else if perpGate.show && !paperMode}
     <div class="perp-gate" role="status">


### PR DESCRIPTION
## Summary
- Rename the paper shortfall ticket CTA from "Top up paper" to **Top up needed** (no free/need subtitle on the button).
- Show equity, free cash, position margin, and ticket shortfall messaging inside the **Paper Funds** modal after click.
- If free cash already covers the ticket, the modal says so; if not, it explains the shortfall clearly.

## Test plan
- [ ] In PAPER mode, size a trade larger than free cash → ticket shows **Top up needed** (compact, no free-cash line)
- [ ] Click it → Paper Funds shows equity / free cash / in positions and a shortfall note
- [ ] Top up enough → modal says free cash covers the ticket; Long/Short works again
- [ ] Open Paper Funds from the topbar Funds button with a small ticket → no false shortfall when cash is enough
- [ ] LIVE mode still shows **Deposit first** when underfunded


Made with [Cursor](https://cursor.com)