### PR TITLE
fix(terminal): TP/SL placeholder no longer stacks on ghosts

### DIFF
--- a/apps/portal/src/lib/terminal/ghost-field-placeholder.test.ts
+++ b/apps/portal/src/lib/terminal/ghost-field-placeholder.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { ghostFieldPlaceholder } from "./ghost-field-placeholder";
+
+describe("ghostFieldPlaceholder", () => {
+  test("clears the label while a ghost is showing", () => {
+    expect(
+      ghostFieldPlaceholder({ hasGhost: true, emptyLabel: "optional" }),
+    ).toBe("");
+    expect(
+      ghostFieldPlaceholder({ hasGhost: true, emptyLabel: "required" }),
+    ).toBe("");
+  });
+
+  test("keeps the empty-field label when there is no ghost", () => {
+    expect(
+      ghostFieldPlaceholder({ hasGhost: false, emptyLabel: "optional" }),
+    ).toBe("optional");
+    expect(
+      ghostFieldPlaceholder({ hasGhost: false, emptyLabel: "required" }),
+    ).toBe("required");
+  });
+});

--- a/apps/portal/src/lib/terminal/ghost-field-placeholder.ts
+++ b/apps/portal/src/lib/terminal/ghost-field-placeholder.ts
@@ -1,0 +1,11 @@
+/**
+ * When a ghost suggestion paints inside an empty ticket field, the native
+ * placeholder must be blank — otherwise "optional" (or similar) stacks on
+ * top of the ghost and both look mixed together.
+ */
+export function ghostFieldPlaceholder(input: {
+  hasGhost: boolean;
+  emptyLabel: string;
+}): string {
+  return input.hasGhost ? "" : input.emptyLabel;
+}

--- a/apps/portal/src/routes/terminal/components/TicketForm.svelte
+++ b/apps/portal/src/routes/terminal/components/TicketForm.svelte
@@ -3,6 +3,7 @@
   import { bookLevelNotional, formatBookPrice } from "$lib/terminal/book";
   import type { PerpTicket } from "$lib/terminal/perp-ticket";
   import { formatGhostSizeLabel } from "$lib/terminal/perp-ticket";
+  import { ghostFieldPlaceholder } from "$lib/terminal/ghost-field-placeholder";
   import { stepInput } from "$lib/terminal/step-input";
   import { SL_CHIP_PCTS, TP_CHIP_PCTS, fmtTriggerPrice } from "$lib/terminal/trade-math";
   import {
@@ -401,7 +402,10 @@
         <input
           bind:value={$tradeTakeProfit}
           inputmode="decimal"
-          placeholder="optional"
+          placeholder={ghostFieldPlaceholder({
+            hasGhost: Boolean($ghostTp),
+            emptyLabel: "optional",
+          })}
           use:stepInput={{ kind: "price" }}
           onkeydown={onTpKeydown}
         />
@@ -445,7 +449,10 @@
         <input
           bind:value={$tradeStopLoss}
           inputmode="decimal"
-          placeholder={$sizingMode === "risk" ? "required" : "optional"}
+          placeholder={ghostFieldPlaceholder({
+            hasGhost: Boolean($ghostSl),
+            emptyLabel: $sizingMode === "risk" ? "required" : "optional",
+          })}
           use:stepInput={{ kind: "price" }}
           onkeydown={onSlKeydown}
         />


### PR DESCRIPTION
## Summary
- When a TP/SL ghost is showing, the native placeholder is blank so `optional` / `required` no longer mix with the ghost price.
- Adds `ghostFieldPlaceholder` + unit tests so future ghost fields keep the same rule.

## Test plan
- [x] placeholder helper unit tests
- [x] typecheck
- [ ] CI green
- [ ] Smoke: empty TP/SL with structure ghost — only ghost price visible, no `optional` under it

Made with [Cursor](https://cursor.com)