### PR TITLE
Terminal settings: display currency, timezone, overnight paper tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ runs/
 trades/
 tasks/
 .tmp/
+.logs/
 .harness/
 .turbo/
 .vercel

--- a/apps/portal/src/lib/terminal/display-currency.test.ts
+++ b/apps/portal/src/lib/terminal/display-currency.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import {
+  formatDisplayMoney,
+  formatDisplayMoneySigned,
+  isDisplayCurrencyCode,
+  rateForCurrency,
+} from "./display-currency";
+
+describe("display-currency", () => {
+  test("whitelist", () => {
+    expect(isDisplayCurrencyCode("EUR")).toBe(true);
+    expect(isDisplayCurrencyCode("DOGE")).toBe(false);
+  });
+
+  test("formats USD unchanged", () => {
+    expect(formatDisplayMoney(1234.5, "USD", 1, 0)).toBe("$1,235");
+  });
+
+  test("converts with rate", () => {
+    expect(formatDisplayMoney(100, "EUR", 0.9, 2)).toBe("€90.00");
+  });
+
+  test("signed helper", () => {
+    expect(formatDisplayMoneySigned(12.5, "USD", 1, 2)).toBe("+$12.50");
+    expect(formatDisplayMoneySigned(-12.5, "USD", 1, 2)).toBe("-$12.50");
+  });
+
+  test("rateForCurrency falls back", () => {
+    expect(rateForCurrency("USD", {})).toBe(1);
+    expect(rateForCurrency("EUR", { EUR: 0.91 })).toBe(0.91);
+    expect(rateForCurrency("EUR", {})).toBeGreaterThan(0);
+  });
+});

--- a/apps/portal/src/lib/terminal/display-currency.ts
+++ b/apps/portal/src/lib/terminal/display-currency.ts
@@ -1,0 +1,180 @@
+// Display-currency preference — UI conversion only. Markets, tickets, and
+// settlement stay USD/USDC; we multiply shown amounts by a USD→fiat rate.
+
+import { formatNumber } from "$lib/utils";
+
+export const DISPLAY_CURRENCIES = [
+  { code: "USD", label: "US Dollar", symbol: "$" },
+  { code: "EUR", label: "Euro", symbol: "€" },
+  { code: "GBP", label: "British Pound", symbol: "£" },
+  { code: "CAD", label: "Canadian Dollar", symbol: "CA$" },
+  { code: "AUD", label: "Australian Dollar", symbol: "A$" },
+  { code: "JPY", label: "Japanese Yen", symbol: "¥" },
+  { code: "CHF", label: "Swiss Franc", symbol: "CHF " },
+  { code: "SGD", label: "Singapore Dollar", symbol: "S$" },
+  { code: "HKD", label: "Hong Kong Dollar", symbol: "HK$" },
+  { code: "INR", label: "Indian Rupee", symbol: "₹" },
+  { code: "BRL", label: "Brazilian Real", symbol: "R$" },
+  { code: "MXN", label: "Mexican Peso", symbol: "MX$" },
+] as const;
+
+export type DisplayCurrencyCode = (typeof DISPLAY_CURRENCIES)[number]["code"];
+
+export const DEFAULT_DISPLAY_CURRENCY: DisplayCurrencyCode = "USD";
+
+const CODE_SET = new Set<string>(DISPLAY_CURRENCIES.map((row) => row.code));
+
+export function isDisplayCurrencyCode(
+  value: unknown,
+): value is DisplayCurrencyCode {
+  return typeof value === "string" && CODE_SET.has(value);
+}
+
+export function displayCurrencyMeta(code: DisplayCurrencyCode): {
+  code: DisplayCurrencyCode;
+  label: string;
+  symbol: string;
+} {
+  return (
+    DISPLAY_CURRENCIES.find((row) => row.code === code) ?? DISPLAY_CURRENCIES[0]
+  );
+}
+
+/** Digits for money labels — JPY has no minor units in everyday UI. */
+export function displayCurrencyDigits(code: DisplayCurrencyCode): number {
+  return code === "JPY" ? 0 : 2;
+}
+
+/**
+ * Format a USD amount in the user's display currency.
+ * `rate` is units of display currency per 1 USD (USD → 1).
+ */
+export function formatDisplayMoney(
+  usdAmount: number,
+  currency: DisplayCurrencyCode,
+  rate = 1,
+  digits?: number,
+): string {
+  const meta = displayCurrencyMeta(currency);
+  const safeRate =
+    currency === "USD" ? 1 : Number.isFinite(rate) && rate > 0 ? rate : 1;
+  const converted = usdAmount * safeRate;
+  const places = digits ?? (Math.abs(converted) >= 1000 ? 0 : displayCurrencyDigits(currency));
+  const sign = converted < 0 ? "-" : "";
+  return `${sign}${meta.symbol}${formatNumber(Math.abs(converted), places)}`;
+}
+
+export function formatDisplayMoneySigned(
+  usdAmount: number,
+  currency: DisplayCurrencyCode,
+  rate = 1,
+  digits = 2,
+): string {
+  const abs = formatDisplayMoney(Math.abs(usdAmount), currency, rate, digits);
+  if (usdAmount > 0) return `+${abs}`;
+  if (usdAmount < 0) return `-${abs}`;
+  return abs;
+}
+
+const FX_CACHE_KEY = "trader-ralph-terminal/fx-usd/v1";
+const FX_TTL_MS = 6 * 60 * 60_000;
+
+/** Rough fallbacks if the FX endpoint is unreachable (USD = 1). */
+export const FALLBACK_USD_RATES: Record<DisplayCurrencyCode, number> = {
+  USD: 1,
+  EUR: 0.92,
+  GBP: 0.79,
+  CAD: 1.36,
+  AUD: 1.53,
+  JPY: 157,
+  CHF: 0.88,
+  SGD: 1.34,
+  HKD: 7.8,
+  INR: 83,
+  BRL: 5.1,
+  MXN: 17.2,
+};
+
+type FxCache = {
+  fetchedAt: number;
+  rates: Partial<Record<DisplayCurrencyCode, number>>;
+};
+
+function readFxCache(): FxCache | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(FX_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as FxCache;
+    if (
+      !parsed ||
+      typeof parsed.fetchedAt !== "number" ||
+      typeof parsed.rates !== "object" ||
+      parsed.rates === null
+    ) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeFxCache(rates: Partial<Record<DisplayCurrencyCode, number>>): void {
+  if (typeof window === "undefined") return;
+  try {
+    const payload: FxCache = { fetchedAt: Date.now(), rates };
+    window.localStorage.setItem(FX_CACHE_KEY, JSON.stringify(payload));
+  } catch {
+    // private mode / quota — non-fatal
+  }
+}
+
+export function rateForCurrency(
+  currency: DisplayCurrencyCode,
+  rates: Partial<Record<DisplayCurrencyCode, number>>,
+): number {
+  if (currency === "USD") return 1;
+  const live = rates[currency];
+  if (typeof live === "number" && Number.isFinite(live) && live > 0) return live;
+  return FALLBACK_USD_RATES[currency] ?? 1;
+}
+
+/**
+ * Load USD→fiat rates (Frankfurter / ECB). Returns merged fallbacks on failure.
+ * Non-USD codes only; USD is always 1.
+ */
+export async function fetchUsdFxRates(
+  force = false,
+): Promise<Partial<Record<DisplayCurrencyCode, number>>> {
+  const cached = readFxCache();
+  if (
+    !force &&
+    cached &&
+    Date.now() - cached.fetchedAt < FX_TTL_MS &&
+    cached.rates
+  ) {
+    return { USD: 1, ...cached.rates };
+  }
+
+  const targets = DISPLAY_CURRENCIES.map((row) => row.code).filter(
+    (code) => code !== "USD",
+  );
+  try {
+    const url = `https://api.frankfurter.app/latest?from=USD&to=${targets.join(",")}`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`fx-http-${res.status}`);
+    const body = (await res.json()) as { rates?: Record<string, number> };
+    const rates: Partial<Record<DisplayCurrencyCode, number>> = { USD: 1 };
+    for (const code of targets) {
+      const value = body.rates?.[code];
+      if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+        rates[code] = value;
+      }
+    }
+    writeFxCache(rates);
+    return rates;
+  } catch {
+    return { ...FALLBACK_USD_RATES };
+  }
+}

--- a/apps/portal/src/lib/terminal/display-currency.ts
+++ b/apps/portal/src/lib/terminal/display-currency.ts
@@ -59,7 +59,9 @@ export function formatDisplayMoney(
   const safeRate =
     currency === "USD" ? 1 : Number.isFinite(rate) && rate > 0 ? rate : 1;
   const converted = usdAmount * safeRate;
-  const places = digits ?? (Math.abs(converted) >= 1000 ? 0 : displayCurrencyDigits(currency));
+  const places =
+    digits ??
+    (Math.abs(converted) >= 1000 ? 0 : displayCurrencyDigits(currency));
   const sign = converted < 0 ? "-" : "";
   return `${sign}${meta.symbol}${formatNumber(Math.abs(converted), places)}`;
 }
@@ -120,7 +122,9 @@ function readFxCache(): FxCache | null {
   }
 }
 
