### PR TITLE
feat(terminal): ghost TP/SL + honest paper receipts

### DIFF
--- a/apps/portal/src/lib/agent/workstream.test.ts
+++ b/apps/portal/src/lib/agent/workstream.test.ts
@@ -80,4 +80,57 @@ describe("projectHarnessTool", () => {
     expect(card.status).toBe("waiting");
     expect(card.statusLabel).toBe("reconciliation needed");
   });
+
+  test("bare output-available is never success without a presentation", () => {
+    const card = projectHarnessTool({
+      toolName: "execute_trade",
+      state: "output-available",
+      output: {
+        summary: "Opened SOL long.",
+        explorerUrls: ["https://solscan.io/tx/signature"],
+      },
+    });
+    expect(card.status).toBe("running");
+  });
+
+  test("pending-client stays running until a Receipt arrives", () => {
+    const card = projectHarnessTool({
+      toolName: "execute_trade",
+      state: "output-available",
+      output: {
+        ok: true,
+        status: "pending-client",
+        paperAction: { name: "place_perp_order", args: {} },
+        presentation: {
+          schema: "harness.presentation.v1",
+          kind: "execution",
+          title: "Paper action ready",
+          summary: "Applying the approved action to the local paper ledger.",
+          status: "running",
+        },
+      },
+    });
+    expect(card.kind).toBe("execution");
+    expect(card.status).toBe("running");
+    expect(card.statusLabel).toBe("working");
+  });
+
+  test("confirmed paper Receipt presentation is success", () => {
+    const card = projectHarnessTool({
+      toolName: "execute_trade",
+      state: "output-available",
+      output: {
+        presentation: {
+          schema: "harness.presentation.v1",
+          kind: "receipt",
+          title: "Paper action confirmed",
+          summary: "Filled on the paper ledger.",
+          status: "success",
+        },
+      },
+    });
+    expect(card.kind).toBe("receipt");
+    expect(card.status).toBe("success");
+    expect(card.statusLabel).toBe("done");
+  });
 });

