### PR TITLE
Clarify terminal chrome: Positions dock vs Desk chat

### DIFF
--- a/apps/portal/src/lib/slugs.ts
+++ b/apps/portal/src/lib/slugs.ts
@@ -30,6 +30,13 @@ export const RESERVED_SLUGS = new Set([
   "robots.txt",
   "llms.txt",
   "favicon.ico",
+  // Open WebUI (and other local tools) share localhost:3000 in some setups
+  // and soft-navigate to /error|/auth — those must not hit the asset loader.
+  "error",
+  "auth",
+  "admin",
+  "signin",
+  "signup",
 ]);
 
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{0,31}$/;

--- a/apps/portal/src/lib/terminal/prefs.test.ts
+++ b/apps/portal/src/lib/terminal/prefs.test.ts
@@ -155,8 +155,8 @@ describe("dock + drawer prefs", () => {
     expect(parsePrefs(JSON.stringify({ dockTab: "journal" })).dockTab).toBe(
       "journal",
     );
-    expect(parsePrefs(JSON.stringify({ dockTab: "desk" })).dockTab).toBe(
-      "desk",
+    expect(parsePrefs(JSON.stringify({ dockTab: "positions" })).dockTab).toBe(
+      "positions",
     );
     expect(parsePrefs(JSON.stringify({ dockTab: "watch" })).dockTab).toBe(
       "watch",
@@ -164,6 +164,12 @@ describe("dock + drawer prefs", () => {
     expect(
       parsePrefs(JSON.stringify({ dockTab: "settings" })).dockTab,
     ).toBeUndefined();
+  });
+
+  test("dockTab migrates legacy desk → positions", () => {
+    expect(parsePrefs(JSON.stringify({ dockTab: "desk" })).dockTab).toBe(
+      "positions",
+    );
   });
 
   test("macroOpen accepts booleans only", () => {

--- a/apps/portal/src/lib/terminal/prefs.ts
+++ b/apps/portal/src/lib/terminal/prefs.ts
@@ -30,7 +30,7 @@ export const MARKETS_MAX_AGE = 24 * 60 * 60_000;
 export const ALERT_LOG_KEY = "trader-ralph-alert-log";
 export const ONBOARD_KEY = "trader-ralph-terminal/phx-referral/v2";
 
-// Draggable dashboard: chart + book stay anchored; desk/journal live in
+// Draggable dashboard: chart + book stay anchored; positions/journal live in
 // the bottom dock. Markets / spot / screener / events / watch panels are
 // retired from the grid (watchlist is a topbar drawer). Macro research
 // still folds into the macro drawer. mergeLayout drops retired ids from
@@ -60,7 +60,7 @@ export type TerminalPrefs = {
   tradeAmount: string;
   tradeRiskUsd: string;
   tradeLeverage: number;
-  dockTab: "desk" | "journal" | "alerts" | "watch";
+  dockTab: "positions" | "journal" | "alerts" | "watch";
   macroOpen: boolean;
   /** Structure-level chart lines (PDH/PDL + swing pivots) — default ON. */
   showLevels: boolean;
@@ -174,12 +174,14 @@ export function parsePrefs(raw: string | null): Partial<TerminalPrefs> {
     prefs.tradeLeverage = data.tradeLeverage;
   }
   if (
-    data.dockTab === "desk" ||
+    data.dockTab === "positions" ||
     data.dockTab === "journal" ||
     data.dockTab === "alerts" ||
-    data.dockTab === "watch"
+    data.dockTab === "watch" ||
+    // Legacy label from before the Positions rename (topbar Desk = chat).
+    data.dockTab === "desk"
   ) {
-    prefs.dockTab = data.dockTab;
+    prefs.dockTab = data.dockTab === "desk" ? "positions" : data.dockTab;
   }
   if (typeof data.macroOpen === "boolean") prefs.macroOpen = data.macroOpen;
   if (typeof data.showLevels === "boolean") prefs.showLevels = data.showLevels;
@@ -224,7 +226,7 @@ export function persistPrefs(
   _tradeAmount: string,
   _tradeRiskUsd: string,
   _tradeLeverage: number,
-  _dockTab: "desk" | "journal" | "alerts" | "watch",
+  _dockTab: "positions" | "journal" | "alerts" | "watch",
   _macroOpen: boolean,
   _showLevels: boolean,
   _rays: Record<string, number[]>,

--- a/apps/portal/src/routes/[slug=slug]/+page.server.ts
+++ b/apps/portal/src/routes/[slug=slug]/+page.server.ts
@@ -12,7 +12,9 @@ import type { PageServerLoad } from "./$types";
 export const config = { isr: { expiration: 60 } };
 
 export const load: PageServerLoad = async ({ params }) => {
-  const asset = await findBySlug(params.slug);
+  // Catalog/API failures must not surface as a generic 500 on every unknown
+  // path (e.g. leftover /error navigations from other localhost:3000 apps).
+  const asset = await findBySlug(params.slug).catch(() => null);
   if (!asset) error(404, "Unknown asset");
 
   const [bundle, perpSymbols, catalog] = await Promise.all([

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -739,7 +739,7 @@
   let pendingSpotAssetId: string | null = null;
 
   // Watchlist: starred symbols (uppercase), persisted in prefs.
-  // Lives in the bottom dock (Desk / Journal / Alerts / Watch).
+  // Lives in the bottom dock (Positions / Journal / Alerts / Watch).
   let watchlist: string[] = [];
   // Screener controls (persisted; screener panel retired but prefs kept).
   let screenSort: "movers" | "volume" | "cap" = "movers";
@@ -945,8 +945,9 @@
       wizardPollTimer = null;
     }
   }
-  // Bottom dock (desk / journal / alerts / watch).
-  let dockTab: "desk" | "journal" | "alerts" | "watch" = "desk";
+  // Bottom dock (positions / journal / alerts / watch).
+  // Topbar "Desk" is the AI chat — different surface, deliberately.
+  let dockTab: "positions" | "journal" | "alerts" | "watch" = "positions";
   const { alertLog } = alertsStore;
   // Meme safety rails: SPL authority checks per selected mint (cached —
   // authorities effectively never un-revoke).
@@ -6243,18 +6244,18 @@
       </div>
     </section>
 
-    <!-- Bottom dock: risk never leaves the screen — desk/journal/alerts/watch
+    <!-- Bottom dock: risk never leaves the screen — positions/journal/alerts/watch
          tabs span the full width directly under the chart row. -->
     <section class="panel dock" aria-label="Trading desk dock">
       <div class="dock-tabs" role="tablist" aria-label="Dock views">
         <button
           role="tab"
-          aria-selected={dockTab === "desk"}
-          class:active={dockTab === "desk"}
+          aria-selected={dockTab === "positions"}
+          class:active={dockTab === "positions"}
           type="button"
-          onclick={() => (dockTab = "desk")}
+          onclick={() => (dockTab = "positions")}
         >
-          Desk
+          Positions
         </button>
         <button
           role="tab"

--- a/apps/portal/src/routes/terminal/components/Topbar.svelte
+++ b/apps/portal/src/routes/terminal/components/Topbar.svelte
@@ -169,34 +169,12 @@
       {/if}
     </button>
     <button
-      class="ghost"
+      class="secondary desk-btn"
       type="button"
       aria-expanded={$chatState.open}
       onclick={onToggleChat}
     >
-      desk
-    </button>
-    <button
-      class="ghost settings-btn"
-      type="button"
-      aria-label="Settings"
-      title="Settings"
-      onclick={onopensettings}
-    >
-      <svg
-        class="settings-gear"
-        viewBox="0 0 24 24"
-        width="17"
-        height="17"
-        aria-hidden="true"
-        fill="currentColor"
-      >
-        <!-- Circular cogwheel: teeth around a ring, hole in the hub. -->
-        <path
-          fill-rule="evenodd"
-          d="M19.14 12.94c.04-.31.06-.63.06-.94 0-.31-.02-.63-.06-.94l2.03-1.58a.49.49 0 0 0 .12-.61l-1.92-3.32a.488.488 0 0 0-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.484.484 0 0 0-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58a.49.49 0 0 0-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.03-1.58zM12 15.6A3.6 3.6 0 1 0 12 8.4a3.6 3.6 0 0 0 0 7.2z"
-        />
-      </svg>
+      Desk
     </button>
     <div class="account-bay">
     {#if $privyAuth.authenticated && !paperMode}
@@ -349,6 +327,28 @@
       </div>
     {/if}
     </div>
+    <button
+      class="ghost settings-btn"
+      type="button"
+      aria-label="Settings"
+      title="Settings"
+      onclick={onopensettings}
+    >
+      <svg
+        class="settings-gear"
+        viewBox="0 0 24 24"
+        width="17"
+        height="17"
+        aria-hidden="true"
+        fill="currentColor"
+      >
+        <!-- Circular cogwheel: teeth around a ring, hole in the hub. -->
+        <path
+          fill-rule="evenodd"
+          d="M19.14 12.94c.04-.31.06-.63.06-.94 0-.31-.02-.63-.06-.94l2.03-1.58a.49.49 0 0 0 .12-.61l-1.92-3.32a.488.488 0 0 0-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.484.484 0 0 0-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58a.49.49 0 0 0-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.03-1.58zM12 15.6A3.6 3.6 0 1 0 12 8.4a3.6 3.6 0 0 0 0 7.2z"
+        />
+      </svg>
+    </button>
   </div>
 </header>
 
@@ -519,7 +519,8 @@
     font-variant-numeric: tabular-nums;
   }
 
-  .alerts-btn {
+  .alerts-btn,
+  .desk-btn {
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
@@ -558,6 +559,7 @@
     .mode-pill,
     .mode-toggle button,
     .alerts-btn,
+    .desk-btn,
     .connect-btn {
       transition: none;
     }

--- a/scripts/keep-portal-dev.cmd
+++ b/scripts/keep-portal-dev.cmd
@@ -1,0 +1,7 @@
+@echo off
+REM Double-click or run from Explorer to keep http://127.0.0.1:3001/terminal alive
+REM in its own window (survives Cursor agent shells closing).
+cd /d "%~dp0\.."
+title Harness portal :3001
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0keep-portal-dev.ps1" 3001
+pause

--- a/scripts/keep-portal-dev.ps1
+++ b/scripts/keep-portal-dev.ps1
@@ -1,0 +1,47 @@
+# Run the Harness portal Vite server and restart it if it exits.
+# Use this from a normal PowerShell / Terminal window (outside Cursor) so
+# the process is not torn down when agent shells end.
+#
+#   .\scripts\keep-portal-dev.ps1
+#   .\scripts\keep-portal-dev.ps1 3001
+#   .\scripts\keep-portal-dev.cmd   # opens a dedicated window
+
+param(
+  [int]$Port = 3001
+)
+
+$ErrorActionPreference = "Continue"
+$Root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$Portal = Join-Path $Root "apps\portal"
+$LogDir = Join-Path $Root ".logs"
+$Log = Join-Path $LogDir "portal-vite-$Port.log"
+
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" +
+  [System.Environment]::GetEnvironmentVariable("Path", "User")
+
+if (-not (Get-Command bun -ErrorAction SilentlyContinue)) {
+  Write-Host "ERROR: bun not found on PATH. Install bun, then re-run."
+  exit 1
+}
+
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+Set-Location $Portal
+
+function Write-Log([string]$Message) {
+  $line = "[$((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ'))] $Message"
+  Write-Host $line
+  Add-Content -Path $Log -Value $line -Encoding utf8
+}
+
+Write-Host "Harness portal dev server on http://127.0.0.1:${Port}/terminal"
+Write-Host "Log: $Log"
+Write-Host "Ctrl+C stops the keeper (and the current Vite child)."
+Write-Host ""
+
+while ($true) {
+  Write-Log "starting vite :$Port"
+  # cmd.exe redirection keeps UTF-8 and mirrors the bash keeper.
+  cmd /c "bunx vite --host 127.0.0.1 --port $Port >> `"$Log`" 2>&1"
+  Write-Log "vite exited code=$LASTEXITCODE; restarting in 2s"
+  Start-Sleep -Seconds 2
+}


### PR DESCRIPTION
## Summary
- Rename the bottom dock **Desk** tab to **Positions** so it no longer collides with the topbar **Desk** AI chat (legacy `desk` prefs migrate automatically).
- Size the topbar Desk button like Alerts (`secondary`) and move Settings to the right of Funds.
- Reserve localhost soft-nav slugs (`error`/`auth`/…) and 404 soft-fail slug loads so Open WebUI leftovers don't 500 the portal.
- Add Windows Vite keep-alive scripts (`scripts/keep-portal-dev.ps1` / `.cmd`) alongside the existing macOS keeper.

## Test plan
- [ ] Open `/terminal` — bottom dock shows Positions | Journal | Alerts | Watch
- [ ] Topbar Desk opens the chat rail; Settings sits after Funds
- [ ] `bun test apps/portal/src/lib/terminal/prefs.test.ts` passes (legacy desk → positions)
- [ ] Visit `/error` locally → 404, not tokensxyz 500

Made with [Cursor](https://cursor.com)