### PR TITLE
fix(auth): session hygiene + live Auto always asks

### DIFF
--- a/apps/portal/agent/lib/auth.ts
+++ b/apps/portal/agent/lib/auth.ts
@@ -54,6 +54,30 @@ export function requireAgentPrincipal(ctx: EveContext): AgentPrincipal {
   };
 }
 
+export function decideTransactionApproval(
+  principal: AgentPrincipal,
+):
+  | { type: "denied"; reason: string }
+  | { type: "approved"; reason: string }
+  | "user-approval" {
+  if (principal.paused) {
+    return { type: "denied", reason: "Money-PAUSE is engaged." };
+  }
+  if (principal.agentMode === "observe") {
+    return { type: "denied", reason: "Observe mode is read-only." };
+  }
+  if (principal.agentMode === "ask") return "user-approval";
+  if (principal.accountMode === "paper") {
+    return {
+      type: "approved",
+      reason: "Auto mode permits paper execution.",
+    };
+  }
+  // Live money always requires an explicit approval — Auto never silently
+  // signs/broadcasts against the server-custody wallet.
+  return "user-approval";
+}
+
 export function transactionApproval(
   ctx: ApprovalContext<Record<string, unknown>>,
 ) {
@@ -63,31 +87,5 @@ export function transactionApproval(
   } catch {
     return { type: "denied" as const, reason: "Session owner mismatch." };
   }
-  if (principal.paused) {
-    return { type: "denied" as const, reason: "Money-PAUSE is engaged." };
-  }
-  if (principal.agentMode === "observe") {
-    return { type: "denied" as const, reason: "Observe mode is read-only." };
-  }
-  if (principal.agentMode === "ask") return "user-approval" as const;
-  if (principal.accountMode === "paper") {
-    return {
-      type: "approved" as const,
-      reason: "Auto mode permits paper execution.",
-    };
-  }
-
-  const input = ctx.toolInput ?? {};
-  const notional = Number(input.sizeUsd ?? input.amountUsd ?? 0);
-  const leverage = Number(input.leverage ?? 0);
-  if (
-    (Number.isFinite(notional) && notional > 5_000) ||
-    (Number.isFinite(leverage) && leverage > 20)
-  ) {
-    return "user-approval" as const;
-  }
-  return {
-    type: "approved" as const,
-    reason: "Auto mode within the server risk envelope.",
-  };
+  return decideTransactionApproval(principal);
 }

