### PR TITLE
fix(custody): ack agent wallet + owner-only SOL evacuate

### DIFF
--- a/apps/portal/agent/lib/custody-policy.ts
+++ b/apps/portal/agent/lib/custody-policy.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure custody policy helpers — keep money-path clamps testable without RPC.
+ */
+
+export function assertAgentWalletAck(
+  ack: unknown,
+  expectedAddress: string,
+): { ok: true } | { ok: false; error: string } {
+  if (typeof ack !== "string" || !ack.trim()) {
+    return { ok: false, error: "agent-wallet-ack-required" };
+  }
+  if (ack.trim() !== expectedAddress) {
+    return { ok: false, error: "agent-wallet-ack-mismatch" };
+  }
+  return { ok: true };
+}
+
+/** Withdrawals may only land on the Privy-linked owner wallet — never tool input. */
+export function resolveOwnerWithdrawDestination(input: {
+  ownerSolanaWallet: string | null | undefined;
+  agentWalletAddress: string;
+}): { ok: true; destination: string } | { ok: false; error: string } {
+  const destination = String(input.ownerSolanaWallet ?? "").trim();
+  if (!destination) {
+    return { ok: false, error: "owner-solana-wallet-missing" };
+  }
+  if (destination === input.agentWalletAddress) {
+    return { ok: false, error: "owner-wallet-matches-agent" };
+  }
+  return { ok: true, destination };
+}
+
+/** Leave rent so the agent wallet account stays usable after evacuate. */
+export const AGENT_WALLET_RENT_RESERVE_LAMPORTS = 1_000_000;
+
+export function clampWithdrawLamports(input: {
+  balanceLamports: number;
+  requestedLamports: number | "max";
+  rentReserveLamports?: number;
+}): { ok: true; lamports: number } | { ok: false; error: string } {
+  const reserve =
+    input.rentReserveLamports ?? AGENT_WALLET_RENT_RESERVE_LAMPORTS;
+  const spendable = Math.max(0, input.balanceLamports - reserve);
+  if (spendable <= 0) {
+    return { ok: false, error: "agent-wallet-below-rent-reserve" };
+  }
+  const requested =
+    input.requestedLamports === "max"
+      ? spendable
+      : Math.floor(input.requestedLamports);
+  if (!Number.isFinite(requested) || requested <= 0) {
+    return { ok: false, error: "withdraw-lamports-invalid" };
+  }
+  if (requested > spendable) {
+    return { ok: false, error: "withdraw-exceeds-spendable" };
+  }
+  return { ok: true, lamports: requested };
+}

