### PR TITLE
feat(agent): default to DeepSeek V4 Flash

### DIFF
--- a/apps/portal/agent/agent.ts
+++ b/apps/portal/agent/agent.ts
@@ -1,6 +1,7 @@
 import { deepseek } from "@ai-sdk/deepseek";
 import { defineAgent, defineDynamic } from "eve";
 import type { SessionContext } from "eve/context";
+import { PLATFORM_DEFAULT_LLM } from "./lib/llm-catalog";
 import { createUserLanguageModel } from "./lib/llm-model";
 import { llmProfileStore } from "./lib/llm-profile-store";
 
@@ -50,7 +51,7 @@ export default defineAgent({
     "A persistent, authenticated trading copilot for the Harness terminal.",
   model: defineDynamic({
     // Platform default when the user has no BYOK profile.
-    fallback: deepseek("deepseek-v4-pro"),
+    fallback: deepseek(PLATFORM_DEFAULT_LLM.model),
     events: {
       // Live LanguageModel (with the caller's API key) is only valid on
       // step.started — session/turn scopes must be serializable model ids.

--- a/apps/portal/agent/lib/llm-catalog.ts
+++ b/apps/portal/agent/lib/llm-catalog.ts
@@ -15,6 +15,18 @@ export type LlmProviderOption = {
   keyHint: string;
 };
 
+export const DEEPSEEK_V4_FLASH_MODEL = {
+  id: "deepseek-v4-flash",
+  gatewayId: "deepseek/deepseek-v4-flash",
+  label: "DeepSeek V4 Flash",
+} as const;
+
+export const PLATFORM_DEFAULT_LLM = {
+  provider: "deepseek",
+  model: DEEPSEEK_V4_FLASH_MODEL.id,
+  label: "Harness default (DeepSeek V4 Flash)",
+} as const;
+
 export const LLM_PROVIDERS: readonly LlmProviderOption[] = [
   {
     id: "deepseek",
@@ -22,7 +34,10 @@ export const LLM_PROVIDERS: readonly LlmProviderOption[] = [
     keyHint: "DEEPSEEK_API_KEY from platform.deepseek.com",
     models: [
       { id: "deepseek-v4-pro", label: "DeepSeek V4 Pro" },
-      { id: "deepseek-v4-flash", label: "DeepSeek V4 Flash" },
+      {
+        id: DEEPSEEK_V4_FLASH_MODEL.id,
+        label: DEEPSEEK_V4_FLASH_MODEL.label,
+      },
     ],
   },
   {

--- a/apps/portal/src/lib/agent/llm-catalog.test.ts
+++ b/apps/portal/src/lib/agent/llm-catalog.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
   apiKeyLast4,
+  DEEPSEEK_V4_FLASH_MODEL,
   isLlmProviderId,
   isSafeLlmModelId,
   LLM_PROVIDERS,
+  PLATFORM_DEFAULT_LLM,
   providerModels,
 } from "../../../agent/lib/llm-catalog";
 
@@ -26,6 +28,23 @@ describe("llm-catalog", () => {
     expect(providerModels("xai").some((model) => model.id === "grok-4.5")).toBe(
       true,
     );
+  });
+
+  test("uses DeepSeek V4 Flash for the platform default", () => {
+    expect(DEEPSEEK_V4_FLASH_MODEL).toEqual({
+      id: "deepseek-v4-flash",
+      gatewayId: "deepseek/deepseek-v4-flash",
+      label: "DeepSeek V4 Flash",
+    });
+    expect(PLATFORM_DEFAULT_LLM).toEqual({
+      provider: "deepseek",
+      model: "deepseek-v4-flash",
+      label: "Harness default (DeepSeek V4 Flash)",
+    });
+    expect(providerModels(PLATFORM_DEFAULT_LLM.provider)).toContainEqual({
+      id: PLATFORM_DEFAULT_LLM.model,
+      label: DEEPSEEK_V4_FLASH_MODEL.label,
+    });
   });
 
   test("accepts provider-discovered model ids but rejects path/control input", () => {

--- a/apps/portal/src/lib/ai.ts
+++ b/apps/portal/src/lib/ai.ts
@@ -7,8 +7,10 @@
 // Calls go to the same-origin /deepseek proxy (see vite.config.ts), which
 // injects the API key server-side — the key is never in the client bundle.
 
+import { DEEPSEEK_V4_FLASH_MODEL } from "../../agent/lib/llm-catalog";
+
 const AI_ENDPOINT = "/deepseek/chat/completions";
-const MODEL = "deepseek-chat";
+const MODEL = DEEPSEEK_V4_FLASH_MODEL.id;
 
 export type AiPhase = "idle" | "loading" | "ready" | "error";
 

--- a/apps/portal/src/lib/chat-models.ts
+++ b/apps/portal/src/lib/chat-models.ts
@@ -1,10 +1,12 @@
+import { DEEPSEEK_V4_FLASH_MODEL } from "../../agent/lib/llm-catalog";
+
 export type ChatTier = "free" | "pro";
 export type TaskClass = "chat" | "analysis";
 export type ChatModelChoice = "auto" | "free" | "pro";
 
 export type ResolvedModel = {
   tier: ChatTier;
-  /** AI Gateway "provider/model" string for pro; sentinel "deepseek-chat"
+  /** AI Gateway "provider/model" string for pro; direct DeepSeek model id
    * for free (raw DeepSeek path the endpoint already owns). */
   model: string;
   /** true when a frontier/pro model was actually selected — drives the
@@ -12,7 +14,8 @@ export type ResolvedModel = {
   proLabel: boolean;
 };
 
-export const FREE_MODEL = "deepseek-chat";
+export const FREE_MODEL = DEEPSEEK_V4_FLASH_MODEL.id;
+export const FREE_GATEWAY_MODEL = DEEPSEEK_V4_FLASH_MODEL.gatewayId;
 export const PRO_MODEL = "anthropic/claude-opus-4.8";
 export const PRO_LABEL = "Pro (open beta)";
 

--- a/apps/portal/src/routes/api/agent/llm-profiles/+server.ts
+++ b/apps/portal/src/routes/api/agent/llm-profiles/+server.ts
@@ -1,5 +1,9 @@
 import { json } from "@sveltejs/kit";
-import { isLlmProviderId, LLM_PROVIDERS } from "$agent/lib/llm-catalog";
+import {
+  isLlmProviderId,
+  LLM_PROVIDERS,
+  PLATFORM_DEFAULT_LLM,
+} from "$agent/lib/llm-catalog";
 import { assertProviderModelAvailable } from "$agent/lib/llm-model-discovery";
 import {
   isLlmProfileStoreConfigured,
@@ -25,11 +29,7 @@ export const GET: RequestHandler = async ({ request, setHeaders }) => {
       catalog,
       profiles: [],
       storeConfigured: false,
-      platformDefault: {
-        provider: "deepseek",
-        model: "deepseek-v4-pro",
-        label: "Harness default (DeepSeek V4 Pro)",
-      },
+      platformDefault: PLATFORM_DEFAULT_LLM,
     });
   }
 
@@ -39,11 +39,7 @@ export const GET: RequestHandler = async ({ request, setHeaders }) => {
       catalog,
       profiles,
       storeConfigured: true,
-      platformDefault: {
-        provider: "deepseek",
-        model: "deepseek-v4-pro",
-        label: "Harness default (DeepSeek V4 Pro)",
-      },
+      platformDefault: PLATFORM_DEFAULT_LLM,
     });
   } catch {
     return json({ error: "llm-store-unavailable" }, { status: 503 });

--- a/apps/portal/src/routes/api/chat/+server.ts
+++ b/apps/portal/src/routes/api/chat/+server.ts
@@ -19,6 +19,7 @@ import {
 } from "$lib/chat-core";
 import {
   type ChatModelChoice,
+  FREE_GATEWAY_MODEL,
   FREE_MODEL,
   type ResolvedModel,
   resolveModel,
@@ -539,7 +540,7 @@ function freeModelConfigs(): ChatModelConfig[] {
     configs.push({
       url: AI_GATEWAY_URL,
       apiKey: gatewayKey,
-      model: "deepseek/deepseek-chat",
+      model: FREE_GATEWAY_MODEL,
     });
   }
   return configs;

--- a/apps/portal/src/routes/api/desk/[slug]/+server.ts
+++ b/apps/portal/src/routes/api/desk/[slug]/+server.ts
@@ -4,6 +4,7 @@
 // input facts, falling back to null (the page then shows the pulse instead).
 
 import { json } from "@sveltejs/kit";
+import { DEEPSEEK_V4_FLASH_MODEL } from "$agent/lib/llm-catalog";
 import { env } from "$env/dynamic/private";
 import { getPerpSymbols } from "$lib/server/phoenix-markets";
 import {
@@ -82,7 +83,7 @@ async function generateRead(asset: Asset): Promise<string | null> {
       authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
-      model: "deepseek-chat",
+      model: DEEPSEEK_V4_FLASH_MODEL.id,
       temperature: 0.5,
       max_tokens: 220,
       messages: [

--- a/apps/portal/src/routes/terminal/components/AgentModelsPanel.svelte
+++ b/apps/portal/src/routes/terminal/components/AgentModelsPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { PLATFORM_DEFAULT_LLM } from "$agent/lib/llm-catalog";
   import {
     createLlmProfile,
     deleteLlmProfile,
@@ -28,7 +29,7 @@
   let catalog = $state<LlmCatalogProvider[]>([]);
   let profiles = $state<LlmProfilePublic[]>([]);
   let storeConfigured = $state(true);
-  let platformLabel = $state("Harness default (DeepSeek V4 Pro)");
+  let platformLabel = $state<string>(PLATFORM_DEFAULT_LLM.label);
   let busyId = $state<string | null>(null);
 
   let name = $state("My model");


### PR DESCRIPTION
## What changed

- switches the EVE platform fallback from DeepSeek V4 Pro to DeepSeek V4 Flash
- centralizes the direct API model id, AI Gateway model id, label, and platform default
- updates the settings API/UI plus legacy free-chat, terminal read, and desk-read paths
- adds a regression test for the platform default and removes retired runtime aliases

## Why

DeepSeek now identifies the fast V4 model as `deepseek-v4-flash`. The legacy `deepseek-chat` and `deepseek-reasoner` aliases were retired on July 24, 2026. V4 Flash is DeepSeek's faster, economical tier and supports the tool calls used by the agent.

Official model details: https://api-docs.deepseek.com/quick_start/pricing

## User impact

Users without a BYOK profile now use V4 Flash by default. Existing BYOK selections are unchanged. Settings consistently shows **Harness default (DeepSeek V4 Flash)**.

## Validation

- `bun run test` — 539 portal tests and 16 UI token tests pass
- `bun run build`
- Biome check on all changed files
- local browser smoke at `http://localhost:3000/terminal`: V4 Flash default visible, no console errors
