### PR TITLE
Add session P&L, close preview, reconnect, and PAPER watermark

### DIFF
--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -8,6 +8,7 @@
   import AuthModal from "./components/AuthModal.svelte";
   import BookLadder from "./components/BookLadder.svelte";
   import CheatSheetModal from "./components/CheatSheetModal.svelte";
+  import ClosePreviewModal from "./components/ClosePreviewModal.svelte";
   import CommandPalette from "./components/CommandPalette.svelte";
   import FundingWizard from "./components/FundingWizard.svelte";
   import FundsModal from "./components/FundsModal.svelte";
@@ -1215,19 +1216,19 @@
   // ── Day P&L (device-local equity history) ──────────────────────────
   // Sampled on the trader refresh; baseline = first sample of the UTC day,
   // shifted by in-app deposits/withdrawals at their confirm sites.
-  // PAPER has no flow-adjusted daily baseline yet: suppress the live wallet's
-  // equity history entirely rather than subtracting the simulated ledger's
-  // equity from a live baseline (a dishonest mixed number). A dedicated paper
-  // daily baseline is a deferred follow-up.
-  $: equityPoints =
-    !paperMode && phoenixAuthority
-      ? $equityHistory[phoenixAuthority] ?? []
-      : [];
+  // PAPER uses a dedicated "paper" wallet key so simulated equity never
+  // poisons the live baseline (and paper Day P&L still works).
+  const PAPER_EQUITY_KEY = "paper";
+  $: equityAuthority = paperMode
+    ? PAPER_EQUITY_KEY
+    : phoenixAuthority || null;
+  $: equityPoints = equityAuthority
+    ? $equityHistory[equityAuthority] ?? []
+    : [];
   $: equityValues = equityPoints.map((point) => point.equity);
-  $: equityBaseline =
-    !paperMode && phoenixAuthority
-      ? $equityBaselines[phoenixAuthority] ?? null
-      : null;
+  $: equityBaseline = equityAuthority
+    ? $equityBaselines[equityAuthority] ?? null
+    : null;
   $: sessionPnlUsd = equityBaseline
     ? accountEquityUsd - equityBaseline.equity
     : null;
@@ -1235,6 +1236,10 @@
     equityBaseline && equityBaseline.equity > 0 && sessionPnlUsd !== null
       ? (sessionPnlUsd / equityBaseline.equity) * 100
       : null;