--- a/apps/portal/agent/lib/custody-wallet.ts
+++ b/apps/portal/agent/lib/custody-wallet.ts
@@ -1,0 +1,155 @@
+import {
+  PublicKey,
+  SystemProgram,
+  type VersionedTransaction,
+} from "@solana/web3.js";
+import {
+  buildSignableTransaction,
+  createSolanaConnection,
+} from "../../src/lib/phoenix-trade";
+import { getUserById } from "../../src/lib/server/privy";
+import {
+  AGENT_WALLET_RENT_RESERVE_LAMPORTS,
+  clampWithdrawLamports,
+  resolveOwnerWithdrawDestination,
+} from "./custody-policy";
+import { getServerWallet, signAndSendWithServerWallet } from "./server-wallet";
+
+function rpcUrl(): string {
+  return String(
+    process.env.PUBLIC_SOLANA_RPC_URL ??
+      process.env.SOLANA_RPC_URL ??
+      "https://api.mainnet-beta.solana.com",
+  ).trim();
+}
+
+export type CustodyWalletSnapshot = {
+  agentWalletAddress: string;
+  ownerSolanaWallet: string | null;
+  custody: "eve-server";
+  solBalanceLamports: number;
+  solBalance: number;
+  spendableLamports: number;
+  rentReserveLamports: number;
+  masterSecretConfigured: boolean;
+};
+
+export async function readCustodyWalletSnapshot(
+  userId: string,
+): Promise<CustodyWalletSnapshot> {
+  const wallet = getServerWallet(userId);
+  const owner = await getUserById(userId);
+  const connection = createSolanaConnection(rpcUrl());
+  const solBalanceLamports = await connection.getBalance(
+    new PublicKey(wallet.address),
+  );
+  const spendableLamports = Math.max(
+    0,
+    solBalanceLamports - AGENT_WALLET_RENT_RESERVE_LAMPORTS,
+  );
+  return {
+    agentWalletAddress: wallet.address,
+    ownerSolanaWallet: owner?.solanaWallet ?? null,
+    custody: "eve-server",
+    solBalanceLamports,
+    solBalance: solBalanceLamports / 1e9,
+    spendableLamports,
+    rentReserveLamports: AGENT_WALLET_RENT_RESERVE_LAMPORTS,
+    masterSecretConfigured: true,
+  };
+}
+
+/**
+ * Evacuate SOL from the server-custody agent wallet to the Privy-linked
+ * owner Solana wallet only. Destination is never taken from the client body.
+ */
+export async function withdrawAgentSolToOwner(input: {
+  userId: string;
+  lamports: number | "max";
+}): Promise<{
+  signature: string;
+  lamports: number;
+  destination: string;
+  agentWalletAddress: string;
+}> {
+  const wallet = getServerWallet(input.userId);
+  const owner = await getUserById(input.userId);
+  const destination = resolveOwnerWithdrawDestination({
+    ownerSolanaWallet: owner?.solanaWallet,
+    agentWalletAddress: wallet.address,
+  });
+  if (!destination.ok) throw new Error(destination.error);
+
+  const connection = createSolanaConnection(rpcUrl());
+  const balanceLamports = await connection.getBalance(
+    new PublicKey(wallet.address),
+  );
+  const clamped = clampWithdrawLamports({
+    balanceLamports,
+    requestedLamports: input.lamports,
+  });
+  if (!clamped.ok) throw new Error(clamped.error);
+
+  // Defense in depth: only a SystemProgram transfer to the resolved owner.
+  const instruction = SystemProgram.transfer({
+    fromPubkey: new PublicKey(wallet.address),
+    toPubkey: new PublicKey(destination.destination),
+    lamports: clamped.lamports,
+  });
+  const { transaction } = await buildSignableTransaction(
+    rpcUrl(),
+    wallet.address,
+    [instruction],
+  );
+  // Reject any bundled extra program — evacuate is transfer-only.
+  assertTransferOnlyTransaction(transaction, wallet.address);
+
+  const receipt = await signAndSendWithServerWallet({
+    wallet,
+    transaction,
+    connection,
+  });
+  if (receipt.status !== "confirmed") {
+    throw new Error(
+      receipt.status === "unknown"
+        ? `withdraw-outcome-unknown:${receipt.signature}`
+        : `withdraw-rejected:${receipt.signature}`,
+    );
+  }
+  return {
+    signature: receipt.signature,
+    lamports: clamped.lamports,
+    destination: destination.destination,
+    agentWalletAddress: wallet.address,
+  };
+}
+
+function assertTransferOnlyTransaction(
+  transaction: VersionedTransaction,
+  feePayer: string,
+): void {
+  if (transaction.message.header.numRequiredSignatures !== 1) {
+    throw new Error("withdraw-extra-signers-rejected");
+  }
+  if (transaction.message.staticAccountKeys[0]?.toBase58() !== feePayer) {
+    throw new Error("withdraw-fee-payer-mismatch");
+  }
+  const compiled = transaction.message.compiledInstructions;
+  if (compiled.length < 1) throw new Error("withdraw-empty-transaction");
+  // Allow compute-budget prefix + exactly one SystemProgram transfer.
+  const keys = transaction.message.staticAccountKeys;
+  const systemId = SystemProgram.programId.toBase58();
+  const computeBudgetId = "ComputeBudget111111111111111111111111111111";
+  let transferCount = 0;
+  for (const ix of compiled) {
+    const programId = keys[ix.programIdIndex]?.toBase58();
+    if (programId === computeBudgetId) continue;
+    if (programId !== systemId) {
+      throw new Error(`withdraw-program-rejected:${programId ?? "unknown"}`);
+    }
+    transferCount += 1;
+  }
+  if (transferCount !== 1) {
+    throw new Error("withdraw-transfer-count-invalid");
+  }
+}