--- a/apps/portal/src/lib/agent/workstream.ts
+++ b/apps/portal/src/lib/agent/workstream.ts
@@ -144,8 +144,20 @@ export function projectHarnessTool(
   const kind = isContext
     ? "context"
     : (normalizeKind(presentation?.kind) ?? inferKind(toolName, output));
+  const presentationStatus = text(presentation?.status);
+  const outputStatus = text(output?.status);
+  // A completed tool that already shipped a presentation envelope is done
+  // unless an explicit status says otherwise. Bare Eve lifecycle tokens
+  // (output-available) alone are never success — see normalizeStatus.
+  const statusFallback =
+    presentation &&
+    !presentationStatus &&
+    !outputStatus &&
+    source.state === "output-available"
+      ? "success"
+      : source.state;
   const status = normalizeStatus(
-    text(presentation?.status) ?? source.state,
+    presentationStatus ?? outputStatus ?? statusFallback,
     source.approvalPending === true,
   );
   const severity = text(presentation?.severity);
@@ -256,7 +268,7 @@ function normalizeStatus(
   approvalPending: boolean,
 ): WorkstreamStatus {
   if (approvalPending) return "waiting";
-  const status = (raw ?? "").toLowerCase();
+  const status = (raw ?? "").toLowerCase().trim();
   if (
     status.includes("error") ||
     status.includes("fail") ||
@@ -266,8 +278,20 @@ function normalizeStatus(
   }
   if (status.includes("denied") || status === "deny") return "denied";
   if (status.includes("pause") || status.includes("suspend")) return "paused";
+  // Tool lifecycle tokens are not outcomes — never promote them to success.
   if (
-    status.includes("output") ||
+    status === "output-available" ||
+    status === "input-available" ||
+    status === "input-streaming" ||
+    status === "pending-client" ||
+    status.includes("running") ||
+    status.includes("stream") ||
+    status.includes("signing") ||
+    status.includes("submitting")
+  ) {
+    return "running";
+  }
+  if (
     status.includes("success") ||
     status.includes("complete") ||
     status.includes("confirm") ||
@@ -276,17 +300,11 @@ function normalizeStatus(
   ) {
     return "success";
   }
-  if (
-    status.includes("input") ||
-    status.includes("running") ||
-    status.includes("stream") ||
-    status.includes("signing") ||
-    status.includes("submitting")
-  ) {
-    return "running";
-  }
   if (status.includes("approval") || status.includes("waiting")) {
     return "waiting";
+  }
+  if (status.includes("input")) {
+    return "running";
   }
   return "pending";
 }

--- a/apps/portal/src/lib/terminal/perp-ticket.test.ts
+++ b/apps/portal/src/lib/terminal/perp-ticket.test.ts
@@ -31,6 +31,10 @@ function inputs(overrides: Partial<PerpTicketInputs> = {}): PerpTicketInputs {
     stateKnown: true,
     chainVerified: true,
     collateralUsd: 1_000,
+    candles: [],
+    prevDayHigh: null,
+    prevDayLow: null,
+    symbol: "SOL",
     ...overrides,
   };
 }
@@ -199,5 +203,69 @@ describe("funding gate", () => {
     ticket.setInputs(inputs({ collateralUsd: 5, chainVerified: false }));
     ticket.setNow(Date.now() + 10_000);
     expect(get(ticket.needsPhoenixFunding)).toBe(false);
+  });
+});
+
+describe("ghost TP/SL", () => {
+  test("ghosts appear from prev-day structure when fields are empty", () => {
+    const ticket = createPerpTicket();
+    ticket.setInputs(
+      inputs({
+        prevDayLow: 95,
+        prevDayHigh: 110,
+      }),
+    );
+    ticket.tradeType.set("limit");
+    ticket.tradeLimitPrice.set("100");
+    expect(get(ticket.ghostSl)?.source).toBe("prev-day");
+    expect(get(ticket.ghostSl)?.value).toBeCloseTo(95 * (1 - 0.3 / 100));
+    // TP needs a stop distance for r-multiple when no opposing swings.
+    ticket.tradeStopLoss.set("95");
+    expect(get(ticket.ghostTp)?.source).toBe("r-multiple");
+    expect(get(ticket.ghostSl)).toBeNull(); // field no longer empty
+  });
+
+  test("filled fields never show ghosts; dismiss hides until side/symbol reset", () => {
+    const ticket = createPerpTicket();
+    ticket.setInputs(inputs({ prevDayLow: 95 }));
+    ticket.tradeType.set("limit");
+    ticket.tradeLimitPrice.set("100");
+    expect(get(ticket.ghostSl)).not.toBeNull();
+
+    ticket.dismissGhostSl();
+    expect(get(ticket.ghostSl)).toBeNull();
+
+    ticket.tradeSide.set("sell");
+    ticket.setInputs(inputs({ prevDayHigh: 110, symbol: "SOL" }));
+    ticket.tradeType.set("limit");
+    ticket.tradeLimitPrice.set("100");
+    expect(get(ticket.ghostSl)).not.toBeNull();
+
+    ticket.dismissGhostSl();
+    ticket.setInputs(inputs({ prevDayHigh: 110, symbol: "BTC" }));
+    expect(get(ticket.ghostSl)).not.toBeNull();
+  });
+
+  test("acceptGhostSl writes fmtTriggerPrice and drives risk sizing", () => {
+    const ticket = createPerpTicket();
+    ticket.setInputs(inputs({ prevDayLow: 95 }));
+    ticket.tradeType.set("limit");
+    ticket.tradeLimitPrice.set("100");
+    ticket.sizingMode.set("risk");
+    ticket.tradeRiskUsd.set("50");
+    expect(ticket.acceptGhostSl()).toBe(true);
+    const sl = get(ticket.tradeStopLoss);
+    expect(sl).toBe(fmtTriggerPrice(95 * (1 - 0.3 / 100)));
+    expect(get(ticket.riskNotionalUsd)).toBe(riskNotional(50, 100, Number(sl)));
+    expect(get(ticket.ghostSl)).toBeNull();
+  });
+
+  test("no candles and no prev-day levels → no ghosts", () => {
+    const ticket = createPerpTicket();
+    ticket.setInputs(inputs());
+    ticket.tradeType.set("limit");
+    ticket.tradeLimitPrice.set("100");
+    expect(get(ticket.ghostTp)).toBeNull();
+    expect(get(ticket.ghostSl)).toBeNull();
   });
 });

