### PR TITLE
feat(terminal): ghost size/leverage from journal (#549)

### DIFF
--- a/apps/portal/src/lib/terminal/perp-ticket.test.ts
+++ b/apps/portal/src/lib/terminal/perp-ticket.test.ts
@@ -35,6 +35,7 @@ function inputs(overrides: Partial<PerpTicketInputs> = {}): PerpTicketInputs {
     prevDayHigh: null,
     prevDayLow: null,
     symbol: "SOL",
+    journalEntries: [],
     ...overrides,
   };
 }
@@ -267,5 +268,65 @@ describe("ghost TP/SL", () => {
     ticket.tradeLimitPrice.set("100");
     expect(get(ticket.ghostTp)).toBeNull();
     expect(get(ticket.ghostSl)).toBeNull();
+  });
+});
+
+describe("ghost size/leverage", () => {
+  function journalSeed(count: number, symbol = "SOL") {
+    return Array.from({ length: count }, (_, index) => ({
+      ts: 1_700_000_000_000 + index,
+      venue: "perp" as const,
+      symbol,
+      action: "buy",
+      notionalUsd: 20 + index * 2,
+      price: 100,
+      leverage: index % 2 === 0 ? 5 : 5,
+      mode: "paper" as const,
+      signature: `sig-${index}`,
+    }));
+  }
+
+  test("≥5 journal entries → ghost; Tab accept sets amount + leverage", () => {
+    const ticket = createPerpTicket();
+    ticket.setInputs(inputs({ journalEntries: journalSeed(5) }));
+    ticket.tradeAmount.set("");
+    ticket.sizingMode.set("usd");
+    const ghost = get(ticket.ghostSize);
+    expect(ghost).not.toBeNull();
+    if (!ghost) throw new Error("expected ghost size");
+    expect(ghost.sampleSize).toBe(5);
+    expect(ticket.acceptGhostSize()).toBe(true);
+    expect(get(ticket.tradeAmount)).toBe(String(Math.round(ghost.notionalUsd)));
+    expect(get(ticket.tradeLeverage)).toBe(5);
+    expect(get(ticket.ghostSize)).toBeNull();
+  });
+
+  test("below floor or risk mode → no ghost", () => {
+    const ticket = createPerpTicket();
+    ticket.setInputs(inputs({ journalEntries: journalSeed(4) }));
+    ticket.tradeAmount.set("");
+    expect(get(ticket.ghostSize)).toBeNull();
+
+    ticket.setInputs(inputs({ journalEntries: journalSeed(6) }));
+    ticket.tradeAmount.set("");
+    ticket.sizingMode.set("risk");
+    expect(get(ticket.ghostSize)).toBeNull();
+  });
+
+  test("dismiss hides until symbol reset", () => {
+    const ticket = createPerpTicket();
+    ticket.setInputs(inputs({ journalEntries: journalSeed(5) }));
+    ticket.tradeAmount.set("");
+    expect(get(ticket.ghostSize)).not.toBeNull();
+    ticket.dismissGhostSize();
+    expect(get(ticket.ghostSize)).toBeNull();
+    ticket.setInputs(
+      inputs({
+        symbol: "BTC",
+        journalEntries: journalSeed(5, "BTC"),
+      }),
+    );
+    ticket.tradeAmount.set("");
+    expect(get(ticket.ghostSize)).not.toBeNull();
   });
 });

--- a/apps/portal/src/lib/terminal/perp-ticket.ts
+++ b/apps/portal/src/lib/terminal/perp-ticket.ts
@@ -10,10 +10,13 @@
 // +page.svelte on purpose: this module holds state and pure math only, and
 // must never import web3.js or issue network calls.
 import { derived, get, writable } from "svelte/store";
+import type { JournalEntry } from "$lib/journal";
 import type { DepthLevel, MarketPoint } from "$lib/phoenix-market-data";
 import {
   GHOST_DEFAULTS,
+  type GhostSizing,
   type GhostValue,
+  ghostSizing,
   ghostStop,
   ghostTakeProfit,
 } from "./autocomplete";
@@ -49,6 +52,8 @@ export type PerpTicketInputs = {
   prevDayHigh: number | null;
   prevDayLow: number | null;
   symbol: string;
+  /** Local journal — size/leverage ghosts; page-injected, never loadJournal here. */
+  journalEntries: JournalEntry[];
 };
 
 type MarketInputs = Pick<
@@ -65,8 +70,27 @@ type AccountInputs = Pick<
 >;
 type StructureInputs = Pick<
   PerpTicketInputs,
-  "candles" | "prevDayHigh" | "prevDayLow" | "symbol"
+  "candles" | "prevDayHigh" | "prevDayLow" | "symbol" | "journalEntries"
 >;