--- a/apps/portal/agent/lib/live-access-store.ts
+++ b/apps/portal/agent/lib/live-access-store.ts
@@ -8,6 +8,8 @@ export type LiveAccessRecord = {
   enabled: boolean;
   updatedAt: string;
   version: number;
+  /** Agent wallet address the user acknowledged when enabling live. */
+  ackedAgentWallet?: string;
 };
 
 function pathname(ownerId: string): string {
@@ -36,6 +38,7 @@ export async function isLiveAgentEnabled(ownerId: string): Promise<boolean> {
 export async function setLiveAgentEnabled(
   ownerId: string,
   enabled: boolean,
+  options: { ackedAgentWallet?: string } = {},
 ): Promise<LiveAccessRecord> {
   if (!ownerId.trim()) throw new Error("live-access-owner-invalid");
   if (!isLiveAccessStoreConfigured()) {
@@ -48,7 +51,15 @@ export async function setLiveAgentEnabled(
     enabled,
     updatedAt: now,
     version: (existing?.value.version ?? 0) + 1,
+    ...(enabled && options.ackedAgentWallet
+      ? { ackedAgentWallet: options.ackedAgentWallet }
+      : existing?.value.ackedAgentWallet
+        ? { ackedAgentWallet: existing.value.ackedAgentWallet }
+        : {}),
   };
+  if (!enabled) {
+    delete record.ackedAgentWallet;
+  }
   await writePrivateJson(pathname(ownerId), record);
   return record;
 }

--- a/apps/portal/src/lib/agent/custody-policy.test.ts
+++ b/apps/portal/src/lib/agent/custody-policy.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import {
+  AGENT_WALLET_RENT_RESERVE_LAMPORTS,
+  assertAgentWalletAck,
+  clampWithdrawLamports,
+  resolveOwnerWithdrawDestination,
+} from "../../../agent/lib/custody-policy";
+
+describe("assertAgentWalletAck", () => {
+  test("requires exact address match", () => {
+    expect(assertAgentWalletAck("Abc111", "Abc111")).toEqual({ ok: true });
+    expect(assertAgentWalletAck(" Abc111 ", "Abc111")).toEqual({ ok: true });
+    expect(assertAgentWalletAck("", "Abc111")).toEqual({
+      ok: false,
+      error: "agent-wallet-ack-required",
+    });
+    expect(assertAgentWalletAck("other", "Abc111")).toEqual({
+      ok: false,
+      error: "agent-wallet-ack-mismatch",
+    });
+  });
+});
+
+describe("resolveOwnerWithdrawDestination", () => {
+  test("rejects missing or self destination", () => {
+    expect(
+      resolveOwnerWithdrawDestination({
+        ownerSolanaWallet: null,
+        agentWalletAddress: "agent",
+      }),
+    ).toEqual({ ok: false, error: "owner-solana-wallet-missing" });
+    expect(
+      resolveOwnerWithdrawDestination({
+        ownerSolanaWallet: "agent",
+        agentWalletAddress: "agent",
+      }),
+    ).toEqual({ ok: false, error: "owner-wallet-matches-agent" });
+    expect(
+      resolveOwnerWithdrawDestination({
+        ownerSolanaWallet: "owner",
+        agentWalletAddress: "agent",
+      }),
+    ).toEqual({ ok: true, destination: "owner" });
+  });
+});
+
+describe("clampWithdrawLamports", () => {
+  test("keeps rent reserve and supports max", () => {
+    const balance = AGENT_WALLET_RENT_RESERVE_LAMPORTS + 5_000_000;
+    expect(
+      clampWithdrawLamports({
+        balanceLamports: balance,
+        requestedLamports: "max",
+      }),
+    ).toEqual({ ok: true, lamports: 5_000_000 });
+    expect(
+      clampWithdrawLamports({
+        balanceLamports: balance,
+        requestedLamports: 1_000_000,
+      }),
+    ).toEqual({ ok: true, lamports: 1_000_000 });
+    expect(
+      clampWithdrawLamports({
+        balanceLamports: AGENT_WALLET_RENT_RESERVE_LAMPORTS,
+        requestedLamports: "max",
+      }),
+    ).toEqual({ ok: false, error: "agent-wallet-below-rent-reserve" });
+    expect(
+      clampWithdrawLamports({
+        balanceLamports: balance,
+        requestedLamports: 9_000_000,
+      }),
+    ).toEqual({ ok: false, error: "withdraw-exceeds-spendable" });
+  });
+});

--- a/apps/portal/src/lib/agent/custody-wallet-api.ts
+++ b/apps/portal/src/lib/agent/custody-wallet-api.ts
@@ -1,0 +1,55 @@
+import { fetchWithPrivyAuth } from "$lib/privy-fetch";
+
+export type CustodyWalletSnapshot = {
+  agentWalletAddress: string;
+  ownerSolanaWallet: string | null;
+  custody: "eve-server";
+  solBalanceLamports: number;
+  solBalance: number;
+  spendableLamports: number;
+  rentReserveLamports: number;
+  masterSecretConfigured: boolean;
+};
+
+export async function fetchCustodyWallet(): Promise<CustodyWalletSnapshot> {
+  const response = await fetchWithPrivyAuth("/api/agent/custody-wallet", {
+    headers: { "content-type": "application/json" },
+  });
+  if (!response.ok) throw new Error(`custody-wallet-${response.status}`);
+  return (await response.json()) as CustodyWalletSnapshot;
+}
+
+/** Evacuate spendable SOL to the Privy-linked owner wallet (server-resolved). */
+export async function withdrawCustodySol(
+  lamports: number | "max" = "max",
+): Promise<{
+  signature: string;
+  lamports: number;
+  destination: string;
+  agentWalletAddress: string;
+  explorerUrl: string;
+}> {
+  const response = await fetchWithPrivyAuth("/api/agent/custody-wallet", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ lamports }),
+  });
+  const body = (await response.json().catch(() => ({}))) as {
+    error?: string;
+    signature?: string;
+    lamports?: number;
+    destination?: string;
+    agentWalletAddress?: string;
+    explorerUrl?: string;
+  };
+  if (!response.ok || !body.signature) {
+    throw new Error(body.error ?? `custody-withdraw-${response.status}`);
+  }
+  return {
+    signature: body.signature,
+    lamports: body.lamports ?? 0,
+    destination: body.destination ?? "",
+    agentWalletAddress: body.agentWalletAddress ?? "",
+    explorerUrl: body.explorerUrl ?? `https://solscan.io/tx/${body.signature}`,
+  };
+}