+  // PAPER day-P&L sample (60s throttle inside recordEquitySample).
+  $: if (browser && paperMode) {
+    recordEquitySample(PAPER_EQUITY_KEY, accountEquityUsd);
+  }
   // Market context attached to every money event — the model's "state".
   function marketContext(): Record<string, unknown> {
     return {
@@ -1263,7 +1268,7 @@
       openOrders: perpOpenOrders,
       // Paper has no flow-adjusted daily baseline yet — null is honest;
       // mixing the simulator with a live wallet baseline is not.
-      dayPnlUsd: paperMode ? null : sessionPnlUsd,
+      dayPnlUsd: sessionPnlUsd,
       equityUsd: accountEquityUsd,
       monitorRows: markets.map((market) => ({
         symbol: market.symbol,
@@ -2999,6 +3004,14 @@
   function resetPaperAccount(): void {
     paperLedger.set(resetPaperLedger());
     pendingOrder = null;
+    // Pin day baseline to the restored starting balance so the wipe
+    // doesn't read as a huge Day P&L loss.
+    const day = new Date().toISOString().slice(0, 10);
+    equityBaselines.update((baselines) => ({
+      ...baselines,
+      [PAPER_EQUITY_KEY]: { day, equity: PAPER_STARTING_BALANCE },
+    }));
+    recordEquitySample(PAPER_EQUITY_KEY, PAPER_STARTING_BALANCE);
     alertsStore.pushToast({
       ts: Date.now(),
       title: "Paper reset",
@@ -3008,6 +3021,7 @@
 
   function topUpPaperAccount(amount = 1_000): void {
     paperLedger.set(topUpPaperCash($paperLedger, amount));
+    shiftEquityBaseline(PAPER_EQUITY_KEY, amount);
     alertsStore.pushToast({
       ts: Date.now(),
       title: "Paper top-up",
@@ -3789,6 +3803,51 @@
   let armedHotkey: { key: "c" | "x"; until: number } | null = null;
   $: if (armedHotkey && nowMs > armedHotkey.until) armedHotkey = null;
 
+  // Close preview: Close / partial / hotkey-C opens a confirm with
+  // entry → mark + est. P&L before sending.
+  let closePreview: {
+    position: PhoenixPosition;
+    fraction: number;
+  } | null = null;
+  $: flattenEstPnl = enrichedPositions.reduce(
+    (sum, position) => sum + (position.unrealizedPnl ?? 0),
+    0,
+  );
+
+  function openClosePreview(position: PhoenixPosition, fraction = 1): void {
+    closePreview = { position, fraction };
+  }
+
+  function confirmClosePreview(): void {
+    const preview = closePreview;
+    if (!preview) return;
+    closePreview = null;
+    if (preview.fraction < 1) {
+      void closePhoenixPositionFraction(preview.position, preview.fraction);
+      return;
+    }
+    void closePhoenixPosition(
+      preview.position.symbol,
+      preview.position.size,
+      preview.position.subaccountIndex,
+    );
+  }
+
+  async function reconnectMarketData(): Promise<void> {
+    alertsStore.pushToast({
+      ts: Date.now(),
+      title: "Reconnecting",
+      body: "Retrying market stream + RPC…",
+    });
+    streamHealth = "connecting";
+    await probeRpc();
+    if (tradeMode === "perps" && selectedSymbol) {
+      startPhoenixStream(selectedSymbol);
+    } else {
+      void bootPhoenixMarketData();
+    }
+  }
+
   // Status-line model: every field already derived here; the tx stage text
   // is pre-rendered because txStageText stays with the signing pipeline
   // (the ticket's order-stage readout shares it).
@@ -3812,6 +3871,7 @@
     paperMode,
     equityUsd: accountEquityUsd,
     upnlUsd: accountUpnlUsd,
+    sessionPnlUsd,
     freeCollateralUsd: phoenixCollateral,
     fundingPercent,
     walletAddress: $privyAuth.walletAddress ?? "",
@@ -5676,7 +5736,8 @@
       !paperFundsOpen &&
       !settingsOpen &&
       !paletteOpen &&
-      !cheatOpen
+      !cheatOpen &&
+      !closePreview
     ) {
       const ticketKey = event.key.toLowerCase();
       if (ticketKey === "b" || ticketKey === "s") {
@@ -5700,7 +5761,8 @@
       paperFundsOpen ||
       settingsOpen ||
       paletteOpen ||
-      cheatOpen
+      cheatOpen ||
+      closePreview
     ) {
       return;
     }
@@ -5743,15 +5805,11 @@
         resetChartView();
         break;
       case "c": {
-        // Two-stage market close of the selected symbol's position.
+        // Two-stage market close of the selected symbol's position → preview.
         if (tradeMode !== "perps" || !selectedPosition) break;
         if (armedHotkey?.key === "c" && Date.now() < armedHotkey.until) {
           armedHotkey = null;
-          void closePhoenixPosition(
-            selectedPosition.symbol,
-            selectedPosition.size,
-            selectedPosition.subaccountIndex,
-          );
+          openClosePreview(selectedPosition, 1);
         } else {
           armedHotkey = { key: "c", until: Date.now() + 3_000 };
         }
@@ -5978,6 +6036,9 @@
         </aside>
 
         <div class="chart-canvas-shell">
+          {#if paperMode}
+            <div class="paper-watermark" aria-hidden="true">PAPER</div>
+          {/if}
           <div class="chart-overlay">
             <div class="chart-symbol-line">
               {#if tradeMode === "spot" && spotAsset}
@@ -6499,20 +6560,16 @@
       ondeposit={openFunds}
       onselectsymbol={chooseMonitorRow}
       onshare={(position) => sharePhoenixPosition(position, marketMids)}
-      onclose={(position) =>
-        closePhoenixPosition(
-          position.symbol,
-          position.size,
-          position.subaccountIndex,
-        )}
+      onclose={(position) => openClosePreview(position, 1)}
       onclosepartial={(position, fraction) =>
-        closePhoenixPositionFraction(position, fraction)}
+        openClosePreview(position, fraction)}
       oncancelorder={(order) => cancelPhoenixOrderById(order)}
       oncancelside={(side) => cancelAllPhoenixOrdersOnSide(side)}
       onflatten={onFlattenClick}
       onmarginopen={openMarginAdd}
       onmarginsubmit={(position) => submitMarginAdd(position)}
       onresetpaper={resetPaperAccount}
+      {flattenEstPnl}
     />
 {/snippet}
 
@@ -6532,6 +6589,7 @@
     status={statusModel}
     onshowshortcuts={() => (cheatOpen = true)}
     onjumptopositions={() => scrollToSection("section-perp")}
+    onreconnect={() => void reconnectMarketData()}
   />
 </main>
 
@@ -6547,6 +6605,24 @@
 
 {#if ackOpen}
   <AckModal onagree={onAckAgree} onclose={() => { ackOpen = false; pendingAckAction = null; }} />
+{/if}
+
+{#if closePreview}
+  {@const previewPos = closePreview.position}
+  <ClosePreviewModal
+    position={previewPos}
+    mark={marketMids[previewPos.symbol] ??
+      (previewPos.symbol === selectedSymbol ? latestPrice : null)}
+    fraction={closePreview.fraction}
+    {paperMode}
+    {displayCurrency}
+    fxRate={displayFxRate}
+    busy={closingKeys.has(
+      `${previewPos.symbol}:${previewPos.subaccountIndex}`,
+    )}
+    onconfirm={confirmClosePreview}
+    onclose={() => (closePreview = null)}
+  />
 {/if}
 
 {#if wizardOpen}
@@ -6606,12 +6682,7 @@
     {watchlist}
     positions={enrichedPositions}
     openOrders={perpOpenOrders}
-    oncloseposition={(position) =>
-      void closePhoenixPosition(
-        position.symbol,
-        position.size,
-        position.subaccountIndex,
-      )}
+    oncloseposition={(position) => openClosePreview(position, 1)}
     oncancelorders={(symbol) => void cancelSymbolBookOrders(symbol)}
     onflatten={onFlattenClick}
     repeatLast={lastOrderIntent
@@ -7150,6 +7221,21 @@
     min-height: 0;
     background: var(--chart-bg);
     overflow: hidden;
+  }
+
+  .paper-watermark {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    display: grid;
+    place-items: center;
+    pointer-events: none;
+    color: var(--accent);
+    font-size: clamp(3.5rem, 12vw, 7rem);
+    font-weight: 900;
+    letter-spacing: 0.18em;
+    opacity: 0.07;
+    user-select: none;
   }
 
   .chart-overlay {

--- a/apps/portal/src/routes/terminal/components/ClosePreviewModal.svelte
+++ b/apps/portal/src/routes/terminal/components/ClosePreviewModal.svelte
@@ -1,0 +1,172 @@
+<script lang="ts">
+  import type { PhoenixPosition } from "$lib/phoenix-trade";
+  import {
+    formatDisplayMoney,
+    formatDisplayMoneySigned,
+    type DisplayCurrencyCode,
+  } from "$lib/terminal/display-currency";
+  import { formatNumber, formatPrice } from "$lib/utils";
+  import { onMount } from "svelte";
+
+  let {
+    position,
+    mark,
+    fraction = 1,
+    paperMode = false,
+    displayCurrency = "USD",
+    fxRate = 1,
+    busy = false,
+    onconfirm,
+    onclose,
+  }: {
+    position: PhoenixPosition;
+    mark: number | null;
+    fraction?: number;
+    paperMode?: boolean;
+    displayCurrency?: DisplayCurrencyCode;
+    fxRate?: number;
+    busy?: boolean;
+    onconfirm: () => void;
+    onclose: () => void;
+  } = $props();
+
+  let panel: HTMLElement | undefined = $state();
+
+  const closeSize = $derived(Math.abs(position.size) * fraction);
+  const side = $derived(position.size > 0 ? "Long" : "Short");
+  const entry = $derived(position.entryPrice);
+  const estPnl = $derived(
+    entry !== null && mark !== null
+      ? (mark - entry) * position.size * fraction
+      : position.unrealizedPnl !== null
+        ? position.unrealizedPnl * fraction
+        : null,
+  );
+  const pctLabel = $derived(
+    fraction >= 0.999 ? "Full" : `${Math.round(fraction * 100)}%`,
+  );
+
+  onMount(() => {
+    panel?.focus();
+  });
+
+  function onWinKeydown(event: KeyboardEvent): void {
+    if (event.key === "Escape") onclose();
+  }
+
+  function onPanelKeydown(event: KeyboardEvent): void {
+    if (event.key === "Escape") {
+      onclose();
+      return;
+    }
+    event.stopPropagation();
+  }
+</script>
+
+<svelte:window onkeydown={onWinKeydown} />
+
+<div class="modal-backdrop" role="presentation" onclick={() => onclose()}>
+  <div
+    bind:this={panel}
+    class="modal close-preview"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Confirm close"
+    tabindex="-1"
+    onclick={(event) => event.stopPropagation()}
+    onkeydown={onPanelKeydown}
+  >
+    <div class="panel-head">
+      <div>
+        <p>{paperMode ? "PAPER_CLOSE" : "CLOSE"}</p>
+        <h2>{pctLabel} close · {position.symbol}</h2>
+      </div>
+      <button class="modal-close" type="button" aria-label="Cancel" onclick={() => onclose()}
+        >×</button
+      >
+    </div>
+
+    <div class="modal-body mono">
+      <div class="row">
+        <span>Side</span>
+        <b class:positive={position.size > 0} class:negative={position.size < 0}>{side}</b>
+      </div>
+      <div class="row">
+        <span>Size</span>
+        <b>{formatNumber(closeSize, 4)}</b>
+      </div>
+      <div class="row">
+        <span>Entry → mark</span>
+        <b>
+          {formatPrice(entry)}
+          →
+          {formatPrice(mark)}
+        </b>
+      </div>
+      <div class="row pnl">
+        <span>Est. P&amp;L</span>
+        {#if estPnl !== null}
+          <b class:positive={estPnl >= 0} class:negative={estPnl < 0}>
+            {formatDisplayMoneySigned(estPnl, displayCurrency, fxRate, 2)}
+          </b>
+        {:else}
+          <b>--</b>
+        {/if}
+      </div>
+    </div>
+
+    <div class="modal-actions">
+      <button class="secondary" type="button" onclick={() => onclose()}>Cancel</button>
+      <button class="primary" type="button" disabled={busy} onclick={() => onconfirm()}>
+        {#if busy}<span class="spinner" aria-hidden="true"></span>{/if}
+        {busy ? "Closing…" : paperMode ? "Confirm paper close" : "Confirm close"}
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .close-preview {
+    max-width: 22rem;
+  }
+
+  .modal-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+    padding: 0.85rem 1rem 0.4rem;
+  }
+
+  .row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 1rem;
+    color: var(--muted);
+    font-size: 0.78rem;
+  }
+
+  .row b {
+    color: var(--ink);
+    font-weight: 700;
+  }
+
+  .row.pnl b {
+    font-size: 0.95rem;
+  }
+
+  .positive {
+    color: var(--up);
+  }
+
+  .negative {
+    color: var(--down);
+  }
+
+  .modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem 1rem;
+  }
+</style>

--- a/apps/portal/src/routes/terminal/components/PerpDeskPanel.svelte
+++ b/apps/portal/src/routes/terminal/components/PerpDeskPanel.svelte
@@ -54,6 +54,7 @@
     freeCollateralUsd,
     flattenArmed,
     flattenBusy,
+    flattenEstPnl = null,
     bidSweepSymbols,
     askSweepSymbols,
     cancelSweepBusy,
@@ -99,6 +100,8 @@
     freeCollateralUsd: number;
     flattenArmed: boolean;
     flattenBusy: boolean;
+    /** Aggregate est. P&L if flatten confirms now (shown while armed). */
+    flattenEstPnl?: number | null;
     bidSweepSymbols: string[];
     askSweepSymbols: string[];
     cancelSweepBusy: boolean;
@@ -171,10 +174,25 @@
         class:armed={flattenArmed}
         type="button"
         disabled={flattenBusy}
+        title={flattenArmed && flattenEstPnl !== null && flattenEstPnl !== undefined
+          ? `Est. P&L ${flattenEstPnl >= 0 ? "+" : ""}${flattenEstPnl.toFixed(2)}`
+          : "Close all positions"}
         onclick={onflatten}
       >
         {#if flattenBusy}<span class="spinner" aria-hidden="true"></span>{/if}
-        {flattenBusy ? "Flattening…" : flattenArmed ? "Confirm flatten" : "FLATTEN"}
+        {#if flattenBusy}
+          Flattening…
+        {:else if flattenArmed}
+          Confirm{#if flattenEstPnl !== null && flattenEstPnl !== undefined}
+            {" "}{formatDisplayMoneySigned(
+              flattenEstPnl,
+              displayCurrency,
+              fxRate,
+              2,
+            )}{/if}
+        {:else}
+          FLATTEN
+        {/if}
       </button>
     {/if}
     {#if paperMode && onresetpaper}

--- a/apps/portal/src/routes/terminal/components/StatusLine.svelte
+++ b/apps/portal/src/routes/terminal/components/StatusLine.svelte
@@ -28,6 +28,8 @@
     paperMode: boolean;
     equityUsd: number;
     upnlUsd: number;
+    /** Day P&L vs UTC-day equity baseline (null until first sample). */
+    sessionPnlUsd: number | null;
     freeCollateralUsd: number;
     fundingPercent: number | null;
     walletAddress: string;
@@ -40,11 +42,17 @@
     status,
     onshowshortcuts,
     onjumptopositions,
+    onreconnect,
   }: {
     status: StatusModel;
     onshowshortcuts: () => void;
     onjumptopositions: () => void;
+    onreconnect?: () => void;
   } = $props();
+
+  const streamNeedsHelp = $derived(
+    status.streamHealth === "offline" || status.streamHealth === "stale",
+  );
 </script>
 
 <footer class="status-line" aria-label="Terminal status">
@@ -54,7 +62,21 @@
   <span class="sl-sep" aria-hidden="true"></span>
   <span>{status.symbol} · {status.sessionNote}</span>
   <span class="sl-sep" aria-hidden="true"></span>
-  <span class:positive={status.streamHealth === "live"} class:warn-txt={status.streamHealth !== "live"}>WS {status.streamHealth}</span>
+  {#if streamNeedsHelp && onreconnect}
+    <button
+      type="button"
+      class="sl-reconnect warn-txt"
+      title="Reconnect market data"
+      onclick={onreconnect}
+    >
+      WS {status.streamHealth} · retry
+    </button>
+  {:else}
+    <span
+      class:positive={status.streamHealth === "live"}
+      class:warn-txt={status.streamHealth !== "live"}
+    >WS {status.streamHealth}</span>
+  {/if}
   <span>RPC {status.rpcLatencyMs !== null ? `${status.rpcLatencyMs}ms` : "--"}</span>
   {#if status.apiSlotLag !== null}
     <span class:warn-txt={status.apiSlotLag > 150} title="Phoenix indexer slots behind the chain tip">
@@ -100,6 +122,20 @@
           0,
         )}</span
       >
+      {#if status.sessionPnlUsd !== null}
+        <span
+          class:positive={status.sessionPnlUsd >= 0}
+          class:negative={status.sessionPnlUsd < 0}
+          title="Today vs UTC-day equity baseline"
+        >
+          Today {formatDisplayMoneySigned(
+            status.sessionPnlUsd,
+            status.displayCurrency,
+            status.fxRate,
+            2,
+          )}
+        </span>
+      {/if}
       <span class:positive={status.upnlUsd >= 0} class:negative={status.upnlUsd < 0}>
         uPNL {formatDisplayMoneySigned(
           status.upnlUsd,
@@ -162,6 +198,21 @@
   }
 
   .sl-help:hover { color: var(--ink); }
+
+  .sl-reconnect {
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    padding: 0;
+    cursor: pointer;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .sl-reconnect:hover {
+    color: var(--ink);
+  }
 
   /* Account money in the fixed line: equity/uPnL/free/funding, one click
      from the perp desk. */

--- a/scripts/keep-portal-dev.cmd
+++ b/scripts/keep-portal-dev.cmd
@@ -1,7 +1,14 @@
 @echo off
-REM Double-click or run from Explorer to keep http://127.0.0.1:3001/terminal alive
-REM in its own window (survives Cursor agent shells closing).
+REM Keep http://127.0.0.1:3001/terminal alive in this window.
+REM If Vite crashes or is killed, this loop restarts it.
+REM Close this window ONLY when you want the server to stop.
 cd /d "%~dp0\.."
-title Harness portal :3001
+title Harness portal :3001 (KEEP ALIVE)
+
+:loop
+echo.
+echo [%date% %time%] starting keep-portal-dev.ps1 ...
 powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0keep-portal-dev.ps1" 3001
-pause
+echo [%date% %time%] keeper exited with code %ERRORLEVEL% — restarting in 2s
+timeout /t 2 /nobreak >nul
+goto loop

--- a/scripts/keep-portal-dev.ps1
+++ b/scripts/keep-portal-dev.ps1
@@ -1,10 +1,8 @@
 # Run the Harness portal Vite server and restart it if it exits.
-# Use this from a normal PowerShell / Terminal window (outside Cursor) so
-# the process is not torn down when agent shells end.
+# Prefer scripts/keep-portal-dev.cmd (loops even if this script is Ctrl+C'd).
 #
-#   .\scripts\keep-portal-dev.ps1
+#   .\scripts\keep-portal-dev.cmd
 #   .\scripts\keep-portal-dev.ps1 3001
-#   .\scripts\keep-portal-dev.cmd   # opens a dedicated window
 
 param(
   [int]$Port = 3001
@@ -33,15 +31,33 @@ function Write-Log([string]$Message) {
   Add-Content -Path $Log -Value $line -Encoding utf8
 }
 
-Write-Host "Harness portal dev server on http://127.0.0.1:${Port}/terminal"
+# Treat Ctrl+C as a restart signal inside the .cmd outer loop, not a silent stop.
+[Console]::TreatControlCAsInput = $false
+
+Write-Host "Harness portal on http://127.0.0.1:${Port}/terminal"
 Write-Host "Log: $Log"
-Write-Host "Ctrl+C stops the keeper (and the current Vite child)."
+Write-Host "Close this window to stop. (Ctrl+C restarts via the .cmd loop.)"
 Write-Host ""
 
 while ($true) {
   Write-Log "starting vite :$Port"
-  # cmd.exe redirection keeps UTF-8 and mirrors the bash keeper.
-  cmd /c "bunx vite --host 127.0.0.1 --port $Port >> `"$Log`" 2>&1"
-  Write-Log "vite exited code=$LASTEXITCODE; restarting in 2s"
+
+  # Run Vite as its own process so we can detect death via Wait + port check.
+  $proc = Start-Process -FilePath "bun" `
+    -ArgumentList @("x", "vite", "--host", "127.0.0.1", "--port", "$Port") `
+    -WorkingDirectory $Portal `
+    -NoNewWindow `
+    -PassThru
+
+  if (-not $proc) {
+    Write-Log "failed to spawn vite; retrying in 2s"
+    Start-Sleep -Seconds 2
+    continue
+  }
+
+  Write-Host "vite pid=$($proc.Id) — waiting"
+  Wait-Process -Id $proc.Id -ErrorAction SilentlyContinue
+  $code = $proc.ExitCode
+  Write-Log "vite exited code=$code; restarting in 2s"
   Start-Sleep -Seconds 2
 }


### PR DESCRIPTION
## Summary
- Status line shows **Today** (UTC-day equity delta) next to open **uPNL**, including a dedicated paper day baseline (top-ups/resets adjust it).
- Close / partial / hotkey `C` opens a confirm with side, size, entry → mark, and est. P&L; flatten's confirm step shows aggregate est. P&L.
- Stale/offline WS exposes a footer **retry** that re-probes RPC and restarts the market stream.
- Large faded **PAPER** watermark on the chart in paper mode.
- Windows keep-alive scripts loop after Vite dies (no fake-alive `pause` window).

## Test plan
- [ ] `/terminal` status line shows Today + uPNL in PAPER after equity samples; they match with one open unrealized position and diverge after a close
- [ ] Positions → Close shows preview; Confirm closes; Cancel dismisses
- [ ] Arm FLATTEN → confirm label includes est. P&L
- [ ] With WS stale/offline, footer shows retry and recovers stream
- [ ] PAPER mode shows chart watermark; LIVE does not
- [ ] `bun run --cwd apps/portal typecheck` clean

Made with [Cursor](https://cursor.com)