--- a/apps/portal/src/lib/terminal/perp-ticket.ts
+++ b/apps/portal/src/lib/terminal/perp-ticket.ts
@@ -10,7 +10,13 @@
 // +page.svelte on purpose: this module holds state and pure math only, and
 // must never import web3.js or issue network calls.
 import { derived, get, writable } from "svelte/store";
-import type { DepthLevel } from "$lib/phoenix-market-data";
+import type { DepthLevel, MarketPoint } from "$lib/phoenix-market-data";
+import {
+  GHOST_DEFAULTS,
+  type GhostValue,
+  ghostStop,
+  ghostTakeProfit,
+} from "./autocomplete";
 import {
   buildTradePreview,
   fmtTriggerPrice,
@@ -38,6 +44,11 @@ export type PerpTicketInputs = {
   stateKnown: boolean;
   chainVerified: boolean;
   collateralUsd: number;
+  // Chart structure for TP/SL ghosts (page-injected; never fetched here).
+  candles: MarketPoint[];
+  prevDayHigh: number | null;
+  prevDayLow: number | null;
+  symbol: string;
 };
 
 type MarketInputs = Pick<
@@ -51,6 +62,10 @@ type VisibilityInputs = Pick<
 type AccountInputs = Pick<
   PerpTicketInputs,
   "hasAuthority" | "stateKnown" | "chainVerified" | "collateralUsd"
+>;
+type StructureInputs = Pick<
+  PerpTicketInputs,
+  "candles" | "prevDayHigh" | "prevDayLow" | "symbol"
 >;
 
 export function createPerpTicket() {
@@ -89,7 +104,29 @@ export function createPerpTicket() {
     chainVerified: false,
     collateralUsd: 0,
   });
+  const structure = writable<StructureInputs>({
+    candles: [],
+    prevDayHigh: null,
+    prevDayLow: null,
+    symbol: "",
+  });
   const now = writable(0);
+  const ghostTpDismissed = writable(false);
+  const ghostSlDismissed = writable(false);
+
+  function clearGhostDismissed(): void {
+    ghostTpDismissed.set(false);
+    ghostSlDismissed.set(false);
+  }
+
+  // Side flips via bind ($tradeSide = …) bypass setSide — subscribe so
+  // dismissed flags always reset when the ticket side changes.
+  let lastSide = get(tradeSide);
+  tradeSide.subscribe((side) => {
+    if (side === lastSide) return;
+    lastSide = side;
+    clearGhostDismissed();
+  });
 
   let lastInputs: PerpTicketInputs | null = null;
   function setInputs(next: PerpTicketInputs): void {
@@ -135,6 +172,23 @@ export function createPerpTicket() {
         stateKnown: next.stateKnown,
         chainVerified: next.chainVerified,
         collateralUsd: next.collateralUsd,
+      });
+    }
+    if (
+      !prev ||
+      prev.candles !== next.candles ||
+      prev.prevDayHigh !== next.prevDayHigh ||
+      prev.prevDayLow !== next.prevDayLow ||
+      prev.symbol !== next.symbol
+    ) {
+      if (prev && prev.symbol !== next.symbol) {
+        clearGhostDismissed();
+      }
+      structure.set({
+        candles: next.candles,
+        prevDayHigh: next.prevDayHigh,
+        prevDayLow: next.prevDayLow,
+        symbol: next.symbol,
       });
     }
   }
@@ -297,6 +351,50 @@ export function createPerpTicket() {
         : null,
   );
 