--- a/apps/portal/src/lib/agent/live-access-api.ts
+++ b/apps/portal/src/lib/agent/live-access-api.ts
@@ -1,30 +1,59 @@
 import { fetchWithPrivyAuth } from "$lib/privy-fetch";
 
-export async function fetchLiveAgentAccess(): Promise<{
+export type LiveAgentAccess = {
   enabled: boolean;
   storeConfigured: boolean;
-}> {
+  custody: "eve-server";
+  agentWalletAddress: string | null;
+  ownerSolanaWallet: string | null;
+  masterSecretConfigured: boolean;
+  ackedAgentWallet?: string | null;
+  updatedAt?: string;
+};
+
+export async function fetchLiveAgentAccess(): Promise<LiveAgentAccess> {
   const response = await fetchWithPrivyAuth("/api/agent/live-access", {
     headers: { "content-type": "application/json" },
   });
   if (!response.ok) throw new Error(`live-access-${response.status}`);
-  return (await response.json()) as {
-    enabled: boolean;
-    storeConfigured: boolean;
-  };
+  return (await response.json()) as LiveAgentAccess;
 }
 
 /** Explicit ack before the agent may run live executions for this user. */
-export async function setLiveAgentAccess(enabled: boolean): Promise<void> {
+export async function setLiveAgentAccess(
+  enabled: boolean,
+  options: { ackAgentWallet?: string } = {},
+): Promise<LiveAgentAccess> {
   const response = await fetchWithPrivyAuth("/api/agent/live-access", {
     method: "PUT",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ enabled }),
+    body: JSON.stringify({
+      enabled,
+      ...(enabled && options.ackAgentWallet
+        ? { ackAgentWallet: options.ackAgentWallet }
+        : {}),
+    }),
   });
   if (!response.ok) {
     const body = (await response.json().catch(() => ({}))) as {
       error?: string;
+      agentWalletAddress?: string;
     };
     throw new Error(body.error ?? `live-access-${response.status}`);
   }
+  return (await response.json()) as LiveAgentAccess;
+}
+
+/**
+ * Enable live agent access by acknowledging the server-derived agent wallet.
+ * Fetches the address first so the client cannot invent one.
+ */
+export async function enableLiveAgentAccess(): Promise<LiveAgentAccess> {
+  const current = await fetchLiveAgentAccess();
+  if (!current.masterSecretConfigured || !current.agentWalletAddress) {
+    throw new Error("agent-wallet-master-secret-missing");
+  }
+  return setLiveAgentAccess(true, {
+    ackAgentWallet: current.agentWalletAddress,
+  });
 }

