### PR TITLE
Fix Phoenix funds hydration and compact agent header

### DIFF
--- a/apps/portal/src/lib/phoenix-trade.test.ts
+++ b/apps/portal/src/lib/phoenix-trade.test.ts
@@ -1,9 +1,49 @@
 import { describe, expect, test } from "bun:test";
 import {
   mergeTraderView,
+  overlayOnChainCollateral,
   type PhoenixTraderState,
   parseTraderStatePayload,
 } from "./phoenix-trade";
+
+describe("overlayOnChainCollateral", () => {
+  test("replaces stale parent collateral inside the all-subaccount total", () => {
+    const state: PhoenixTraderState = {
+      registered: true,
+      apiSlot: 10,
+      collateralUsd: 0,
+      totalCollateralUsd: 25,
+      effectiveCollateralUsd: null,
+      unrealizedPnlUsd: null,
+      riskTier: null,
+      positions: [],
+      orders: [],
+    };
+
+    const overlaid = overlayOnChainCollateral(state, 61.51);
+    expect(overlaid.collateralUsd).toBe(61.51);
+    expect(overlaid.totalCollateralUsd).toBeCloseTo(86.51);
+    expect(overlaid.chainVerified).toBe(true);
+  });
+
+  test("uses chain collateral as the total when the indexer has no snapshot", () => {
+    const state: PhoenixTraderState = {
+      registered: false,
+      apiSlot: null,
+      collateralUsd: null,
+      totalCollateralUsd: null,
+      effectiveCollateralUsd: null,
+      unrealizedPnlUsd: null,
+      riskTier: null,
+      positions: [],
+      orders: [],
+    };
+
+    expect(overlayOnChainCollateral(state, 61.51).totalCollateralUsd).toBe(
+      61.51,
+    );
+  });
+});
 
 // Lot decimals mirror the live /exchange config for the fixture symbols
 // (ANSEM baseLotsDecimals=0 → 1 lot = 1 unit; AAPL=3 → 1 lot = 0.001).

--- a/apps/portal/src/lib/phoenix-trade.ts
+++ b/apps/portal/src/lib/phoenix-trade.ts
@@ -212,6 +212,30 @@ export type ParsedTraderSnapshot = {
   subaccountIndexes: number[];
 };
 
+/**
+ * Replace the indexer's parent collateral with the current trader-PDA value
+ * while preserving isolated-subaccount margin in the account total. The
+ * indexer can lag immediately after a deposit, so updating only
+ * `collateralUsd` would leave `totalCollateralUsd` stale in the funds header.
+ */
+export function overlayOnChainCollateral(
+  state: PhoenixTraderState,
+  chainCollateralUsd: number,
+): PhoenixTraderState {
+  const indexedParentUsd = state.collateralUsd ?? 0;
+  const isolatedUsd =
+    state.totalCollateralUsd === null
+      ? 0
+      : Math.max(0, state.totalCollateralUsd - indexedParentUsd);
+  return {
+    ...state,
+    registered: true,
+    collateralUsd: chainCollateralUsd,
+    totalCollateralUsd: chainCollateralUsd + isolatedUsd,
+    chainVerified: true,
+  };
+}
+
 // Pure parser for the /v1/trader/state payload — exported so tests can feed
 // it fixture payloads (isolated-subaccount positions included) without
 // network. Live schema (2026-07-03): { traderPdaIndex, snapshot:

--- a/apps/portal/src/lib/terminal/account-format.test.ts
+++ b/apps/portal/src/lib/terminal/account-format.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  accountFundsPresentation,
   aiErr,
   humanizeBalanceError,
   humanizePrivyError,
@@ -7,6 +8,50 @@ import {
   shortEmail,
   walletStatusText,
 } from "./account-format";