+  // Ghost TP/SL: only when the field is empty and not dismissed. Honest
+  // structure only — null candles / missing levels yield no ghost.
+  const ghostSl = derived(
+    [tradeStopLoss, ghostSlDismissed, tradeSide, triggerRefPrice, structure],
+    ([$sl, $dismissed, $side, $ref, $structure]): GhostValue | null => {
+      if ($dismissed || $sl.trim() !== "" || $ref === null || $ref <= 0) {
+        return null;
+      }
+      return ghostStop($structure.candles, $side, $ref, {
+        window: GHOST_DEFAULTS.swingWindow,
+        bufferPct: GHOST_DEFAULTS.stopBufferPct,
+        prevDayHigh: $structure.prevDayHigh,
+        prevDayLow: $structure.prevDayLow,
+      });
+    },
+  );
+  const ghostTp = derived(
+    [
+      tradeTakeProfit,
+      ghostTpDismissed,
+      tradeSide,
+      triggerRefPrice,
+      structure,
+      tradeStopLoss,
+    ],
+    ([$tp, $dismissed, $side, $ref, $structure, $sl]): GhostValue | null => {
+      if ($dismissed || $tp.trim() !== "" || $ref === null || $ref <= 0) {
+        return null;
+      }
+      const stop = Number($sl);
+      return ghostTakeProfit(
+        $structure.candles,
+        $side,
+        $ref,
+        Number.isFinite(stop) && stop > 0 ? stop : null,
+        {
+          window: GHOST_DEFAULTS.swingWindow,
+          rMultiple: GHOST_DEFAULTS.tpRMultiple,
+        },
+      );
+    },
+  );
+  const ghostSymbol = derived(structure, ($structure) => $structure.symbol);
+
   // Clicking a book level: prefill a limit order at that price. Side/type/
   // price only — size/TP/SL stay put.
   function prefill(price: number, side: TradeSide): void {
@@ -333,6 +431,28 @@ export function createPerpTicket() {
     );
   }
 
+  function acceptGhostTp(): boolean {
+    const ghost = get(ghostTp);
+    if (!ghost) return false;
+    tradeTakeProfit.set(fmtTriggerPrice(ghost.value));
+    return true;
+  }
+
+  function acceptGhostSl(): boolean {
+    const ghost = get(ghostSl);
+    if (!ghost) return false;
+    tradeStopLoss.set(fmtTriggerPrice(ghost.value));
+    return true;
+  }
+
+  function dismissGhostTp(): void {
+    ghostTpDismissed.set(true);
+  }
+
+  function dismissGhostSl(): void {
+    ghostSlDismissed.set(true);
+  }
+
   return {
     // fields
     tradeSide,
@@ -361,6 +481,9 @@ export function createPerpTicket() {
     slPnlUsd,
     riskNotionalUsd,
     effectiveTradeAmount,
+    ghostTp,
+    ghostSl,
+    ghostSymbol,
     // api
     setInputs,
     setNow,
@@ -368,6 +491,10 @@ export function createPerpTicket() {
     setSide,
     setTakeProfitPct,
     setStopLossPct,
+    acceptGhostTp,
+    acceptGhostSl,
+    dismissGhostTp,
+    dismissGhostSl,
   };
 }
 

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -1202,6 +1202,10 @@
     stateKnown: phoenixStateKnown,
     chainVerified: paperMode || phoenixTrader?.chainVerified === true,
     collateralUsd: phoenixCollateral,
+    candles: tradeMode === "perps" ? chartPoints : [],
+    prevDayHigh: tradeMode === "perps" ? structLevels.prevDayHigh : null,
+    prevDayLow: tradeMode === "perps" ? structLevels.prevDayLow : null,
+    symbol: selectedSymbol,
   });
   $: perpTicket.setNow(nowMs);
 

--- a/apps/portal/src/routes/terminal/components/AgentChat.svelte
+++ b/apps/portal/src/routes/terminal/components/AgentChat.svelte
@@ -300,6 +300,15 @@
               status: "failed" as const,
             }
       : null;
+    const rawOutput =
+      part.output && typeof part.output === "object"
+        ? (part.output as Record<string, unknown>)
+        : null;
+    const pendingPaperAction =
+      !paperReceipt &&
+      rawOutput !== null &&
+      rawOutput.paperAction !== undefined &&
+      rawOutput.paperAction !== null;
     return projectHarnessTool({
       toolName: part.toolName,
       state: part.state,
@@ -314,7 +323,20 @@
               status: receiptPresentation?.status,
             },
           }
