### PR TITLE
Refactor agent into a persistent trading workspace

### DIFF
--- a/apps/portal/agent/instructions.md
+++ b/apps/portal/agent/instructions.md
@@ -26,6 +26,11 @@ action is involved.
   Load `plan-trade` for that action. If the user delegated a missing choice,
   make a conservative choice; otherwise ask one short question only when the
   answer materially changes risk.
+- In paper mode, an `execute_trade` result with `pending-client` means the
+  browser is applying the already-approved action to its local ledger. Do not
+  ask for another confirmation or tell the user to say “go.” State that the
+  Receipt card will reconcile the final paper outcome and treat that card as
+  authoritative.
 - Load `create-routine` only for recurring reviews, alerts, or unattended
   management.
 - The user may install extra Agent Skills (Claude `SKILL.md` / OpenAI Codex

--- a/apps/portal/agent/instructions.md
+++ b/apps/portal/agent/instructions.md
@@ -38,6 +38,29 @@ action is involved.
   load it and use `install_user_skill` only after the user has clearly asked
   to create or install the described skill.
 
+## Run a trading task loop
+
+For any request with more than one meaningful step, operate as a harness:
+
+1. **Inspect** — establish the requested account mode, policy, fresh market
+   facts, current exposure, and the exact objective. Do not fetch data that
+   cannot change the decision.
+2. **Plan** — choose a short, ordered path with a falsifiable trade thesis,
+   invalidation, bounded size, protection, and a verification step. A plan is
+   working state, not transaction authority.
+3. **Act** — execute only the next justified action. In Ask mode, park cleanly
+   at the approval boundary. In Auto mode, continue within server policy.
+4. **Verify** — reconcile the tool Receipt against fresh account state. If the
+   outcome is unknown or observations contradict the plan, stop and explain;
+   never retry a money action speculatively.
+5. **Report** — lead with the outcome, then the Receipt or current state,
+   remaining exposure, invalidation, and the one most useful next action.
+
+Re-plan when a tool result invalidates an assumption. Do not expose private
+chain-of-thought; show only concise decisions, evidence, and work status. Treat
+each new user message as an update to the current objective unless they clearly
+start a different task.
+
 ## Hard boundaries
 
 - Never invent quotes, account state, signatures, or fills.

--- a/apps/portal/src/lib/agent/commands.test.ts
+++ b/apps/portal/src/lib/agent/commands.test.ts
@@ -5,7 +5,10 @@ describe("agent commands", () => {
   test("recognizes exact workspace commands without swallowing normal prompts", () => {
     expect(parseAgentCommand(" /new ")).toEqual({ name: "new" });
     expect(parseAgentCommand("/auto")).toEqual({ name: "mode", mode: "auto" });
-    expect(parseAgentCommand("/pause")).toEqual({ name: "paused", paused: true });
+    expect(parseAgentCommand("/pause")).toEqual({
+      name: "paused",
+      paused: true,
+    });
     expect(parseAgentCommand("/new position on SOL")).toBeNull();
     expect(parseAgentCommand("explain /auto mode")).toBeNull();
   });

--- a/apps/portal/src/lib/agent/commands.test.ts
+++ b/apps/portal/src/lib/agent/commands.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { parseAgentCommand } from "./commands";
+
+describe("agent commands", () => {
+  test("recognizes exact workspace commands without swallowing normal prompts", () => {
+    expect(parseAgentCommand(" /new ")).toEqual({ name: "new" });
+    expect(parseAgentCommand("/auto")).toEqual({ name: "mode", mode: "auto" });
+    expect(parseAgentCommand("/pause")).toEqual({ name: "paused", paused: true });
+    expect(parseAgentCommand("/new position on SOL")).toBeNull();
+    expect(parseAgentCommand("explain /auto mode")).toBeNull();
+  });
+});

--- a/apps/portal/src/lib/agent/commands.ts
+++ b/apps/portal/src/lib/agent/commands.ts
@@ -1,0 +1,29 @@
+import type { AgentMode } from "./modes";
+
+export type AgentCommand =
+  | { name: "new" | "threads" | "settings" }
+  | { name: "mode"; mode: AgentMode }
+  | { name: "paused"; paused: boolean };
+
+export function parseAgentCommand(value: string): AgentCommand | null {
+  switch (value.trim().toLowerCase()) {
+    case "/new":
+      return { name: "new" };
+    case "/threads":
+      return { name: "threads" };
+    case "/settings":
+      return { name: "settings" };
+    case "/observe":
+      return { name: "mode", mode: "observe" };
+    case "/ask":
+      return { name: "mode", mode: "ask" };
+    case "/auto":
+      return { name: "mode", mode: "auto" };
+    case "/pause":
+      return { name: "paused", paused: true };
+    case "/resume":
+      return { name: "paused", paused: false };
+    default:
+      return null;
+  }
+}

--- a/apps/portal/src/lib/agent/conversation.svelte.ts
+++ b/apps/portal/src/lib/agent/conversation.svelte.ts
@@ -10,7 +10,7 @@ import {
   type EveMessagePart,
   useEveAgent,
 } from "eve/svelte";
-import { onMount } from "svelte";
+import { onDestroy, onMount } from "svelte";
 import { AGENT_ACTION_META, type AgentActionName } from "./actions";
 import {
   activateAgentConversation,
@@ -32,6 +32,10 @@ import {
   type AgentThreadStorage,
   prepareAgentThreadForResume,
 } from "./thread-cache";
+import {
+  createTurnCancellation,
+  type TurnCancellationSnapshot,
+} from "./turn-cancellation";
 
 export type AgentConversationOptions = {
   buildClientContext: () => AgentClientContext;
@@ -97,8 +101,11 @@ export function createAgentConversation(options: AgentConversationOptions) {
   );
   let reconnecting = $state(isSessionState(restoredThread?.session));
   let recoveryError = $state("");
+  let cancellation = $state<TurnCancellationSnapshot>({ state: "idle" });
+  let turnCancellation!: ReturnType<typeof createTurnCancellation>;
   let eve = $state.raw(createAgent(restoredThread));
   let recoveryController: AbortController | null = null;
+  let persistTimer: ReturnType<typeof setTimeout> | null = null;
 
   const working = $derived(
     eve.status === "submitted" || eve.status === "streaming",
@@ -118,7 +125,10 @@ export function createAgentConversation(options: AgentConversationOptions) {
 
   $effect(() => {
     if (!options.storage) return;
-    persistCurrent();
+    void eve.session;
+    void eve.events.length;
+    void paperActionReceipts;
+    schedulePersist();
   });
 
   $effect(() => {
@@ -149,12 +159,34 @@ export function createAgentConversation(options: AgentConversationOptions) {
     return () => recoveryController?.abort();
   });
 
+  onDestroy(() => {
+    recoveryController?.abort();
+    persistCurrent();
+    eve.stop();
+  });
+
   function createAgent(thread: AgentThreadSnapshot | null) {
-    return useEveAgent({
-      initialSession: thread?.session as never,
-      initialEvents: thread?.events as never,
+    const session = new Client({
+      host: "",
       headers: options.headers,
+      preserveCompletedSessions: true,
+    }).session(isSessionState(thread?.session) ? thread.session : undefined);
+    const cancellationControl = createTurnCancellation({
+      cancel: (turnId) => session.cancel({ turnId }),
+      onChange: (snapshot) => {
+        cancellation = snapshot;
+      },
+    });
+    turnCancellation = cancellationControl;
+    return useEveAgent({
+      session,
+      initialEvents: thread?.events as never,
+      onEvent(event) {
+        cancellationControl.observe(event);
+      },
       onFinish(snapshot) {
+        cancellationControl.reset();
+        cancelScheduledPersistence();
         persistSnapshot(snapshot.session, snapshot.events);
       },
     });
@@ -230,10 +262,26 @@ export function createAgentConversation(options: AgentConversationOptions) {
   }
 
   function persistCurrent(): void {
+    cancelScheduledPersistence();
     persistSnapshot(eve.session, eve.events);
   }
 
+  function schedulePersist(): void {
+    if (persistTimer !== null) return;
+    persistTimer = setTimeout(() => {
+      persistTimer = null;
+      persistSnapshot(eve.session, eve.events);
+    }, 150);
+  }
+
+  function cancelScheduledPersistence(): void {
+    if (persistTimer === null) return;
+    clearTimeout(persistTimer);
+    persistTimer = null;
+  }
+
   function send(message: string): Promise<void> {
+    turnCancellation.reset();
     if (conversationTitle === "New conversation") {
       conversationTitle = titleFromMessage(message);
       persistCurrent();
@@ -245,6 +293,7 @@ export function createAgentConversation(options: AgentConversationOptions) {
   }
 
   function respond(requestId: string, approved: boolean): Promise<void> {
+    turnCancellation.reset();
     return eve.send({
       inputResponses: [{ requestId, optionId: approved ? "approve" : "deny" }],
     });
@@ -357,6 +406,15 @@ export function createAgentConversation(options: AgentConversationOptions) {
     get conversations() {
       return conversations;
     },
+    get conversationTitle() {
+      return conversationTitle;
+    },
+    get cancellationError() {
+      return cancellation.error ?? "";
+    },
+    get cancellationState() {
+      return cancellation.state;
+    },
     get error() {
       return eve.error;
     },
@@ -382,6 +440,10 @@ export function createAgentConversation(options: AgentConversationOptions) {
       return paperActionReceipts[toolCallId];
     },
     archiveConversation,
+    cancel() {
+      if (!working) return;
+      turnCancellation.request();
+    },
     newConversation,
     persist: persistCurrent,
     restoreConversation,

--- a/apps/portal/src/lib/agent/conversation.svelte.ts
+++ b/apps/portal/src/lib/agent/conversation.svelte.ts
@@ -306,7 +306,9 @@ export function createAgentConversation(options: AgentConversationOptions) {
   }
 
   function respond(requestId: string, approved: boolean): Promise<void> {
-    turnCancellation.reset();
+    // An input response resumes the parked durable turn. Keep its observed
+    // turn id so Stop can still cancel the resumed execution.
+    turnCancellation.resume();
     return eve.send({
       inputResponses: [{ requestId, optionId: approved ? "approve" : "deny" }],
     });

--- a/apps/portal/src/lib/agent/conversation.svelte.ts
+++ b/apps/portal/src/lib/agent/conversation.svelte.ts
@@ -95,6 +95,11 @@ export function createAgentConversation(options: AgentConversationOptions) {
   let paperActionReceipts = $state<Record<string, AgentPaperActionReceipt>>({
     ...(restoredThread?.paperActionReceipts ?? {}),
   });
+  let answeredToolCallIds = $state<Record<string, true>>(
+    Object.fromEntries(
+      (restoredThread?.answeredToolCallIds ?? []).map((callId) => [callId, true]),
+    ),
+  );
   const paperActionRuns = new Set<string>(
     restoredThread?.paperActionRuns ??
       Object.keys(restoredThread?.paperActionReceipts ?? {}),
@@ -111,7 +116,11 @@ export function createAgentConversation(options: AgentConversationOptions) {
     eve.status === "submitted" || eve.status === "streaming",
   );
   const busy = $derived(reconnecting || recoveryError.length > 0 || working);
-  const messages = $derived(eve.data.messages.map(projectConversationMessage));
+  const messages = $derived(
+    eve.data.messages.map((message) =>
+      projectConversationMessage(message, answeredToolCallIds),
+    ),
+  );
   const pendingRequestCount = $derived(
     messages.reduce(
       (count, message) =>
@@ -250,6 +259,7 @@ export function createAgentConversation(options: AgentConversationOptions) {
         thread: {
           session,
           events,
+          answeredToolCallIds: Object.keys(answeredToolCallIds),
           paperActionRuns: [...paperActionRuns],
           paperActionReceipts,
         },
@@ -282,7 +292,10 @@ export function createAgentConversation(options: AgentConversationOptions) {
 
   function send(message: string): Promise<void> {
     turnCancellation.reset();
-    if (conversationTitle === "New conversation") {
+    const hasUserMessage = eve.data.messages.some(
+      (conversationMessage) => conversationMessage.role === "user",
+    );
+    if (!hasUserMessage) {
       conversationTitle = titleFromMessage(message);
       persistCurrent();
     }
@@ -299,12 +312,26 @@ export function createAgentConversation(options: AgentConversationOptions) {
     });
   }
 
-  function respondToTool(toolCallId: string, approved: boolean): Promise<void> {
+  async function respondToTool(
+    toolCallId: string,
+    approved: boolean,
+  ): Promise<void> {
     const requestId = eve.data.messages
       .flatMap((message) => message.parts.filter(isDynamicToolPart))
       .find((part) => part.toolCallId === toolCallId)?.toolMetadata?.eve
       ?.inputRequest?.requestId;
-    return requestId ? respond(requestId, approved) : Promise.resolve();
+    if (!requestId || answeredToolCallIds[toolCallId]) return;
+    answeredToolCallIds = { ...answeredToolCallIds, [toolCallId]: true };
+    persistCurrent();
+    try {
+      await respond(requestId, approved);
+    } catch (error) {
+      const nextAnswered = { ...answeredToolCallIds };
+      delete nextAnswered[toolCallId];
+      answeredToolCallIds = nextAnswered;
+      persistCurrent();
+      throw error;
+    }
   }
 
   function newConversation(): void {
@@ -375,6 +402,9 @@ export function createAgentConversation(options: AgentConversationOptions) {
     activeConversationId = record.id;
     conversationTitle = record.title;
     paperActionReceipts = { ...(prepared.paperActionReceipts ?? {}) };
+    answeredToolCallIds = Object.fromEntries(
+      (prepared.answeredToolCallIds ?? []).map((callId) => [callId, true]),
+    );
     paperActionRuns.clear();
     for (const callId of prepared.paperActionRuns ?? []) {
       paperActionRuns.add(callId);
@@ -453,18 +483,24 @@ export function createAgentConversation(options: AgentConversationOptions) {
   };
 }
 
-function projectConversationMessage(message: {
-  role: string;
-  parts: readonly EveMessagePart[];
-}): AgentConversationMessage {
+function projectConversationMessage(
+  message: {
+    role: string;
+    parts: readonly EveMessagePart[];
+  },
+  answeredToolCallIds: Readonly<Record<string, true>>,
+): AgentConversationMessage {
   return {
     role: message.role,
-    parts: message.parts.flatMap(projectConversationPart),
+    parts: message.parts.flatMap((part) =>
+      projectConversationPart(part, answeredToolCallIds),
+    ),
   };
 }
 
 function projectConversationPart(
   part: EveMessagePart,
+  answeredToolCallIds: Readonly<Record<string, true>>,
 ): AgentConversationPart[] {
   if (part.type === "text") {
     return [{ type: "text", text: part.text }];
@@ -479,7 +515,9 @@ function projectConversationPart(
       input: part.input,
       output: part.output,
       ...(part.errorText ? { errorText: part.errorText } : {}),
-      approvalPending: Boolean(part.toolMetadata?.eve?.inputRequest),
+      approvalPending:
+        Boolean(part.toolMetadata?.eve?.inputRequest) &&
+        !answeredToolCallIds[part.toolCallId],
     },
   ];
 }

--- a/apps/portal/src/lib/agent/conversation.svelte.ts
+++ b/apps/portal/src/lib/agent/conversation.svelte.ts
@@ -97,7 +97,10 @@ export function createAgentConversation(options: AgentConversationOptions) {
   });
   let answeredToolCallIds = $state<Record<string, true>>(
     Object.fromEntries(
-      (restoredThread?.answeredToolCallIds ?? []).map((callId) => [callId, true]),
+      (restoredThread?.answeredToolCallIds ?? []).map((callId) => [
+        callId,
+        true,
+      ]),
     ),
   );
   const paperActionRuns = new Set<string>(

--- a/apps/portal/src/lib/agent/paper-host.ts
+++ b/apps/portal/src/lib/agent/paper-host.ts
@@ -2,7 +2,7 @@
 // Live signing stays on /terminal — this host mutates the shared paper ledger.
 
 import { get } from "svelte/store";
-import { buildDeskContext } from "$lib/chat-context";
+import { buildStandaloneDeskContext } from "$lib/chat-context";
 import {
   DEFAULT_PHOENIX_SYMBOL,
   fetchPhoenixCandles,
@@ -69,22 +69,25 @@ async function resolvePrice(
   return null;
 }
 
-export function buildPaperDeskContext(): Record<string, unknown> {
+export function buildAgentPageDeskContext(
+  accountMode: "paper" | "live",
+): Record<string, unknown> {
   const ledger = get(paperLedger);
   const trader = ledgerToTraderState(ledger);
-  return buildDeskContext({
-    accountMode: "paper",
+  return buildStandaloneDeskContext({
+    accountMode,
     symbol: readPrefsSymbol(),
     timeframe: readPrefsTimeframe(),
-    positions: trader.positions,
-    openOrders: trader.orders,
-    dayPnlUsd: null,
-    equityUsd: trader.totalCollateralUsd,
-    monitorRows: [],
+    paperPositions: trader.positions,
+    paperOpenOrders: trader.orders,
+    paperEquityUsd: trader.totalCollateralUsd,
     watchlist: readWatchlist(),
-    headlines: [],
     nowMs: Date.now(),
   });
+}
+
+export function buildPaperDeskContext(): Record<string, unknown> {
+  return buildAgentPageDeskContext("paper");
 }
 
 export function createPaperAgentHost(): AgentHostHandlers {

--- a/apps/portal/src/lib/agent/run-visibility.test.ts
+++ b/apps/portal/src/lib/agent/run-visibility.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { backgroundRunMode } from "./run-visibility";
+
+describe("background agent run visibility", () => {
+  test("surfaces a LIVE run after the terminal switches to PAPER", () => {
+    expect(
+      backgroundRunMode("paper", {
+        live: true,
+        paper: false,
+      }),
+    ).toBe("live");
+  });
+
+  test("surfaces a PAPER run after the terminal switches to LIVE", () => {
+    expect(
+      backgroundRunMode("live", {
+        live: false,
+        paper: true,
+      }),
+    ).toBe("paper");
+  });
+
+  test("does not duplicate the active workspace status", () => {
+    expect(
+      backgroundRunMode("paper", {
+        live: false,
+        paper: true,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/portal/src/lib/agent/run-visibility.ts
+++ b/apps/portal/src/lib/agent/run-visibility.ts
@@ -1,0 +1,27 @@
+export type AgentAccountMode = "live" | "paper";
+
+export type AgentRunStatus = {
+  active: boolean;
+  canCancel: boolean;
+  label: string;
+  stopping: boolean;
+  cancel: () => void;
+};
+
+export function backgroundRunMode(
+  activeMode: AgentAccountMode,
+  running: Readonly<Record<AgentAccountMode, boolean>>,
+): AgentAccountMode | null {
+  const inactiveMode = activeMode === "paper" ? "live" : "paper";
+  return running[inactiveMode] ? inactiveMode : null;
+}
+
+export function idleAgentRunStatus(): AgentRunStatus {
+  return {
+    active: false,
+    canCancel: false,
+    label: "Ready",
+    stopping: false,
+    cancel: () => undefined,
+  };
+}

--- a/apps/portal/src/lib/agent/scoped-storage.test.ts
+++ b/apps/portal/src/lib/agent/scoped-storage.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import {
-  scopeAgentStorage,
-  type AgentStorageScope,
-} from "./scoped-storage";
+import { type AgentStorageScope, scopeAgentStorage } from "./scoped-storage";
 import type { AgentThreadStorage } from "./thread-cache";
 
 function memoryStorage(): AgentThreadStorage {

--- a/apps/portal/src/lib/agent/scoped-storage.test.ts
+++ b/apps/portal/src/lib/agent/scoped-storage.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import {
+  scopeAgentStorage,
+  type AgentStorageScope,
+} from "./scoped-storage";
+import type { AgentThreadStorage } from "./thread-cache";
+
+function memoryStorage(): AgentThreadStorage {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+    removeItem: (key) => values.delete(key),
+  };
+}
+
+const paper: AgentStorageScope = {
+  accountMode: "paper",
+  ownerId: "did:privy:trader-1",
+};
+
+describe("scoped agent storage", () => {
+  test("keeps PAPER and LIVE conversations isolated for the same owner", () => {
+    const storage = memoryStorage();
+    const paperStorage = scopeAgentStorage(storage, paper);
+    const liveStorage = scopeAgentStorage(storage, {
+      ...paper,
+      accountMode: "live",
+    });
+
+    paperStorage.setItem("harness.eve.conversations.v1", "paper-history");
+    liveStorage.setItem("harness.eve.conversations.v1", "live-history");
+
+    expect(paperStorage.getItem("harness.eve.conversations.v1")).toBe(
+      "paper-history",
+    );
+    expect(liveStorage.getItem("harness.eve.conversations.v1")).toBe(
+      "live-history",
+    );
+  });
+
+  test("claims an existing unscoped history once without copying it into LIVE", () => {
+    const storage = memoryStorage();
+    storage.setItem("harness.eve.conversations.v1", "existing-history");
+    const paperStorage = scopeAgentStorage(storage, paper);
+    const liveStorage = scopeAgentStorage(storage, {
+      ...paper,
+      accountMode: "live",
+    });
+
+    expect(liveStorage.getItem("harness.eve.conversations.v1")).toBeNull();
+    expect(paperStorage.getItem("harness.eve.conversations.v1")).toBe(
+      "existing-history",
+    );
+    expect(storage.getItem("harness.eve.conversations.v1")).toBeNull();
+  });
+});

--- a/apps/portal/src/lib/agent/scoped-storage.ts
+++ b/apps/portal/src/lib/agent/scoped-storage.ts
@@ -1,0 +1,29 @@
+import type { AgentThreadStorage } from "./thread-cache";
+
+export type AgentStorageScope = {
+  ownerId: string;
+  accountMode: "paper" | "live";
+};
+
+export function scopeAgentStorage(
+  storage: AgentThreadStorage,
+  scope: AgentStorageScope,
+): AgentThreadStorage {
+  const prefix = `harness.agent.${encodeURIComponent(scope.ownerId)}.${scope.accountMode}.`;
+  return {
+    getItem: (key) => {
+      const scopedKey = `${prefix}${key}`;
+      const scopedValue = storage.getItem(scopedKey);
+      if (scopedValue !== null) return scopedValue;
+
+      if (scope.accountMode !== "paper") return null;
+      const legacyValue = storage.getItem(key);
+      if (legacyValue === null) return null;
+      storage.setItem(scopedKey, legacyValue);
+      storage.removeItem(key);
+      return legacyValue;
+    },
+    setItem: (key, value) => storage.setItem(`${prefix}${key}`, value),
+    removeItem: (key) => storage.removeItem(`${prefix}${key}`),
+  };
+}

--- a/apps/portal/src/lib/agent/scroll-policy.test.ts
+++ b/apps/portal/src/lib/agent/scroll-policy.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { isNearAgentTail } from "./scroll-policy";
+
+describe("agent scroll policy", () => {
+  test("sticks to streaming output while the reader is near the tail", () => {
+    expect(
+      isNearAgentTail({
+        scrollHeight: 1_000,
+        clientHeight: 500,
+        scrollTop: 430,
+      }),
+    ).toBe(true);
+  });
+
+  test("preserves the reader's position when they scroll into history", () => {
+    expect(
+      isNearAgentTail({
+        scrollHeight: 1_000,
+        clientHeight: 500,
+        scrollTop: 180,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/portal/src/lib/agent/scroll-policy.ts
+++ b/apps/portal/src/lib/agent/scroll-policy.ts
@@ -1,0 +1,9 @@
+export function isNearAgentTail(input: {
+  scrollHeight: number;
+  clientHeight: number;
+  scrollTop: number;
+  threshold?: number;
+}): boolean {
+  const remaining = input.scrollHeight - input.clientHeight - input.scrollTop;
+  return remaining <= (input.threshold ?? 96);
+}

--- a/apps/portal/src/lib/agent/thread-cache.test.ts
+++ b/apps/portal/src/lib/agent/thread-cache.test.ts
@@ -25,6 +25,7 @@ describe("agent thread cache", () => {
         { type: "user-message", id: "event-6", text: "Long SOL in paper mode" },
         { type: "assistant-message", id: "event-7", text: "Plan ready" },
       ],
+      answeredToolCallIds: ["approval-1"],
     };
 
     saveAgentThread(storage, thread);

--- a/apps/portal/src/lib/agent/thread-cache.ts
+++ b/apps/portal/src/lib/agent/thread-cache.ts
@@ -7,6 +7,7 @@ export interface AgentThreadStorage {
 export interface AgentThreadSnapshot {
   session: unknown;
   events: readonly unknown[];
+  answeredToolCallIds?: readonly string[];
   paperActionRuns?: readonly string[];
   paperActionReceipts?: Record<string, AgentPaperActionReceipt>;
 }
@@ -35,6 +36,9 @@ export function loadAgentThread(
     return {
       session: current.session,
       events: current.events,
+      ...(isStringArray(current.answeredToolCallIds)
+        ? { answeredToolCallIds: current.answeredToolCallIds }
+        : {}),
       ...(Array.isArray(current.paperActionRuns)
         ? { paperActionRuns: current.paperActionRuns }
         : {}),
@@ -67,10 +71,15 @@ export function saveAgentThread(
       version: 2,
       session: thread.session,
       events: thread.events,
+      answeredToolCallIds: thread.answeredToolCallIds,
       paperActionRuns: thread.paperActionRuns,
       paperActionReceipts: thread.paperActionReceipts,
     }),
   );
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
 }
 
 function parseReceiptMap(

--- a/apps/portal/src/lib/agent/thread-cache.ts
+++ b/apps/portal/src/lib/agent/thread-cache.ts
@@ -79,7 +79,9 @@ export function saveAgentThread(
 }
 
 function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+  return (
+    Array.isArray(value) && value.every((entry) => typeof entry === "string")
+  );
 }
 
 function parseReceiptMap(

--- a/apps/portal/src/lib/agent/turn-cancellation.test.ts
+++ b/apps/portal/src/lib/agent/turn-cancellation.test.ts
@@ -52,4 +52,27 @@ describe("turn cancellation", () => {
     expect(states).toEqual(["requested", "cancelling", "idle"]);
     expect(cancellation.snapshot()).toEqual({ state: "idle" });
   });
+
+  test("keeps the durable turn id when an approval resumes the same turn", async () => {
+    const calls: string[] = [];
+    const cancellation = createTurnCancellation({
+      cancel: async (turnId) => {
+        calls.push(turnId);
+      },
+    });
+
+    cancellation.observe({
+      type: "turn.started",
+      data: { turnId: "turn-awaiting-approval" },
+    });
+    cancellation.resume();
+    cancellation.request();
+    await cancellation.settled();
+
+    expect(calls).toEqual(["turn-awaiting-approval"]);
+    expect(cancellation.snapshot()).toMatchObject({
+      state: "cancelling",
+      turnId: "turn-awaiting-approval",
+    });
+  });
 });

--- a/apps/portal/src/lib/agent/turn-cancellation.test.ts
+++ b/apps/portal/src/lib/agent/turn-cancellation.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { createTurnCancellation } from "./turn-cancellation";
+
+describe("turn cancellation", () => {
+  test("queues an early Stop request and cancels once the turn id arrives", async () => {
+    const calls: string[] = [];
+    const states: string[] = [];
+    const cancellation = createTurnCancellation({
+      cancel: async (turnId) => {
+        calls.push(turnId);
+      },
+      onChange: (snapshot) => states.push(snapshot.state),
+    });
+
+    cancellation.request();
+    expect(cancellation.snapshot()).toMatchObject({ state: "requested" });
+    expect(calls).toEqual([]);
+
+    cancellation.observe({
+      type: "turn.started",
+      data: { turnId: "turn-42" },
+    });
+    await cancellation.settled();
+    cancellation.observe({
+      type: "turn.started",
+      data: { turnId: "turn-42" },
+    });
+
+    expect(calls).toEqual(["turn-42"]);
+    expect(states).toEqual(["requested", "cancelling"]);
+    expect(cancellation.snapshot()).toMatchObject({
+      state: "cancelling",
+      turnId: "turn-42",
+    });
+  });
+
+  test("returns to idle when the durable turn settles", async () => {
+    const states: string[] = [];
+    const cancellation = createTurnCancellation({
+      cancel: async () => undefined,
+      onChange: (snapshot) => states.push(snapshot.state),
+    });
+
+    cancellation.observe({
+      type: "turn.started",
+      data: { turnId: "turn-7" },
+    });
+    cancellation.request();
+    await cancellation.settled();
+    cancellation.observe({ type: "turn.cancelled" });
+
+    expect(states).toEqual(["requested", "cancelling", "idle"]);
+    expect(cancellation.snapshot()).toEqual({ state: "idle" });
+  });
+});

--- a/apps/portal/src/lib/agent/turn-cancellation.ts
+++ b/apps/portal/src/lib/agent/turn-cancellation.ts
@@ -97,10 +97,20 @@ export function createTurnCancellation(options: {
     emit();
   }
 
+  function resume(): void {
+    requested = false;
+    sentTurnId = undefined;
+    state = "idle";
+    error = undefined;
+    pending = null;
+    emit();
+  }
+
   return {
     observe,
     request,
     reset,
+    resume,
     settled: () => pending ?? Promise.resolve(),
     snapshot,
   };

--- a/apps/portal/src/lib/agent/turn-cancellation.ts
+++ b/apps/portal/src/lib/agent/turn-cancellation.ts
@@ -1,0 +1,107 @@
+export type TurnCancellationState =
+  | "idle"
+  | "requested"
+  | "cancelling"
+  | "error";
+
+export type TurnCancellationSnapshot = {
+  state: TurnCancellationState;
+  turnId?: string;
+  error?: string;
+};
+
+export type TurnCancellationEvent = {
+  type: string;
+  data?: unknown;
+};
+
+export function createTurnCancellation(options: {
+  cancel: (turnId: string) => Promise<unknown>;
+  onChange?: (snapshot: TurnCancellationSnapshot) => void;
+}) {
+  let requested = false;
+  let turnId: string | undefined;
+  let sentTurnId: string | undefined;
+  let state: TurnCancellationState = "idle";
+  let error: string | undefined;
+  let pending: Promise<void> | null = null;
+
+  function snapshot(): TurnCancellationSnapshot {
+    return {
+      state,
+      ...(turnId ? { turnId } : {}),
+      ...(error ? { error } : {}),
+    };
+  }
+
+  function emit(): void {
+    options.onChange?.(snapshot());
+  }
+
+  function dispatch(): void {
+    if (!requested || !turnId || sentTurnId === turnId) return;
+    sentTurnId = turnId;
+    state = "cancelling";
+    emit();
+    pending = options.cancel(turnId).then(
+      () => undefined,
+      (cause: unknown) => {
+        requested = false;
+        sentTurnId = undefined;
+        state = "error";
+        error =
+          cause instanceof Error ? cause.message : "Unable to stop this run.";
+        emit();
+      },
+    );
+  }
+
+  function observe(event: TurnCancellationEvent): void {
+    const eventTurnId =
+      typeof event.data === "object" &&
+      event.data !== null &&
+      "turnId" in event.data &&
+      typeof event.data.turnId === "string"
+        ? event.data.turnId
+        : undefined;
+    if (event.type === "turn.started" && eventTurnId) {
+      turnId = eventTurnId;
+      dispatch();
+      return;
+    }
+    if (
+      event.type === "turn.cancelled" ||
+      event.type === "turn.completed" ||
+      event.type === "turn.failed"
+    ) {
+      reset();
+    }
+  }
+
+  function request(): void {
+    if (state === "requested" || state === "cancelling") return;
+    requested = true;
+    error = undefined;
+    state = "requested";
+    emit();
+    dispatch();
+  }
+
+  function reset(): void {
+    requested = false;
+    turnId = undefined;
+    sentTurnId = undefined;
+    state = "idle";
+    error = undefined;
+    pending = null;
+    emit();
+  }
+
+  return {
+    observe,
+    request,
+    reset,
+    settled: () => pending ?? Promise.resolve(),
+    snapshot,
+  };
+}

--- a/apps/portal/src/lib/agent/workstream.test.ts
+++ b/apps/portal/src/lib/agent/workstream.test.ts
@@ -1,7 +1,20 @@
 import { describe, expect, test } from "bun:test";
-import { projectHarnessTool } from "./workstream";
+import { projectHarnessTool, settleIdleActivity } from "./workstream";
 
 describe("projectHarnessTool", () => {
+  test("settles generic activity that EVE leaves open after the session parks", () => {
+    const card = projectHarnessTool({
+      toolName: "load_skill",
+      state: "input-available",
+    });
+
+    expect(settleIdleActivity(card, true)).toMatchObject({
+      status: "success",
+      statusLabel: "done",
+      tone: "neutral",
+    });
+  });
+
   test("projects a standardized memory envelope", () => {
     const card = projectHarnessTool({
       toolName: "remember",

--- a/apps/portal/src/lib/agent/workstream.ts
+++ b/apps/portal/src/lib/agent/workstream.ts
@@ -94,6 +94,25 @@ export type HarnessPresentationEnvelope = {
   nextRunAt?: string;
 };
 
+export function settleIdleActivity(
+  card: WorkstreamCard,
+  sessionIdle: boolean,
+): WorkstreamCard {
+  if (
+    !sessionIdle ||
+    card.kind !== "activity" ||
+    !["pending", "running"].includes(card.status)
+  ) {
+    return card;
+  }
+  return {
+    ...card,
+    status: "success",
+    statusLabel: "done",
+    tone: "neutral",
+  };
+}
+
 export type HarnessToolProjectionInput = {
   toolName?: string;
   state?: string;

--- a/apps/portal/src/lib/chat-context.test.ts
+++ b/apps/portal/src/lib/chat-context.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { buildDeskContext, type DeskSnapshotInput } from "./chat-context";
+import {
+  buildDeskContext,
+  buildStandaloneDeskContext,
+  type DeskSnapshotInput,
+} from "./chat-context";
 
 function baseInput(
   overrides: Partial<DeskSnapshotInput> = {},
@@ -54,6 +58,29 @@ describe("buildDeskContext", () => {
     expect(
       buildDeskContext(baseInput({ accountMode: "paper" })).accountMode,
     ).toBe("paper");
+  });
+});
+
+describe("buildStandaloneDeskContext", () => {
+  test("does not present paper portfolio state as live account context", () => {
+    const output = buildStandaloneDeskContext({
+      accountMode: "live",
+      symbol: "SOL",
+      timeframe: "1h",
+      paperPositions: [{ symbol: "BTC", size: 2 }],
+      paperOpenOrders: [{ symbol: "ETH", side: "buy" }],
+      paperEquityUsd: 10_000,
+      watchlist: ["SOL", "BTC"],
+      nowMs: 1_752_936_120_000,
+    });
+
+    expect(output).toMatchObject({
+      accountMode: "live",
+      positions: [],
+      openOrders: [],
+      equityUsd: null,
+      portfolioContext: "fetch-required",
+    });
   });
 });
 

--- a/apps/portal/src/lib/chat-context.ts
+++ b/apps/portal/src/lib/chat-context.ts
@@ -28,6 +28,44 @@ export type DeskSnapshotInput = {
   nowMs: number;
 };
 
+export type StandaloneDeskSnapshotInput = {
+  symbol: string;
+  timeframe: string;
+  accountMode: "live" | "paper";
+  paperPositions: unknown[];
+  paperOpenOrders: unknown[];
+  paperEquityUsd: number | null;
+  watchlist: string[];
+  nowMs: number;
+};
+
+/**
+ * Builds context for the full agent workspace when the terminal page is not
+ * mounted. PAPER can use the persisted local ledger. LIVE deliberately carries
+ * no paper portfolio rows: the agent must fetch fresh server-owned state.
+ */
+export function buildStandaloneDeskContext(
+  input: StandaloneDeskSnapshotInput,
+): Record<string, unknown> {
+  const paper = input.accountMode === "paper";
+  return {
+    ...buildDeskContext({
+      symbol: input.symbol,
+      timeframe: input.timeframe,
+      accountMode: input.accountMode,
+      positions: paper ? input.paperPositions : [],
+      openOrders: paper ? input.paperOpenOrders : [],
+      dayPnlUsd: null,
+      equityUsd: paper ? input.paperEquityUsd : null,
+      monitorRows: [],
+      watchlist: input.watchlist,
+      headlines: [],
+      nowMs: input.nowMs,
+    }),
+    portfolioContext: paper ? "client-canonical" : "fetch-required",
+  };
+}
+
 /** Serialize the desk snapshot for the endpoint. Caps (exact): positions 20,
  * openOrders 20, monitorRows 12, watchlist 30, headlines 8, total JSON
  * length 10_000 chars — when over, drop monitorRows→headlines→openOrders

--- a/apps/portal/src/routes/terminal/agent/+page.svelte
+++ b/apps/portal/src/routes/terminal/agent/+page.svelte
@@ -4,13 +4,16 @@
   import { onMount } from "svelte";
   import { goto } from "$app/navigation";
   import { page } from "$app/state";
-  import AgentChat from "../components/AgentChat.svelte";
+  import AgentSurface from "../components/AgentSurface.svelte";
   import AuthModal from "../components/AuthModal.svelte";
   import {
     type AgentActionExecutor,
     executeAgentHostAction,
   } from "$lib/agent/host";
-  import { buildPaperDeskContext, createPaperAgentHost } from "$lib/agent/paper-host";
+  import {
+    buildAgentPageDeskContext,
+    createPaperAgentHost,
+  } from "$lib/agent/paper-host";
   import { chatState } from "$lib/chat";
   import { initializePrivyAuth, privyAuth } from "$lib/privy-auth";
 
@@ -58,8 +61,8 @@
   </nav>
 
   <main class="agent-main">
-    <AgentChat
-      buildContext={buildPaperDeskContext}
+    <AgentSurface
+      buildContext={() => buildAgentPageDeskContext(accountMode)}
       {executePaperAction}
       onRequestAuth={requestAuth}
       {accountMode}

--- a/apps/portal/src/routes/terminal/components/AgentChat.svelte
+++ b/apps/portal/src/routes/terminal/components/AgentChat.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
-  import { browser } from "$app/environment";
+  import { tick } from "svelte";
   import { closeChat } from "$lib/chat";
+  import { parseAgentCommand } from "$lib/agent/commands";
   import {
     type AgentClientContext,
     type AgentConversationPart,
     type AgentConversationToolPart,
     createAgentConversation,
   } from "$lib/agent/conversation.svelte";
+  import type { AgentThreadStorage } from "$lib/agent/thread-cache";
   import { AGENT_MODE_LABEL, type AgentMode } from "$lib/agent/modes";
   import {
     type AgentActionExecutor,
@@ -25,6 +27,7 @@
   import { getPrivyAccessToken, privyAuth } from "$lib/privy-auth";
   import { llmProfileHeaderValue } from "$lib/agent/llm-profile-selection";
   import { projectPriceQuote } from "$lib/agent/price-presentation";
+  import { isNearAgentTail } from "$lib/agent/scroll-policy";
   import {
     fetchAgentSkills,
     type SkillListItem,
@@ -34,8 +37,6 @@
     findSkillMention,
     insertSkillMention,
   } from "$lib/agent/skill-mentions";
-  import AgentConversationHistory from "./AgentConversationHistory.svelte";
-  import AgentSettingsModal from "./AgentSettingsModal.svelte";
   import AgentSkillPalette from "./AgentSkillPalette.svelte";
   import MarkdownMessage from "./MarkdownMessage.svelte";
   import PriceQuoteCard from "./PriceQuoteCard.svelte";
@@ -49,7 +50,9 @@
     focusComposerRequest = 0,
     executePaperAction = executeAgentAction,
     onExpand = undefined,
+    onCollapse = undefined,
     onClose = undefined,
+    storage,
   }: {
     buildContext: () => Record<string, unknown>;
     onRequestAuth: () => void;
@@ -58,15 +61,23 @@
     focusComposerRequest?: number;
     executePaperAction?: AgentActionExecutor;
     onExpand?: () => void;
+    onCollapse?: () => void;
     onClose?: () => void;
+    storage: AgentThreadStorage;
   } = $props();
 
   let draft = $state("");
   let scrollEl: HTMLDivElement | null = $state(null);
   let inputEl: HTMLTextAreaElement | null = $state(null);
   let settingsOpen = $state(false);
+  let SettingsModal = $state.raw<
+    typeof import("./AgentSettingsModal.svelte").default | null
+  >(null);
   let settingsSection = $state<"models" | "skills">("models");
   let historyOpen = $state(false);
+  let ConversationHistory = $state.raw<
+    typeof import("./AgentConversationHistory.svelte").default | null
+  >(null);
   let availableSkills = $state<SkillListItem[]>([]);
   let skillsLoading = $state(false);
   let skillsLoadedAt = 0;
@@ -75,14 +86,18 @@
   let skillQuery = $state("");
   let skillMentionStart = $state(-1);
   let skillPaletteIndex = $state(0);
+  let stickToTail = $state(true);
+  let showJumpToLatest = $state(false);
   let handledFocusComposerRequest = 0;
   const agentModes: AgentMode[] = ["observe", "ask", "auto"];
+  // AgentSurface remounts the workspace when its owner/account storage scope changes.
+  // svelte-ignore state_referenced_locally
   const conversation = createAgentConversation({
     buildClientContext,
     executePaperAction: (name, args) => executePaperAction(name, args),
     headers: resolveConversationHeaders,
     isPaper: () => accountMode === "paper",
-    storage: browser ? localStorage : undefined,
+    storage,
   });
 
   async function resolveConversationHeaders(): Promise<Record<string, string>> {
@@ -112,13 +127,37 @@
 
   const agentWorking = $derived(conversation.working);
   const busy = $derived(conversation.busy);
-  const pendingRequestCount = $derived(conversation.pendingRequestCount);
   const hasActiveTool = $derived(
     conversation.messages
       .flatMap((message) => message.parts.filter(isToolPart))
       .some((part) =>
         ["pending", "running", "waiting"].includes(projectPart(part).status),
       ),
+  );
+  const runLabel = $derived(
+    conversation.reconnecting
+      ? "Reconnecting"
+      : conversation.cancellationState === "requested" ||
+          conversation.cancellationState === "cancelling"
+        ? "Stopping"
+        : conversation.working
+          ? "Working"
+          : conversation.status === "error"
+            ? "Needs attention"
+            : "Ready",
+  );
+  const pendingApprovalItems = $derived.by(() =>
+    conversation.messages.flatMap((message) =>
+      message.parts
+        .filter(isToolPart)
+        .filter((part) => part.approvalPending)
+        .map((part) => ({
+          id: part.toolCallId,
+          toolName: part.toolName,
+          card: projectPart(part),
+          approvalPending: true,
+        })),
+    ),
   );
   const matchingSkills = $derived(
     filterMentionedSkills(availableSkills, skillQuery),
@@ -128,7 +167,8 @@
     if (!scrollEl) return;
     void conversation.messages.length;
     void conversation.status;
-    scrollEl.scrollTop = scrollEl.scrollHeight;
+    if (stickToTail) void scrollToLatest();
+    else showJumpToLatest = true;
   });
 
   $effect(() => {
@@ -154,7 +194,7 @@
     if (
       skillsLoading ||
       !$privyAuth.authenticated ||
-      (skillsLoadedAt > 0 && Date.now() - skillsLoadedAt < 5_000)
+      (skillsLoadedAt > 0 && Date.now() - skillsLoadedAt < 5 * 60_000)
     ) {
       return;
     }
@@ -218,16 +258,37 @@
     });
   }
 
-  function openSettings(section: "models" | "skills"): void {
+  async function openSettings(section: "models" | "skills"): Promise<void> {
     settingsSection = section;
     settingsOpen = true;
+    SettingsModal ??= (await import("./AgentSettingsModal.svelte")).default;
+  }
+
+  async function openHistory(): Promise<void> {
+    historyOpen = true;
+    ConversationHistory ??= (
+      await import("./AgentConversationHistory.svelte")
+    ).default;
   }
 
   function sendMessage(value: string): void {
     const text = value.trim();
     if (!text || busy) return;
+    const command = parseAgentCommand(text);
+    if (command) {
+      draft = "";
+      if (command.name === "new") newConversation();
+      else if (command.name === "threads") void openHistory();
+      else if (command.name === "settings") void openSettings("models");
+      else if (command.name === "mode") setAgentMode(command.mode);
+      else if (command.name === "paused") setAgentPaused(command.paused);
+      inputEl?.focus();
+      return;
+    }
     closeSkillPalette();
     draft = "";
+    stickToTail = true;
+    showJumpToLatest = false;
     void conversation.send(text);
     inputEl?.focus();
   }
@@ -370,6 +431,31 @@
 
   function newConversation(): void {
     conversation.newConversation();
+    stickToTail = true;
+    showJumpToLatest = false;
+  }
+
+  function useStarter(prompt: string): void {
+    draft = prompt;
+    requestAnimationFrame(() => {
+      inputEl?.focus();
+      inputEl?.setSelectionRange(prompt.length, prompt.length);
+    });
+  }
+
+  function handleThreadScroll(): void {
+    if (!scrollEl) return;
+    stickToTail = isNearAgentTail(scrollEl);
+    if (stickToTail) showJumpToLatest = false;
+  }
+
+  async function scrollToLatest(force = false): Promise<void> {
+    if (!scrollEl || (!force && !stickToTail)) return;
+    await tick();
+    if (!scrollEl) return;
+    scrollEl.scrollTop = scrollEl.scrollHeight;
+    stickToTail = true;
+    showJumpToLatest = false;
   }
 
   function handleExpand(): void {
@@ -401,14 +487,19 @@
           </span>
         {/if}
         <span class="agent-title">Agent</span>
-        <span class="tag durable">
-          DURABLE{pendingRequestCount ? ` · ${pendingRequestCount}` : ""}
+        <span class="conversation-title" title={conversation.conversationTitle}>
+          {conversation.conversationTitle}
+        </span>
+        <span class="run-status" class:working={agentWorking}>
+          <i aria-hidden="true"></i>{runLabel}
         </span>
         {#if $agentState.paused}
           <span class="tag pause" title="Money-PAUSE engaged">PAUSE</span>
         {/if}
         {#if accountMode === "paper"}
           <span class="tag paper">PAPER</span>
+        {:else}
+          <span class="tag live">LIVE</span>
         {/if}
       </div>
       <div class="picker" role="radiogroup" aria-label="Approval mode">
@@ -449,7 +540,7 @@
         type="button"
         aria-label="Conversation history"
         title="Conversations"
-        onclick={() => (historyOpen = true)}
+        onclick={() => void openHistory()}
       >
         <svg viewBox="0 0 24 24" aria-hidden="true">
           <path d="M3 12a9 9 0 1 0 3-6.7L3 8" />
@@ -483,7 +574,7 @@
       <button
         class="ghost"
         type="button"
-        disabled={busy}
+        disabled={agentWorking || conversation.reconnecting}
         onclick={newConversation}
         title="New durable conversation"
       >
@@ -494,13 +585,18 @@
           Expand
         </button>
       {/if}
+      {#if layout === "page" && onCollapse}
+        <button class="ghost" type="button" onclick={onCollapse} title="Return to dock">
+          Dock
+        </button>
+      {/if}
       {#if layout === "dock"}
         <button class="ghost" type="button" onclick={handleClose}>Close</button>
       {/if}
     </div>
   </header>
 
-  <div class="agent-scroll" bind:this={scrollEl}>
+  <div class="agent-scroll" bind:this={scrollEl} onscroll={handleThreadScroll}>
     <div class="agent-thread">
       {#if conversation.messages.length === 0 && conversation.status === "ready"}
         <div class="agent-empty">
@@ -512,12 +608,42 @@
                 ? "Observe — research only, no orders."
                 : "Ask mode — every transaction waits for your approval."}
           </p>
-          <ul>
-            <li>show my wallet address and balance</li>
-            <li>long SOL $50 @ 3x market</li>
-            <li>show my live positions and open orders</li>
-            <li>move stop to break-even on SOL</li>
-          </ul>
+          <div class="starter-grid">
+            <button
+              type="button"
+              onclick={() =>
+                useStarter("Review my account, current exposure, and biggest risk.")}
+            >
+              <strong>Review account</strong><span>Exposure, PnL, and risk</span>
+            </button>
+            <button
+              type="button"
+              onclick={() =>
+                useStarter(
+                  "Build a trade plan for SOL with entry, invalidation, sizing, take-profit, and stop-loss.",
+                )}
+            >
+              <strong>Plan a SOL trade</strong><span>Entry, size, TP, and SL</span>
+            </button>
+            <button
+              type="button"
+              onclick={() =>
+                useStarter(
+                  "Inspect my open positions and recommend the safest risk adjustments. Do not execute yet.",
+                )}
+            >
+              <strong>Manage risk</strong><span>Stops and open positions</span>
+            </button>
+            <button
+              type="button"
+              onclick={() =>
+                useStarter(
+                  "Create a recurring routine to review my portfolio and market risk every morning.",
+                )}
+            >
+              <strong>Create a routine</strong><span>Persistent scheduled checks</span>
+            </button>
+          </div>
         </div>
       {/if}
 
@@ -534,6 +660,10 @@
               {#if isFirstToolPart(message.parts, part)}
                 <ToolActivity
                   items={toolActivityItems(message.parts)}
+                  showApprovalActions={!message.parts.some(
+                    (messagePart) =>
+                      isToolPart(messagePart) && messagePart.approvalPending,
+                  )}
                   onAnswer={(toolCallId, approved) =>
                     answerTool(toolCallId, approved)}
                 />
@@ -581,9 +711,30 @@
         <p class="state error">{conversation.error?.message ?? "agent-transport-error"}</p>
       {/if}
     </div>
+    {#if showJumpToLatest}
+      <button
+        class="jump-latest"
+        type="button"
+        onclick={() => void scrollToLatest(true)}
+      >
+        Latest ↓
+      </button>
+    {/if}
   </div>
 
   <form class="composer" onsubmit={submit}>
+    {#if pendingApprovalItems.length > 0}
+      <aside class="approval-tray" aria-label="Pending agent approval">
+        <div class="approval-heading">
+          <strong>Approval required</strong>
+          <span>{pendingApprovalItems.length} pending</span>
+        </div>
+        <ToolActivity
+          items={pendingApprovalItems}
+          onAnswer={(toolCallId, approved) => answerTool(toolCallId, approved)}
+        />
+      </aside>
+    {/if}
     <div class="composer-shell">
       {#if skillPaletteOpen}
         <AgentSkillPalette
@@ -605,40 +756,54 @@
         bind:this={inputEl}
         bind:value={draft}
         rows={layout === "page" ? 3 : 2}
-        placeholder="Message the agent · @ for skills"
+        placeholder="Message the agent · @ skills · / commands"
         disabled={busy || !$privyAuth.authenticated}
         onkeydown={onKeydown}
         oninput={onComposerInput}
       ></textarea>
       <div class="composer-bar">
         <span class="composer-hint">
-          Enter to send · Shift+Enter newline · @ skills
+          Enter to send · @ skills · /new /threads /pause
         </span>
-        <button
-          class="secondary"
-          type="submit"
-          disabled={busy || !$privyAuth.authenticated || draft.trim().length === 0}
-        >
-          Send
-        </button>
+        {#if agentWorking}
+          <button
+            class="stop"
+            type="button"
+            disabled={conversation.cancellationState !== "idle"}
+            onclick={() => conversation.cancel()}
+          >
+            {conversation.cancellationState === "idle" ? "Stop" : "Stopping…"}
+          </button>
+        {:else}
+          <button
+            class="secondary"
+            type="submit"
+            disabled={busy || !$privyAuth.authenticated || draft.trim().length === 0}
+          >
+            Send
+          </button>
+        {/if}
       </div>
+      {#if conversation.cancellationError}
+        <p class="cancel-error">{conversation.cancellationError}</p>
+      {/if}
     </div>
   </form>
 </div>
 
-{#if settingsOpen}
-  <AgentSettingsModal
+{#if settingsOpen && SettingsModal}
+  <SettingsModal
     initialSection={settingsSection}
     {onRequestAuth}
     onclose={() => (settingsOpen = false)}
   />
 {/if}
 
-{#if historyOpen}
-  <AgentConversationHistory
+{#if historyOpen && ConversationHistory}
+  <ConversationHistory
     conversations={conversation.conversations}
     activeId={conversation.activeConversationId}
-    {busy}
+    busy={agentWorking || conversation.reconnecting}
     onnew={() => conversation.newConversation()}
     onresume={(id) => conversation.resumeConversation(id)}
     onarchive={(id) => conversation.archiveConversation(id)}
@@ -745,14 +910,57 @@
     display: flex;
     align-items: center;
     gap: 0.4rem;
+    min-width: 0;
   }
 
   .agent-title {
+    flex: 0 0 auto;
     color: var(--accent);
     font-size: 0.62rem;
     font-weight: 800;
     letter-spacing: 0.1em;
     text-transform: uppercase;
+  }
+
+  .conversation-title {
+    max-width: 12rem;
+    overflow: hidden;
+    color: var(--muted);
+    font-size: 0.68rem;
+    font-weight: 650;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .layout-dock .conversation-title {
+    max-width: 7rem;
+  }
+
+  .run-status {
+    display: inline-flex;
+    flex: 0 0 auto;
+    align-items: center;
+    gap: 0.28rem;
+    color: var(--faint);
+    font-size: 0.6rem;
+  }
+
+  .run-status i {
+    width: 0.4rem;
+    height: 0.4rem;
+    border-radius: 50%;
+    background: var(--muted);
+  }
+
+  .run-status.working i {
+    background: var(--up);
+    animation: pulse-status 0.75s ease-in-out infinite alternate;
+  }
+
+  @keyframes pulse-status {
+    to {
+      opacity: 0.3;
+    }
   }
 
   .compact-page-id,
@@ -793,7 +1001,7 @@
     color: var(--amber);
   }
 
-  .tag.durable {
+  .tag.live {
     color: var(--up);
   }
 
@@ -886,6 +1094,7 @@
   }
 
   .agent-scroll {
+    position: relative;
     flex: 1 1 auto;
     min-height: 0;
     overflow-y: auto;
@@ -928,20 +1137,59 @@
     min-height: 2.6em;
   }
 
-  .agent-empty ul {
+  .starter-grid {
     margin: 0;
     padding: 0;
-    list-style: none;
     display: grid;
-    gap: 0.35rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.45rem;
+    text-align: left;
   }
 
-  .agent-empty li {
+  .starter-grid button {
+    display: grid;
+    gap: 0.18rem;
+    min-width: 0;
+    padding: 0.6rem;
+    color: var(--muted);
+    font: inherit;
     font-size: 0.76rem;
-    color: var(--faint);
     border: 1px solid var(--line-soft);
-    padding: 0.4rem 0.55rem;
+    background: var(--surface-2);
+    cursor: pointer;
     text-align: left;
+  }
+
+  .starter-grid button:hover,
+  .starter-grid button:focus-visible {
+    color: var(--ink);
+    border-color: var(--accent);
+    outline: none;
+  }
+
+  .starter-grid strong {
+    color: var(--ink);
+    font-size: 0.72rem;
+  }
+
+  .starter-grid span {
+    color: var(--faint);
+    font-size: 0.65rem;
+  }
+
+  .jump-latest {
+    position: sticky;
+    bottom: 0.6rem;
+    display: block;
+    margin: 0 0.7rem 0 auto;
+    padding: 0.28rem 0.5rem;
+    color: var(--ink);
+    font: inherit;
+    font-size: 0.65rem;
+    font-weight: 700;
+    border: 1px solid var(--line);
+    background: var(--surface-2);
+    cursor: pointer;
   }
 
   .msg {
@@ -1033,6 +1281,30 @@
     width: 100%;
   }
 
+  .approval-tray {
+    max-width: 48rem;
+    margin: 0 auto 0.55rem;
+    padding: 0.6rem 0.7rem;
+    border: 1px solid var(--amber);
+    background: var(--surface-2);
+  }
+
+  .approval-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.25rem;
+    color: var(--amber);
+    font-size: 0.64rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+
+  .approval-heading span {
+    color: var(--faint);
+  }
+
   .layout-page .composer {
     position: sticky;
     z-index: 3;
@@ -1089,7 +1361,8 @@
 
   /* Local button skins — full page may not load terminal.css utilities. */
   .primary,
-  .secondary {
+  .secondary,
+  .stop {
     font: inherit;
     font-size: 0.72rem;
     font-weight: 700;
@@ -1107,6 +1380,24 @@
   .secondary {
     color: var(--ink);
     background: var(--surface-2);
+  }
+
+  .stop {
+    min-width: 4.5rem;
+    color: var(--red);
+    border-color: var(--red);
+    background: transparent;
+  }
+
+  .stop:disabled {
+    opacity: 0.55;
+    cursor: wait;
+  }
+
+  .cancel-error {
+    margin: 0;
+    color: var(--red);
+    font-size: 0.66rem;
   }
 
   .secondary:disabled {
@@ -1160,6 +1451,10 @@
       min-width: 4.2rem;
     }
 
+    .layout-page .conversation-title {
+      max-width: 8rem;
+    }
+
     .layout-dock {
       /* Narrow: full-width sheet under topbar, still above status line. */
       position: fixed;
@@ -1175,8 +1470,20 @@
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .thinking i {
+    .thinking i,
+    .run-status.working i {
       animation: none;
+    }
+  }
+
+  @media (max-width: 560px) {
+    .starter-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .conversation-title,
+    .run-status {
+      display: none;
     }
   }
 </style>

--- a/apps/portal/src/routes/terminal/components/AgentChat.svelte
+++ b/apps/portal/src/routes/terminal/components/AgentChat.svelte
@@ -28,6 +28,7 @@
   import { getPrivyAccessToken, privyAuth } from "$lib/privy-auth";
   import { llmProfileHeaderValue } from "$lib/agent/llm-profile-selection";
   import { projectPriceQuote } from "$lib/agent/price-presentation";
+  import type { AgentRunStatus } from "$lib/agent/run-visibility";
   import { isNearAgentTail } from "$lib/agent/scroll-policy";
   import {
     fetchAgentSkills,
@@ -53,6 +54,7 @@
     onExpand = undefined,
     onCollapse = undefined,
     onClose = undefined,
+    onRunStateChange = undefined,
     storage,
   }: {
     buildContext: () => Record<string, unknown>;
@@ -64,6 +66,7 @@
     onExpand?: () => void;
     onCollapse?: () => void;
     onClose?: () => void;
+    onRunStateChange?: (status: AgentRunStatus) => void;
     storage: AgentThreadStorage;
   } = $props();
 
@@ -147,6 +150,18 @@
             ? "Needs attention"
             : "Ready",
   );
+  $effect(() => {
+    const stopping =
+      conversation.cancellationState === "requested" ||
+      conversation.cancellationState === "cancelling";
+    onRunStateChange?.({
+      active: conversation.working || conversation.reconnecting || stopping,
+      canCancel: conversation.working && !stopping,
+      label: runLabel,
+      stopping,
+      cancel: () => conversation.cancel(),
+    });
+  });
   const pendingApprovalItems = $derived.by(() =>
     conversation.messages.flatMap((message) =>
       message.parts

--- a/apps/portal/src/routes/terminal/components/AgentChat.svelte
+++ b/apps/portal/src/routes/terminal/components/AgentChat.svelte
@@ -1419,21 +1419,38 @@
 
   @media (max-width: 1100px) {
     .layout-page .agent-head {
-      justify-content: flex-start;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      grid-template-areas:
+        "title actions"
+        "modes modes";
+      align-items: center;
       gap: 0.45rem;
-      min-height: 3.1rem;
       padding: 0.55rem 0.7rem;
+    }
+
+    .layout-page .agent-head-left {
+      display: contents;
+    }
+
+    .layout-page .agent-title-row {
+      grid-area: title;
+    }
+
+    .layout-page .picker {
+      grid-area: modes;
+      width: 100%;
+    }
+
+    .layout-page .picker button {
+      flex: 1 1 0;
+      min-width: 0;
+    }
+
+    .layout-page .agent-head-right {
+      grid-area: actions;
+      justify-content: flex-end;
       overflow-x: auto;
-      overflow-y: hidden;
-    }
-
-    .layout-page .agent-head-left,
-    .layout-page .agent-head-right {
-      flex: 0 0 auto;
-    }
-
-    .layout-page .agent-head-right {
-      margin-left: auto;
     }
 
     .layout-page .compact-page-id,
@@ -1445,10 +1462,6 @@
       align-items: center;
       justify-content: center;
       text-decoration: none;
-    }
-
-    .layout-page .picker button {
-      min-width: 4.2rem;
     }
 
     .layout-page .conversation-title {

--- a/apps/portal/src/routes/terminal/components/AgentChat.svelte
+++ b/apps/portal/src/routes/terminal/components/AgentChat.svelte
@@ -22,6 +22,7 @@
   } from "$lib/agent/state";
   import {
     projectHarnessTool,
+    settleIdleActivity,
     type WorkstreamCard,
   } from "$lib/agent/workstream";
   import { getPrivyAccessToken, privyAuth } from "$lib/privy-auth";
@@ -370,7 +371,7 @@
       rawOutput !== null &&
       rawOutput.paperAction !== undefined &&
       rawOutput.paperAction !== null;
-    return projectHarnessTool({
+    const card = projectHarnessTool({
       toolName: part.toolName,
       state: part.state,
       input: part.input,
@@ -401,6 +402,10 @@
       errorText: part.errorText,
       approvalPending: part.approvalPending,
     });
+    return settleIdleActivity(
+      card,
+      conversation.status === "ready" && !part.approvalPending,
+    );
   }
 
   function messageToolParts(

--- a/apps/portal/src/routes/terminal/components/AgentSurface.svelte
+++ b/apps/portal/src/routes/terminal/components/AgentSurface.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
   import { browser } from "$app/environment";
   import type { AgentActionExecutor } from "$lib/agent/host";
-  import { scopeAgentStorage } from "$lib/agent/scoped-storage";
   import { privyAuth } from "$lib/privy-auth";
-  import AgentChat from "./AgentChat.svelte";
+  import AgentWorkspace from "./AgentWorkspace.svelte";
 
   let {
     buildContext,
@@ -29,13 +28,9 @@
 </script>
 
 {#if browser && $privyAuth.authenticated && $privyAuth.userId}
-  {@const scopeKey = `${$privyAuth.userId}:${accountMode}`}
-  {@const storage = scopeAgentStorage(localStorage, {
-    ownerId: $privyAuth.userId,
-    accountMode,
-  })}
-  {#key scopeKey}
-    <AgentChat
+  {#key $privyAuth.userId}
+    <AgentWorkspace
+      ownerId={$privyAuth.userId}
       {buildContext}
       {onRequestAuth}
       {accountMode}
@@ -45,7 +40,6 @@
       {onExpand}
       {onCollapse}
       {onClose}
-      {storage}
     />
   {/key}
 {:else}

--- a/apps/portal/src/routes/terminal/components/AgentSurface.svelte
+++ b/apps/portal/src/routes/terminal/components/AgentSurface.svelte
@@ -1,0 +1,200 @@
+<script lang="ts">
+  import { browser } from "$app/environment";
+  import type { AgentActionExecutor } from "$lib/agent/host";
+  import { scopeAgentStorage } from "$lib/agent/scoped-storage";
+  import { privyAuth } from "$lib/privy-auth";
+  import AgentChat from "./AgentChat.svelte";
+
+  let {
+    buildContext,
+    onRequestAuth,
+    accountMode = "paper",
+    layout = "dock",
+    focusComposerRequest = 0,
+    executePaperAction,
+    onExpand,
+    onCollapse,
+    onClose,
+  }: {
+    buildContext: () => Record<string, unknown>;
+    onRequestAuth: () => void;
+    accountMode?: "live" | "paper";
+    layout?: "dock" | "page";
+    focusComposerRequest?: number;
+    executePaperAction?: AgentActionExecutor;
+    onExpand?: () => void;
+    onCollapse?: () => void;
+    onClose?: () => void;
+  } = $props();
+</script>
+
+{#if browser && $privyAuth.authenticated && $privyAuth.userId}
+  {@const scopeKey = `${$privyAuth.userId}:${accountMode}`}
+  {@const storage = scopeAgentStorage(localStorage, {
+    ownerId: $privyAuth.userId,
+    accountMode,
+  })}
+  {#key scopeKey}
+    <AgentChat
+      {buildContext}
+      {onRequestAuth}
+      {accountMode}
+      {layout}
+      {focusComposerRequest}
+      {executePaperAction}
+      {onExpand}
+      {onCollapse}
+      {onClose}
+      {storage}
+    />
+  {/key}
+{:else}
+  <section
+    class="agent-gate"
+    class:layout-dock={layout === "dock"}
+    class:layout-page={layout === "page"}
+    aria-label="Agent chat"
+  >
+    <header>
+      <span class="eyebrow">Agent</span>
+      <span class:paper={accountMode === "paper"} class="account">
+        {accountMode}
+      </span>
+    </header>
+    <div class="gate-body" aria-live="polite">
+      {#if $privyAuth.status === "loading"}
+        <span class="status-dot working" aria-hidden="true"></span>
+        <h2>Restoring your workspace</h2>
+        <p>Your conversations and agent session will appear here.</p>
+      {:else}
+        <span class="status-dot" aria-hidden="true"></span>
+        <h2>Your trading workspace</h2>
+        <p>Sign in to open your private, persistent agent conversations.</p>
+        <button type="button" onclick={onRequestAuth}>Sign in</button>
+      {/if}
+    </div>
+  </section>
+{/if}
+
+<style>
+  .agent-gate {
+    display: flex;
+    min-height: 0;
+    flex-direction: column;
+    background: var(--surface);
+    color: var(--ink);
+  }
+
+  .layout-dock {
+    position: fixed;
+    right: 0;
+    top: var(--topbar-h, 3rem);
+    bottom: var(--status-h, 1.9rem);
+    width: var(--agent-dock-w, min(42vw, 28rem));
+    border-left: 1px solid var(--line);
+    z-index: 25;
+  }
+
+  .layout-page {
+    width: 100%;
+    height: 100%;
+  }
+
+  header {
+    display: flex;
+    min-height: 3rem;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.7rem 0.9rem;
+    border-bottom: 1px solid var(--line-soft);
+  }
+
+  .eyebrow,
+  .account {
+    font-size: 0.62rem;
+    font-weight: 800;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+  }
+
+  .eyebrow {
+    color: var(--accent);
+  }
+
+  .account {
+    padding: 0.12rem 0.3rem;
+    color: var(--muted);
+    border: 1px solid var(--line-soft);
+  }
+
+  .account.paper {
+    color: var(--amber);
+  }
+
+  .gate-body {
+    display: grid;
+    flex: 1;
+    place-content: center;
+    justify-items: center;
+    padding: 2rem;
+    text-align: center;
+  }
+
+  .gate-body h2 {
+    margin: 0.8rem 0 0.35rem;
+    font-size: 1rem;
+  }
+
+  .gate-body p {
+    max-width: 24rem;
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.82rem;
+    line-height: 1.5;
+  }
+
+  .gate-body button {
+    margin-top: 1rem;
+    padding: 0.45rem 0.75rem;
+    color: var(--accent-contrast);
+    font: inherit;
+    font-size: 0.75rem;
+    font-weight: 750;
+    border: 1px solid var(--accent);
+    background: var(--accent);
+    cursor: pointer;
+  }
+
+  .status-dot {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 50%;
+    background: var(--muted);
+  }
+
+  .status-dot.working {
+    background: var(--accent);
+    animation: pulse 1s ease-in-out infinite alternate;
+  }
+
+  @keyframes pulse {
+    to {
+      opacity: 0.35;
+    }
+  }
+
+  @media (max-width: 1100px) {
+    .layout-dock {
+      left: 0;
+      width: auto;
+      border-left: 0;
+      z-index: 30;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .status-dot.working {
+      animation: none;
+    }
+  }
+</style>

--- a/apps/portal/src/routes/terminal/components/AgentWorkspace.svelte
+++ b/apps/portal/src/routes/terminal/components/AgentWorkspace.svelte
@@ -1,0 +1,236 @@
+<script lang="ts">
+  import type { AgentActionExecutor } from "$lib/agent/host";
+  import {
+    backgroundRunMode,
+    idleAgentRunStatus,
+    type AgentAccountMode,
+    type AgentRunStatus,
+  } from "$lib/agent/run-visibility";
+  import { scopeAgentStorage } from "$lib/agent/scoped-storage";
+  import AgentChat from "./AgentChat.svelte";
+
+  let {
+    ownerId,
+    buildContext,
+    onRequestAuth,
+    accountMode = "paper",
+    layout = "dock",
+    focusComposerRequest = 0,
+    executePaperAction,
+    onExpand,
+    onCollapse,
+    onClose,
+  }: {
+    ownerId: string;
+    buildContext: () => Record<string, unknown>;
+    onRequestAuth: () => void;
+    accountMode?: AgentAccountMode;
+    layout?: "dock" | "page";
+    focusComposerRequest?: number;
+    executePaperAction?: AgentActionExecutor;
+    onExpand?: () => void;
+    onCollapse?: () => void;
+    onClose?: () => void;
+  } = $props();
+
+  // AgentSurface keys this component by owner; each storage adapter is fixed
+  // for the lifetime of that owner workspace.
+  // svelte-ignore state_referenced_locally
+  const paperStorage = scopeAgentStorage(localStorage, {
+    ownerId,
+    accountMode: "paper",
+  });
+  // svelte-ignore state_referenced_locally
+  const liveStorage = scopeAgentStorage(localStorage, {
+    ownerId,
+    accountMode: "live",
+  });
+  // The active account is mounted immediately; the effect below retains every
+  // workspace after its first visit.
+  // svelte-ignore state_referenced_locally
+  let paperMounted = $state(accountMode === "paper");
+  // svelte-ignore state_referenced_locally
+  let liveMounted = $state(accountMode === "live");
+  let paperRun = $state.raw<AgentRunStatus>(idleAgentRunStatus());
+  let liveRun = $state.raw<AgentRunStatus>(idleAgentRunStatus());
+
+  $effect(() => {
+    if (accountMode === "paper") paperMounted = true;
+    if (accountMode === "live") liveMounted = true;
+  });
+
+  const backgroundMode = $derived(
+    backgroundRunMode(accountMode, {
+      live: liveRun.active,
+      paper: paperRun.active,
+    }),
+  );
+  const backgroundRun = $derived(
+    backgroundMode === "live"
+      ? liveRun
+      : backgroundMode === "paper"
+        ? paperRun
+        : null,
+  );
+
+  function setRun(mode: AgentAccountMode, status: AgentRunStatus): void {
+    if (mode === "paper") paperRun = status;
+    else liveRun = status;
+  }
+</script>
+
+<div class="agent-workspace">
+  {#if paperMounted}
+    <div
+      class="workspace-view"
+      class:active={accountMode === "paper"}
+      aria-hidden={accountMode !== "paper"}
+      inert={accountMode !== "paper"}
+    >
+      <AgentChat
+        {buildContext}
+        {onRequestAuth}
+        accountMode="paper"
+        {layout}
+        focusComposerRequest={accountMode === "paper" ? focusComposerRequest : 0}
+        {executePaperAction}
+        {onExpand}
+        {onCollapse}
+        {onClose}
+        storage={paperStorage}
+        onRunStateChange={(status) => setRun("paper", status)}
+      />
+    </div>
+  {/if}
+
+  {#if liveMounted}
+    <div
+      class="workspace-view"
+      class:active={accountMode === "live"}
+      aria-hidden={accountMode !== "live"}
+      inert={accountMode !== "live"}
+    >
+      <AgentChat
+        {buildContext}
+        {onRequestAuth}
+        accountMode="live"
+        {layout}
+        focusComposerRequest={accountMode === "live" ? focusComposerRequest : 0}
+        {executePaperAction}
+        {onExpand}
+        {onCollapse}
+        {onClose}
+        storage={liveStorage}
+        onRunStateChange={(status) => setRun("live", status)}
+      />
+    </div>
+  {/if}
+
+  {#if backgroundMode && backgroundRun}
+    <aside class="background-run" role="alert" aria-live="assertive">
+      <i class:stopping={backgroundRun.stopping} aria-hidden="true"></i>
+      <span>
+        <strong>{backgroundMode} agent {backgroundRun.label.toLowerCase()}</strong>
+        <small>Run remains visible after the account switch.</small>
+      </span>
+      <button
+        type="button"
+        disabled={!backgroundRun.canCancel}
+        onclick={backgroundRun.cancel}
+      >
+        {backgroundRun.stopping ? "Stopping…" : "Stop"}
+      </button>
+    </aside>
+  {/if}
+</div>
+
+<style>
+  .agent-workspace,
+  .workspace-view.active {
+    display: contents;
+  }
+
+  .workspace-view:not(.active) {
+    display: none;
+  }
+
+  .background-run {
+    position: fixed;
+    top: calc(var(--topbar-h, 3rem) + 0.55rem);
+    right: 0.65rem;
+    z-index: 45;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    width: min(23rem, calc(100vw - 1.3rem));
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.55rem 0.65rem;
+    color: var(--ink);
+    border: 1px solid var(--amber);
+    background: var(--surface-2);
+  }
+
+  .background-run i {
+    width: 0.45rem;
+    height: 0.45rem;
+    border-radius: 50%;
+    background: var(--up);
+    animation: pulse 0.75s ease-in-out infinite alternate;
+  }
+
+  .background-run i.stopping {
+    background: var(--amber);
+  }
+
+  .background-run span {
+    display: grid;
+    min-width: 0;
+    gap: 0.08rem;
+  }
+
+  .background-run strong {
+    overflow: hidden;
+    font-size: 0.69rem;
+    letter-spacing: 0.035em;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .background-run small {
+    overflow: hidden;
+    color: var(--muted);
+    font-size: 0.61rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .background-run button {
+    min-height: 1.8rem;
+    padding: 0 0.55rem;
+    color: var(--ink);
+    font: inherit;
+    font-size: 0.65rem;
+    font-weight: 750;
+    border: 1px solid var(--line);
+    background: var(--surface-2);
+    cursor: pointer;
+  }
+
+  .background-run button:disabled {
+    color: var(--faint);
+    cursor: wait;
+  }
+
+  @keyframes pulse {
+    to {
+      opacity: 0.3;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .background-run i {
+      animation: none;
+    }
+  }
+</style>

--- a/apps/portal/src/routes/terminal/components/SidePanel.svelte
+++ b/apps/portal/src/routes/terminal/components/SidePanel.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   // Dock shell — presentation lives in AgentChat (shared with full-page).
-  import { goto } from "$app/navigation";
   import { onDestroy } from "svelte";
-  import AgentChat from "./AgentChat.svelte";
+  import AgentSurface from "./AgentSurface.svelte";
 
   let {
     buildContext,
@@ -28,9 +27,18 @@
 
   let resizeHandle: HTMLDivElement | undefined = $state();
   let resizing = $state(false);
+  let expanded = $state(false);
 
   function expand(): void {
-    void goto(`/terminal/agent?account=${accountMode}`);
+    expanded = true;
+  }
+
+  function collapse(): void {
+    expanded = false;
+  }
+
+  function onGlobalKeydown(event: KeyboardEvent): void {
+    if (event.key === "Escape" && expanded) collapse();
   }
 
   function startResize(event: PointerEvent): void {
@@ -84,40 +92,62 @@
   });
 </script>
 
-<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-<div
-  bind:this={resizeHandle}
-  class="dock-resizer"
-  class:active={resizing}
-  role="separator"
-  aria-label="Resize agent dock"
-  aria-orientation="vertical"
-  aria-valuemin={minDockWidth}
-  aria-valuemax={maxDockWidth}
-  aria-valuenow={Math.round(dockWidth)}
-  tabindex="0"
-  title="Drag to resize agent dock"
-  onpointerdown={startResize}
-  onpointermove={resize}
-  onpointerup={finishResize}
-  onpointercancel={cancelResize}
-  onlostpointercapture={cancelResize}
-  onkeydown={resizeWithKeyboard}
->
-  <span aria-hidden="true"></span>
+<svelte:window onkeydown={onGlobalKeydown} />
+
+<div class="agent-panel" class:expanded>
+  {#if !expanded}
+    <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+    <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+    <div
+      bind:this={resizeHandle}
+      class="dock-resizer"
+      class:active={resizing}
+      role="separator"
+      aria-label="Resize agent dock"
+      aria-orientation="vertical"
+      aria-valuemin={minDockWidth}
+      aria-valuemax={maxDockWidth}
+      aria-valuenow={Math.round(dockWidth)}
+      tabindex="0"
+      title="Drag to resize agent dock"
+      onpointerdown={startResize}
+      onpointermove={resize}
+      onpointerup={finishResize}
+      onpointercancel={cancelResize}
+      onlostpointercapture={cancelResize}
+      onkeydown={resizeWithKeyboard}
+    >
+      <span aria-hidden="true"></span>
+    </div>
+  {/if}
+
+  <AgentSurface
+    {buildContext}
+    {onRequestAuth}
+    {accountMode}
+    {focusComposerRequest}
+    layout={expanded ? "page" : "dock"}
+    onExpand={expand}
+    onCollapse={collapse}
+  />
 </div>
 
-<AgentChat
-  {buildContext}
-  {onRequestAuth}
-  {accountMode}
-  {focusComposerRequest}
-  layout="dock"
-  onExpand={expand}
-/>
-
 <style>
+  .agent-panel {
+    display: contents;
+  }
+
+  .agent-panel.expanded {
+    position: fixed;
+    inset: 0;
+    z-index: 80;
+    display: flex;
+    min-width: 0;
+    min-height: 0;
+    flex-direction: column;
+    background: var(--surface);
+  }
+
   .dock-resizer {
     position: fixed;
     top: var(--topbar-h, 3rem);

--- a/apps/portal/src/routes/terminal/components/ToolActivity.svelte
+++ b/apps/portal/src/routes/terminal/components/ToolActivity.svelte
@@ -11,9 +11,11 @@
   let {
     items,
     onAnswer,
+    showApprovalActions = true,
   }: {
     items: ToolActivityItem[];
     onAnswer: (id: string, approved: boolean) => void;
+    showApprovalActions?: boolean;
   } = $props();
 
   const running = $derived(
@@ -164,7 +166,7 @@
             </div>
           {/if}
 
-          {#if item.approvalPending}
+          {#if item.approvalPending && showApprovalActions}
             <div class="actions">
               <button type="button" onclick={() => onAnswer(item.id, true)}>
                 {item.card.kind === "context" ? "Apply" : "Approve"}


### PR DESCRIPTION
## Outcome

Refactors the EVE agent into a faster, persistent, Codex-like trading workspace while preserving the server-authoritative PAPER/LIVE, Observe/Ask/Auto, PAUSE, signing, approval, and receipt boundaries.

## What changed

- binds each workspace to one long-lived EVE `ClientSession`
- adds real server-turn cancellation via EVE's guarded `session.cancel({ turnId })`
- preserves the durable turn id when an approval resumes the same execution
- keeps visited PAPER and LIVE workspaces mounted across account toggles
- surfaces any inactive run in a compact background-run banner with a Stop control
- keeps the same agent instance alive when switching between dock and fullscreen
- scopes conversation history by authenticated owner and PAPER/LIVE account
- safely migrates existing unscoped history into the owner's PAPER workspace
- throttles incremental persistence instead of rewriting all history for every stream update
- prevents streaming auto-scroll from pulling users away from older messages
- pins pending approvals above the composer and remembers resolved approvals durably
- adds quick task starters and `/new`, `/threads`, `/settings`, `/observe`, `/ask`, `/auto`, `/pause`, and `/resume`
- lazily loads history and settings UI
- fixes standalone LIVE context so paper ledger state can never be presented as live account state
- upgrades the trading prompt to an inspect → plan → act → verify → report harness
- treats browser-confirmed PAPER receipts as authoritative and removes redundant confirmations
- settles parked EVE activity cards to a truthful completed state
- replaces the noisy durable badge with a compact conversation title and run status

## Safety

- no live transaction policy or signer bypasses
- Ask approvals remain pinned and explicit
- approval resumes remain cancellable on their original durable turn
- active runs remain visible and stoppable after PAPER/LIVE switches
- PAUSE and account mode remain server-authoritative
- unknown execution outcomes still stop instead of speculative retry
- routines remain observe-and-alert only

## QA

Static validation:

- `bun run test` — pass (562 portal tests)
- agent-focused tests — pass (77 tests)
- `bun run typecheck` — pass, 0 Svelte warnings
- `bun run build` — pass

Hosted preview validation at https://preview.trader-ralph.com/terminal:

- persistent PAPER conversation survives reload, dock/fullscreen transitions, and account switches
- PAPER and LIVE histories remain isolated
- real EVE Stop transitions Working → Stopping → Ready
- PAPER Ask flow pins exactly one execution approval, applies the browser receipt, and clears it after answer
- completed tool work projects as Done with a confirmed PAPER receipt
- an active PAPER run remains visible after switching to LIVE and exposes a working Stop control
- LIVE opens with no PAPER portfolio state
- settings lazy-loads and responsive two-row controls remain usable at the hosted browser viewport