--- a/apps/portal/src/routes/api/agent/custody-wallet/+server.ts
+++ b/apps/portal/src/routes/api/agent/custody-wallet/+server.ts
@@ -1,0 +1,83 @@
+import { json } from "@sveltejs/kit";
+import {
+  readCustodyWalletSnapshot,
+  withdrawAgentSolToOwner,
+} from "$agent/lib/custody-wallet";
+import { requireAgentUser } from "$lib/server/agent-api";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async ({ request, setHeaders }) => {
+  setHeaders({ "cache-control": "no-store" });
+  const user = await requireAgentUser(request);
+  if (user instanceof Response) return user;
+
+  try {
+    const snapshot = await readCustodyWalletSnapshot(user);
+    return json(snapshot);
+  } catch (error: unknown) {
+    const message =
+      error instanceof Error ? error.message : "custody-wallet-unavailable";
+    if (message.includes("master-secret")) {
+      return json(
+        { error: "agent-wallet-master-secret-missing" },
+        { status: 503 },
+      );
+    }
+    return json({ error: message }, { status: 503 });
+  }
+};
+
+export const POST: RequestHandler = async ({ request, setHeaders }) => {
+  setHeaders({ "cache-control": "no-store" });
+  const user = await requireAgentUser(request);
+  if (user instanceof Response) return user;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: "invalid-body" }, { status: 400 });
+  }
+  if (!body || typeof body !== "object") {
+    return json({ error: "invalid-body" }, { status: 400 });
+  }
+  const record = body as Record<string, unknown>;
+  // Destination is NEVER accepted from the client — server resolves Privy owner.
+  if ("destination" in record || "to" in record || "ownerWallet" in record) {
+    return json(
+      { error: "withdraw-destination-not-accepted" },
+      { status: 400 },
+    );
+  }
+
+  let lamports: number | "max";
+  if (record.lamports === "max") {
+    lamports = "max";
+  } else if (
+    typeof record.lamports === "number" &&
+    Number.isFinite(record.lamports)
+  ) {
+    lamports = Math.floor(record.lamports);
+  } else {
+    return json({ error: "withdraw-lamports-invalid" }, { status: 400 });
+  }
+
+  try {
+    const result = await withdrawAgentSolToOwner({ userId: user, lamports });
+    return json({
+      ok: true,
+      ...result,
+      explorerUrl: `https://solscan.io/tx/${result.signature}`,
+    });
+  } catch (error: unknown) {
+    const message =
+      error instanceof Error ? error.message : "custody-withdraw-failed";
+    const status =
+      message.startsWith("owner-") ||
+      message.startsWith("withdraw-") ||
+      message.startsWith("agent-wallet-below")
+        ? 400
+        : 503;
+    return json({ error: message }, { status });
+  }
+};

--- a/apps/portal/src/routes/api/agent/live-access/+server.ts
+++ b/apps/portal/src/routes/api/agent/live-access/+server.ts
@@ -1,27 +1,57 @@
 import { json } from "@sveltejs/kit";
+import { assertAgentWalletAck } from "$agent/lib/custody-policy";
 import {
   isLiveAccessStoreConfigured,
   isLiveAgentEnabled,
   setLiveAgentEnabled,
 } from "$agent/lib/live-access-store";
+import { getServerWallet } from "$agent/lib/server-wallet";
 import { requireAgentUser } from "$lib/server/agent-api";
+import { getUserById } from "$lib/server/privy";
 import type { RequestHandler } from "./$types";
