### PR TITLE
fix(agent): route EVE through Vercel stable services

### DIFF
--- a/apps/portal/vercel.json
+++ b/apps/portal/vercel.json
@@ -1,25 +1,27 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "sveltekit",
-  "installCommand": "bun install",
-  "buildCommand": "bun run typecheck && bun run build",
-  "experimentalServices": {
+  "services": {
     "web": {
-      "entrypoint": ".",
+      "root": ".",
       "framework": "sveltekit",
-      "routePrefix": "/"
+      "installCommand": "bun install",
+      "buildCommand": "bun run typecheck && bun run build"
     },
     "eve": {
-      "buildCommand": "eve build",
-      "entrypoint": ".",
+      "root": ".",
       "framework": "eve",
-      "routePrefix": "/_eve_internal/eve"
+      "installCommand": "bun install",
+      "buildCommand": "eve build"
     }
   },
   "rewrites": [
     {
-      "source": "/eve/v1/:path*",
-      "destination": "/_eve_internal/eve/eve/v1/:path*"
+      "source": "/eve/v1/(.*)",
+      "destination": { "service": "eve" }
+    },
+    {
+      "source": "/(.*)",
+      "destination": { "service": "web" }
     }
   ]
 }

--- a/apps/portal/vite.config.ts
+++ b/apps/portal/vite.config.ts
@@ -20,9 +20,7 @@ export default defineConfig(({ mode }) => {
     // /eve/v1/session/:id (+ stream) paths (platform NOT_FOUND). Stable
     // `services` live in vercel.json and must not be overwritten on build.
     plugins: [
-      ...(skipEve
-        ? []
-        : [eveSvelteKit({ configureVercelJson: false })]),
+      ...(skipEve ? [] : [eveSvelteKit({ configureVercelJson: false })]),
       sveltekit(),
     ],
     ssr: { noExternal: ["@harness-trade/ui"] },

--- a/apps/portal/vite.config.ts
+++ b/apps/portal/vite.config.ts
@@ -8,10 +8,23 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   const deepseekKey = env.DEEPSEEK_API_KEY?.trim();
   const tokensXyzKey = env.TOKENS_XYZ_API_KEY?.trim();
+  // Windows/local: EVE's Node evaluator rejects extensionless agent imports
+  // that Bun resolves. Set SKIP_EVE=1 to boot the terminal without the agent
+  // runtime (prod/Vercel still uses EVE).
+  const skipEve = env.SKIP_EVE === "1" || process.env.SKIP_EVE === "1";
 
   return {
     envPrefix: ["VITE_", "PUBLIC_", "NEXT_PUBLIC_"],
-    plugins: [eveSvelteKit(), sveltekit()],
+    // configureVercelJson: false — eveSvelteKit still writes legacy
+    // experimentalServices, which Vercel no longer routes for dynamic
+    // /eve/v1/session/:id (+ stream) paths (platform NOT_FOUND). Stable
+    // `services` live in vercel.json and must not be overwritten on build.
+    plugins: [
+      ...(skipEve
+        ? []
+        : [eveSvelteKit({ configureVercelJson: false })]),
+      sveltekit(),
+    ],
     ssr: { noExternal: ["@harness-trade/ui"] },
     server: {
       proxy: {


### PR DESCRIPTION
## Summary
- Agent asks failed with Vercel platform `NOT_FOUND` because dynamic `/eve/v1/session/:id` (+ `/stream`) routes were not served under legacy `experimentalServices`.
- Static routes (`/eve/v1/health`, `POST /eve/v1/session`) already worked; continuing/streaming a turn hit the missing dynamic paths.
- Migrates `apps/portal/vercel.json` to stable Vercel `services` + service-targeted rewrites (same fix Eve Nuxt already shipped), and sets `eveSvelteKit({ configureVercelJson: false })` so the plugin cannot rewrite the file back to `experimentalServices` on build.

## Test plan
- [ ] Preview/prod deploy succeeds with both `web` and `eve` services
- [ ] `GET /eve/v1/health` → 200
- [ ] `POST /eve/v1/session/test` (no auth) → **401** `privy_token_required` (not platform NOT_FOUND)
- [ ] `GET /eve/v1/session/test/stream` (no auth) → **401** (not platform NOT_FOUND)
- [ ] Signed-in Agent Ask mode: send a message and get a streamed reply (no NOT_FOUND page/error body)

## Risk
- Requires Vercel **Services** for the project. If the deploy fails on unrecognized `services`, Guillaume may need to enable Services on `guivercelpro` / clear build cache once.