### PR TITLE
fix(agent): stabilize settings modal layout

### DIFF
--- a/apps/portal/src/routes/terminal/components/AgentSettingsModal.svelte
+++ b/apps/portal/src/routes/terminal/components/AgentSettingsModal.svelte
@@ -95,7 +95,7 @@
 
   .settings-modal {
     width: min(52rem, 100%);
-    max-height: min(44rem, calc(100dvh - 2rem));
+    height: min(44rem, calc(100dvh - 2rem));
     overflow: hidden;
     border: 1px solid var(--line);
     background: var(--surface);
@@ -190,6 +190,7 @@
   .settings-content {
     min-width: 0;
     overflow: auto;
+    scrollbar-gutter: stable;
     padding: 1rem 1.1rem 1.5rem;
   }
 


### PR DESCRIPTION
## What changed

- Keep the agent settings modal at a stable viewport-bounded height.
- Reserve the settings content scrollbar gutter so content does not shift horizontally when a section starts scrolling.

## Why

The modal used `max-height` only, so its frame inherited each section's intrinsic content height. Switching Models → Skills changed the dialog height by 82.8 px and moved the centered frame by 41.4 px.

## Impact

Models and Skills now share the same fixed frame on desktop and compact layouts. Section content scrolls inside the modal without moving the header, navigation, or dialog position.

## Validation

- `bun run typecheck`
- `bun run build`
- `bun run test` — 523 passing
- Local terminal browser QA at `http://localhost:3000/terminal`
  - Desktop Models ↔ Skills shift: `0 px`
  - 640 × 800 compact Models ↔ Skills shift: `0 px`