+
+function custodyPayload(userId: string) {
+  let agentWalletAddress: string | null = null;
+  let masterSecretConfigured = false;
+  try {
+    agentWalletAddress = getServerWallet(userId).address;
+    masterSecretConfigured = true;
+  } catch {
+    agentWalletAddress = null;
+    masterSecretConfigured = false;
+  }
+  return { agentWalletAddress, masterSecretConfigured };
+}
 
 export const GET: RequestHandler = async ({ request, setHeaders }) => {
   setHeaders({ "cache-control": "no-store" });
   const user = await requireAgentUser(request);
   if (user instanceof Response) return user;
 
+  const custody = custodyPayload(user);
+  const owner = await getUserById(user);
+
   if (!isLiveAccessStoreConfigured()) {
     return json({
       enabled: false,
       storeConfigured: false,
+      custody: "eve-server" as const,
+      agentWalletAddress: custody.agentWalletAddress,
+      ownerSolanaWallet: owner?.solanaWallet ?? null,
+      masterSecretConfigured: custody.masterSecretConfigured,
     });
   }
 
   try {
     const enabled = await isLiveAgentEnabled(user);
-    return json({ enabled, storeConfigured: true });
+    return json({
+      enabled,
+      storeConfigured: true,
+      custody: "eve-server" as const,
+      agentWalletAddress: custody.agentWalletAddress,
+      ownerSolanaWallet: owner?.solanaWallet ?? null,
+      masterSecretConfigured: custody.masterSecretConfigured,
+    });
   } catch {
     return json({ error: "live-access-unavailable" }, { status: 503 });
   }
@@ -45,17 +75,50 @@ export const PUT: RequestHandler = async ({ request, setHeaders }) => {
   if (!body || typeof body !== "object") {
     return json({ error: "invalid-body" }, { status: 400 });
   }
-  const enabled = (body as Record<string, unknown>).enabled;
+  const record = body as Record<string, unknown>;
+  const enabled = record.enabled;
   if (typeof enabled !== "boolean") {
     return json({ error: "live-access-enabled-invalid" }, { status: 400 });
   }
 
+  let agentWalletAddress: string;
   try {
-    const record = await setLiveAgentEnabled(user, enabled);
+    agentWalletAddress = getServerWallet(user).address;
+  } catch {
+    return json(
+      { error: "agent-wallet-master-secret-missing" },
+      { status: 503 },
+    );
+  }
+
+  if (enabled) {
+    const ack = assertAgentWalletAck(record.ackAgentWallet, agentWalletAddress);
+    if (!ack.ok) {
+      return json(
+        {
+          error: ack.error,
+          agentWalletAddress,
+          custody: "eve-server",
+        },
+        { status: 400 },
+      );
+    }
+  }
+
+  try {
+    const saved = await setLiveAgentEnabled(user, enabled, {
+      ackedAgentWallet: enabled ? agentWalletAddress : undefined,
+    });
+    const owner = await getUserById(user);
     return json({
-      enabled: record.enabled,
-      updatedAt: record.updatedAt,
+      enabled: saved.enabled,
+      updatedAt: saved.updatedAt,
       storeConfigured: true,
+      custody: "eve-server" as const,
+      agentWalletAddress,
+      ownerSolanaWallet: owner?.solanaWallet ?? null,
+      ackedAgentWallet: saved.ackedAgentWallet ?? null,
+      masterSecretConfigured: true,
     });
   } catch (error: unknown) {
     const message =

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -177,7 +177,14 @@
     unregisterAgentHost,
     type AgentActionResult,
   } from "$lib/agent/host";
-  import { setLiveAgentAccess } from "$lib/agent/live-access-api";
+  import {
+    enableLiveAgentAccess,
+    setLiveAgentAccess,
+  } from "$lib/agent/live-access-api";
+  import {
+    fetchCustodyWallet,
+    withdrawCustodySol,
+  } from "$lib/agent/custody-wallet-api";
   import { agentState } from "$lib/agent/state";
   import { fetchMintSafety, fetchSolanaLamports, solanaRpcUrl } from "$lib/solana-rpc";
   import { swrRead, swrWrite } from "$lib/swr";
@@ -540,6 +547,12 @@
   let solBalanceValue: number | null = null;
   let walletCopied = false;
   let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
+  let agentCustodyAddress: string | null = null;
+  let agentCustodySolText = "-- SOL";
+  let agentCustodySpendableLamports = 0;
+  let agentCustodyCopied = false;
+  let agentCustodyBusy = false;
+  let agentCustodyCopyTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Phoenix onboarding (beta whitelist + referral attribution).
   let phoenixWhitelisted: boolean | null = null;
@@ -1063,6 +1076,12 @@
     void screenWallet(normalizedWalletAddress);
   }
   $: phoenixAuthority = $privyAuth.authenticated ? normalizedWalletAddress : "";
+  $: if (browser && $privyAuth.authenticated) void refreshAgentCustodyWallet();
+  $: if (browser && !$privyAuth.authenticated) {
+    agentCustodyAddress = null;
+    agentCustodySolText = "-- SOL";
+    agentCustodySpendableLamports = 0;
+  }
   // Lazy web3 boundary (plan 8.1): $lib/phoenix-trade statically pulls
   // @solana/web3.js + @ellipsis-labs/rise (~1.1 MB pre-minify) — the dynamic
   // import keeps that graph out of the entry chunk. The module registry
@@ -3393,11 +3412,27 @@
     }
     const nextPaper = !paperMode;
     if (!nextPaper) {
-      // Live agent execution requires an explicit server-side enablement.
-      // Terminal LIVE mode still works for manual tickets; the agent stays
+      // Live agent execution requires an explicit server-side enablement
+      // that acknowledges the separate server-custody agent wallet address.
+      // Terminal LIVE still works for manual Privy tickets; the agent stays
       // on paper until this ack succeeds.
       try {
-        await setLiveAgentAccess(true);
+        const access = await enableLiveAgentAccess();
+        const agentAddr = access.agentWalletAddress;
+        const ownerAddr =
+          access.ownerSolanaWallet ?? $privyAuth.walletAddress ?? null;
+        alertsStore.pushToast({
+          ts: Date.now(),
+          title: "Live agent wallet armed",
+          body: agentAddr
+            ? `Agent trades use server-custody ${shortAddress(agentAddr)}${
+                ownerAddr
+                  ? ` — distinct from your Privy wallet ${shortAddress(ownerAddr)}`
+                  : ""
+              }. Fund the agent wallet, or withdraw SOL back to Privy from the account menu.`
+            : "Live agent access enabled.",
+        });
+        void refreshAgentCustodyWallet();
       } catch (error) {
         alertsStore.pushToast({
           ts: Date.now(),
@@ -4518,6 +4553,60 @@
       }, 1600);
     } catch {
       walletBalanceError = "Clipboard unavailable in this browser.";
+    }
+  }
+
+  async function refreshAgentCustodyWallet(): Promise<void> {
+    if (!$privyAuth.authenticated) {
+      agentCustodyAddress = null;
+      agentCustodySolText = "-- SOL";
+      agentCustodySpendableLamports = 0;
+      return;
+    }
+    try {
+      const snapshot = await fetchCustodyWallet();
+      agentCustodyAddress = snapshot.agentWalletAddress;
+      agentCustodySolText = `${snapshot.solBalance.toFixed(4)} SOL`;
+      agentCustodySpendableLamports = snapshot.spendableLamports;
+    } catch {
+      // Master secret / RPC may be unavailable in local/dev — keep last known.
+    }
+  }
+
+  async function copyAgentCustodyAddress(): Promise<void> {
+    if (!agentCustodyAddress) return;
+    try {
+      await navigator.clipboard.writeText(agentCustodyAddress);
+      agentCustodyCopied = true;
+      if (agentCustodyCopyTimer) clearTimeout(agentCustodyCopyTimer);
+      agentCustodyCopyTimer = setTimeout(() => {
+        agentCustodyCopied = false;
+      }, 1600);
+    } catch {
+      walletBalanceError = "Clipboard unavailable in this browser.";
+    }
+  }
+
+  async function withdrawAgentCustodySol(): Promise<void> {
+    if (agentCustodyBusy || agentCustodySpendableLamports <= 0) return;
+    agentCustodyBusy = true;
+    try {
+      const result = await withdrawCustodySol("max");
+      alertsStore.pushToast({
+        ts: Date.now(),
+        title: "Agent SOL withdrawn",
+        body: `Sent ${(result.lamports / 1e9).toFixed(4)} SOL to your Privy wallet.`,
+      });
+      await refreshAgentCustodyWallet();
+      void refreshWalletBalance();
+    } catch (error) {
+      alertsStore.pushToast({
+        ts: Date.now(),
+        title: "Agent withdraw failed",
+        body: error instanceof Error ? error.message : "withdraw-failed",
+      });
+    } finally {
+      agentCustodyBusy = false;
     }
   }
 