--- a/apps/portal/src/lib/agent/auth-hardening.test.ts
+++ b/apps/portal/src/lib/agent/auth-hardening.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { parseAccountMode } from "../../../agent/lib/auth";
+import {
+  type AgentPrincipal,
+  decideTransactionApproval,
+  parseAccountMode,
+} from "../../../agent/lib/auth";
 import {
   liveAccessOwnerHash,
   liveAccessPathForOwner,
@@ -31,5 +35,46 @@ describe("account mode clamp", () => {
 
   test("paper stays paper", () => {
     expect(parseAccountMode("paper", "true")).toBe("paper");
+  });
+});
+
+function principal(patch: Partial<AgentPrincipal> = {}): AgentPrincipal {
+  return {
+    userId: "did:privy:test",
+    agentMode: "auto",
+    accountMode: "paper",
+    paused: false,
+    ...patch,
+  };
+}
+
+describe("live auto never silent-approves", () => {
+  test("auto + paper stays approved", () => {
+    expect(decideTransactionApproval(principal())).toEqual({
+      type: "approved",
+      reason: "Auto mode permits paper execution.",
+    });
+  });
+
+  test("auto + live always asks the user", () => {
+    expect(decideTransactionApproval(principal({ accountMode: "live" }))).toBe(
+      "user-approval",
+    );
+  });
+
+  test("ask mode always asks", () => {
+    expect(decideTransactionApproval(principal({ agentMode: "ask" }))).toBe(
+      "user-approval",
+    );
+  });
+
+  test("observe and pause deny", () => {
+    expect(
+      decideTransactionApproval(principal({ agentMode: "observe" })),
+    ).toEqual({ type: "denied", reason: "Observe mode is read-only." });
+    expect(decideTransactionApproval(principal({ paused: true }))).toEqual({
+      type: "denied",
+      reason: "Money-PAUSE is engaged.",
+    });
   });
 });

--- a/apps/portal/src/lib/agent/live-access-api.ts
+++ b/apps/portal/src/lib/agent/live-access-api.ts
@@ -1,20 +1,11 @@
-import { getPrivyAccessToken } from "$lib/privy-auth";
-
-async function authHeaders(): Promise<HeadersInit> {
-  const token = await getPrivyAccessToken();
-  if (!token) throw new Error("auth-required");
-  return {
-    authorization: `Bearer ${token}`,
-    "content-type": "application/json",
-  };
-}
+import { fetchWithPrivyAuth } from "$lib/privy-fetch";
 
 export async function fetchLiveAgentAccess(): Promise<{
   enabled: boolean;
   storeConfigured: boolean;
 }> {
-  const response = await fetch("/api/agent/live-access", {
-    headers: await authHeaders(),
+  const response = await fetchWithPrivyAuth("/api/agent/live-access", {
+    headers: { "content-type": "application/json" },
   });
   if (!response.ok) throw new Error(`live-access-${response.status}`);
   return (await response.json()) as {
@@ -25,9 +16,9 @@ export async function fetchLiveAgentAccess(): Promise<{
 
 /** Explicit ack before the agent may run live executions for this user. */
 export async function setLiveAgentAccess(enabled: boolean): Promise<void> {
-  const response = await fetch("/api/agent/live-access", {
+  const response = await fetchWithPrivyAuth("/api/agent/live-access", {
     method: "PUT",
-    headers: await authHeaders(),
+    headers: { "content-type": "application/json" },
     body: JSON.stringify({ enabled }),
   });
   if (!response.ok) {

--- a/apps/portal/src/lib/agent/llm-profiles-api.ts
+++ b/apps/portal/src/lib/agent/llm-profiles-api.ts
@@ -1,6 +1,6 @@
 import type { LlmProviderId } from "$agent/lib/llm-catalog";
 import type { DiscoveredLlmModel } from "$agent/lib/llm-model-discovery";
-import { getPrivyAccessToken } from "$lib/privy-auth";
+import { fetchWithPrivyAuth } from "$lib/privy-fetch";
 
 export type { DiscoveredLlmModel };
 export type { LlmProviderId };
@@ -34,18 +34,11 @@ export type LlmProfilesResponse = {
   };
 };
 
-async function authHeaders(): Promise<HeadersInit> {
-  const token = await getPrivyAccessToken();
-  if (!token) throw new Error("auth-required");
-  return {
-    authorization: `Bearer ${token}`,
-    "content-type": "application/json",
-  };
-}
+const JSON_HEADERS = { "content-type": "application/json" };
 
 export async function fetchLlmProfiles(): Promise<LlmProfilesResponse> {
-  const response = await fetch("/api/agent/llm-profiles", {
-    headers: await authHeaders(),
+  const response = await fetchWithPrivyAuth("/api/agent/llm-profiles", {
+    headers: JSON_HEADERS,
   });
   if (!response.ok) throw new Error(`llm-profiles-${response.status}`);
   return (await response.json()) as LlmProfilesResponse;
@@ -58,9 +51,9 @@ export async function createLlmProfile(input: {
   apiKey: string;
   active?: boolean;
 }): Promise<LlmProfilePublic> {
-  const response = await fetch("/api/agent/llm-profiles", {
+  const response = await fetchWithPrivyAuth("/api/agent/llm-profiles", {
     method: "POST",
-    headers: await authHeaders(),
+    headers: JSON_HEADERS,
     body: JSON.stringify(input),
   });
   const body = (await response.json()) as {
@@ -77,11 +70,14 @@ export async function discoverLlmModels(input: {
   provider: LlmProviderId;
   apiKey: string;
 }): Promise<DiscoveredLlmModel[]> {
-  const response = await fetch("/api/agent/llm-profiles/discover", {
-    method: "POST",
-    headers: await authHeaders(),
-    body: JSON.stringify(input),
-  });
+  const response = await fetchWithPrivyAuth(
+    "/api/agent/llm-profiles/discover",
+    {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(input),
+    },
+  );
   const body = (await response.json()) as {
     models?: DiscoveredLlmModel[];
     error?: string;
@@ -102,11 +98,11 @@ export async function updateLlmProfile(
     active?: boolean;
   },
 ): Promise<LlmProfilePublic> {
-  const response = await fetch(
+  const response = await fetchWithPrivyAuth(
     `/api/agent/llm-profiles/${encodeURIComponent(id)}`,
     {
       method: "PATCH",
-      headers: await authHeaders(),
+      headers: JSON_HEADERS,
       body: JSON.stringify(patch),
     },
   );
@@ -121,11 +117,11 @@ export async function updateLlmProfile(
 }
 
 export async function deleteLlmProfile(id: string): Promise<void> {
-  const response = await fetch(
+  const response = await fetchWithPrivyAuth(
     `/api/agent/llm-profiles/${encodeURIComponent(id)}`,
     {
       method: "DELETE",
-      headers: await authHeaders(),
+      headers: JSON_HEADERS,
     },
   );
   if (!response.ok) {

--- a/apps/portal/src/lib/agent/skills-api.ts
+++ b/apps/portal/src/lib/agent/skills-api.ts
@@ -1,4 +1,4 @@
-import { getPrivyAccessToken } from "$lib/privy-auth";
+import { fetchWithPrivyAuth } from "$lib/privy-fetch";
 
 export type SkillListItem = {
   name: string;
@@ -18,18 +18,11 @@ export type SkillsListResponse = {
   storeConfigured: boolean;
 };
 
-async function authHeaders(): Promise<HeadersInit> {
-  const token = await getPrivyAccessToken();
-  if (!token) throw new Error("auth-required");
-  return {
-    authorization: `Bearer ${token}`,
-    "content-type": "application/json",
-  };
-}
+const JSON_HEADERS = { "content-type": "application/json" };
 
 export async function fetchAgentSkills(): Promise<SkillsListResponse> {
-  const response = await fetch("/api/agent/skills", {
-    headers: await authHeaders(),
+  const response = await fetchWithPrivyAuth("/api/agent/skills", {
+    headers: JSON_HEADERS,
   });
   if (!response.ok) {
     throw new Error(`skills-list-${response.status}`);
@@ -43,9 +36,9 @@ export async function installAgentSkill(input: {
   files?: Record<string, string>;
   enabled?: boolean;
 }): Promise<SkillListItem> {
-  const response = await fetch("/api/agent/skills", {
+  const response = await fetchWithPrivyAuth("/api/agent/skills", {
     method: "POST",
-    headers: await authHeaders(),
+    headers: JSON_HEADERS,
     body: JSON.stringify(input),
   });
   const body = (await response.json()) as {
@@ -62,11 +55,11 @@ export async function setAgentSkillEnabled(
   name: string,
   enabled: boolean,
 ): Promise<SkillListItem> {
-  const response = await fetch(
+  const response = await fetchWithPrivyAuth(
     `/api/agent/skills/${encodeURIComponent(name)}`,
     {
       method: "PATCH",
-      headers: await authHeaders(),
+      headers: JSON_HEADERS,
       body: JSON.stringify({ enabled }),
     },
   );
@@ -81,11 +74,11 @@ export async function setAgentSkillEnabled(
 }
 
 export async function deleteAgentSkill(name: string): Promise<void> {
-  const response = await fetch(
+  const response = await fetchWithPrivyAuth(
     `/api/agent/skills/${encodeURIComponent(name)}`,
     {
       method: "DELETE",
-      headers: await authHeaders(),
+      headers: JSON_HEADERS,
     },
   );
   if (!response.ok) {

--- a/apps/portal/src/lib/chat.ts
+++ b/apps/portal/src/lib/chat.ts
@@ -9,6 +9,7 @@ import { getAgentPolicy, setProposals } from "./agent/state";
 import type { ChatMessage } from "./chat-core";
 import type { ChatModelChoice } from "./chat-models";
 import { getPrivyAccessToken } from "./privy-auth";
+import { fetchWithPrivyAuth } from "./privy-fetch";
 
 const CHAT_OPEN_KEY = "harness.chat.v1";
 const CHAT_ENDPOINT = "/api/chat";
@@ -86,8 +87,9 @@ export type SendChatOptions = {
   accountMode?: "live" | "paper";
 };
 
-/** POST /api/chat. Attaches Authorization from getPrivyAccessToken() and the
- * edge token when one resolves. See module header for the state machine. */
+/** POST /api/chat. Attaches Authorization from Privy (refresh-once on 401).
+ * Edge tool calls on the server use that same verified Bearer — no dual
+ * body edgeToken credential. */
 export async function sendChatMessage(
   text: string,
   context: Record<string, unknown>,
@@ -99,9 +101,8 @@ export async function sendChatMessage(
   pushMessage({ role: "user", content: trimmed });
   setPhase("waiting");
 
-  let token: string | null = null;
   try {
-    token = await getPrivyAccessToken();
+    await getPrivyAccessToken();
   } catch {
     // No usable credential (Privy unconfigured/unavailable) — same lane as 401.
     setPhase("auth");
@@ -112,12 +113,11 @@ export async function sendChatMessage(
   try {
     const state = get(chatState);
     const policy = getAgentPolicy();
-    response = await fetch(CHAT_ENDPOINT, {
+    response = await fetchWithPrivyAuth(CHAT_ENDPOINT, {
       method: "POST",
-      headers: buildHeaders(token),
+      headers: { "content-type": "application/json" },
       body: JSON.stringify(
         buildBody(
-          token,
           state.messages,
           context,
           state.modelChoice,
@@ -240,25 +240,14 @@ function setError(message: string): void {
   chatState.update((state) => ({ ...state, phase: "error", error: message }));
 }
 
-function buildHeaders(token: string | null): Record<string, string> {
-  const headers: Record<string, string> = {
-    "content-type": "application/json",
-  };
-  if (token) {
-    headers.authorization = `Bearer ${token}`;
-  }
-  return headers;
-}
-
 function buildBody(
-  token: string | null,
   history: ChatUiMessage[],
   context: Record<string, unknown>,
   modelChoice: ChatModelChoice,
   agentMode: string,
   paused: boolean,
 ): Record<string, unknown> {
-  const body: Record<string, unknown> = {
+  return {
     history: history.map((message) => ({
       role: message.role,
       content: message.content,
@@ -268,10 +257,6 @@ function buildBody(
     agentMode,
     paused,
   };
-  if (token) {
-    body.edgeToken = token;
-  }
-  return body;
 }
 
 function networkErrorMessage(error: unknown): string {

--- a/apps/portal/src/lib/privy-fetch.ts
+++ b/apps/portal/src/lib/privy-fetch.ts
@@ -1,0 +1,61 @@
+import { getPrivyAccessToken, logoutPrivy, privyAuth } from "$lib/privy-auth";
+
+type FetchInput = Parameters<typeof fetch>[0];
+type FetchInit = Parameters<typeof fetch>[1];
+
+function mergeAuthHeaders(
+  init: FetchInit | undefined,
+  token: string | null,
+): HeadersInit {
+  const headers = new Headers(init?.headers ?? undefined);
+  if (token) headers.set("authorization", `Bearer ${token}`);
+  else headers.delete("authorization");
+  return headers;
+}
+
+/** Drop any mirrored access token so the next getPrivyAccessToken() is fresh. */
+export function clearMirroredAccessToken(): void {
+  privyAuth.update((state) =>
+    state.accessToken === null ? state : { ...state, accessToken: null },
+  );
+}
+
+/**
+ * fetch() with Privy Bearer auth. On 401: clear mirrored token, refresh once,
+ * retry. A second 401 forces logout so the UI must re-authenticate.
+ */
+export async function fetchWithPrivyAuth(
+  input: FetchInput,
+  init?: FetchInit,
+): Promise<Response> {
+  let token = await getPrivyAccessToken();
+  let response = await fetch(input, {
+    ...init,
+    headers: mergeAuthHeaders(init, token),
+  });
+  if (response.status !== 401) return response;
+
+  clearMirroredAccessToken();
+  token = await getPrivyAccessToken();
+  if (!token) {
+    try {
+      await logoutPrivy();
+    } catch {
+      // UI already sees unauthenticated.
+    }
+    return response;
+  }
+
+  response = await fetch(input, {
+    ...init,
+    headers: mergeAuthHeaders(init, token),
+  });
+  if (response.status === 401) {
+    try {
+      await logoutPrivy();
+    } catch {
+      // best-effort
+    }
+  }
+  return response;
+}

--- a/apps/portal/src/routes/api/chat/+server.ts
+++ b/apps/portal/src/routes/api/chat/+server.ts
@@ -53,7 +53,6 @@ type QueuedAction = {
 type ChatRequestBody = {
   history: ChatMessage[];
   context: unknown;
-  edgeToken?: string;
   modelChoice: ChatModelChoice;
   /** When set, enable agent action tools + agent system prompt. */
   agentMode?: AgentMode;
@@ -110,16 +109,9 @@ export const POST: RequestHandler = async ({ request, fetch, setHeaders }) => {
   const body = await readChatBody(request);
   if (!body) return json({ error: "bad-request" }, { status: 400 });
 
-  // Edge credentials must be the verified session token (or another Privy
-  // token for the same sub). Never forward a mismatched body edgeToken.
-  let edgeToken = token;
-  if (body.edgeToken && body.edgeToken !== token) {
-    const edgeUser = await verifyPrivyAccessToken(body.edgeToken);
-    if (!edgeUser || edgeUser !== userId) {
-      return json({ error: "edge-token-mismatch" }, { status: 403 });
-    }
-    edgeToken = body.edgeToken;
-  }
+  // Edge tool calls use the verified Authorization bearer only — never a
+  // second credential from the request body.
+  const edgeToken = token;
 
   const history = capHistory(body.history);
   const contextJson = JSON.stringify(body.context);
@@ -249,7 +241,11 @@ async function readChatBody(request: Request): Promise<ChatRequestBody | null> {
   if (!Array.isArray(body.history)) return null;
   const history = parseHistory(body.history);
   if (!history) return null;
-  if ("edgeToken" in body && typeof body.edgeToken !== "string") return null;
+  // Ignore legacy body.edgeToken if present — Authorization is the only
+  // credential. Reject only when the field exists and is the wrong type.
+  if ("edgeToken" in body && body.edgeToken !== undefined) {
+    if (typeof body.edgeToken !== "string") return null;
+  }
   const modelChoice = parseModelChoice(body.modelChoice);
   if (!modelChoice) return null;
   let agentMode: AgentMode | undefined;
@@ -267,7 +263,6 @@ async function readChatBody(request: Request): Promise<ChatRequestBody | null> {
   return {
     history,
     context: body.context,
-    edgeToken: typeof body.edgeToken === "string" ? body.edgeToken : undefined,
     modelChoice,
     agentMode,
     paused: body.paused === true,

--- a/docs/adr/0001-server-authoritative-trading-harness.md
+++ b/docs/adr/0001-server-authoritative-trading-harness.md
@@ -85,7 +85,10 @@ Execution, even when navigation and trading appear in the same user request.
 
 - Observe denies all Executions.
 - Ask parks every Execution for explicit user approval.
-- Auto may allow Executions inside server policy limits.
+- Auto may allow **paper** Executions without a prompt. **Live** Executions
+  always require explicit user approval — Auto never silently signs against
+  the server-custody wallet (`decideTransactionApproval` in
+  `agent/lib/auth.ts`).
 - PAUSE denies every Execution, including Routine-created Tasks.
 - Approvals are bound to the exact Plan and Execution digests and expire.
 - A changed amount, side, asset, leverage, price, trigger, protection, venue,


### PR DESCRIPTION
## Summary
- Add `fetchWithPrivyAuth`: on 401 clear mirrored token, refresh once, retry; second 401 forces logout.
- Wire it through chat, live-access, skills, and LLM profile clients; stop sending a dual body `edgeToken` — `/api/chat` uses the verified Authorization bearer only.
- Live Auto never silent-approves server-custody executions (always `user-approval`); ADR updated; unit tests cover the clamp.

## Test plan
- [x] `bun test apps/portal/src/lib/agent/auth-hardening.test.ts` (8 pass)
- [x] `bun run typecheck` (0 errors)
- [x] `bun run --cwd apps/portal test` (538 pass)
- [ ] CI green on this PR
- [ ] Smoke: expired session on chat/skills forces re-login after one refresh attempt
- [ ] Smoke: Auto + live trade proposal requires explicit approval

## Risk notes
- Live Auto users who previously got silent approval under the notional/leverage envelope will now see approval prompts — intentional money-path hardening.
- Local Windows `bun run build` hit a Vercel symlink EPERM after a successful Vite build; CI/Linux is the arbiter.

Made with [Cursor](https://cursor.com)