-        : part.output,
+        : pendingPaperAction
+          ? {
+              ...rawOutput,
+              status: "pending-client",
+              presentation: {
+                schema: "harness.presentation.v1",
+                kind: "execution",
+                title: "Applying to paper ledger…",
+                summary:
+                  "Waiting for the local paper ledger Receipt before this action counts as done.",
+                status: "running",
+              },
+            }
+          : part.output,
       errorText: part.errorText,
       approvalPending: part.approvalPending,
     });

--- a/apps/portal/src/routes/terminal/components/TicketForm.svelte
+++ b/apps/portal/src/routes/terminal/components/TicketForm.svelte
@@ -3,11 +3,12 @@
   import { bookLevelNotional, formatBookPrice } from "$lib/terminal/book";
   import type { PerpTicket } from "$lib/terminal/perp-ticket";
   import { stepInput } from "$lib/terminal/step-input";
-  import { SL_CHIP_PCTS, TP_CHIP_PCTS } from "$lib/terminal/trade-math";
+  import { SL_CHIP_PCTS, TP_CHIP_PCTS, fmtTriggerPrice } from "$lib/terminal/trade-math";
   import {
     formatDisplayMoney,
     type DisplayCurrencyCode,
   } from "$lib/terminal/display-currency";
+  import { track } from "$lib/telemetry";
   import { formatNumber, formatPercent, formatPrice } from "$lib/utils";
 
   // Perp ticket form: state (the nine fields + every ticket-only derived)
@@ -151,9 +152,84 @@
     tpPnlUsd,
     slPnlUsd,
     riskNotionalUsd,
+    ghostTp,
+    ghostSl,
+    ghostSymbol,
     setTakeProfitPct,
     setStopLossPct,
+    acceptGhostTp,
+    acceptGhostSl,
+    dismissGhostTp,
+    dismissGhostSl,
   } = ticket;
+
+  // Telemetry: once per ghost value per field (not per render).
+  let shownTpKey = "";
+  let shownSlKey = "";
+  $effect(() => {
+    const ghost = $ghostTp;
+    const symbol = $ghostSymbol;
+    if (!ghost) {
+      shownTpKey = "";
+      return;
+    }
+    const key = `${symbol}:${ghost.source}:${ghost.value}`;
+    if (key === shownTpKey) return;
+    shownTpKey = key;
+    track("ghost_shown", { field: "tp", source: ghost.source, symbol });
+  });
+  $effect(() => {
+    const ghost = $ghostSl;
+    const symbol = $ghostSymbol;
+    if (!ghost) {
+      shownSlKey = "";
+      return;
+    }
+    const key = `${symbol}:${ghost.source}:${ghost.value}`;
+    if (key === shownSlKey) return;
+    shownSlKey = key;
+    track("ghost_shown", { field: "sl", source: ghost.source, symbol });
+  });
+
+  function onTpKeydown(event: KeyboardEvent): void {
+    if (event.key === "Tab" && !event.shiftKey && $ghostTp) {
+      event.preventDefault();
+      const source = $ghostTp.source;
+      const symbol = $ghostSymbol;
+      if (acceptGhostTp()) {
+        track("ghost_accepted", { field: "tp", source, symbol });
+      }
+      return;
+    }
+    if (event.key === "Escape" && $ghostTp) {
+      event.preventDefault();
+      event.stopPropagation();
+      const source = $ghostTp.source;
+      const symbol = $ghostSymbol;
+      dismissGhostTp();
+      track("ghost_dismissed", { field: "tp", source, symbol });
+    }
+  }
+
+  function onSlKeydown(event: KeyboardEvent): void {
+    if (event.key === "Tab" && !event.shiftKey && $ghostSl) {
+      event.preventDefault();
+      const source = $ghostSl.source;
+      const symbol = $ghostSymbol;
+      if (acceptGhostSl()) {
+        track("ghost_accepted", { field: "sl", source, symbol });
+      }
+      return;
+    }
+    if (event.key === "Escape" && $ghostSl) {
+      event.preventDefault();
+      event.stopPropagation();
+      const source = $ghostSl.source;
+      const symbol = $ghostSymbol;
+      dismissGhostSl();
+      track("ghost_dismissed", { field: "sl", source, symbol });
+    }
+  }
 
   // ── Size presets ───────────────────────────────────────────────────
   // USD mode: % of free collateral × leverage; Max keeps the same $0.01