@@ -6341,8 +6430,18 @@
     onrefreshbalances={() => {
       void refreshWalletBalance();
       void refreshPhoenixTrader();
+      void refreshAgentCustodyWallet();
     }}
     ontogglepaper={togglePaperMode}
+    agentCustody={{
+      address: agentCustodyAddress,
+      solText: agentCustodySolText,
+      spendableLamports: agentCustodySpendableLamports,
+      copied: agentCustodyCopied,
+      busy: agentCustodyBusy,
+    }}
+    oncopyagentcustody={copyAgentCustodyAddress}
+    onwithdrawagentcustody={withdrawAgentCustodySol}
   />
 
   {#if showOpenBetaBanner}

--- a/apps/portal/src/routes/terminal/components/Topbar.svelte
+++ b/apps/portal/src/routes/terminal/components/Topbar.svelte
@@ -38,6 +38,9 @@
     oncopyaddress,
     onrefreshbalances,
     ontogglepaper,
+    agentCustody = null,
+    oncopyagentcustody = undefined,
+    onwithdrawagentcustody = undefined,
   }: {
     wallet: {
       balanceText: string;
@@ -68,6 +71,15 @@
     oncopyaddress: () => void | Promise<void>;
     onrefreshbalances: () => void;
     ontogglepaper: () => void;
+    agentCustody?: {
+      address: string | null;
+      solText: string;
+      spendableLamports: number;
+      copied: boolean;
+      busy: boolean;
+    } | null;
+    oncopyagentcustody?: () => void | Promise<void>;
+    onwithdrawagentcustody?: () => void | Promise<void>;
   } = $props();
 
   // Aliases keep the moved markup verbatim against the page's names.
@@ -229,6 +241,38 @@
                 <span class="copy-hint" class:done={walletCopied}>{walletCopied ? "Copied" : "Copy"}</span>
               {/if}
             </button>
+
+            {#if agentCustody?.address}
+              <button
+                class="account-row copyable"
+                type="button"
+                onclick={() => void oncopyagentcustody?.()}
+              >
+                <span class="account-row-label">Agent wallet</span>
+                <span class="account-row-value mono">
+                  {shortAddress(agentCustody.address)}
+                  <small class="funds-split">{agentCustody.solText} · server custody</small>
+                </span>
+                <span class="copy-hint" class:done={agentCustody.copied}
+                  >{agentCustody.copied ? "Copied" : "Copy"}</span
+                >
+              </button>
+              <button
+                class="account-action"
+                type="button"
+                disabled={agentCustody.busy || agentCustody.spendableLamports <= 0}
+                onclick={() => void onwithdrawagentcustody?.()}
+              >
+                {agentCustody.busy
+                  ? "Withdrawing…"
+                  : agentCustody.spendableLamports <= 0
+                    ? "No agent SOL to withdraw"
+                    : "Withdraw agent SOL to Privy"}
+              </button>
+              <p class="account-dropdown-note warn">
+                Agent live trades use this server-custody wallet — not your Privy wallet above.
+              </p>
+            {/if}
 
             {#if walletScreen.checked}
               <div class="account-row">

--- a/docs/adr/0001-server-authoritative-trading-harness.md
+++ b/docs/adr/0001-server-authoritative-trading-harness.md
@@ -69,9 +69,14 @@ Execution, even when navigation and trading appear in the same user request.
 - Private keys and seed phrases are never exposed to the model, browser,
   EVE durable state, or logs.
 - Live agent execution additionally requires an explicit server-side live
-  access enablement record (`agent/lib/live-access-store.ts`). Client
-  `x-harness-account-mode: live` alone is not sufficient; without the
-  record the session is clamped to paper.
+  access enablement record (`agent/lib/live-access-store.ts`). Enabling
+  live requires acknowledging the exact derived agent wallet address
+  (`ackAgentWallet`). Client `x-harness-account-mode: live` alone is not
+  sufficient; without the record the session is clamped to paper.
+- The agent wallet address is surfaced to the owner, and SOL may be
+  evacuated only to the Privy-linked owner Solana wallet via
+  `/api/agent/custody-wallet` (destination is server-resolved; never
+  accepted from the client body).
 - Signing capability is not a Mandate; both signer capability and policy
   authority must be valid.
 - The server constructs transactions from canonical domain operations and


### PR DESCRIPTION
## Summary
- Enabling live agent access now requires acknowledging the exact server-derived agent wallet address (no silent dual-wallet enable).
- Account menu surfaces the agent custody wallet separately from Privy and can withdraw spendable SOL only to the Privy-linked owner wallet (destination server-resolved; client cannot supply `to`).
- ADR updated for custody ack + evacuate hatch.

## Test plan
- [x] `bun test apps/portal/src/lib/agent/custody-policy.test.ts` (+ auth-hardening)
- [x] `bun run typecheck` (0 errors)
- [x] `bun run --cwd apps/portal test` (542 pass)
- [ ] CI green
- [ ] Smoke: PAPER→LIVE toast shows agent vs Privy addresses
- [ ] Smoke: account menu shows Agent wallet + withdraw (when funded)

## Risk notes
- Does not eliminate `AGENT_WALLET_MASTER_SECRET` blast radius (needs Privy delegated signing later); this makes the dual wallet impossible to miss and lets owners evacuate SOL.
- Withdraw is SOL-only transfer; USDC/token balances still need venue/tool paths.

Made with [Cursor](https://cursor.com)