+
+const TICKET_LEVERAGES = [1, 2, 5, 10, 20] as const;
+
+/** Snap journal modal leverage onto the ticket <select> options. */
+export function snapTicketLeverage(value: number): number {
+  let best: (typeof TICKET_LEVERAGES)[number] = TICKET_LEVERAGES[0];
+  for (const option of TICKET_LEVERAGES) {
+    if (Math.abs(option - value) < Math.abs(best - value)) best = option;
+  }
+  return best;
+}
+
+export function formatGhostSizeLabel(ghost: GhostSizing): string {
+  const notional =
+    ghost.notionalUsd >= 10
+      ? Math.round(ghost.notionalUsd)
+      : Math.round(ghost.notionalUsd * 100) / 100;
+  return `$${notional} @ ${snapTicketLeverage(ghost.leverage)}x`;
+}
 
 export function createPerpTicket() {
   // ── User-editable fields (three external writers besides the inputs:
@@ -109,14 +133,17 @@ export function createPerpTicket() {
     prevDayHigh: null,
     prevDayLow: null,
     symbol: "",
+    journalEntries: [],
   });
   const now = writable(0);
   const ghostTpDismissed = writable(false);
   const ghostSlDismissed = writable(false);
+  const ghostSizeDismissed = writable(false);
 
   function clearGhostDismissed(): void {
     ghostTpDismissed.set(false);
     ghostSlDismissed.set(false);
+    ghostSizeDismissed.set(false);
   }
 
   // Side flips via bind ($tradeSide = …) bypass setSide — subscribe so
@@ -179,7 +206,8 @@ export function createPerpTicket() {
       prev.candles !== next.candles ||
       prev.prevDayHigh !== next.prevDayHigh ||
       prev.prevDayLow !== next.prevDayLow ||
-      prev.symbol !== next.symbol
+      prev.symbol !== next.symbol ||
+      prev.journalEntries !== next.journalEntries
     ) {
       if (prev && prev.symbol !== next.symbol) {
         clearGhostDismissed();
@@ -189,6 +217,7 @@ export function createPerpTicket() {
         prevDayHigh: next.prevDayHigh,
         prevDayLow: next.prevDayLow,
         symbol: next.symbol,
+        journalEntries: next.journalEntries,
       });
     }
   }
@@ -395,6 +424,19 @@ export function createPerpTicket() {
   );
   const ghostSymbol = derived(structure, ($structure) => $structure.symbol);
 
+  // Ghost size/leverage from journal — USD sizing only, empty field, ≥5 samples.
+  const ghostSize = derived(
+    [sizingMode, tradeAmount, ghostSizeDismissed, structure],
+    ([$mode, $amount, $dismissed, $structure]): GhostSizing | null => {
+      if ($dismissed || $mode !== "usd" || $amount.trim() !== "") return null;
+      return ghostSizing(
+        $structure.journalEntries,
+        $structure.symbol,
+        GHOST_DEFAULTS.sizingMinSample,
+      );
+    },
+  );
+
   // Clicking a book level: prefill a limit order at that price. Side/type/
   // price only — size/TP/SL stay put.
   function prefill(price: number, side: TradeSide): void {
@@ -445,12 +487,28 @@ export function createPerpTicket() {
     return true;
   }
 
+  function acceptGhostSize(): boolean {
+    const ghost = get(ghostSize);
+    if (!ghost) return false;
+    const notional =
+      ghost.notionalUsd >= 10
+        ? Math.round(ghost.notionalUsd)
+        : Math.round(ghost.notionalUsd * 100) / 100;
+    tradeAmount.set(String(notional));
+    tradeLeverage.set(snapTicketLeverage(ghost.leverage));
+    return true;
+  }
+
   function dismissGhostTp(): void {
     ghostTpDismissed.set(true);
   }
 
   function dismissGhostSl(): void {
     ghostSlDismissed.set(true);
+  }
+
+  function dismissGhostSize(): void {
+    ghostSizeDismissed.set(true);
   }
 
   return {
@@ -483,6 +541,7 @@ export function createPerpTicket() {
     effectiveTradeAmount,
     ghostTp,
     ghostSl,
+    ghostSize,
     ghostSymbol,
     // api
     setInputs,
@@ -493,8 +552,10 @@ export function createPerpTicket() {
     setStopLossPct,
     acceptGhostTp,
     acceptGhostSl,
+    acceptGhostSize,
     dismissGhostTp,
     dismissGhostSl,
+    dismissGhostSize,
   };
 }
 

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -1248,6 +1248,7 @@
     prevDayHigh: tradeMode === "perps" ? structLevels.prevDayHigh : null,
     prevDayLow: tradeMode === "perps" ? structLevels.prevDayLow : null,
     symbol: selectedSymbol,
+    journalEntries,
   });
   $: perpTicket.setNow(nowMs);
 

