### PR TITLE
fix(auth): harden edgeToken, Privy verify, and live agent gate

### DIFF
--- a/apps/portal/agent/channels/eve.ts
+++ b/apps/portal/agent/channels/eve.ts
@@ -4,6 +4,7 @@ import {
   withAuthChallenges,
 } from "eve/channels/auth";
 import { eveChannel } from "eve/channels/eve";
+import { isLiveAgentEnabled } from "../lib/live-access-store";
 import { verifyPrivyToken } from "../lib/privy-auth";
 
 function requestMode(
@@ -35,6 +36,19 @@ const privyAuth: AuthFn<Request> = withAuthChallenges(
         message: "The Privy session is invalid or expired.",
       });
     }
+
+    const requestedAccount = requestMode(
+      request,
+      "x-harness-account-mode",
+      ["paper", "live"],
+      "paper",
+    );
+    // Live is never taken from the client header alone — require a durable
+    // server-side enablement record (fail closed to paper).
+    const liveEnabled =
+      requestedAccount === "live" ? await isLiveAgentEnabled(userId) : false;
+    const accountMode = liveEnabled ? "live" : "paper";
+
     return {
       authenticator: "privy",
       issuer: "privy.io",
@@ -48,12 +62,8 @@ const privyAuth: AuthFn<Request> = withAuthChallenges(
           ["observe", "ask", "auto"],
           "ask",
         ),
-        accountMode: requestMode(
-          request,
-          "x-harness-account-mode",
-          ["paper", "live"],
-          "paper",
-        ),
+        accountMode,
+        liveAccess: liveEnabled ? "true" : "false",
         paused:
           request.headers.get("x-harness-agent-paused") === "true"
             ? "true"

--- a/apps/portal/agent/lib/auth.ts
+++ b/apps/portal/agent/lib/auth.ts
@@ -22,8 +22,15 @@ function parseMode(value: unknown): AgentMode {
   return value === "observe" || value === "auto" ? value : "ask";
 }
 
-function parseAccountMode(value: unknown): AccountMode {
-  return value === "live" ? "live" : "paper";
+/** Exported for unit tests — live requires the server-stamped liveAccess flag. */
+export function parseAccountMode(
+  value: unknown,
+  liveAccess: unknown,
+): AccountMode {
+  if (value !== "live") return "paper";
+  // Defense in depth: even if a stale attribute says live, require the
+  // server-stamped liveAccess flag from Eve auth.
+  return liveAccess === true || liveAccess === "true" ? "live" : "paper";
 }
 
 export function requireAgentPrincipal(ctx: EveContext): AgentPrincipal {
@@ -42,7 +49,7 @@ export function requireAgentPrincipal(ctx: EveContext): AgentPrincipal {
   return {
     userId: current.principalId,
     agentMode: parseMode(attrs.agentMode),
-    accountMode: parseAccountMode(attrs.accountMode),
+    accountMode: parseAccountMode(attrs.accountMode, attrs.liveAccess),
     paused: attrs.paused === true || attrs.paused === "true",
   };
 }

--- a/apps/portal/agent/lib/live-access-store.ts
+++ b/apps/portal/agent/lib/live-access-store.ts
@@ -1,0 +1,63 @@
+import { createHash } from "node:crypto";
+import { ownerPartition, readPrivateJson, writePrivateJson } from "./blob-json";
+
+const ROOT = "agent-state/v1/live-access";
+
+export type LiveAccessRecord = {
+  ownerId: string;
+  enabled: boolean;
+  updatedAt: string;
+  version: number;
+};
+
+function pathname(ownerId: string): string {
+  return `${ROOT}/${ownerPartition(ownerId)}.json`;
+}
+
+export function isLiveAccessStoreConfigured(): boolean {
+  return Boolean(process.env.BLOB_READ_WRITE_TOKEN?.trim());
+}
+
+/**
+ * Live agent execution is denied unless the owner has explicitly enabled it.
+ * Unconfigured vault → not enabled (fail closed to paper).
+ */
+export async function isLiveAgentEnabled(ownerId: string): Promise<boolean> {
+  if (!ownerId.trim() || !isLiveAccessStoreConfigured()) return false;
+  try {
+    const stored = await readPrivateJson<LiveAccessRecord>(pathname(ownerId));
+    if (!stored || stored.value.ownerId !== ownerId) return false;
+    return stored.value.enabled === true;
+  } catch {
+    return false;
+  }
+}
+
+export async function setLiveAgentEnabled(
+  ownerId: string,
+  enabled: boolean,
+): Promise<LiveAccessRecord> {
+  if (!ownerId.trim()) throw new Error("live-access-owner-invalid");
+  if (!isLiveAccessStoreConfigured()) {
+    throw new Error("live-access-store-unconfigured");
+  }
+  const existing = await readPrivateJson<LiveAccessRecord>(pathname(ownerId));
+  const now = new Date().toISOString();
+  const record: LiveAccessRecord = {
+    ownerId,
+    enabled,
+    updatedAt: now,
+    version: (existing?.value.version ?? 0) + 1,
+  };
+  await writePrivateJson(pathname(ownerId), record);
+  return record;
+}
+
+/** Deterministic id for tests — not a secret. */
+export function liveAccessPathForOwner(ownerId: string): string {
+  return pathname(ownerId);
+}
+
+export function liveAccessOwnerHash(ownerId: string): string {
+  return createHash("sha256").update(ownerId).digest("hex").slice(0, 32);
+}

--- a/apps/portal/agent/lib/privy-auth.ts
+++ b/apps/portal/agent/lib/privy-auth.ts
@@ -1,3 +1,7 @@
+// Canonical Privy access-token verification for Eve and SvelteKit.
+// ES256 JWTs: iss privy.io, aud = app id, sub = user DID.
+// JWKS: https://auth.privy.io/api/v1/apps/{appId}/jwks.json
+
 const PRIVY_ISSUER = "privy.io";
 const JWKS_TTL_MS = 10 * 60_000;
 
@@ -10,7 +14,10 @@ function appId(): string {
       process.env.NEXT_PUBLIC_PRIVY_APP_ID ??
       process.env.VITE_PRIVY_APP_ID ??
       "",
-  ).trim();
+  )
+    .trim()
+    .replace(/^"+|"+$/g, "")
+    .replace(/\\n$/, "");
 }
 
 function decodeJson(value: string): Record<string, unknown> {
@@ -20,28 +27,32 @@ function decodeJson(value: string): Record<string, unknown> {
   >;
 }
 
-async function fetchJwks(id: string): Promise<PrivyJwk[]> {
-  if (jwksCache && Date.now() - jwksCache.at < JWKS_TTL_MS) {
-    return jwksCache.keys;
+async function fetchJwks(id: string): Promise<PrivyJwk[] | null> {
+  const cached = jwksCache;
+  if (cached && Date.now() - cached.at < JWKS_TTL_MS) return cached.keys;
+  try {
+    const response = await fetch(
+      `https://auth.privy.io/api/v1/apps/${encodeURIComponent(id)}/jwks.json`,
+    );
+    if (!response.ok) return cached ? cached.keys : null;
+    const payload = (await response.json()) as { keys?: unknown };
+    const keys = Array.isArray(payload.keys)
+      ? (payload.keys.filter(
+          (key) => typeof key === "object" && key !== null,
+        ) as PrivyJwk[])
+      : [];
+    if (keys.length === 0) return cached ? cached.keys : null;
+    jwksCache = { keys, at: Date.now() };
+    return keys;
+  } catch {
+    return cached ? cached.keys : null;
   }
-  const response = await fetch(
-    `https://auth.privy.io/api/v1/apps/${encodeURIComponent(id)}/jwks.json`,
-  );
-  if (!response.ok) throw new Error("privy-jwks-unavailable");
-  const payload = (await response.json()) as { keys?: unknown };
-  const keys = Array.isArray(payload.keys)
-    ? (payload.keys.filter(
-        (key) => typeof key === "object" && key !== null,
-      ) as PrivyJwk[])
-    : [];
-  if (keys.length === 0) throw new Error("privy-jwks-empty");
-  jwksCache = { keys, at: Date.now() };
-  return keys;
 }
 
+/** Verify a Privy access token. Returns the user's DID (sub) or null. */
 export async function verifyPrivyToken(token: string): Promise<string | null> {
   const id = appId();
-  if (!id) return null;
+  if (!id || !token.trim()) return null;
   try {
     const parts = token.split(".");
     if (parts.length !== 3) return null;
@@ -58,16 +69,24 @@ export async function verifyPrivyToken(token: string): Promise<string | null> {
     if (
       typeof payload.exp !== "number" ||
       payload.exp * 1_000 <= Date.now() ||
-      typeof payload.sub !== "string"
+      typeof payload.sub !== "string" ||
+      !payload.sub
     ) {
       return null;
     }
+    // Optional nbf: reject tokens that are not yet valid.
+    if (typeof payload.nbf === "number" && payload.nbf * 1_000 > Date.now()) {
+      return null;
+    }
     const keys = await fetchJwks(id);
+    if (!keys || keys.length === 0) return null;
     const kid = typeof header.kid === "string" ? header.kid : "";
-    const candidates = [
-      ...keys.filter((key) => key.kid === kid),
-      ...keys.filter((key) => key.kid !== kid),
-    ];
+    const candidates = kid
+      ? [
+          ...keys.filter((key) => key.kid === kid),
+          ...keys.filter((key) => key.kid !== kid),
+        ]
+      : keys;
     const signature = Buffer.from(signatureB64, "base64url");
     const message = Buffer.from(`${headerB64}.${payloadB64}`);
     for (const jwk of candidates) {
@@ -94,3 +113,6 @@ export async function verifyPrivyToken(token: string): Promise<string | null> {
     return null;
   }
 }
+
+/** Alias used by SvelteKit routes — same verifier as Eve. */
+export const verifyPrivyAccessToken = verifyPrivyToken;

--- a/apps/portal/src/lib/agent/auth-hardening.test.ts
+++ b/apps/portal/src/lib/agent/auth-hardening.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { parseAccountMode } from "../../../agent/lib/auth";
+import {
+  liveAccessOwnerHash,
+  liveAccessPathForOwner,
+} from "../../../agent/lib/live-access-store";
+
+describe("live-access paths", () => {
+  test("partitions by owner hash", () => {
+    const a = liveAccessOwnerHash("did:privy:alice");
+    const b = liveAccessOwnerHash("did:privy:bob");
+    expect(a).not.toBe(b);
+    expect(liveAccessPathForOwner("did:privy:alice")).toContain(a);
+    expect(liveAccessPathForOwner("did:privy:alice")).toContain(
+      "agent-state/v1/live-access/",
+    );
+  });
+});
+
+describe("account mode clamp", () => {
+  test("live without liveAccess flag becomes paper", () => {
+    expect(parseAccountMode("live", "false")).toBe("paper");
+    expect(parseAccountMode("live", false)).toBe("paper");
+    expect(parseAccountMode("live", undefined)).toBe("paper");
+  });
+
+  test("live with liveAccess flag stays live", () => {
+    expect(parseAccountMode("live", "true")).toBe("live");
+    expect(parseAccountMode("live", true)).toBe("live");
+  });
+
+  test("paper stays paper", () => {
+    expect(parseAccountMode("paper", "true")).toBe("paper");
+  });
+});

--- a/apps/portal/src/lib/agent/live-access-api.ts
+++ b/apps/portal/src/lib/agent/live-access-api.ts
@@ -1,0 +1,39 @@
+import { getPrivyAccessToken } from "$lib/privy-auth";
+
+async function authHeaders(): Promise<HeadersInit> {
+  const token = await getPrivyAccessToken();
+  if (!token) throw new Error("auth-required");
+  return {
+    authorization: `Bearer ${token}`,
+    "content-type": "application/json",
+  };
+}
+
+export async function fetchLiveAgentAccess(): Promise<{
+  enabled: boolean;
+  storeConfigured: boolean;
+}> {
+  const response = await fetch("/api/agent/live-access", {
+    headers: await authHeaders(),
+  });
+  if (!response.ok) throw new Error(`live-access-${response.status}`);
+  return (await response.json()) as {
+    enabled: boolean;
+    storeConfigured: boolean;
+  };
+}
+
+/** Explicit ack before the agent may run live executions for this user. */
+export async function setLiveAgentAccess(enabled: boolean): Promise<void> {
+  const response = await fetch("/api/agent/live-access", {
+    method: "PUT",
+    headers: await authHeaders(),
+    body: JSON.stringify({ enabled }),
+  });
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as {
+      error?: string;
+    };
+    throw new Error(body.error ?? `live-access-${response.status}`);
+  }
+}

--- a/apps/portal/src/lib/server/privy.ts
+++ b/apps/portal/src/lib/server/privy.ts
@@ -3,7 +3,11 @@
 // users/get-all): Basic auth `app_id:app_secret` plus a `privy-app-id`
 // header. Every function fails soft — callers receive null on any failure
 // and decide policy (the eligibility endpoint fails open).
+//
+// Access-token verification is shared with Eve via `$agent/lib/privy-auth`
+// so JWKS / iss / aud / exp / nbf behavior cannot drift.
 
+import { verifyPrivyAccessToken as verifyPrivyAccessTokenShared } from "$agent/lib/privy-auth";
 import { env as privateEnv } from "$env/dynamic/private";
 import { env as publicEnv } from "$env/dynamic/public";
 
@@ -148,104 +152,20 @@ export async function getUserById(
   }
 }
 
-// ── Access-token verification ─────────────────────────────────────────
-// Privy access tokens are ES256 JWTs with iss "privy.io", aud = app id and
-// sub = the user's DID (docs.privy.io authentication/access-tokens). The
-// app's public keys are served as a JWKS at
-// https://auth.privy.io/api/v1/apps/{appId}/jwks.json (P-256, kid-keyed) —
-// verified live. Signatures check out against those keys via WebCrypto
-// (JWS ES256 signatures are raw r||s, which is exactly what WebCrypto's
-// ECDSA verify expects).
-
-const JWKS_TTL_MS = 10 * 60_000;
-type PrivyJwk = JsonWebKey & { kid?: string };
-let jwksCache: { keys: PrivyJwk[]; at: number } | null = null;
-
-/** Verify a Privy access token. Returns the user's DID (sub) or null. */
+/**
+ * Verify a Privy access token. Shared with Eve (`$agent/lib/privy-auth`)
+ * so JWKS / iss / aud / exp / nbf behavior cannot drift.
+ */
 export async function verifyPrivyAccessToken(
   token: string,
 ): Promise<string | null> {
-  const appId = readAppId();
-  if (!appId) return null;
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-    const [headerB64, payloadB64, signatureB64] = parts;
-
-    const header = JSON.parse(
-      Buffer.from(headerB64, "base64url").toString("utf8"),
-    ) as { alg?: unknown; kid?: unknown };
-    if (header.alg !== "ES256") return null;
-
-    const payload = JSON.parse(
-      Buffer.from(payloadB64, "base64url").toString("utf8"),
-    ) as { iss?: unknown; aud?: unknown; exp?: unknown; sub?: unknown };
-    if (payload.iss !== "privy.io") return null;
-    const audOk = Array.isArray(payload.aud)
-      ? payload.aud.includes(appId)
-      : payload.aud === appId;
-    if (!audOk) return null;
-    if (typeof payload.exp !== "number" || payload.exp * 1000 <= Date.now()) {
-      return null;
-    }
-    if (typeof payload.sub !== "string" || !payload.sub) return null;
-
-    const keys = await fetchJwks(appId);
-    if (!keys || keys.length === 0) return null;
-    // Prefer the kid match; fall back to trying every key so a rotation
-    // between our cache refreshes cannot reject a valid token.
-    const kid = typeof header.kid === "string" ? header.kid : null;
-    const candidates = kid
-      ? [
-          ...keys.filter((key) => key.kid === kid),
-          ...keys.filter((key) => key.kid !== kid),
-        ]
-      : keys;
-
-    const signature = Buffer.from(signatureB64, "base64url");
-    const message = Buffer.from(`${headerB64}.${payloadB64}`);
-    for (const jwk of candidates) {
-      const key = await crypto.subtle.importKey(
-        "jwk",
-        jwk,
-        { name: "ECDSA", namedCurve: "P-256" },
-        false,
-        ["verify"],
-      );
-      const valid = await crypto.subtle.verify(
-        { name: "ECDSA", hash: "SHA-256" },
-        key,
-        signature,
-        message,
-      );
-      if (valid) return payload.sub;
-    }
-    return null;
-  } catch {
-    return null;
+  // Ensure PUBLIC_PRIVY_APP_ID from SvelteKit env is visible to the shared
+  // verifier (Eve reads process.env directly).
+  if (!process.env.PUBLIC_PRIVY_APP_ID?.trim()) {
+    const fromKit = cleanEnv(publicEnv.PUBLIC_PRIVY_APP_ID);
+    if (fromKit) process.env.PUBLIC_PRIVY_APP_ID = fromKit;
   }
-}
-
-async function fetchJwks(appId: string): Promise<PrivyJwk[] | null> {
-  const cached = jwksCache;
-  if (cached && Date.now() - cached.at < JWKS_TTL_MS) return cached.keys;
-  try {
-    const response = await fetch(
-      `https://auth.privy.io/api/v1/apps/${encodeURIComponent(appId)}/jwks.json`,
-    );
-    if (!response.ok) return cached ? cached.keys : null;
-    const data = (await response.json()) as { keys?: unknown };
-    const keys = Array.isArray(data.keys)
-      ? (data.keys.filter(
-          (key) => typeof key === "object" && key !== null,
-        ) as PrivyJwk[])
-      : [];
-    if (keys.length === 0) return cached ? cached.keys : null;
-    jwksCache = { keys, at: Date.now() };
-    return keys;
-  } catch {
-    return cached ? cached.keys : null; // stale-on-error
-  }
+  return verifyPrivyAccessTokenShared(token);
 }
 
 function readCredentials(): PrivyCredentials | null {

--- a/apps/portal/src/routes/api/agent/live-access/+server.ts
+++ b/apps/portal/src/routes/api/agent/live-access/+server.ts
@@ -1,0 +1,65 @@
+import { json } from "@sveltejs/kit";
+import {
+  isLiveAccessStoreConfigured,
+  isLiveAgentEnabled,
+  setLiveAgentEnabled,
+} from "$agent/lib/live-access-store";
+import { requireAgentUser } from "$lib/server/agent-api";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async ({ request, setHeaders }) => {
+  setHeaders({ "cache-control": "no-store" });
+  const user = await requireAgentUser(request);
+  if (user instanceof Response) return user;
+
+  if (!isLiveAccessStoreConfigured()) {
+    return json({
+      enabled: false,
+      storeConfigured: false,
+    });
+  }
+
+  try {
+    const enabled = await isLiveAgentEnabled(user);
+    return json({ enabled, storeConfigured: true });
+  } catch {
+    return json({ error: "live-access-unavailable" }, { status: 503 });
+  }
+};
+
+export const PUT: RequestHandler = async ({ request, setHeaders }) => {
+  setHeaders({ "cache-control": "no-store" });
+  const user = await requireAgentUser(request);
+  if (user instanceof Response) return user;
+
+  if (!isLiveAccessStoreConfigured()) {
+    return json({ error: "live-access-store-unconfigured" }, { status: 503 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: "invalid-body" }, { status: 400 });
+  }
+  if (!body || typeof body !== "object") {
+    return json({ error: "invalid-body" }, { status: 400 });
+  }
+  const enabled = (body as Record<string, unknown>).enabled;
+  if (typeof enabled !== "boolean") {
+    return json({ error: "live-access-enabled-invalid" }, { status: 400 });
+  }
+
+  try {
+    const record = await setLiveAgentEnabled(user, enabled);
+    return json({
+      enabled: record.enabled,
+      updatedAt: record.updatedAt,
+      storeConfigured: true,
+    });
+  } catch (error: unknown) {
+    const message =
+      error instanceof Error ? error.message : "live-access-store-error";
+    return json({ error: message }, { status: 503 });
+  }
+};

--- a/apps/portal/src/routes/api/agent/skills/+server.ts
+++ b/apps/portal/src/routes/api/agent/skills/+server.ts
@@ -6,7 +6,7 @@ import {
   skillStore,
   type UserSkillSummary,
 } from "$agent/lib/skill-store";
-import { verifyPrivyAccessToken } from "$lib/server/privy";
+import { requireAgentUser } from "$lib/server/agent-api";
 import type { RequestHandler } from "./$types";
 
 const BUILTINS = BUILTIN_SKILLS.map((skill) => ({
@@ -17,20 +17,9 @@ const BUILTINS = BUILTIN_SKILLS.map((skill) => ({
   loadSkillId: skill.name,
 }));
 
-async function requireUser(request: Request): Promise<string | Response> {
-  const authorization = request.headers.get("authorization") ?? "";
-  const token = authorization.startsWith("Bearer ")
-    ? authorization.slice(7).trim()
-    : "";
-  if (!token) return json({ error: "auth-required" }, { status: 401 });
-  const userId = await verifyPrivyAccessToken(token);
-  if (!userId) return json({ error: "auth-invalid" }, { status: 401 });
-  return userId;
-}
-
 export const GET: RequestHandler = async ({ request, setHeaders }) => {
   setHeaders({ "cache-control": "no-store" });
-  const user = await requireUser(request);
+  const user = await requireAgentUser(request);
   if (user instanceof Response) return user;
 
   if (!isSkillStoreConfigured()) {
@@ -62,7 +51,7 @@ export const GET: RequestHandler = async ({ request, setHeaders }) => {
 
 export const POST: RequestHandler = async ({ request, setHeaders }) => {
   setHeaders({ "cache-control": "no-store" });
-  const user = await requireUser(request);
+  const user = await requireAgentUser(request);
   if (user instanceof Response) return user;
   if (!isSkillStoreConfigured()) {
     return json({ error: "skill-store-unconfigured" }, { status: 503 });

--- a/apps/portal/src/routes/api/agent/skills/[name]/+server.ts
+++ b/apps/portal/src/routes/api/agent/skills/[name]/+server.ts
@@ -1,19 +1,8 @@
 import { json } from "@sveltejs/kit";
 import { SkillFormatException } from "$agent/lib/skill-format";
 import { isSkillStoreConfigured, skillStore } from "$agent/lib/skill-store";
-import { verifyPrivyAccessToken } from "$lib/server/privy";
+import { requireAgentUser } from "$lib/server/agent-api";
 import type { RequestHandler } from "./$types";
-
-async function requireUser(request: Request): Promise<string | Response> {
-  const authorization = request.headers.get("authorization") ?? "";
-  const token = authorization.startsWith("Bearer ")
-    ? authorization.slice(7).trim()
-    : "";
-  if (!token) return json({ error: "auth-required" }, { status: 401 });
-  const userId = await verifyPrivyAccessToken(token);
-  if (!userId) return json({ error: "auth-invalid" }, { status: 401 });
-  return userId;
-}
 
 export const PATCH: RequestHandler = async ({
   request,
@@ -21,7 +10,7 @@ export const PATCH: RequestHandler = async ({
   setHeaders,
 }) => {
   setHeaders({ "cache-control": "no-store" });
-  const user = await requireUser(request);
+  const user = await requireAgentUser(request);
   if (user instanceof Response) return user;
   if (!isSkillStoreConfigured()) {
     return json({ error: "skill-store-unconfigured" }, { status: 503 });
@@ -72,7 +61,7 @@ export const DELETE: RequestHandler = async ({
   setHeaders,
 }) => {
   setHeaders({ "cache-control": "no-store" });
-  const user = await requireUser(request);
+  const user = await requireAgentUser(request);
   if (user instanceof Response) return user;
   if (!isSkillStoreConfigured()) {
     return json({ error: "skill-store-unconfigured" }, { status: 503 });

--- a/apps/portal/src/routes/api/chat/+server.ts
+++ b/apps/portal/src/routes/api/chat/+server.ts
@@ -110,6 +110,17 @@ export const POST: RequestHandler = async ({ request, fetch, setHeaders }) => {
   const body = await readChatBody(request);
   if (!body) return json({ error: "bad-request" }, { status: 400 });
 
+  // Edge credentials must be the verified session token (or another Privy
+  // token for the same sub). Never forward a mismatched body edgeToken.
+  let edgeToken = token;
+  if (body.edgeToken && body.edgeToken !== token) {
+    const edgeUser = await verifyPrivyAccessToken(body.edgeToken);
+    if (!edgeUser || edgeUser !== userId) {
+      return json({ error: "edge-token-mismatch" }, { status: 403 });
+    }
+    edgeToken = body.edgeToken;
+  }
+
   const history = capHistory(body.history);
   const contextJson = JSON.stringify(body.context);
   if (typeof contextJson !== "string") {
@@ -142,7 +153,7 @@ export const POST: RequestHandler = async ({ request, fetch, setHeaders }) => {
   const generated = await generateReply({
     context: body.context,
     edgeFetch: fetch,
-    edgeToken: body.edgeToken,
+    edgeToken,
     history,
     nowMs,
     resolvedModel,

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -177,6 +177,7 @@
     unregisterAgentHost,
     type AgentActionResult,
   } from "$lib/agent/host";
+  import { setLiveAgentAccess } from "$lib/agent/live-access-api";
   import { agentState } from "$lib/agent/state";
   import { fetchMintSafety, fetchSolanaLamports, solanaRpcUrl } from "$lib/solana-rpc";
   import { swrRead, swrWrite } from "$lib/swr";
@@ -3377,7 +3378,7 @@
     applyPaperMids();
   }
 
-  function togglePaperMode(): void {
+  async function togglePaperMode(): Promise<void> {
     if (liveSignerInFlight) {
       phoenixActionError =
         "Wallet signing is already in progress — finish or reject it before switching PAPER/LIVE.";
@@ -3390,7 +3391,33 @@
       });
       return;
     }
-    paperMode = !paperMode;
+    const nextPaper = !paperMode;
+    if (!nextPaper) {
+      // Live agent execution requires an explicit server-side enablement.
+      // Terminal LIVE mode still works for manual tickets; the agent stays
+      // on paper until this ack succeeds.
+      try {
+        await setLiveAgentAccess(true);
+      } catch (error) {
+        alertsStore.pushToast({
+          ts: Date.now(),
+          title: "Live agent not enabled",
+          body:
+            error instanceof Error
+              ? error.message
+              : "Could not enable live agent access. Staying on PAPER for agent trades.",
+        });
+        // Still allow UI live for manual trading; agent will clamp to paper
+        // until the vault ack exists.
+      }
+    } else {
+      try {
+        await setLiveAgentAccess(false);
+      } catch {
+        // Best-effort revoke; UI paper mode still applies.
+      }
+    }
+    paperMode = nextPaper;
     if (paperMode) enterPaperSafetyBoundary();
     else exitPaperSafetyBoundary();
     track("paper_mode_toggled", { paperMode });

--- a/docs/adr/0001-server-authoritative-trading-harness.md
+++ b/docs/adr/0001-server-authoritative-trading-harness.md
@@ -59,10 +59,20 @@ Execution, even when navigation and trading appear in the same user request.
 - The server resolves the user's wallet and signer capability from that
   principal. Wallet identifiers are never accepted from model tool input or
   browser context.
-- Privy is the WalletAdapter. Private keys and seed phrases are neither stored
-  by Harness nor exposed to the model, browser, EVE durable state, or logs.
-- The user explicitly enables delegated server signing and can revoke it.
-  Signing capability is not a Mandate; both signer capability and policy
+- Current implementation: live agent wallets are **server-custody** keys
+  derived from `AGENT_WALLET_MASTER_SECRET` + Privy principal (see
+  `agent/lib/server-wallet.ts`). Privy authenticates the user and provides
+  the browser embedded wallet for manual terminal signing; it is not the
+  live agent signer today. Target evolution may move to Privy delegated
+  signing — until then, document and rotate the master secret as a
+  production secret.
+- Private keys and seed phrases are never exposed to the model, browser,
+  EVE durable state, or logs.
+- Live agent execution additionally requires an explicit server-side live
+  access enablement record (`agent/lib/live-access-store.ts`). Client
+  `x-harness-account-mode: live` alone is not sufficient; without the
+  record the session is clamped to paper.
+- Signing capability is not a Mandate; both signer capability and policy
   authority must be valid.
 - The server constructs transactions from canonical domain operations and
   allowlisted venue adapters. The model cannot supply transaction bytes, fee


### PR DESCRIPTION
## Summary
- `/api/chat` only forwards an edge Bearer token that matches the verified session user (same token or same Privy `sub`); mismatch → 403.
- Eve and SvelteKit share one Privy JWT verifier (`agent/lib/privy-auth`) including `nbf` + stale-on-error JWKS.
- `x-harness-account-mode: live` is no longer enough: live agent mode requires a server-side live-access record (`/api/agent/live-access`). Toggling off PAPER on the terminal attempts to enable it; without the vault ack, Eve clamps to paper.
- Skills routes use shared `requireAgentUser`. ADR updated to document server-custody wallets + live-access gate.

## Test plan
- [x] `bun run typecheck` — 0 errors
- [x] `bun run --cwd apps/portal test` — 534 pass
- [ ] Signed-in chat with matching Bearer works
- [ ] Spoofed body `edgeToken` for another user → 403
- [ ] Agent with live header but no live-access record stays paper
- [ ] Toggle LIVE with `BLOB_READ_WRITE_TOKEN` → live-access enabled; agent can request live

Made with [Cursor](https://cursor.com)