@@ -276,12 +352,22 @@
           <em class="field-note">{$tradeSide === "buy" ? "above" : "below"} entry</em>
         {/if}
       </span>
-      <input
-        bind:value={$tradeTakeProfit}
-        inputmode="decimal"
-        placeholder="optional"
-        use:stepInput={{ kind: "price" }}
-      />
+      <span class="ghost-input">
+        <input
+          bind:value={$tradeTakeProfit}
+          inputmode="decimal"
+          placeholder="optional"
+          use:stepInput={{ kind: "price" }}
+          onkeydown={onTpKeydown}
+        />
+        {#if $ghostTp}
+          <span
+            class="ghost-overlay"
+            aria-hidden="true"
+            title={$ghostTp.provenance}
+          >{fmtTriggerPrice($ghostTp.value)}</span>
+        {/if}
+      </span>
     </label>
     <div class="chip-row" role="group" aria-label="Quick take profit">
       {#each TP_CHIP_PCTS as pct (pct)}
@@ -310,12 +396,22 @@
           <em class="field-note field-note-amber">sets your size</em>
         {/if}
       </span>
-      <input
-        bind:value={$tradeStopLoss}
-        inputmode="decimal"
-        placeholder={$sizingMode === "risk" ? "required" : "optional"}
-        use:stepInput={{ kind: "price" }}
-      />
+      <span class="ghost-input">
+        <input
+          bind:value={$tradeStopLoss}
+          inputmode="decimal"
+          placeholder={$sizingMode === "risk" ? "required" : "optional"}
+          use:stepInput={{ kind: "price" }}
+          onkeydown={onSlKeydown}
+        />
+        {#if $ghostSl}
+          <span
+            class="ghost-overlay"
+            aria-hidden="true"
+            title={$ghostSl.provenance}
+          >{fmtTriggerPrice($ghostSl.value)}</span>
+        {/if}
+      </span>
     </label>
     <div class="chip-row" role="group" aria-label="Quick stop loss">
       {#each SL_CHIP_PCTS as pct (pct)}
@@ -545,6 +641,25 @@
     display: grid;
     gap: 0.3rem;
     align-content: start;
+  }
+
+  .ghost-input {
+    position: relative;
+    display: block;
+  }
+
+  .ghost-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    padding: 0 0.55rem;
+    pointer-events: none;
+    color: var(--faint);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.85rem;
+    letter-spacing: normal;
+    text-transform: none;
   }
 
   .pct-chip {


### PR DESCRIPTION
## Summary
- Empty perp TP/SL fields show faint structure-based ghost levels (swing / prev-day / R-multiple); Tab accepts, Escape dismisses, no chrome beyond hover provenance.
- Chart candles + PDH/PDL feed the ticket store from the terminal page; side/symbol flips clear dismissals.
- Money-path honesty: Eve `output-available` and paper `pending-client` no longer read as success; pending paper actions show “Applying to paper ledger…” until a confirmed/rejected/unknown Receipt exists.

## Test plan
- [x] `bun run typecheck` — 0 errors
- [x] `bun run --cwd apps/portal test` — 530 pass
- [x] `bun run --cwd packages/ui test` — 16 pass
- [ ] Open perp ticket on SOL with chart history: empty SL/TP show ghosts; Tab fills; Escape dismisses; typed values hide ghosts
- [ ] Risk mode: accept SL ghost → size-from-stop updates
- [ ] Paper agent `execute_trade`: card stays working until paper Receipt; unknown still says reconciliation needed

Closes #548

Made with [Cursor](https://cursor.com)