--- a/apps/portal/src/routes/terminal/components/TicketForm.svelte
+++ b/apps/portal/src/routes/terminal/components/TicketForm.svelte
@@ -2,6 +2,7 @@
   import type { DepthLevel } from "$lib/phoenix-market-data";
   import { bookLevelNotional, formatBookPrice } from "$lib/terminal/book";
   import type { PerpTicket } from "$lib/terminal/perp-ticket";
+  import { formatGhostSizeLabel } from "$lib/terminal/perp-ticket";
   import { stepInput } from "$lib/terminal/step-input";
   import { SL_CHIP_PCTS, TP_CHIP_PCTS, fmtTriggerPrice } from "$lib/terminal/trade-math";
   import {
@@ -154,18 +155,22 @@
     riskNotionalUsd,
     ghostTp,
     ghostSl,
+    ghostSize,
     ghostSymbol,
     setTakeProfitPct,
     setStopLossPct,
     acceptGhostTp,
     acceptGhostSl,
+    acceptGhostSize,
     dismissGhostTp,
     dismissGhostSl,
+    dismissGhostSize,
   } = ticket;
 
   // Telemetry: once per ghost value per field (not per render).
   let shownTpKey = "";
   let shownSlKey = "";
+  let shownSizeKey = "";
   $effect(() => {
     const ghost = $ghostTp;
     const symbol = $ghostSymbol;
@@ -189,6 +194,18 @@
     if (key === shownSlKey) return;
     shownSlKey = key;
     track("ghost_shown", { field: "sl", source: ghost.source, symbol });
+  });
+  $effect(() => {
+    const ghost = $ghostSize;
+    const symbol = $ghostSymbol;
+    if (!ghost) {
+      shownSizeKey = "";
+      return;
+    }
+    const key = `${symbol}:journal:${ghost.sampleSize}:${ghost.notionalUsd}:${ghost.leverage}`;
+    if (key === shownSizeKey) return;
+    shownSizeKey = key;
+    track("ghost_shown", { field: "size", source: "journal", symbol });
   });
 
   function onTpKeydown(event: KeyboardEvent): void {
@@ -231,6 +248,24 @@
     }
   }
 
+  function onSizeKeydown(event: KeyboardEvent): void {
+    if (event.key === "Tab" && !event.shiftKey && $ghostSize) {
+      event.preventDefault();
+      const symbol = $ghostSymbol;
+      if (acceptGhostSize()) {
+        track("ghost_accepted", { field: "size", source: "journal", symbol });
+      }
+      return;
+    }
+    if (event.key === "Escape" && $ghostSize) {
+      event.preventDefault();
+      event.stopPropagation();
+      const symbol = $ghostSymbol;
+      dismissGhostSize();
+      track("ghost_dismissed", { field: "size", source: "journal", symbol });
+    }
+  }
+
   // ── Size presets ───────────────────────────────────────────────────
   // USD mode: % of free collateral × leverage; Max keeps the same $0.01
   // margin buffer the funding gate tolerates so a Max ticket can't flash
@@ -258,13 +293,23 @@
         >{$sizingMode === "usd" ? "from stop →" : "← plain size"}</button>
       </span>
       {#if $sizingMode === "usd"}
-        <input
-          bind:this={sizeInput}
-          bind:value={$tradeAmount}
-          inputmode="decimal"
-          use:stepInput={{ kind: "usd" }}
-          oninput={() => onmanualsize()}
-        />
+        <span class="ghost-input">
+          <input
+            bind:this={sizeInput}
+            bind:value={$tradeAmount}
+            inputmode="decimal"
+            use:stepInput={{ kind: "usd" }}
+            oninput={() => onmanualsize()}
+            onkeydown={onSizeKeydown}
+          />
+          {#if $ghostSize}
+            <span
+              class="ghost-overlay"
+              aria-hidden="true"
+              title={$ghostSize.provenance}
+            >{formatGhostSizeLabel($ghostSize)}</span>
+          {/if}
+        </span>
       {:else}
         <input
           bind:this={sizeInput}


### PR DESCRIPTION
## Summary
- Empty USD size field shows a ghost like $24 @ 5x from the local journal (median notional + modal leverage) when there are at least 5 perp trades on the symbol.
- Tab accepts size + leverage together; Escape dismisses. Risk mode and thin history show nothing.
- Same telemetry contract as TP/SL ghosts.

Closes #549

## Test plan
- [x] perp-ticket unit tests
- [x] typecheck
- [x] portal test suite
- [ ] CI green
- [ ] Smoke: clear size with journal history on SOL, Tab to accept

Made with [Cursor](https://cursor.com)