-function writeFxCache(rates: Partial<Record<DisplayCurrencyCode, number>>): void {
+function writeFxCache(
+  rates: Partial<Record<DisplayCurrencyCode, number>>,
+): void {
   if (typeof window === "undefined") return;
   try {
     const payload: FxCache = { fetchedAt: Date.now(), rates };
@@ -136,7 +140,8 @@ export function rateForCurrency(
 ): number {
   if (currency === "USD") return 1;
   const live = rates[currency];
-  if (typeof live === "number" && Number.isFinite(live) && live > 0) return live;
+  if (typeof live === "number" && Number.isFinite(live) && live > 0)
+    return live;
   return FALLBACK_USD_RATES[currency] ?? 1;
 }
 

--- a/apps/portal/src/lib/terminal/display-timezone.test.ts
+++ b/apps/portal/src/lib/terminal/display-timezone.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import {
+  detectBrowserTimezone,
+  formatClockInZone,
+  formatTimeHmInZone,
+  isDisplayTimezoneId,
+  isValidIanaTimezone,
+  timezoneAbbrev,
+} from "./display-timezone";
+
+describe("display-timezone", () => {
+  test("validates curated and IANA ids", () => {
+    expect(isDisplayTimezoneId("UTC")).toBe(true);
+    expect(isDisplayTimezoneId("America/New_York")).toBe(true);
+    expect(isDisplayTimezoneId("Not/AZone")).toBe(false);
+    expect(isValidIanaTimezone("Asia/Tokyo")).toBe(true);
+    expect(isValidIanaTimezone("Mars/Phobos")).toBe(false);
+  });
+
+  test("formats UTC clock", () => {
+    // 2024-01-15T12:34:56.000Z
+    const ms = Date.UTC(2024, 0, 15, 12, 34, 56);
+    expect(formatClockInZone(ms, "UTC")).toBe("12:34:56 UTC");
+    expect(formatTimeHmInZone(ms, "UTC")).toBe("12:34");
+    expect(timezoneAbbrev(ms, "UTC")).toBe("UTC");
+  });
+
+  test("shifts into New York", () => {
+    const ms = Date.UTC(2024, 0, 15, 17, 0, 0); // 12:00 EST
+    expect(formatTimeHmInZone(ms, "America/New_York")).toBe("12:00");
+  });
+
+  test("detectBrowserTimezone returns a valid id", () => {
+    expect(isValidIanaTimezone(detectBrowserTimezone())).toBe(true);
+  });
+});

--- a/apps/portal/src/lib/terminal/display-timezone.ts
+++ b/apps/portal/src/lib/terminal/display-timezone.ts
@@ -1,0 +1,156 @@
+// Display timezone preference — clocks and journal/tape stamps only.
+// Market data / candle axes stay on exchange time (UTC) unless noted.
+
+export type DisplayTimezoneId = string;
+
+export const DEFAULT_DISPLAY_TIMEZONE: DisplayTimezoneId = "UTC";
+
+/** Curated IANA zones for the settings picker (valid Intl timeZone ids). */
+export const DISPLAY_TIMEZONES: { id: DisplayTimezoneId; label: string }[] = [
+  { id: "UTC", label: "UTC" },
+  { id: "America/New_York", label: "New York (Eastern)" },
+  { id: "America/Chicago", label: "Chicago (Central)" },
+  { id: "America/Denver", label: "Denver (Mountain)" },
+  { id: "America/Los_Angeles", label: "Los Angeles (Pacific)" },
+  { id: "America/Toronto", label: "Toronto" },
+  { id: "America/Sao_Paulo", label: "São Paulo" },
+  { id: "America/Mexico_City", label: "Mexico City" },
+  { id: "Europe/London", label: "London" },
+  { id: "Europe/Paris", label: "Paris" },
+  { id: "Europe/Berlin", label: "Berlin" },
+  { id: "Europe/Zurich", label: "Zurich" },
+  { id: "Europe/Moscow", label: "Moscow" },
+  { id: "Asia/Dubai", label: "Dubai" },
+  { id: "Asia/Kolkata", label: "India (IST)" },
+  { id: "Asia/Singapore", label: "Singapore" },
+  { id: "Asia/Hong_Kong", label: "Hong Kong" },
+  { id: "Asia/Shanghai", label: "Shanghai" },
+  { id: "Asia/Tokyo", label: "Tokyo" },
+  { id: "Asia/Seoul", label: "Seoul" },
+  { id: "Australia/Sydney", label: "Sydney" },
+  { id: "Pacific/Auckland", label: "Auckland" },
+];
+
+const CURATED_IDS = new Set(DISPLAY_TIMEZONES.map((row) => row.id));
+
+export function isValidIanaTimezone(value: unknown): value is DisplayTimezoneId {
+  if (typeof value !== "string" || value.length === 0 || value.length > 64) {
+    return false;
+  }
+  try {
+    // Throws RangeError for unknown zones.
+    new Intl.DateTimeFormat("en-US", { timeZone: value }).format(0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function isDisplayTimezoneId(
+  value: unknown,
+): value is DisplayTimezoneId {
+  return typeof value === "string" && CURATED_IDS.has(value);
+}
+
+/** Browser IANA zone when supported; otherwise UTC. */
+export function detectBrowserTimezone(): DisplayTimezoneId {
+  try {
+    const zone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    if (isValidIanaTimezone(zone)) return zone;
+  } catch {
+    // ignore
+  }
+  return DEFAULT_DISPLAY_TIMEZONE;
+}
+
+/**
+ * Ensure the settings list includes the active zone (e.g. a detected local
+ * zone that isn't in the curated set).
+ */
+export function timezonesForPicker(
+  active: DisplayTimezoneId,
+): { id: DisplayTimezoneId; label: string }[] {
+  if (DISPLAY_TIMEZONES.some((row) => row.id === active)) {
+    return DISPLAY_TIMEZONES;
+  }
+  if (!isValidIanaTimezone(active)) return DISPLAY_TIMEZONES;
+  return [
+    { id: active, label: `${active.replace(/_/g, " ")} (local)` },
+    ...DISPLAY_TIMEZONES,
+  ];
+}
+
+function partsInZone(
+  ms: number,
+  timeZone: DisplayTimezoneId,
+): Record<string, string> {
+  const zone = isValidIanaTimezone(timeZone)
+    ? timeZone
+    : DEFAULT_DISPLAY_TIMEZONE;
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone: zone,
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    timeZoneName: "short",
+  });
+  const out: Record<string, string> = {};
+  for (const part of fmt.formatToParts(new Date(ms))) {
+    if (part.type !== "literal") out[part.type] = part.value;
+  }
+  return out;
+}
+
+/** Short zone label for the clock, e.g. "UTC", "EST", "GMT+9". */
+export function timezoneAbbrev(
+  ms: number,
+  timeZone: DisplayTimezoneId,
+): string {
+  const name = partsInZone(ms, timeZone).timeZoneName;
+  if (!name) return timeZone === "UTC" ? "UTC" : timeZone;
+  return name;
+}
+
+/** Status-line clock: `HH:MM:SS EST`. */
+export function formatClockInZone(
+  ms: number,
+  timeZone: DisplayTimezoneId,
+): string {
+  const p = partsInZone(ms, timeZone);
+  const h = p.hour ?? "00";
+  const m = p.minute ?? "00";
+  const s = p.second ?? "00";
+  const abbr = p.timeZoneName ?? "UTC";
+  return `${h}:${m}:${s} ${abbr}`;
+}
+
+/** Compact time `HH:MM` in the display zone. */
+export function formatTimeHmInZone(
+  ms: number,
+  timeZone: DisplayTimezoneId,
+): string {
+  const p = partsInZone(ms, timeZone);
+  return `${p.hour ?? "00"}:${p.minute ?? "00"}`;
+}
+
+/** Compact `HH:MM:SS` in the display zone (no abbrev). */
+export function formatTimeHmsInZone(
+  ms: number,
+  timeZone: DisplayTimezoneId,
+): string {
+  const p = partsInZone(ms, timeZone);
+  return `${p.hour ?? "00"}:${p.minute ?? "00"}:${p.second ?? "00"}`;
+}
+
+/** `MM-DD HH:MM` style stamp for alert history. */
+export function formatStampInZone(
+  ms: number,
+  timeZone: DisplayTimezoneId,
+): string {
+  const p = partsInZone(ms, timeZone);
+  return `${p.month ?? "00"}-${p.day ?? "00"} ${p.hour ?? "00"}:${p.minute ?? "00"}`;
+}

--- a/apps/portal/src/lib/terminal/display-timezone.ts
+++ b/apps/portal/src/lib/terminal/display-timezone.ts
@@ -33,7 +33,9 @@ export const DISPLAY_TIMEZONES: { id: DisplayTimezoneId; label: string }[] = [
 
 const CURATED_IDS = new Set(DISPLAY_TIMEZONES.map((row) => row.id));
 
-export function isValidIanaTimezone(value: unknown): value is DisplayTimezoneId {
+export function isValidIanaTimezone(
+  value: unknown,
+): value is DisplayTimezoneId {
   if (typeof value !== "string" || value.length === 0 || value.length > 64) {
     return false;
   }

--- a/apps/portal/src/lib/terminal/paper-pnl-log.ts
+++ b/apps/portal/src/lib/terminal/paper-pnl-log.ts
@@ -1,0 +1,69 @@
+import { browser, dev } from "$app/environment";
+
+export const PAPER_PNL_LOG_INTERVAL_MS = 30 * 60 * 1000;
+
+export type PaperPnlPositionSnap = {
+  symbol: string;
+  size: number;
+  entry: number | null;
+  upnl: number | null;
+  marginUsd: number | null;
+};
+
+export type PaperPnlSnapshot = {
+  ts: number;
+  reason: string;
+  upnlUsd: number;
+  equityUsd: number;
+  freeCollateralUsd: number;
+  positions: PaperPnlPositionSnap[];
+};
+
+/** Latest values for the interval callback (avoids stale closures). */
+export type PaperPnlSnapRef = {
+  paperMode: boolean;
+  upnlUsd: number;
+  equityUsd: number;
+  freeCollateralUsd: number;
+  positions: PaperPnlPositionSnap[];
+};
+
+export async function postPaperPnlSnapshot(
+  snap: PaperPnlSnapshot,
+): Promise<boolean> {
+  if (!browser || !dev) return false;
+  try {
+    const res = await fetch("/api/dev/paper-pnl", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(snap),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export function startPaperPnlLogger(
+  ref: PaperPnlSnapRef,
+  intervalMs = PAPER_PNL_LOG_INTERVAL_MS,
+): () => void {
+  if (!browser || !dev) return () => {};
+
+  const flush = (reason: string): void => {
+    if (!ref.paperMode) return;
+    void postPaperPnlSnapshot({
+      ts: Date.now(),
+      reason,
+      upnlUsd: ref.upnlUsd,
+      equityUsd: ref.equityUsd,
+      freeCollateralUsd: ref.freeCollateralUsd,
+      positions: ref.positions,
+    });
+  };
+
+  // Baseline is posted from the page when PAPER turns on; this timer only
+  // handles the recurring 30-minute samples.
+  const timer = window.setInterval(() => flush("interval"), intervalMs);
+  return () => window.clearInterval(timer);
+}

--- a/apps/portal/src/lib/terminal/prefs.test.ts
+++ b/apps/portal/src/lib/terminal/prefs.test.ts
@@ -62,6 +62,26 @@ describe("parsePrefs", () => {
     ).toBeUndefined();
   });
 
+  test("accepts displayCurrency whitelist", () => {
+    expect(
+      parsePrefs(JSON.stringify({ displayCurrency: "EUR" })).displayCurrency,
+    ).toBe("EUR");
+    expect(
+      parsePrefs(JSON.stringify({ displayCurrency: "DOGE" })).displayCurrency,
+    ).toBeUndefined();
+  });
+
+  test("accepts displayTimezone IANA ids", () => {
+    expect(
+      parsePrefs(JSON.stringify({ displayTimezone: "America/New_York" }))
+        .displayTimezone,
+    ).toBe("America/New_York");
+    expect(
+      parsePrefs(JSON.stringify({ displayTimezone: "Not/AZone" }))
+        .displayTimezone,
+    ).toBeUndefined();
+  });
+
   test("rejects out-of-enum values field by field", () => {
     const prefs = parsePrefs(
       JSON.stringify({

--- a/apps/portal/src/lib/terminal/prefs.ts
+++ b/apps/portal/src/lib/terminal/prefs.ts
@@ -7,6 +7,14 @@ import {
   PHOENIX_TIMEFRAMES,
   type PhoenixTimeframe,
 } from "$lib/phoenix-market-data";
+import {
+  isDisplayCurrencyCode,
+  type DisplayCurrencyCode,
+} from "$lib/terminal/display-currency";
+import {
+  isValidIanaTimezone,
+  type DisplayTimezoneId,
+} from "$lib/terminal/display-timezone";
 
 // Legacy "trader-ralph-terminal" key names kept across the Harness rebrand —
 // renaming them would silently wipe every user's saved prefs and layout.
@@ -60,6 +68,10 @@ export type TerminalPrefs = {
   rays: Record<string, number[]>;
   /** Simulated paper trading — local ledger, live market data. */
   paperMode: boolean;
+  /** Fiat used for money labels (trading still USD). */
+  displayCurrency: DisplayCurrencyCode;
+  /** IANA timezone for clocks and journal/tape stamps. */
+  displayTimezone: DisplayTimezoneId;
 };
 
 /** Rays per symbol — placing a 13th evicts the oldest (FIFO). */
@@ -173,6 +185,12 @@ export function parsePrefs(raw: string | null): Partial<TerminalPrefs> {
   if (typeof data.showLevels === "boolean") prefs.showLevels = data.showLevels;
   if (data.rays !== undefined) prefs.rays = parseRays(data.rays);
   if (typeof data.paperMode === "boolean") prefs.paperMode = data.paperMode;
+  if (isDisplayCurrencyCode(data.displayCurrency)) {
+    prefs.displayCurrency = data.displayCurrency;
+  }
+  if (isValidIanaTimezone(data.displayTimezone)) {
+    prefs.displayTimezone = data.displayTimezone;
+  }
   return prefs;
 }
 
@@ -211,6 +229,8 @@ export function persistPrefs(
   _showLevels: boolean,
   _rays: Record<string, number[]>,
   _paperMode: boolean,
+  _displayCurrency: DisplayCurrencyCode,
+  _displayTimezone: DisplayTimezoneId,
 ): void {
   if (typeof window === "undefined") return;
   try {
@@ -237,6 +257,8 @@ export function persistPrefs(
         showLevels: _showLevels,
         rays: _rays,
         paperMode: _paperMode,
+        displayCurrency: _displayCurrency,
+        displayTimezone: _displayTimezone,
       }),
     );
   } catch {

--- a/apps/portal/src/lib/terminal/prefs.ts
+++ b/apps/portal/src/lib/terminal/prefs.ts
@@ -8,12 +8,12 @@ import {
   type PhoenixTimeframe,
 } from "$lib/phoenix-market-data";
 import {
-  isDisplayCurrencyCode,
   type DisplayCurrencyCode,
+  isDisplayCurrencyCode,
 } from "$lib/terminal/display-currency";
 import {
-  isValidIanaTimezone,
   type DisplayTimezoneId,
+  isValidIanaTimezone,
 } from "$lib/terminal/display-timezone";
 
 // Legacy "trader-ralph-terminal" key names kept across the Harness rebrand —

--- a/apps/portal/src/routes/api/dev/paper-pnl/+server.ts
+++ b/apps/portal/src/routes/api/dev/paper-pnl/+server.ts
@@ -1,0 +1,61 @@
+import { dev } from "$app/environment";
+import { error, json } from "@sveltejs/kit";
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { RequestHandler } from "./$types";
+
+/** Repo-root .logs — Vite cwd is apps/portal. */
+function logPath(): string {
+  return join(process.cwd(), "..", "..", ".logs", "paper-upnl.jsonl");
+}
+
+async function ensureLogDir(): Promise<void> {
+  await mkdir(join(process.cwd(), "..", "..", ".logs"), { recursive: true });
+}
+
+export const POST: RequestHandler = async ({ request }) => {
+  if (!dev) error(404, "Not found");
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    error(400, "Expected JSON body");
+  }
+  if (!body || typeof body !== "object") error(400, "Expected object body");
+
+  const row = {
+    ...(body as Record<string, unknown>),
+    receivedAt: new Date().toISOString(),
+  };
+  await ensureLogDir();
+  await appendFile(logPath(), `${JSON.stringify(row)}\n`, "utf8");
+  return json({ ok: true }, { headers: { "cache-control": "no-store" } });
+};
+
+/** Tail recent samples (default 48 ≈ 24h at 30m). */
+export const GET: RequestHandler = async ({ url }) => {
+  if (!dev) error(404, "Not found");
+
+  const limit = Math.min(
+    500,
+    Math.max(1, Number(url.searchParams.get("limit") ?? "48") || 48),
+  );
+  try {
+    const raw = await readFile(logPath(), "utf8");
+    const lines = raw
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+    const slice = lines.slice(-limit).map((line) => JSON.parse(line) as unknown);
+    return json(
+      { path: logPath(), count: slice.length, samples: slice },
+      { headers: { "cache-control": "no-store" } },
+    );
+  } catch {
+    return json(
+      { path: logPath(), count: 0, samples: [] },
+      { headers: { "cache-control": "no-store" } },
+    );
+  }
+};

--- a/apps/portal/src/routes/api/dev/paper-pnl/+server.ts
+++ b/apps/portal/src/routes/api/dev/paper-pnl/+server.ts
@@ -1,7 +1,7 @@
-import { dev } from "$app/environment";
-import { error, json } from "@sveltejs/kit";
 import { appendFile, mkdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { error, json } from "@sveltejs/kit";
+import { dev } from "$app/environment";
 import type { RequestHandler } from "./$types";
 
 /** Repo-root .logs — Vite cwd is apps/portal. */
@@ -47,7 +47,9 @@ export const GET: RequestHandler = async ({ url }) => {
       .split("\n")
       .map((line) => line.trim())
       .filter(Boolean);
-    const slice = lines.slice(-limit).map((line) => JSON.parse(line) as unknown);
+    const slice = lines
+      .slice(-limit)
+      .map((line) => JSON.parse(line) as unknown);
     return json(
       { path: logPath(), count: slice.length, samples: slice },
       { headers: { "cache-control": "no-store" } },

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -12,6 +12,7 @@
   import FundingWizard from "./components/FundingWizard.svelte";
   import FundsModal from "./components/FundsModal.svelte";
   import PaperFundsModal from "./components/PaperFundsModal.svelte";
+  import SettingsModal from "./components/SettingsModal.svelte";
   import JournalPanel from "./components/JournalPanel.svelte";
   import PerpDeskPanel from "./components/PerpDeskPanel.svelte";
   import SpotTicketForm from "./components/SpotTicketForm.svelte";
@@ -124,6 +125,21 @@
     startPaperPnlLogger,
     type PaperPnlSnapRef,
   } from "$lib/terminal/paper-pnl-log";
+  import {
+    DEFAULT_DISPLAY_CURRENCY,
+    fetchUsdFxRates,
+    formatDisplayMoney,
+    rateForCurrency,
+    type DisplayCurrencyCode,
+  } from "$lib/terminal/display-currency";
+  import {
+    DEFAULT_DISPLAY_TIMEZONE,
+    detectBrowserTimezone,
+    formatTimeHmInZone,
+    formatTimeHmsInZone,
+    timezoneAbbrev,
+    type DisplayTimezoneId,
+  } from "$lib/terminal/display-timezone";
   import {
     disconnectedRows,
     emptyMarketStats,
@@ -626,6 +642,11 @@
   // (deep-link `?fund=` and openPhoenixFunding pre-set them).
   let fundsOpen = false;
   let paperFundsOpen = false;
+  let settingsOpen = false;
+  let displayCurrency: DisplayCurrencyCode = DEFAULT_DISPLAY_CURRENCY;
+  let displayTimezone: DisplayTimezoneId = DEFAULT_DISPLAY_TIMEZONE;
+  let fxRates: Partial<Record<DisplayCurrencyCode, number>> = { USD: 1 };
+  $: displayFxRate = rateForCurrency(displayCurrency, fxRates);
   let fundsTab: "receive" | "convert" | "phoenix" = "receive";
   let tradeOpen = false;
   let pendingBook: { bids: DepthLevel[]; asks: DepthLevel[]; mid: number | null } | null =
@@ -1522,6 +1543,8 @@
       showLevels,
       rays,
       paperMode,
+      displayCurrency,
+      displayTimezone,
     );
 
   onMount(() => {
@@ -1535,6 +1558,9 @@
     prefsReady = true;
     createChartInstance();
     void bootPhoenixMarketData();
+    void fetchUsdFxRates().then((rates) => {
+      fxRates = rates;
+    });
     // Boot dedupe: warm panels defer the edge fetch burst until the stream
     // is live (or 3s), and the post-Privy rerun only fires when auth
     // actually changed the token — cold unauthenticated boots used to fetch
@@ -3788,6 +3814,9 @@
     freeCollateralUsd: phoenixCollateral,
     fundingPercent,
     walletAddress: $privyAuth.walletAddress ?? "",
+    displayCurrency,
+    fxRate: displayFxRate,
+    displayTimezone,
   };
 
   function onFlattenClick(): void {
@@ -5270,7 +5299,7 @@
     if (aiDisabled() || journalToday.length === 0) return;
     const snapshot = {
       trades: journalToday.map((entry) => ({
-        timeUtc: new Date(entry.ts).toISOString().slice(11, 16),
+        timeUtc: formatTimeHmInZone(entry.ts, displayTimezone),
         venue: entry.venue,
         symbol: entry.symbol,
         action: entry.action,
@@ -5478,6 +5507,14 @@
     if (prefs.showLevels !== undefined) showLevels = prefs.showLevels;
     if (prefs.rays !== undefined) rays = prefs.rays;
     if (prefs.paperMode !== undefined) paperMode = prefs.paperMode;
+    if (prefs.displayCurrency !== undefined) {
+      displayCurrency = prefs.displayCurrency;
+    }
+    if (prefs.displayTimezone !== undefined) {
+      displayTimezone = prefs.displayTimezone;
+    } else {
+      displayTimezone = detectBrowserTimezone();
+    }
     // Without Privy, live trading is impossible — stay in paper regardless
     // of a previously saved LIVE preference.
     if (!readPrivyConfig().appId) paperMode = true;
@@ -5599,12 +5636,20 @@
       // Modal-priority: if a modal owns this Escape, close only it and leave
       // the side chat — one Escape never doubles as chat-close.
       const modalOwned =
-        tradeOpen || authOpen || alertsOpen || fundsOpen || paperFundsOpen || paletteOpen || cheatOpen;
+        tradeOpen ||
+        authOpen ||
+        alertsOpen ||
+        fundsOpen ||
+        paperFundsOpen ||
+        settingsOpen ||
+        paletteOpen ||
+        cheatOpen;
       if (tradeOpen) tradeOpen = false;
       if (authOpen) authOpen = false;
       if (alertsOpen) alertsOpen = false;
       if (fundsOpen) fundsOpen = false;
       if (paperFundsOpen) paperFundsOpen = false;
+      if (settingsOpen) settingsOpen = false;
       if (paletteOpen) paletteOpen = false;
       if (cheatOpen) cheatOpen = false;
       if ($chatState.open && !modalOwned) closeChat();
@@ -5628,6 +5673,7 @@
       !alertsOpen &&
       !fundsOpen &&
       !paperFundsOpen &&
+      !settingsOpen &&
       !paletteOpen &&
       !cheatOpen
     ) {
@@ -5645,7 +5691,16 @@
         return;
       }
     }
-    if (authOpen || tradeOpen || alertsOpen || fundsOpen || paperFundsOpen || paletteOpen || cheatOpen) {
+    if (
+      authOpen ||
+      tradeOpen ||
+      alertsOpen ||
+      fundsOpen ||
+      paperFundsOpen ||
+      settingsOpen ||
+      paletteOpen ||
+      cheatOpen
+    ) {
       return;
     }
     // Backtick summons the side chat — same input/modal guards as the other
@@ -5766,9 +5821,17 @@
     {layoutCustomized}
     {logoutBusy}
     {paperMode}
-    paperFundsLabel={`$${formatNumber(accountEquityUsd, 0)}`}
+    paperFundsLabel={formatDisplayMoney(
+      accountEquityUsd,
+      displayCurrency,
+      displayFxRate,
+      0,
+    )}
+    {displayCurrency}
+    fxRate={displayFxRate}
     onopenauth={openAuthModal}
     onopenfunds={openFunds}
+    onopensettings={() => (settingsOpen = true)}
     onopenalerts={() => (alertsOpen = true)}
     onresetlayout={resetLayout}
     onToggleChat={toggleChat}
@@ -6090,12 +6153,12 @@
 
         <strong
           class="chart-range"
-          title={`${chartRangeLabel} · UTC · ${candleCountdown}`}
+          title={`${chartRangeLabel} · ${timezoneAbbrev(nowMs, displayTimezone)} · ${candleCountdown}`}
         >
           {#if chartFooterCompact}
-            {candleCountdown} UTC
+            {candleCountdown} {timezoneAbbrev(nowMs, displayTimezone)}
           {:else}
-            {chartRangeLabel} · UTC · {candleCountdown}
+            {chartRangeLabel} · {timezoneAbbrev(nowMs, displayTimezone)} · {candleCountdown}
           {/if}
         </strong>
 
@@ -6226,6 +6289,7 @@
       <div class="dock-body">
         {#if dockTab === "journal"}
           <JournalPanel
+            displayTimezone={displayTimezone}
             {journalEntries}
             {journalToday}
             {recapRead}
@@ -6237,7 +6301,7 @@
             {#each $alertLog as fired (fired.ts)}
               <div class="dock-alert-row">
                 <span class="dock-alert-ts">
-                  {new Date(fired.ts).toISOString().slice(11, 19)}
+                  {formatTimeHmsInZone(fired.ts, displayTimezone)}
                 </span>
                 <b>{fired.title}</b>
                 <span>{fired.body}</span>
@@ -6312,7 +6376,7 @@
                 onpick={prefillFromBook}
               />
             {:else}
-              <Tape {trades} />
+              <Tape {trades} displayTimezone={displayTimezone} />
             {/if}
           </div>
         {/if}
@@ -6373,7 +6437,7 @@
             onpick={prefillFromBook}
           />
 
-          <Tape {trades} />
+          <Tape {trades} displayTimezone={displayTimezone} />
         {:else}
           <!-- Enter from any ticket input submits, gated exactly like the button. -->
           <div
@@ -6428,6 +6492,8 @@
       {marginAddKey}
       bind:marginAddValue
       {paperMode}
+      {displayCurrency}
+      fxRate={displayFxRate}
       ontrade={openTrade}
       ondeposit={openFunds}
       onselectsymbol={chooseMonitorRow}
@@ -6524,6 +6590,7 @@
 
 <AlertsModal
   open={alertsOpen}
+  displayTimezone={displayTimezone}
   symbol={selectedSymbol}
   {latestPrice}
   onclose={() => (alertsOpen = false)}
@@ -6569,6 +6636,8 @@
   {solBalanceValue}
   gasText={walletBalanceText}
   phoenixCollateralUsd={phoenixTrader?.collateralUsd ?? null}
+  {displayCurrency}
+  fxRate={displayFxRate}
   collateral={{
     busy: collateralBusy,
     error: collateralError,
@@ -6592,12 +6661,36 @@
   )}
   openPositions={$paperLedger.positions.length}
   requiredMarginUsd={$requiredMarginUsd}
+  {displayCurrency}
+  fxRate={displayFxRate}
   onclose={() => (paperFundsOpen = false)}
   ontopup={(amount) => {
     topUpPaperAccount(amount);
   }}
   onreset={() => {
     resetPaperAccount();
+  }}
+/>
+
+<SettingsModal
+  open={settingsOpen}
+  currency={displayCurrency}
+  timezone={displayTimezone}
+  {showLevels}
+  {layoutCustomized}
+  onclose={() => (settingsOpen = false)}
+  oncurrencychange={(code) => {
+    displayCurrency = code;
+  }}
+  ontimezonechange={(id) => {
+    displayTimezone = id;
+  }}
+  ontogglelevels={() => {
+    showLevels = !showLevels;
+  }}
+  onresetlayout={resetLayout}
+  onopenshortcuts={() => {
+    cheatOpen = true;
   }}
 />
 
@@ -6650,6 +6743,8 @@
     {selectedLiqDistancePct}
     {accountUpnlUsd}
     {paperMode}
+    {displayCurrency}
+    fxRate={displayFxRate}
     canSubmit={canSubmitPerp}
     perpGate={{
       show: perpGateNotice && phoenixWhitelisted === false,

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -2,6 +2,7 @@
   import "./terminal.css";
 
   import { onMount, tick } from "svelte";
+  import { browser, dev } from "$app/environment";
   import AckModal from "./components/AckModal.svelte";
   import AlertsModal from "./components/AlertsModal.svelte";
   import AuthModal from "./components/AuthModal.svelte";
@@ -118,6 +119,11 @@
     type PaperEvent,
     type PaperMark,
   } from "$lib/terminal/paper-ledger";
+  import {
+    postPaperPnlSnapshot,
+    startPaperPnlLogger,
+    type PaperPnlSnapRef,
+  } from "$lib/terminal/paper-pnl-log";
   import {
     disconnectedRows,
     emptyMarketStats,
@@ -1138,6 +1144,44 @@
   );
   $: accountEquityUsd =
     phoenixTotalCollateral + accountUpnlUsd + (paperMode ? paperSpotEquityUsd : 0);
+  // Live ref for the 30m PAPER uPNL logger (dev only).
+  const paperPnlSnapRef: PaperPnlSnapRef = {
+    paperMode: false,
+    upnlUsd: 0,
+    equityUsd: 0,
+    freeCollateralUsd: 0,
+    positions: [],
+  };
+  $: {
+    paperPnlSnapRef.paperMode = paperMode;
+    paperPnlSnapRef.upnlUsd = accountUpnlUsd;
+    paperPnlSnapRef.equityUsd = accountEquityUsd;
+    paperPnlSnapRef.freeCollateralUsd = phoenixCollateral;
+    paperPnlSnapRef.positions = enrichedPositions.map((position) => ({
+      symbol: position.symbol,
+      size: position.size,
+      entry: position.entryPrice ?? null,
+      upnl: position.unrealizedPnl ?? null,
+      marginUsd: position.marginUsd ?? null,
+    }));
+  }
+  // Catch PAPER turning on after mount (prefs hydrate) so the first sample
+  // is not delayed a full 30 minutes. Depend only on `paperMode` so mark
+  // ticks do not re-fire the baseline.
+  let paperPnlSawOn = false;
+  $: if (browser && dev && paperMode && !paperPnlSawOn) {
+    paperPnlSawOn = true;
+    const snap = paperPnlSnapRef;
+    void postPaperPnlSnapshot({
+      ts: Date.now(),
+      reason: "paper-on",
+      upnlUsd: snap.upnlUsd,
+      equityUsd: snap.equityUsd,
+      freeCollateralUsd: snap.freeCollateralUsd,
+      positions: snap.positions,
+    });
+  }
+  $: if (!paperMode) paperPnlSawOn = false;
   $: marginInUseUsd = enrichedPositions.reduce(
     (sum, position) => sum + (position.marginUsd ?? 0),
     0,
@@ -1554,6 +1598,9 @@
       }
     };
     document.addEventListener("visibilitychange", onVisible);
+    // Dev PAPER: snapshot uPNL immediately, then every 30 minutes → .logs/paper-upnl.jsonl
+    const stopPaperPnlLog =
+      browser && dev ? startPaperPnlLogger(paperPnlSnapRef) : () => {};
     // Same breakpoint as the grid collapse: desktop stacks ladder + ticket,
     // narrow keeps the tab UI (matches railTicketUsable()).
     const stackMq = window.matchMedia("(max-width: 1100px)");
@@ -1597,6 +1644,7 @@
       phoenixStream?.close();
       window.cancelAnimationFrame(bookFrame);
       document.removeEventListener("visibilitychange", onVisible);
+      stopPaperPnlLog();
       stackMq.removeEventListener("change", onStackMq);
       footerRo?.disconnect();
       window.clearInterval(footerWatchTimer);

--- a/apps/portal/src/routes/terminal/components/AlertsModal.svelte
+++ b/apps/portal/src/routes/terminal/components/AlertsModal.svelte
@@ -1,16 +1,22 @@
 <script lang="ts">
   import { alertsStore, type Alert } from "$lib/terminal/alerts";
+  import {
+    formatStampInZone,
+    type DisplayTimezoneId,
+  } from "$lib/terminal/display-timezone";
   import { formatPrice } from "$lib/utils";
 
   let {
     open,
     symbol,
     latestPrice,
+    displayTimezone = "UTC",
     onclose,
   }: {
     open: boolean;
     symbol: string;
     latestPrice: number | null;
+    displayTimezone?: DisplayTimezoneId;
     onclose: () => void;
   } = $props();
 
@@ -100,7 +106,7 @@
           <div class="alert-list">
             {#each $alertLog.slice(0, 10) as fired (fired.ts)}
               <div class="alert-row done">
-                <span class="mono alert-when">{new Date(fired.ts).toISOString().slice(5, 16).replace("T", " ")}Z</span>
+                <span class="mono alert-when">{formatStampInZone(fired.ts, displayTimezone)}</span>
                 <b>{fired.title}</b>
                 <em>{fired.body}</em>
               </div>

--- a/apps/portal/src/routes/terminal/components/FundsModal.svelte
+++ b/apps/portal/src/routes/terminal/components/FundsModal.svelte
@@ -2,6 +2,10 @@
   import { onDestroy } from "svelte";
   import { getJupiterQuote, type JupiterQuote } from "$lib/funding";
   import { formatNumber } from "$lib/utils";
+  import {
+    formatDisplayMoney,
+    type DisplayCurrencyCode,
+  } from "$lib/terminal/display-currency";
 
   // Money movement stays page-side (signing plumbing): deposits/withdrawals
   // fire `ondeposit`/`onwithdraw` into `submitCollateral`, and the swap
@@ -18,6 +22,8 @@
     solBalanceValue,
     gasText,
     phoenixCollateralUsd,
+    displayCurrency = "USD",
+    fxRate = 1,
     collateral,
     onclose,
     ondeposit,
@@ -35,6 +41,8 @@
     solBalanceValue: number | null;
     gasText: string;
     phoenixCollateralUsd: number | null;
+    displayCurrency?: DisplayCurrencyCode;
+    fxRate?: number;
     collateral: { busy: boolean; error: string; signature: string };
     onclose: () => void;
     ondeposit: () => void;
@@ -42,6 +50,9 @@
     oncopyaddress: () => void | Promise<void>;
     onswap: (quote: JupiterQuote) => Promise<string>;
   } = $props();
+
+  const money = (usd: number, digits = 2) =>
+    formatDisplayMoney(usd, displayCurrency, fxRate, digits);
 
   // Aliases keep the moved markup verbatim against the page's names.
   const usdcBalanceText = $derived(usdcBalance.text);
@@ -230,7 +241,7 @@
         {:else}
           <p class="auth-lead">Move <b>USDC</b> between your wallet and your <b>Phoenix margin account</b>.</p>
           <div class="ticket-preview">
-            <div class="preview-row"><span>Phoenix collateral</span><b>{phoenixCollateralUsd !== null ? `$${formatNumber(phoenixCollateralUsd, 2)}` : "--"}</b></div>
+            <div class="preview-row"><span>Phoenix collateral</span><b>{phoenixCollateralUsd !== null ? money(phoenixCollateralUsd, 2) : "--"}</b></div>
             <div class="preview-row"><span>Wallet USDC</span><b>{usdcBalanceText}</b></div>
             <div class="preview-row"><span>SOL (gas)</span><b>{walletBalanceText}</b></div>
           </div>

--- a/apps/portal/src/routes/terminal/components/JournalPanel.svelte
+++ b/apps/portal/src/routes/terminal/components/JournalPanel.svelte
@@ -2,6 +2,10 @@
   import type { AiRead } from "$lib/ai";
   import { journalToCsv, type JournalEntry } from "$lib/journal";
   import { panelStyle, usePanelLayout } from "$lib/terminal/layout";
+  import {
+    formatTimeHmInZone,
+    type DisplayTimezoneId,
+  } from "$lib/terminal/display-timezone";
   import { formatNumber } from "$lib/utils";
   import AiReadLine from "./AiReadLine.svelte";
   import DragHead from "./DragHead.svelte";
@@ -11,6 +15,7 @@
     journalToday,
     recapRead,
     sessionPnlUsd,
+    displayTimezone = "UTC",
     onwipe,
   }: {
     journalEntries: JournalEntry[];
@@ -18,6 +23,7 @@
     recapRead: AiRead;
     /** Day P&L from the equity baseline — null when no wallet/history. */
     sessionPnlUsd: number | null;
+    displayTimezone?: DisplayTimezoneId;
     // Wiping resets page-owned state too (entries source + recap AI state),
     // so the clear action stays a page callback.
     onwipe: () => void;
@@ -87,7 +93,7 @@
   <div class="journal-list">
     {#each [...journalEntries].reverse().slice(0, 12) as entry (entry.ts)}
       <div class="journal-row">
-        <span class="journal-time">{new Date(entry.ts).toISOString().slice(11, 16)}</span>
+        <span class="journal-time">{formatTimeHmInZone(entry.ts, displayTimezone)}</span>
         <span
           class="journal-action"
           class:positive={entry.action === "buy" || entry.action === "long" || entry.action === "limit-buy"}

--- a/apps/portal/src/routes/terminal/components/PaperFundsModal.svelte
+++ b/apps/portal/src/routes/terminal/components/PaperFundsModal.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import { onDestroy, tick } from "svelte";
-  import { formatNumber } from "$lib/utils";
+  import {
+    formatDisplayMoney,
+    type DisplayCurrencyCode,
+  } from "$lib/terminal/display-currency";
 
   let {
     open,
@@ -9,6 +12,8 @@
     marginUsd,
     openPositions,
     requiredMarginUsd = 0,
+    displayCurrency = "USD",
+    fxRate = 1,
     onclose,
     ontopup,
     onreset,
@@ -20,10 +25,15 @@
     openPositions: number;
     /** Margin the open ticket needs — shown when free cash is short. */
     requiredMarginUsd?: number;
+    displayCurrency?: DisplayCurrencyCode;
+    fxRate?: number;
     onclose: () => void;
     ontopup: (amount: number) => void;
     onreset: () => void;
   } = $props();
+
+  const money = (usd: number, digits = 2) =>
+    formatDisplayMoney(usd, displayCurrency, fxRate, digits);
 
   const shortfallUsd = $derived(
     requiredMarginUsd > 0 ? Math.max(0, requiredMarginUsd - freeUsd) : 0,
@@ -143,26 +153,29 @@
       <div class="panel-head">
         <div>
           <p>PAPER_FUNDS</p>
-          <h2>${formatNumber(equityUsd, 2)}</h2>
+          <h2>{money(equityUsd, 2)}</h2>
         </div>
         <button class="modal-close" type="button" aria-label="Close" onclick={() => onclose()}>×</button>
       </div>
       <div class="modal-body">
         <p class="auth-lead">
           Simulated USDC on live market data (perps + spot) — nothing here is real money.
+          {#if displayCurrency !== "USD"}
+            Amounts below are shown in {displayCurrency} (approx).
+          {/if}
         </p>
         <div class="ticket-preview">
           <div class="preview-row">
             <span>Equity</span>
-            <b>${formatNumber(equityUsd, 2)}</b>
+            <b>{money(equityUsd, 2)}</b>
           </div>
           <div class="preview-row">
             <span>Free cash</span>
-            <b>${formatNumber(freeUsd, 2)}</b>
+            <b>{money(freeUsd, 2)}</b>
           </div>
           <div class="preview-row">
             <span>In positions</span>
-            <b>${formatNumber(marginUsd, 2)}</b>
+            <b>{money(marginUsd, 2)}</b>
           </div>
           <div class="preview-row">
             <span>Open positions</span>
@@ -171,13 +184,13 @@
           {#if hasTicketNeed}
             <div class="preview-row">
               <span>This ticket needs</span>
-              <b>${formatNumber(requiredMarginUsd, 2)}</b>
+              <b>{money(requiredMarginUsd, 2)}</b>
             </div>
           {/if}
         </div>
         {#if hasTicketNeed && shortfallUsd > 0.01}
           <p class="fund-note short">
-            Not enough free cash — short ${formatNumber(shortfallUsd, 2)}. Equity can look high while margin is locked in open positions.
+            Not enough free cash — short {money(shortfallUsd, 2)}. Equity can look high while margin is locked in open positions.
           </p>
         {:else if canFundTicket}
           <p class="fund-note ok">
@@ -186,14 +199,14 @@
         {/if}
         <div class="ticket-grid-2">
           <button class="primary" type="button" onclick={() => ontopup(1_000)}>
-            Top up +$1,000
+            Top up +{money(1_000, 0)}
           </button>
           <button class="account-action" type="button" onclick={() => ontopup(5_000)}>
-            Top up +$5,000
+            Top up +{money(5_000, 0)}
           </button>
         </div>
         <button class="account-action wide" type="button" onclick={onreset}>
-          Reset to $10,000
+          Reset to {money(10_000, 0)}
         </button>
       </div>
     </div>

--- a/apps/portal/src/routes/terminal/components/PerpDeskPanel.svelte
+++ b/apps/portal/src/routes/terminal/components/PerpDeskPanel.svelte
@@ -9,6 +9,11 @@
   import { panelStyle, usePanelLayout } from "$lib/terminal/layout";
   import type { SignalRow } from "$lib/terminal/panels";
   import { liqDistancePct, orderCancelKey } from "$lib/terminal/trade-math";
+  import {
+    formatDisplayMoney,
+    formatDisplayMoneySigned,
+    type DisplayCurrencyCode,
+  } from "$lib/terminal/display-currency";
   import { formatNumber, formatPercent, formatPrice } from "$lib/utils";
   import AiReadLine from "./AiReadLine.svelte";
   import DragHead from "./DragHead.svelte";
@@ -55,6 +60,8 @@
     marginAddKey,
     marginAddValue = $bindable(),
     paperMode = false,
+    displayCurrency = "USD",
+    fxRate = 1,
     ontrade,
     ondeposit,
     onselectsymbol,
@@ -98,6 +105,8 @@
     marginAddKey: string | null;
     marginAddValue: string;
     paperMode?: boolean;
+    displayCurrency?: DisplayCurrencyCode;
+    fxRate?: number;
     // Every money handler stays in the page (signing plumbing) — the panel
     // only reports intent through these callbacks.
     ontrade: (side: "buy" | "sell") => void;
@@ -113,6 +122,11 @@
     onmarginsubmit: (position: PhoenixPosition) => void;
     onresetpaper?: () => void;
   } = $props();
+
+  const money = (usd: number, digits = 2) =>
+    formatDisplayMoney(usd, displayCurrency, fxRate, digits);
+  const moneySigned = (usd: number, digits = 2) =>
+    formatDisplayMoneySigned(usd, displayCurrency, fxRate, digits);
 
   const {
     panelOrder,
@@ -174,12 +188,12 @@
 
   {#if authority && trader}
     <div class="venue-strip">
-      <div><span>Collateral</span><b>{trader.collateralUsd !== null ? `$${formatNumber(trader.collateralUsd, 2)}` : "--"}</b></div>
+      <div><span>Collateral</span><b>{trader.collateralUsd !== null ? money(trader.collateralUsd, 2) : "--"}</b></div>
       <div><span>uPnL</span>
         <b
           class:positive={(trader.unrealizedPnlUsd ?? 0) >= 0}
           class:negative={(trader.unrealizedPnlUsd ?? 0) < 0}
-        >{trader.unrealizedPnlUsd !== null ? `$${formatNumber(trader.unrealizedPnlUsd, 2)}` : "--"}</b>
+        >{trader.unrealizedPnlUsd !== null ? money(trader.unrealizedPnlUsd, 2) : "--"}</b>
       </div>
       <div><span>Risk</span><b>{trader.riskTier ?? "--"}</b></div>
       <div>
@@ -189,7 +203,7 @@
           class:negative={(account.leverage ?? 0) > 15}
         >
           {account.exposure > 0
-            ? `$${formatNumber(account.exposure, 0)} · ${formatNumber(account.leverage, 1)}x`
+            ? `${money(account.exposure, 0)} · ${formatNumber(account.leverage, 1)}x`
             : "--"}
         </b>
       </div>
@@ -199,7 +213,7 @@
         <div>
           <span>Day P&L</span>
           <b class:positive={sessionPnlUsd >= 0} class:negative={sessionPnlUsd < 0}>
-            {sessionPnlUsd >= 0 ? "+" : "-"}${formatNumber(Math.abs(sessionPnlUsd), 2)}
+            {moneySigned(sessionPnlUsd, 2)}
             {#if sessionPnlPct !== null}({formatPercent(sessionPnlPct)}){/if}
             <Spark values={equityValues} tone={sessionPnlUsd >= 0 ? "up" : "down"} />
           </b>
@@ -231,7 +245,7 @@
             <span class="pos-side">{pendingOrder.side === "bid" ? "LONG" : "SHORT"}</span>
             <span class="pos-symbol-static">{pendingOrder.symbol}</span>
             <b class="mono">
-              ${formatNumber(pendingOrder.notionalUsd, 2)}
+              {money(pendingOrder.notionalUsd, 2)}
               @ {formatPrice(pendingOrder.refPrice)} · {pendingOrder.leverage}x
             </b>
           </div>
@@ -265,7 +279,7 @@
             >{position.symbol}</button>
             <b class="mono">
               {formatNumber(Math.abs(position.size), 4)}
-              {#if position.positionValue !== null}(${formatNumber(position.positionValue, 2)}){/if}
+              {#if position.positionValue !== null}({money(position.positionValue, 2)}){/if}
             </b>
             <em
               class="mono"
@@ -273,7 +287,7 @@
               class:negative={(position.unrealizedPnl ?? 0) < 0}
             >
               {position.unrealizedPnl !== null
-                ? `${position.unrealizedPnl >= 0 ? "+" : "-"}$${formatNumber(Math.abs(position.unrealizedPnl), 2)}`
+                ? moneySigned(position.unrealizedPnl, 2)
                 : "--"}
               {#if roePct !== null}({roePct >= 0 ? "+" : ""}{formatNumber(roePct, 1)}%){/if}
             </em>
@@ -364,7 +378,7 @@
                 {#if marginBusy}<span class="spinner" aria-hidden="true"></span>{/if}
                 Add margin
               </button>
-              <span class="margin-add-note">free ${formatNumber(Math.max(0, freeCollateralUsd), 2)}</span>
+              <span class="margin-add-note">free {money(Math.max(0, freeCollateralUsd), 2)}</span>
             </div>
           {/if}
         </div>
@@ -372,7 +386,7 @@
       <div class="pos-total mono">
         <span>TOTAL</span>
         <span>
-          exp ${formatNumber(
+          exp {money(
             positions.reduce(
               (sum, position) => sum + (position.positionValue ?? 0),
               0,
@@ -383,7 +397,7 @@
         <span
           class:positive={account.upnl >= 0}
           class:negative={account.upnl < 0}
-        >uPNL {account.upnl >= 0 ? "+" : "-"}${formatNumber(Math.abs(account.upnl), 2)}</span>
+        >uPNL {moneySigned(account.upnl, 2)}</span>
       </div>
     {/if}
 

--- a/apps/portal/src/routes/terminal/components/SettingsModal.svelte
+++ b/apps/portal/src/routes/terminal/components/SettingsModal.svelte
@@ -1,0 +1,335 @@
+<script lang="ts">
+  import { onDestroy, tick } from "svelte";
+  import {
+    DISPLAY_CURRENCIES,
+    type DisplayCurrencyCode,
+  } from "$lib/terminal/display-currency";
+  import {
+    timezonesForPicker,
+    type DisplayTimezoneId,
+  } from "$lib/terminal/display-timezone";
+
+let {
+  open = false,
+  currency,
+  timezone,
+  showLevels = true,
+  layoutCustomized = false,
+  onclose,
+  oncurrencychange,
+  ontimezonechange,
+  ontogglelevels,
+  onresetlayout,
+  onopenshortcuts,
+}: {
+  open?: boolean;
+  currency: DisplayCurrencyCode;
+  timezone: DisplayTimezoneId;
+  showLevels?: boolean;
+  layoutCustomized?: boolean;
+  onclose: () => void;
+  oncurrencychange: (code: DisplayCurrencyCode) => void;
+  ontimezonechange: (id: DisplayTimezoneId) => void;
+  ontogglelevels: () => void;
+  onresetlayout: () => void;
+  onopenshortcuts: () => void;
+} = $props();
+
+let panel = $state<HTMLDivElement>();
+let previousFocus: HTMLElement | null = null;
+let wasOpen = false;
+
+const focusableSelector = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(", ");
+
+function focusableControls(): HTMLElement[] {
+  if (!panel) return [];
+  return Array.from(panel.querySelectorAll<HTMLElement>(focusableSelector));
+}
+
+function restorePreviousFocus(): void {
+  const target = previousFocus;
+  previousFocus = null;
+  if (target?.isConnected) target.focus();
+}
+
+$effect(() => {
+  if (open && !wasOpen) {
+    wasOpen = true;
+    previousFocus =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    void tick().then(() => {
+      if (open) {
+        const select = panel?.querySelector<HTMLSelectElement>(
+          'select[name="currency"]',
+        );
+        (select ?? panel)?.focus();
+      }
+    });
+  } else if (!open && wasOpen) {
+    wasOpen = false;
+    void tick().then(restorePreviousFocus);
+  }
+});
+
+onDestroy(() => {
+  if (wasOpen) restorePreviousFocus();
+});
+
+function trapTab(event: KeyboardEvent): void {
+  if (!panel) return;
+  const focusables = focusableControls();
+  if (focusables.length === 0) {
+    event.preventDefault();
+    panel.focus();
+    return;
+  }
+  const first = focusables[0];
+  const last = focusables[focusables.length - 1];
+  const active = document.activeElement;
+  if (!panel.contains(active)) {
+    event.preventDefault();
+    first.focus();
+    return;
+  }
+  if (event.shiftKey && (active === first || active === panel)) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && active === last) {
+    event.preventDefault();
+    first.focus();
+  }
+}
+
+function onWindowKeydown(event: KeyboardEvent): void {
+  if (!open) return;
+  event.stopImmediatePropagation();
+  if (event.key === "Escape") {
+    onclose();
+    return;
+  }
+  if (event.key === "Tab") trapTab(event);
+}
+
+function onPanelKeydown(event: KeyboardEvent): void {
+  event.stopPropagation();
+  if (event.key === "Escape") {
+    onclose();
+    return;
+  }
+  if (event.key === "Tab") trapTab(event);
+}
+
+function pullFocusInside(event: FocusEvent): void {
+  if (!open || !panel || panel.contains(event.target as Node)) return;
+  const [first] = focusableControls();
+  (first ?? panel).focus();
+}
+
+function onCurrencyInput(event: Event): void {
+  const value = (event.currentTarget as HTMLSelectElement).value;
+  const match = DISPLAY_CURRENCIES.find((row) => row.code === value);
+  if (match) oncurrencychange(match.code);
+}
+
+function onTimezoneInput(event: Event): void {
+  const value = (event.currentTarget as HTMLSelectElement).value;
+  ontimezonechange(value);
+}
+
+const timezoneOptions = $derived(timezonesForPicker(timezone));
+</script>
+
+<svelte:window onkeydown={onWindowKeydown} onfocusin={pullFocusInside} />
+
+{#if open}
+  <div class="modal-backdrop" role="presentation" onclick={() => onclose()}>
+    <div
+      bind:this={panel}
+      class="modal settings-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Settings"
+      tabindex="-1"
+      onclick={(event) => event.stopPropagation()}
+      onkeydown={onPanelKeydown}
+    >
+      <div class="panel-head">
+        <div>
+          <p>TERMINAL</p>
+          <h2>Settings</h2>
+        </div>
+        <button
+          class="modal-close"
+          type="button"
+          aria-label="Close"
+          onclick={() => onclose()}>×</button
+        >
+      </div>
+      <div class="modal-body settings-body">
+        <label class="settings-row currency-row" for="settings-currency">
+          <span class="settings-copy">
+            <strong>Currency</strong>
+            <span
+              >Show balances in a currency you know. Trading still settles in
+              USD.</span
+            >
+          </span>
+          <select
+            id="settings-currency"
+            name="currency"
+            value={currency}
+            onchange={onCurrencyInput}
+          >
+            {#each DISPLAY_CURRENCIES as row (row.code)}
+              <option value={row.code}>{row.code} — {row.label}</option>
+            {/each}
+          </select>
+        </label>
+
+        <label class="settings-row currency-row" for="settings-timezone">
+          <span class="settings-copy">
+            <strong>Timezone</strong>
+            <span
+              >Clocks, journal, tape, and alert times use this zone. Chart
+              candles stay on exchange UTC.</span
+            >
+          </span>
+          <select
+            id="settings-timezone"
+            name="timezone"
+            value={timezone}
+            onchange={onTimezoneInput}
+          >
+            {#each timezoneOptions as row (row.id)}
+              <option value={row.id}>{row.label}</option>
+            {/each}
+          </select>
+        </label>
+
+        <div class="settings-row">
+          <div class="settings-copy">
+            <strong>Structure levels</strong>
+            <span>PDH/PDL and swing pivots on the chart</span>
+          </div>
+          <button
+            class="secondary"
+            type="button"
+            aria-pressed={showLevels}
+            onclick={ontogglelevels}
+          >
+            {showLevels ? "On" : "Off"}
+          </button>
+        </div>
+
+        <div class="settings-row">
+          <div class="settings-copy">
+            <strong>Layout</strong>
+            <span>Reset panel order to defaults</span>
+          </div>
+          <button
+            class="secondary"
+            type="button"
+            disabled={!layoutCustomized}
+            onclick={onresetlayout}
+          >
+            Reset
+          </button>
+        </div>
+
+        <div class="settings-row">
+          <div class="settings-copy">
+            <strong>Keyboard shortcuts</strong>
+            <span>Hotkeys for ticket, chart, and desk</span>
+          </div>
+          <button
+            class="secondary"
+            type="button"
+            onclick={() => {
+              onclose();
+              onopenshortcuts();
+            }}
+          >
+            Open
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .settings-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+  }
+
+  .settings-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin: 0;
+    padding-bottom: 0.85rem;
+    border-bottom: 1px solid var(--line-soft);
+  }
+
+  .settings-row:last-child {
+    padding-bottom: 0;
+    border-bottom: 0;
+  }
+
+  .settings-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    min-width: 0;
+  }
+
+  .settings-copy strong {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--ink);
+  }
+
+  .settings-copy span {
+    font-size: 0.72rem;
+    line-height: 1.35;
+    color: var(--muted);
+  }
+
+  .currency-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .currency-row select {
+    width: 100%;
+    padding: 0.55rem 0.65rem;
+    border: 1px solid var(--line-soft);
+    border-radius: 0;
+    background: var(--panel, rgba(255, 255, 255, 0.03));
+    color: var(--ink);
+    font: inherit;
+    font-size: 0.85rem;
+  }
+
+  .currency-row select:focus {
+    outline: 1px solid var(--accent);
+    outline-offset: 1px;
+  }
+
+  .settings-row .secondary {
+    flex-shrink: 0;
+    min-width: 4.5rem;
+  }
+</style>

--- a/apps/portal/src/routes/terminal/components/StatusLine.svelte
+++ b/apps/portal/src/routes/terminal/components/StatusLine.svelte
@@ -1,5 +1,14 @@
 <script lang="ts">
   import { shortAddress } from "$lib/terminal/account-format";
+  import {
+    formatDisplayMoney,
+    formatDisplayMoneySigned,
+    type DisplayCurrencyCode,
+  } from "$lib/terminal/display-currency";
+  import {
+    formatClockInZone,
+    type DisplayTimezoneId,
+  } from "$lib/terminal/display-timezone";
   import { formatNumber } from "$lib/utils";
 
   // Fixed footer — one already-derived model object per tick from the page.
@@ -22,6 +31,9 @@
     freeCollateralUsd: number;
     fundingPercent: number | null;
     walletAddress: string;
+    displayCurrency: DisplayCurrencyCode;
+    fxRate: number;
+    displayTimezone: DisplayTimezoneId;
   };
 
   let {
@@ -36,7 +48,9 @@
 </script>
 
 <footer class="status-line" aria-label="Terminal status">
-  <span class="mono">{new Date(status.clockMs).toISOString().slice(11, 19)} UTC</span>
+  <span class="mono"
+    >{formatClockInZone(status.clockMs, status.displayTimezone)}</span
+  >
   <span class="sl-sep" aria-hidden="true"></span>
   <span>{status.symbol} · {status.sessionNote}</span>
   <span class="sl-sep" aria-hidden="true"></span>
@@ -78,11 +92,30 @@
       >
         PAPER
       </span>
-      <span>EQ ${formatNumber(status.equityUsd, 0)}</span>
+      <span
+        >EQ {formatDisplayMoney(
+          status.equityUsd,
+          status.displayCurrency,
+          status.fxRate,
+          0,
+        )}</span
+      >
       <span class:positive={status.upnlUsd >= 0} class:negative={status.upnlUsd < 0}>
-        uPNL {status.upnlUsd >= 0 ? "+" : "-"}${formatNumber(Math.abs(status.upnlUsd), 2)}
+        uPNL {formatDisplayMoneySigned(
+          status.upnlUsd,
+          status.displayCurrency,
+          status.fxRate,
+          2,
+        )}
       </span>
-      <span>FREE ${formatNumber(status.freeCollateralUsd, 0)}</span>
+      <span
+        >FREE {formatDisplayMoney(
+          status.freeCollateralUsd,
+          status.displayCurrency,
+          status.fxRate,
+          0,
+        )}</span
+      >
       {#if status.fundingPercent !== null}
         <span>FUND {status.fundingPercent >= 0 ? "+" : ""}{formatNumber(status.fundingPercent, 3)}%/8h</span>
       {/if}

--- a/apps/portal/src/routes/terminal/components/Tape.svelte
+++ b/apps/portal/src/routes/terminal/components/Tape.svelte
@@ -1,11 +1,21 @@
 <script lang="ts">
   import type { TradeTick } from "$lib/phoenix-market-data";
   import { formatBookPrice } from "$lib/terminal/book";
+  import {
+    formatTimeHmsInZone,
+    type DisplayTimezoneId,
+  } from "$lib/terminal/display-timezone";
   import { formatNumber } from "$lib/utils";
 
   // Hot leaf: `trades` is a new array per stream flush — the page passes it
   // through untouched and Svelte scopes the per-print DOM updates here.
-  let { trades }: { trades: TradeTick[] } = $props();
+  let {
+    trades,
+    displayTimezone = "UTC",
+  }: {
+    trades: TradeTick[];
+    displayTimezone?: DisplayTimezoneId;
+  } = $props();
 </script>
 
 <!-- Time & sales: the prints are the heartbeat. -->
@@ -13,7 +23,7 @@
   <div class="tape-header"><span>Time</span><span>Price</span><span>Size</span></div>
   {#each trades.slice(0, 18) as tick (tick.seq)}
     <div class="tape-row" class:bid={tick.side === "buy"} class:ask={tick.side === "sell"}>
-      <span>{new Date(tick.ts).toISOString().slice(11, 19)}</span>
+      <span>{formatTimeHmsInZone(tick.ts, displayTimezone)}</span>
       <span>{formatBookPrice(tick.price)}</span>
       <span>{formatNumber(tick.size * tick.price, 0)}</span>
     </div>

--- a/apps/portal/src/routes/terminal/components/TicketForm.svelte
+++ b/apps/portal/src/routes/terminal/components/TicketForm.svelte
@@ -4,6 +4,10 @@
   import type { PerpTicket } from "$lib/terminal/perp-ticket";
   import { stepInput } from "$lib/terminal/step-input";
   import { SL_CHIP_PCTS, TP_CHIP_PCTS } from "$lib/terminal/trade-math";
+  import {
+    formatDisplayMoney,
+    type DisplayCurrencyCode,
+  } from "$lib/terminal/display-currency";
   import { formatNumber, formatPercent, formatPrice } from "$lib/utils";
 
   // Perp ticket form: state (the nine fields + every ticket-only derived)
@@ -40,6 +44,8 @@
     selectedLiqDistancePct,
     accountUpnlUsd,
     paperMode = false,
+    displayCurrency = "USD",
+    fxRate = 1,
     // Submit gating + status (the signing pipeline stays in the page).
     canSubmit,
     orderBusy,
@@ -88,6 +94,8 @@
     selectedLiqDistancePct: number | null;
     accountUpnlUsd: number;
     paperMode?: boolean;
+    displayCurrency?: DisplayCurrencyCode;
+    fxRate?: number;
     canSubmit: boolean;
     orderBusy: boolean;
     orderStageEntry: TxStageEntry | null;
@@ -113,6 +121,9 @@
     onsizechip: (pct: number | "max") => void;
     onriskchip: (pct: number) => void;
   } = $props();
+
+  const money = (usd: number, digits = 2) =>
+    formatDisplayMoney(usd, displayCurrency, fxRate, digits);
 
   // The store bundle is created once by the page and never replaced —
   // destructuring keeps every `$` subscription identical to the page's.
@@ -334,7 +345,7 @@
   {#if $sizingMode === "risk"}
     <div class="preview-row">
       <span>Size from stop</span>
-      <b>{$riskNotionalUsd !== null ? `$${formatNumber($riskNotionalUsd, 2)}` : "set a stop loss"}</b>
+      <b>{$riskNotionalUsd !== null ? money($riskNotionalUsd, 2) : "set a stop loss"}</b>
     </div>
   {/if}
   <div class="preview-row"><span>Est. entry</span><b>{formatPrice($tradePreview?.entry)}</b></div>
@@ -361,7 +372,7 @@
       <span>At take profit</span>
       <b class="positive">
         {$tpPct >= 0 ? "+" : ""}{formatNumber($tpPct, 1)}%
-        {#if $tpPnlUsd !== null}· +${formatNumber(Math.abs($tpPnlUsd), 2)}{/if}
+        {#if $tpPnlUsd !== null}· +{money(Math.abs($tpPnlUsd), 2)}{/if}
       </b>
     </div>
   {/if}
@@ -370,15 +381,15 @@
       <span>At stop loss</span>
       <b class="negative">
         {$slPct >= 0 ? "+" : ""}{formatNumber($slPct, 1)}%
-        {#if $slPnlUsd !== null}· -${formatNumber(Math.abs($slPnlUsd), 2)}{/if}
+        {#if $slPnlUsd !== null}· -{money(Math.abs($slPnlUsd), 2)}{/if}
       </b>
     </div>
   {/if}
   <div class="preview-row">
     <span>Margin required</span>
     <b class:negative={$needsPhoenixFunding}>
-      ${formatNumber($requiredMarginUsd, 2)}
-      {#if phoenixAuthority}· bal ${formatNumber(phoenixCollateral, 2)}{/if}
+      {money($requiredMarginUsd, 2)}
+      {#if phoenixAuthority}· bal {money(phoenixCollateral, 2)}{/if}
     </b>
   </div>
 </div>
@@ -417,7 +428,7 @@
       class:danger={marginUsedPct > 85 ||
         (selectedLiqDistancePct !== null && selectedLiqDistancePct < 5)}
     >
-      <span>EQ ${formatNumber(accountEquityUsd, 2)}</span>
+      <span>EQ {money(accountEquityUsd, 2)}</span>
       <span>USED {formatNumber(marginUsedPct, 0)}%</span>
       <span>
         {selectedLiqDistancePct !== null
@@ -427,7 +438,7 @@
       <span
         class:positive={accountUpnlUsd >= 0}
         class:negative={accountUpnlUsd < 0}
-      >uPNL ${formatNumber(accountUpnlUsd, 2)}</span>
+      >uPNL {money(accountUpnlUsd, 2)}</span>
     </div>
   {/if}
   <!-- Single reserved status line: error, live tx stage, tx link, or quiet hint. -->

--- a/apps/portal/src/routes/terminal/components/Topbar.svelte
+++ b/apps/portal/src/routes/terminal/components/Topbar.svelte
@@ -9,6 +9,10 @@
   } from "$lib/terminal/account-format";
   import { alertsStore } from "$lib/terminal/alerts";
   import { formatNumber } from "$lib/utils";
+  import {
+    formatDisplayMoney,
+    type DisplayCurrencyCode,
+  } from "$lib/terminal/display-currency";
   import { BrandMark } from "@harness-trade/ui";
 
   const { alerts } = alertsStore;
@@ -21,9 +25,12 @@
     logoutBusy,
     paperMode = false,
     paperFundsLabel = "",
+    displayCurrency = "USD",
+    fxRate = 1,
     height = $bindable(0),
     onopenauth,
     onopenfunds,
+    onopensettings,
     onopenalerts,
     onresetlayout,
     onToggleChat,
@@ -48,9 +55,12 @@
     paperMode?: boolean;
     /** Shown on the paper Funds button, e.g. "$10,000". */
     paperFundsLabel?: string;
+    displayCurrency?: DisplayCurrencyCode;
+    fxRate?: number;
     height?: number;
     onopenauth: () => void;
     onopenfunds: () => void;
+    onopensettings: () => void;
     onopenalerts: () => void;
     onresetlayout: () => void;
     onToggleChat: () => void;
@@ -84,6 +94,9 @@
   const pendingAlertCount = $derived(
     $alerts.filter((a) => !a.triggered).length,
   );
+
+  const money = (usd: number, digits = 2) =>
+    formatDisplayMoney(usd, displayCurrency, fxRate, digits);
 
   // The account menu is fully local; the window handlers own outside-click
   // and Escape close (moved from the page together with the markup).
@@ -163,6 +176,28 @@
     >
       desk
     </button>
+    <button
+      class="ghost settings-btn"
+      type="button"
+      aria-label="Settings"
+      title="Settings"
+      onclick={onopensettings}
+    >
+      <svg
+        class="settings-gear"
+        viewBox="0 0 24 24"
+        width="17"
+        height="17"
+        aria-hidden="true"
+        fill="currentColor"
+      >
+        <!-- Circular cogwheel: teeth around a ring, hole in the hub. -->
+        <path
+          fill-rule="evenodd"
+          d="M19.14 12.94c.04-.31.06-.63.06-.94 0-.31-.02-.63-.06-.94l2.03-1.58a.49.49 0 0 0 .12-.61l-1.92-3.32a.488.488 0 0 0-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.484.484 0 0 0-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58a.49.49 0 0 0-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.03-1.58zM12 15.6A3.6 3.6 0 1 0 12 8.4a3.6 3.6 0 0 0 0 7.2z"
+        />
+      </svg>
+    </button>
     <div class="account-bay">
     {#if $privyAuth.authenticated && !paperMode}
       <div class="account-slot" in:fade|local={{ duration: 160 }} out:fade|local={{ duration: 120 }}>
@@ -240,7 +275,7 @@
                 {balanceText}
                 {#if phoenixTotalCollateral > 0 && usdcBalanceValue !== null}
                   <small class="funds-split">
-                    {formatNumber(usdcBalanceValue, 2)} wallet · {formatNumber(phoenixTotalCollateral, 2)} phoenix
+                    {money(usdcBalanceValue, 2)} wallet · {money(phoenixTotalCollateral, 2)} phoenix
                   </small>
                 {/if}
               </span>
@@ -424,6 +459,20 @@
     width: 11rem;
     height: 2.2rem;
     flex-shrink: 0;
+  }
+
+  .settings-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.2rem;
+    height: 2.2rem;
+    padding: 0;
+    flex-shrink: 0;
+  }
+
+  .settings-gear {
+    display: block;
   }
 
   .account-slot {

--- a/scripts/com.harness.portal-dev.plist
+++ b/scripts/com.harness.portal-dev.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.harness.portal-dev</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/Alexnguyen001912gmail.com/Projects/harness-trade/scripts/keep-portal-dev.sh</string>
+    <string>3001</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>/Users/Alexnguyen001912gmail.com/Projects/harness-trade</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/Users/Alexnguyen001912gmail.com/Projects/harness-trade/.logs/launchagent-portal.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/Alexnguyen001912gmail.com/Projects/harness-trade/.logs/launchagent-portal.err.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/Users/Alexnguyen001912gmail.com/.bun/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+  </dict>
+</dict>
+</plist>

--- a/scripts/keep-portal-dev.sh
+++ b/scripts/keep-portal-dev.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Run the Harness portal Vite server and restart it if it exits.
+# Use this from Terminal.app / iTerm (outside Cursor) so the process
+# is not torn down when agent shells end.
+#
+#   ./scripts/keep-portal-dev.sh
+#   ./scripts/keep-portal-dev.sh 3001
+
+set -euo pipefail
+
+PORT="${1:-3001}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PORTAL="$ROOT/apps/portal"
+LOG_DIR="$ROOT/.logs"
+LOG="$LOG_DIR/portal-vite-${PORT}.log"
+export PATH="${HOME}/.bun/bin:/usr/local/bin:/opt/homebrew/bin:${PATH}"
+
+mkdir -p "$LOG_DIR"
+cd "$PORTAL"
+
+echo "Harness portal dev server on http://127.0.0.1:${PORT}/terminal"
+echo "Log: ${LOG}"
+echo "Ctrl+C stops the keeper (and the current Vite child)."
+echo
+
+while true; do
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] starting vite :${PORT}" | tee -a "$LOG"
+  bunx vite --host 127.0.0.1 --port "$PORT" >>"$LOG" 2>&1 || true
+  code=$?
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] vite exited code=${code}; restarting in 2s" | tee -a "$LOG"
+  sleep 2
+done

--- a/scripts/overnight-paper.sh
+++ b/scripts/overnight-paper.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Keep the Harness portal Vite server awake overnight and print uPNL log hints.
+# Prefer the LaunchAgent (survives logout of Terminal):
+#
+#   cp scripts/com.harness.portal-dev.plist ~/Library/LaunchAgents/
+#   launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.harness.portal-dev.plist
+#
+# Or run this script from Terminal.app / iTerm (outside Cursor):
+#
+#   ./scripts/overnight-paper.sh
+#   ./scripts/overnight-paper.sh 3001
+#
+# Requires: leave http://127.0.0.1:PORT/terminal open in PAPER mode
+# (the browser posts uPNL every 30m to .logs/paper-upnl.jsonl).
+#
+# Stop LaunchAgent:
+#   launchctl bootout gui/$(id -u)/com.harness.portal-dev
+
+set -euo pipefail
+
+PORT="${1:-3001}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LOG_DIR="$ROOT/.logs"
+PID_FILE="$LOG_DIR/overnight-paper.pid"
+VITE_LOG="$LOG_DIR/portal-vite-${PORT}.log"
+UPNL_LOG="$LOG_DIR/paper-upnl.jsonl"
+export PATH="${HOME}/.bun/bin:/usr/local/bin:/opt/homebrew/bin:${PATH}"
+
+mkdir -p "$LOG_DIR"
+
+if [[ -f "$PID_FILE" ]]; then
+  old="$(cat "$PID_FILE" 2>/dev/null || true)"
+  if [[ -n "${old}" ]] && kill -0 "$old" 2>/dev/null; then
+    echo "Already running (pid $old). Log: $VITE_LOG"
+    echo "uPNL samples: $UPNL_LOG"
+    echo "Tail:  tail -f \"$UPNL_LOG\""
+    exit 0
+  fi
+fi
+
+echo "Starting overnight keeper on http://127.0.0.1:${PORT}/terminal"
+echo "  Vite log:  $VITE_LOG"
+echo "  uPNL log:  $UPNL_LOG"
+echo "  Leave the terminal tab open in PAPER mode."
+echo "  Ctrl+C stops this keeper."
+echo
+
+# Prevent idle sleep while this session runs; restart Vite if it exits.
+cd "$ROOT"
+# -i idle sleep, -d display sleep, -m disk sleep, -s system sleep
+caffeinate -dims "$ROOT/scripts/keep-portal-dev.sh" "$PORT" &
+keeper_pid=$!
+echo "$keeper_pid" >"$PID_FILE"
+trap 'kill "$keeper_pid" 2>/dev/null || true; rm -f "$PID_FILE"' EXIT INT TERM
+wait "$keeper_pid"


### PR DESCRIPTION
## Summary
- Add a topbar settings gear with persisted **display currency** (FX-converted balances; trading still USD) and **timezone** (status clock, journal, tape, alerts).
- Convert account money labels across desk, ticket, funds modals, and status line when a non-USD currency is selected.
- Add overnight portal keep-alive scripts plus a 30-minute PAPER uPNL sampler writing to `.logs/paper-upnl.jsonl` (dev-only).

## Test plan
- [ ] Open terminal → gear → change Currency (e.g. EUR); confirm Funds, EQ/FREE/uPNL, desk Collateral, and ticket margin/bal update.
- [ ] Change Timezone (e.g. Asia/Tokyo); confirm status clock, journal, and tape times shift; reload and confirm prefs stick.
- [ ] Confirm market prices / chart candles are unchanged (still exchange units / UTC data).
- [ ] (Optional) Run `./scripts/overnight-paper.sh` or LaunchAgent; leave PAPER tab open and confirm `.logs/paper-upnl.jsonl` gains samples.


Made with [Cursor](https://cursor.com)