### PR TITLE
fix(auth): stop post-login custody refresh loop

### DIFF
--- a/apps/portal/src/lib/agent/custody-refresh.test.ts
+++ b/apps/portal/src/lib/agent/custody-refresh.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { nextCustodyRefresh } from "./custody-refresh";
+
+describe("custody refresh transitions", () => {
+  test("refreshes once when repeated Privy store emissions keep the same user", () => {
+    const first = nextCustodyRefresh(null, {
+      authenticated: true,
+      userId: "did:privy:alice",
+    });
+    expect(first).toEqual({ ownerId: "did:privy:alice", action: "refresh" });
+
+    expect(
+      nextCustodyRefresh(first.ownerId, {
+        authenticated: true,
+        userId: "did:privy:alice",
+      }),
+    ).toEqual({ ownerId: "did:privy:alice", action: "none" });
+  });
+
+  test("resets on logout and refreshes for a different user", () => {
+    const loggedOut = nextCustodyRefresh("did:privy:alice", {
+      authenticated: false,
+      userId: null,
+    });
+    expect(loggedOut).toEqual({ ownerId: null, action: "reset" });
+
+    expect(
+      nextCustodyRefresh("did:privy:alice", {
+        authenticated: true,
+        userId: "did:privy:bob",
+      }),
+    ).toEqual({ ownerId: "did:privy:bob", action: "refresh" });
+  });
+});

--- a/apps/portal/src/lib/agent/custody-refresh.ts
+++ b/apps/portal/src/lib/agent/custody-refresh.ts
@@ -1,0 +1,18 @@
+export type CustodyRefreshAction = "none" | "refresh" | "reset";
+
+type AuthIdentity = {
+  authenticated: boolean;
+  userId: string | null;
+};
+
+export function nextCustodyRefresh(
+  currentOwnerId: string | null,
+  auth: AuthIdentity,
+): { ownerId: string | null; action: CustodyRefreshAction } {
+  const ownerId = auth.authenticated
+    ? (auth.userId ?? "authenticated-user")
+    : null;
+
+  if (ownerId === currentOwnerId) return { ownerId, action: "none" };
+  return { ownerId, action: ownerId ? "refresh" : "reset" };
+}

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -185,6 +185,7 @@
     fetchCustodyWallet,
     withdrawCustodySol,
   } from "$lib/agent/custody-wallet-api";
+  import { nextCustodyRefresh } from "$lib/agent/custody-refresh";
   import { agentState } from "$lib/agent/state";
   import { fetchMintSafety, fetchSolanaLamports, solanaRpcUrl } from "$lib/solana-rpc";
   import { swrRead, swrWrite } from "$lib/swr";
@@ -553,6 +554,7 @@
   let agentCustodyCopied = false;
   let agentCustodyBusy = false;
   let agentCustodyCopyTimer: ReturnType<typeof setTimeout> | null = null;
+  let agentCustodyOwnerId: string | null = null;
 
   // Phoenix onboarding (beta whitelist + referral attribution).
   let phoenixWhitelisted: boolean | null = null;
@@ -1076,11 +1078,20 @@
     void screenWallet(normalizedWalletAddress);
   }
   $: phoenixAuthority = $privyAuth.authenticated ? normalizedWalletAddress : "";
-  $: if (browser && $privyAuth.authenticated) void refreshAgentCustodyWallet();
-  $: if (browser && !$privyAuth.authenticated) {
-    agentCustodyAddress = null;
-    agentCustodySolText = "-- SOL";
-    agentCustodySpendableLamports = 0;
+  $: if (browser) {
+    const transition = nextCustodyRefresh(agentCustodyOwnerId, {
+      authenticated: $privyAuth.authenticated,
+      userId: $privyAuth.userId,
+    });
+    if (transition.action !== "none") {
+      agentCustodyOwnerId = transition.ownerId;
+      if (transition.action === "refresh") void refreshAgentCustodyWallet();
+      else {
+        agentCustodyAddress = null;
+        agentCustodySolText = "-- SOL";
+        agentCustodySpendableLamports = 0;
+      }
+    }
   }
   // Lazy web3 boundary (plan 8.1): $lib/phoenix-trade statically pulls
   // @solana/web3.js + @ellipsis-labs/rise (~1.1 MB pre-minify) — the dynamic


### PR DESCRIPTION
## What changed

- make the authenticated custody-wallet refresh edge-triggered per Privy user
- reset custody state on logout and refresh when the authenticated user changes
- add a regression test covering repeated same-user Privy store emissions

## Root cause

Production commit `92bc554` introduced an unguarded Svelte reactive custody refresh. The refresh calls `fetchWithPrivyAuth()`, which mirrors the access token back into the same `privyAuth` store. Every store write retriggered the reactive custody fetch, creating an unbounded request/store-update loop after OTP login until the renderer hung and crashed.

## User impact

Authenticated users can complete login without the terminal freezing. The custody snapshot still refreshes on login, user switch, explicit balance refresh, and custody withdrawal.

## Validation

- `npx --yes bun@1.3.0 run typecheck` (0 errors, 0 warnings)
- `npx --yes bun@1.3.0 run build`
- `npx --yes bun@1.3.0 run test` (544 passed)
- `npx --yes bun@1.3.0 run lint`
- browser smoke at `http://localhost:3000/terminal` (terminal rendered, no console warnings/errors)