+
+describe("accountFundsPresentation", () => {
+  test("does not present wallet USDC as a complete total while Phoenix is loading", () => {
+    expect(
+      accountFundsPresentation({
+        walletUsd: 1.11,
+        walletText: "1.11 USDC",
+        phoenixUsd: 61.51,
+        phoenixStatus: "loading",
+      }),
+    ).toEqual({
+      totalText: "Loading total…",
+      phoenixText: "Phoenix loading…",
+    });
+  });
+
+  test("labels the wallet-only amount as partial when Phoenix is unavailable", () => {
+    expect(
+      accountFundsPresentation({
+        walletUsd: 1.11,
+        walletText: "1.11 USDC",
+        phoenixUsd: 0,
+        phoenixStatus: "error",
+      }),
+    ).toEqual({
+      totalText: "1.11 USDC · partial",
+      phoenixText: "Phoenix unavailable",
+    });
+  });
+
+  test("adds wallet and Phoenix only after both sources are ready", () => {
+    expect(
+      accountFundsPresentation({
+        walletUsd: 1.11,
+        walletText: "1.11 USDC",
+        phoenixUsd: 61.51,
+        phoenixStatus: "ready",
+      }),
+    ).toEqual({
+      totalText: "62.62 USDC",
+      phoenixText: "$61.51 phoenix",
+    });
+  });
+});
 
 describe("shortAddress", () => {
   test("empty/null → --", () => {

--- a/apps/portal/src/lib/terminal/account-format.ts
+++ b/apps/portal/src/lib/terminal/account-format.ts
@@ -4,6 +4,63 @@
 
 import type { PrivyAuthState } from "$lib/privy-auth";
 
+export type PhoenixFundsStatus = "idle" | "loading" | "ready" | "error";
+
+export type AccountFundsPresentation = {
+  totalText: string;
+  phoenixText: string;
+};
+
+const formatUsdc = (usd: number): string =>
+  `${usd.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })} USDC`;
+
+/**
+ * A wallet balance is only one part of the account total. Keep the total
+ * explicitly pending/partial until Phoenix has answered, so a fast wallet
+ * RPC cannot momentarily understate funds as though the number were final.
+ */
+export function accountFundsPresentation({
+  walletUsd,
+  walletText,
+  phoenixUsd,
+  phoenixStatus,
+}: {
+  walletUsd: number | null;
+  walletText: string;
+  phoenixUsd: number;
+  phoenixStatus: PhoenixFundsStatus;
+}): AccountFundsPresentation {
+  if (walletUsd === null) {
+    return {
+      totalText: walletText,
+      phoenixText:
+        phoenixStatus === "error" ? "Phoenix unavailable" : "Phoenix loading…",
+    };
+  }
+  if (phoenixStatus === "error") {
+    return {
+      totalText: `${formatUsdc(walletUsd)} · partial`,
+      phoenixText: "Phoenix unavailable",
+    };
+  }
+  if (phoenixStatus !== "ready") {
+    return {
+      totalText: "Loading total…",
+      phoenixText: "Phoenix loading…",
+    };
+  }
+  return {
+    totalText: formatUsdc(walletUsd + phoenixUsd),
+    phoenixText: `$${phoenixUsd.toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })} phoenix`,
+  };
+}
+
 export function shortAddress(value: string | null): string {
   const trimmed = String(value ?? "").trim();
   if (!trimmed) return "--";

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -70,9 +70,11 @@
     providePanelLayout,
   } from "$lib/terminal/layout";
   import {
+    accountFundsPresentation,
     aiErr,
     humanizeBalanceError,
     shortAddress,
+    type PhoenixFundsStatus,
     walletFundsLabel,
   } from "$lib/terminal/account-format";
   import {
@@ -548,6 +550,9 @@
   let solBalanceValue: number | null = null;
   let walletCopied = false;
   let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
+  let phoenixFundsStatus: PhoenixFundsStatus = "idle";
+  let phoenixFundsStatusAuthority = "";
+  let phoenixFundsStatusTimer: ReturnType<typeof setTimeout> | null = null;
   let agentCustodyAddress: string | null = null;
   let agentCustodySolText = "-- SOL";
   let agentCustodySpendableLamports = 0;
@@ -1057,13 +1062,13 @@
   // account dropdown row shows the wallet/phoenix split underneath.
   $: phoenixTotalCollateral =
     phoenixTrader?.totalCollateralUsd ?? phoenixCollateral;
-  $: totalFundsText =
-    usdcBalanceValue === null
-      ? usdcBalanceText
-      : `${(usdcBalanceValue + phoenixTotalCollateral).toLocaleString(undefined, {
-          minimumFractionDigits: 2,
-          maximumFractionDigits: 2,
-        })} USDC`;
+  $: fundsPresentation = accountFundsPresentation({
+    walletUsd: usdcBalanceValue,
+    walletText: usdcBalanceText,
+    phoenixUsd: phoenixTotalCollateral,
+    phoenixStatus: paperMode || livePhoenixTrader ? "ready" : phoenixFundsStatus,
+  });
+  $: totalFundsText = fundsPresentation.totalText;
   $: balanceText = walletFundsLabel(
     $privyAuth,
     walletBalanceStatus,
@@ -1112,9 +1117,11 @@
   let refreshedAuthority: string | null = null;
   $: if (phoenixAuthority && refreshedAuthority !== phoenixAuthority) {
     refreshedAuthority = phoenixAuthority;
+    beginPhoenixFundsLoad(phoenixAuthority);
     void refreshPhoenixTrader();
   } else if (!phoenixAuthority) {
     refreshedAuthority = null;
+    clearPhoenixFundsLoad();
   }
   $: if (!paperMode && phoenixAuthority)
     void ensurePhoenixOnboarding(phoenixAuthority, liveExecutionEpoch);
@@ -2110,6 +2117,7 @@
       if (fundsPollTimer !== null) window.clearInterval(fundsPollTimer);
       if (wizardPollTimer !== null) window.clearInterval(wizardPollTimer);
       if (copyResetTimer) clearTimeout(copyResetTimer);
+      if (phoenixFundsStatusTimer) clearTimeout(phoenixFundsStatusTimer);
       spotTicket.dispose();
       if (spotChartTimer) clearInterval(spotChartTimer);
       if (structureTimer !== null) clearTimeout(structureTimer);
@@ -3186,6 +3194,50 @@
   }
 
   // ── Phoenix venue actions ─────────────────────────────────────────
+  function clearPhoenixFundsStatusTimer(): void {
+    if (!phoenixFundsStatusTimer) return;
+    clearTimeout(phoenixFundsStatusTimer);
+    phoenixFundsStatusTimer = null;
+  }
+
+  function clearPhoenixFundsLoad(): void {
+    clearPhoenixFundsStatusTimer();
+    phoenixFundsStatusAuthority = "";
+    phoenixFundsStatus = "idle";
+  }
+
+  function beginPhoenixFundsLoad(authority: string, force = false): void {
+    if (!authority) return;
+    if (!force && livePhoenixTrader) {
+      phoenixFundsStatusAuthority = authority;
+      phoenixFundsStatus = "ready";
+      return;
+    }
+    clearPhoenixFundsStatusTimer();
+    phoenixFundsStatusAuthority = authority;
+    phoenixFundsStatus = "loading";
+    // A slow Phoenix/RPC request must not leave the account header claiming
+    // to load forever. Late responses still land and replace this state.
+    phoenixFundsStatusTimer = setTimeout(() => {
+      if (
+        phoenixFundsStatusAuthority === authority &&
+        phoenixFundsStatus === "loading"
+      ) {
+        phoenixFundsStatus = "error";
+      }
+      phoenixFundsStatusTimer = null;
+    }, 8_000);
+  }
+
+  function settlePhoenixFundsLoad(
+    authority: string,
+    status: "ready" | "error",
+  ): void {
+    if (phoenixFundsStatusAuthority !== authority) return;
+    clearPhoenixFundsStatusTimer();
+    phoenixFundsStatus = status;
+  }
+
   async function refreshPhoenixTrader(): Promise<void> {
     const authority = phoenixAuthority;
     if (!authority) return;
@@ -3195,20 +3247,18 @@
       // Phoenix indexer lags — without the overlay, "Deposit first" kept
       // showing after a successful deposit.
       const trade = await tradeModule();
-      const [state, chainCollateralUsd] = await Promise.all([
+      const [apiState, chainCollateralUsd] = await Promise.all([
         trade.fetchPhoenixTraderState(authority),
         trade.fetchOnChainCollateralUsd(solanaRpcUrl(), authority),
       ]);
-      if (chainCollateralUsd !== null) {
-        state.registered = true;
-        state.collateralUsd = chainCollateralUsd;
-        state.chainVerified = true;
-      } else {
-        state.chainVerified = false;
-      }
+      const state =
+        chainCollateralUsd !== null
+          ? trade.overlayOnChainCollateral(apiState, chainCollateralUsd)
+          : { ...apiState, chainVerified: false };
       // Store is keyed per wallet, so a mid-flight switch cannot
       // cross-pollinate — record under the authority we fetched for.
       recordSnapshot(authority, state);
+      settlePhoenixFundsLoad(authority, "ready");
       // Day P&L rides the same refresh: sample equity as the terminal
       // shows it (collateral + live uPnL), no extra RPC. Wait a tick so
       // the snapshot-derived reactives have settled first.
@@ -3221,6 +3271,7 @@
       }
     } catch {
       // transient API hiccup — keep last state
+      if (!livePhoenixTrader) settlePhoenixFundsLoad(authority, "error");
     }
   }
 
@@ -6414,7 +6465,8 @@
       status: walletBalanceStatus,
       error: walletBalanceError,
       usdcValue: usdcBalanceValue,
-      phoenixCollateral: phoenixTotalCollateral,
+      phoenixStatus: paperMode || livePhoenixTrader ? "ready" : phoenixFundsStatus,
+      phoenixText: fundsPresentation.phoenixText,
       screen: walletScreen,
       whitelisted: phoenixWhitelisted,
       copied: walletCopied,
@@ -6440,6 +6492,7 @@
     oncopyaddress={copyWalletAddress}
     onrefreshbalances={() => {
       void refreshWalletBalance();
+      if (phoenixAuthority) beginPhoenixFundsLoad(phoenixAuthority, true);
       void refreshPhoenixTrader();
       void refreshAgentCustodyWallet();
     }}

--- a/apps/portal/src/routes/terminal/agent/+page.svelte
+++ b/apps/portal/src/routes/terminal/agent/+page.svelte
@@ -146,4 +146,10 @@
     flex-direction: column;
     overflow: hidden;
   }
+
+  @media (max-width: 1100px) {
+    .agent-nav {
+      display: none;
+    }
+  }
 </style>

--- a/apps/portal/src/routes/terminal/components/AgentChat.svelte
+++ b/apps/portal/src/routes/terminal/components/AgentChat.svelte
@@ -394,6 +394,12 @@
   <header class="agent-head">
     <div class="agent-head-left">
       <div class="agent-title-row">
+        {#if layout === "page"}
+          <span class="compact-page-id">
+            <a href="/terminal">Harness</a>
+            <span aria-hidden="true">/</span>
+          </span>
+        {/if}
         <span class="agent-title">Agent</span>
         <span class="tag durable">
           DURABLE{pendingRequestCount ? ` · ${pendingRequestCount}` : ""}
@@ -425,6 +431,18 @@
       </div>
     </div>
     <div class="agent-head-right">
+      {#if layout === "page"}
+        <a class="ghost compact-page-action" href="/terminal">Terminal</a>
+        {#if !$privyAuth.authenticated && $privyAuth.status !== "loading"}
+          <button
+            class="ghost compact-page-action"
+            type="button"
+            onclick={onRequestAuth}
+          >
+            Sign in
+          </button>
+        {/if}
+      {/if}
       <button
         class="ghost icon"
         class:active={historyOpen}
@@ -734,6 +752,26 @@
     font-size: 0.62rem;
     font-weight: 800;
     letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .compact-page-id,
+  .compact-page-action {
+    display: none;
+  }
+
+  .compact-page-id {
+    align-items: center;
+    gap: 0.4rem;
+    color: var(--faint);
+  }
+
+  .compact-page-id a {
+    color: var(--accent);
+    font-size: 0.62rem;
+    font-weight: 800;
+    letter-spacing: 0.1em;
+    text-decoration: none;
     text-transform: uppercase;
   }
 
@@ -1089,6 +1127,39 @@
   }
 
   @media (max-width: 1100px) {
+    .layout-page .agent-head {
+      justify-content: flex-start;
+      gap: 0.45rem;
+      min-height: 3.1rem;
+      padding: 0.55rem 0.7rem;
+      overflow-x: auto;
+      overflow-y: hidden;
+    }
+
+    .layout-page .agent-head-left,
+    .layout-page .agent-head-right {
+      flex: 0 0 auto;
+    }
+
+    .layout-page .agent-head-right {
+      margin-left: auto;
+    }
+
+    .layout-page .compact-page-id,
+    .layout-page .compact-page-action {
+      display: inline-flex;
+    }
+
+    .layout-page .compact-page-action {
+      align-items: center;
+      justify-content: center;
+      text-decoration: none;
+    }
+
+    .layout-page .picker button {
+      min-width: 4.2rem;
+    }
+
     .layout-dock {
       /* Narrow: full-width sheet under topbar, still above status line. */
       position: fixed;

--- a/apps/portal/src/routes/terminal/components/Topbar.svelte
+++ b/apps/portal/src/routes/terminal/components/Topbar.svelte
@@ -5,6 +5,7 @@
   import {
     shortAddress,
     shortEmail,
+    type PhoenixFundsStatus,
     walletStatusText,
   } from "$lib/terminal/account-format";
   import { alertsStore } from "$lib/terminal/alerts";
@@ -48,7 +49,8 @@
       status: "idle" | "loading" | "ready" | "error";
       error: string;
       usdcValue: number | null;
-      phoenixCollateral: number;
+      phoenixStatus: PhoenixFundsStatus;
+      phoenixText: string;
       screen: { flagged: boolean; checked: boolean };
       whitelisted: boolean | null;
       copied: boolean;
@@ -88,7 +90,8 @@
   const walletBalanceStatus = $derived(wallet.status);
   const walletBalanceError = $derived(wallet.error);
   const usdcBalanceValue = $derived(wallet.usdcValue);
-  const phoenixTotalCollateral = $derived(wallet.phoenixCollateral);
+  const phoenixFundsStatus = $derived(wallet.phoenixStatus);
+  const phoenixFundsText = $derived(wallet.phoenixText);
   const walletScreen = $derived(wallet.screen);
   const phoenixWhitelisted = $derived(wallet.whitelisted);
   const walletCopied = $derived(wallet.copied);
@@ -299,19 +302,19 @@
               <span class="account-row-label">Funds</span>
               <span class="account-row-value mono">
                 {balanceText}
-                {#if phoenixTotalCollateral > 0 && usdcBalanceValue !== null}
+                {#if usdcBalanceValue !== null}
                   <small class="funds-split">
-                    {money(usdcBalanceValue, 2)} wallet · {money(phoenixTotalCollateral, 2)} phoenix
+                    {money(usdcBalanceValue, 2)} wallet · {phoenixFundsText}
                   </small>
                 {/if}
               </span>
               <button
                 class="row-action"
                 type="button"
-                disabled={!$privyAuth.walletAddress || walletBalanceStatus === "loading"}
+                disabled={!$privyAuth.walletAddress || walletBalanceStatus === "loading" || phoenixFundsStatus === "loading"}
                 onclick={onrefreshbalances}
               >
-                {walletBalanceStatus === "loading" ? "…" : "Refresh"}
+                {walletBalanceStatus === "loading" || phoenixFundsStatus === "loading" ? "…" : "Refresh"}
               </button>
             </div>
 


### PR DESCRIPTION
## What changed

- Reconcile Phoenix's on-chain parent collateral into the all-subaccount total while preserving isolated margin.
- Keep the total funds label pending until both wallet and Phoenix values are known.
- After 8 seconds, show the wallet balance explicitly as partial with Phoenix unavailable instead of loading forever.
- Collapse the full-page agent's navigation and controls into one compact row at the existing 1100px breakpoint.

## Root cause

The chain overlay updated `collateralUsd` but left the indexer's stale `totalCollateralUsd` untouched. The header preferred that stale total, so a confirmed Phoenix deposit could be absent until the indexer caught up. Separately, a missing Phoenix snapshot was represented as zero, allowing the fast wallet balance to be presented as the complete account total.

## Validation

- `bun run test` — 547 tests passed
- `bun run typecheck` — 0 errors, 0 warnings
- `bun run build`
- `bun run lint`
- Local browser smoke at `/terminal/agent` with no console errors