### PR TITLE
feat: market_review routines and closed-trade post-mortems

### DIFF
--- a/apps/portal/agent/instructions/memory.ts
+++ b/apps/portal/agent/instructions/memory.ts
@@ -44,8 +44,9 @@ serialized transactions, one-time codes, or short-lived market data. Tell the
 user whenever memory is saved or forgotten.
 
 Routines are observe-and-alert only. They may read public market prices and
-create private alerts. They can never sign, broadcast, approve, or execute a
-trade, regardless of agent mode.
+create private alerts. A market_review routine drafts an observe-only plan in
+the alert body; it still cannot sign, broadcast, approve, or execute a trade,
+regardless of agent mode.
         `.trim(),
       });
     },

--- a/apps/portal/agent/lib/persistent-types.ts
+++ b/apps/portal/agent/lib/persistent-types.ts
@@ -22,6 +22,12 @@ export type RoutineCheck =
       kind: "price_above" | "price_below";
       symbol: string;
       priceUsd: number;
+    }
+  | {
+      /** Recurring observe-only market review that drafts a plan Artifact text. */
+      kind: "market_review";
+      symbol: string;
+      timeframe: "15m" | "1h";
     };
 
 export type ObserveRoutine = {

--- a/apps/portal/agent/lib/routine-review.test.ts
+++ b/apps/portal/agent/lib/routine-review.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildMarketReviewPlan,
+  formatMarketReviewAlertBody,
+} from "./routine-review";
+
+describe("buildMarketReviewPlan", () => {
+  test("marks bullish bias and drafts an observe-only plan", () => {
+    const plan = buildMarketReviewPlan({
+      symbol: "SOL",
+      timeframe: "15m",
+      candles: [
+        { high: 101, low: 99, close: 100 },
+        { high: 103, low: 100.5, close: 102 },
+        { high: 105, low: 101, close: 104 },
+      ],
+    });
+
+    expect(plan.bias).toBe("bullish");
+    expect(plan.changePct).toBeCloseTo(4, 5);
+    expect(plan.rangeHigh).toBe(105);
+    expect(plan.rangeLow).toBe(99);
+    expect(plan.draftPlan).toContain("observe-only");
+    expect(plan.draftPlan).toContain("will not execute");
+    expect(formatMarketReviewAlertBody(plan)).toContain("BULLISH");
+  });
+
+  test("marks bearish bias from a drop past the threshold", () => {
+    const plan = buildMarketReviewPlan({
+      symbol: "BTC",
+      timeframe: "1h",
+      candles: [
+        { high: 100_100, low: 99_900, close: 100_000 },
+        { high: 99_500, low: 98_800, close: 99_000 },
+      ],
+    });
+    expect(plan.bias).toBe("bearish");
+    expect(plan.invalidationHint).toContain("above");
+  });
+
+  test("marks neutral inside the threshold band", () => {
+    const plan = buildMarketReviewPlan({
+      symbol: "ETH",
+      timeframe: "15m",
+      candles: [
+        { high: 3501, low: 3499, close: 3500 },
+        { high: 3505, low: 3498, close: 3502 },
+      ],
+    });
+    expect(plan.bias).toBe("neutral");
+    expect(plan.invalidationHint).toContain("outside");
+  });
+});

--- a/apps/portal/agent/lib/routine-review.ts
+++ b/apps/portal/agent/lib/routine-review.ts
@@ -1,0 +1,97 @@
+// Pure helpers for market_review routine ticks. Sweeper fetches candles;
+// this module turns them into an observe-only draft plan (never an Execution).
+
+export type CandleClose = {
+  high: number;
+  low: number;
+  close: number;
+};
+
+export type MarketReviewBias = "bullish" | "bearish" | "neutral";
+
+export type MarketReviewPlan = {
+  bias: MarketReviewBias;
+  changePct: number;
+  rangeHigh: number;
+  rangeLow: number;
+  lastClose: number;
+  invalidationHint: string;
+  draftPlan: string;
+};
+
+const BIAS_THRESHOLD_PCT = 0.5;
+
+export function buildMarketReviewPlan(input: {
+  symbol: string;
+  timeframe: string;
+  candles: CandleClose[];
+}): MarketReviewPlan {
+  const candles = input.candles.filter(
+    (row) =>
+      Number.isFinite(row.high) &&
+      Number.isFinite(row.low) &&
+      Number.isFinite(row.close) &&
+      row.high > 0 &&
+      row.low > 0 &&
+      row.close > 0,
+  );
+  if (candles.length === 0) {
+    throw new Error("routine-review-candles-empty");
+  }
+  const first = candles[0];
+  const last = candles[candles.length - 1];
+  if (!first || !last) {
+    throw new Error("routine-review-candles-empty");
+  }
+  const changePct = ((last.close - first.close) / first.close) * 100;
+  const bias: MarketReviewBias =
+    changePct >= BIAS_THRESHOLD_PCT
+      ? "bullish"
+      : changePct <= -BIAS_THRESHOLD_PCT
+        ? "bearish"
+        : "neutral";
+  const rangeHigh = Math.max(...candles.map((row) => row.high));
+  const rangeLow = Math.min(...candles.map((row) => row.low));
+  const invalidationHint =
+    bias === "bullish"
+      ? `A sustained break below $${formatUsd(rangeLow)} would invalidate the short-term bullish read.`
+      : bias === "bearish"
+        ? `A sustained break above $${formatUsd(rangeHigh)} would invalidate the short-term bearish read.`
+        : `A break outside $${formatUsd(rangeLow)}–$${formatUsd(rangeHigh)} would end the range thesis.`;
+
+  const draftPlan = [
+    `Proposed plan (observe-only — not an order):`,
+    `1. Bias: ${bias} on ${input.symbol} over the last ${input.timeframe} window (${formatSignedPct(changePct)}).`,
+    `2. Watch the ${input.timeframe} range $${formatUsd(rangeLow)}–$${formatUsd(rangeHigh)}; last $${formatUsd(last.close)}.`,
+    `3. Invalidation: ${invalidationHint}`,
+    `4. If you want a ticket, ask Eve to draft one after you confirm direction and risk — this routine will not execute.`,
+  ].join("\n");
+
+  return {
+    bias,
+    changePct,
+    rangeHigh,
+    rangeLow,
+    lastClose: last.close,
+    invalidationHint,
+    draftPlan,
+  };
+}
+
+export function formatMarketReviewAlertBody(plan: MarketReviewPlan): string {
+  return [
+    `${plan.bias.toUpperCase()} · ${formatSignedPct(plan.changePct)} · last $${formatUsd(plan.lastClose)}`,
+    plan.draftPlan,
+  ].join("\n\n");
+}
+
+function formatUsd(value: number): string {
+  return value.toLocaleString("en-US", {
+    maximumFractionDigits: value >= 100 ? 2 : 4,
+  });
+}
+
+function formatSignedPct(value: number): string {
+  const abs = Math.abs(value).toFixed(2);
+  return `${value >= 0 ? "+" : "-"}${abs}%`;
+}

--- a/apps/portal/agent/lib/routine-store.ts
+++ b/apps/portal/agent/lib/routine-store.ts
@@ -46,6 +46,14 @@ function validateCheck(check: RoutineCheck): RoutineCheck {
     if (symbols.length === 0) throw new Error("routine-symbols-required");
     return { kind: check.kind, symbols };
   }
+  if (check.kind === "market_review") {
+    const timeframe = check.timeframe === "1h" ? "1h" : "15m";
+    return {
+      kind: "market_review",
+      symbol: normalizeSymbol(check.symbol),
+      timeframe,
+    };
+  }
   if (!Number.isFinite(check.priceUsd) || check.priceUsd <= 0) {
     throw new Error("routine-price-invalid");
   }

--- a/apps/portal/agent/lib/routine-sweeper.ts
+++ b/apps/portal/agent/lib/routine-sweeper.ts
@@ -10,12 +10,18 @@ import type {
   RoutineObservation,
   RoutineRun,
 } from "./persistent-types";
+import {
+  buildMarketReviewPlan,
+  type CandleClose,
+  formatMarketReviewAlertBody,
+} from "./routine-review";
 import { ROUTINE_ROOT, routinePath, routineStore } from "./routine-store";
 
 const MAX_SCAN = 200;
 const MAX_CLAIMS = 12;
 const LEASE_MS = 4 * 60_000;
 const CURSOR_PATH = "agent-state/v1/system/routine-sweep-cursor.json";
+const REVIEW_CANDLE_LIMIT = 24;
 
 type SweepCursor = { cursor: string | null; updatedAt: string };
 type Claimed = { routine: ObserveRoutine; leaseToken: string };
@@ -73,11 +79,15 @@ async function claim(pathname: string, now: Date): Promise<Claimed | null> {
   }
 }
 
-async function marketPrice(symbol: string): Promise<RoutineObservation> {
+async function fetchCandles(
+  symbol: string,
+  timeframe: string,
+  limit: number,
+): Promise<CandleClose[]> {
   const query = new URLSearchParams({
     symbol,
-    timeframe: "1m",
-    limit: "2",
+    timeframe,
+    limit: String(limit),
   });
   const response = await fetch(
     `https://perp-api.phoenix.trade/candles?${query}`,
@@ -88,17 +98,35 @@ async function marketPrice(symbol: string): Promise<RoutineObservation> {
   if (!Array.isArray(rows) || rows.length === 0) {
     throw new Error("routine-market-malformed");
   }
-  const latest = rows.at(-1);
-  const price =
-    typeof latest === "object" && latest !== null
-      ? Number((latest as Record<string, unknown>).close)
-      : NaN;
-  if (!Number.isFinite(price) || price <= 0) {
-    throw new Error("routine-market-price-invalid");
+  const candles: CandleClose[] = [];
+  for (const row of rows) {
+    if (typeof row !== "object" || row === null) continue;
+    const record = row as Record<string, unknown>;
+    const high = Number(record.high);
+    const low = Number(record.low);
+    const close = Number(record.close);
+    if (
+      Number.isFinite(high) &&
+      Number.isFinite(low) &&
+      Number.isFinite(close) &&
+      high > 0 &&
+      low > 0 &&
+      close > 0
+    ) {
+      candles.push({ high, low, close });
+    }
   }
+  if (candles.length === 0) throw new Error("routine-market-price-invalid");
+  return candles;
+}
+
+async function marketPrice(symbol: string): Promise<RoutineObservation> {
+  const candles = await fetchCandles(symbol, "1m", 2);
+  const latest = candles.at(-1);
+  if (!latest) throw new Error("routine-market-price-invalid");
   return {
     symbol,
-    priceUsd: price,
+    priceUsd: latest.close,
     observedAt: new Date().toISOString(),
     source: "phoenix-public-candles",
   };
@@ -108,6 +136,43 @@ async function observe(routine: ObserveRoutine): Promise<{
   observations: RoutineObservation[];
   alert: RoutineAlert | null;
 }> {
+  if (routine.check.kind === "market_review") {
+    const timeframe = routine.check.timeframe;
+    const candles = await fetchCandles(
+      routine.check.symbol,
+      timeframe,
+      REVIEW_CANDLE_LIMIT,
+    );
+    const plan = buildMarketReviewPlan({
+      symbol: routine.check.symbol,
+      timeframe,
+      candles,
+    });
+    const observation: RoutineObservation = {
+      symbol: routine.check.symbol,
+      priceUsd: plan.lastClose,
+      observedAt: new Date().toISOString(),
+      source: "phoenix-public-candles",
+    };
+    const scheduledFor = routine.lease?.scheduledFor ?? routine.nextRunAt;
+    const runId = `${routine.id}:${scheduledFor}`;
+    return {
+      observations: [observation],
+      alert: {
+        id: runId,
+        ownerId: routine.ownerId,
+        routineId: routine.id,
+        routineRunId: runId,
+        severity: "info",
+        title: `${routine.name} · ${plan.bias}`,
+        body: formatMarketReviewAlertBody(plan),
+        evidence: [observation],
+        status: "unread",
+        createdAt: scheduledFor,
+      },
+    };
+  }
+
   const symbols =
     routine.check.kind === "market_snapshot"
       ? routine.check.symbols

--- a/apps/portal/agent/skills/create-routine/SKILL.md
+++ b/apps/portal/agent/skills/create-routine/SKILL.md
@@ -75,7 +75,9 @@ Context Mutation. Present both explicitly before persistence.
 
 Examples:
 
-- “Review SOL every 15 minutes” creates an Observation-and-Artifact Routine.
+- “Review SOL every 15 minutes” creates a `market_review` Observation Routine
+  that writes a private alert with an observe-only draft plan (bias, range,
+  invalidation). It never executes.
 - “Alert below 25% margin health” creates an edge-triggered alert Routine that
   avoids repeating the same alert until the condition clears and crosses again.
 - “Manage SOL until invalidated” requires a Routine plus a bounded Mandate and

--- a/apps/portal/agent/tools/manage_routine.ts
+++ b/apps/portal/agent/tools/manage_routine.ts
@@ -14,6 +14,11 @@ const check = z.discriminatedUnion("kind", [
     symbol,
     priceUsd: z.number().positive().max(10_000_000),
   }),
+  z.object({
+    kind: z.literal("market_review"),
+    symbol,
+    timeframe: z.enum(["15m", "1h"]).default("15m"),
+  }),
 ]);
 
 const routineSchema = z.discriminatedUnion("action", [
@@ -48,7 +53,7 @@ type Input = z.infer<typeof inputSchema>;
 
 export default defineTool({
   description:
-    "List or manage authenticated user-owned recurring market checks. Routines are strictly observe-and-alert only: they read public Phoenix prices and save private alerts, and can never sign, broadcast, approve, or execute transactions. Confirm timezone and first run before creation.",
+    "List or manage authenticated user-owned recurring market checks. Routines are strictly observe-and-alert only: they read public Phoenix prices and save private alerts (including market_review draft plans), and can never sign, broadcast, approve, or execute transactions. Confirm timezone and first run before creation. Prefer market_review for “check SOL every 15 minutes and propose a plan”.",
   inputSchema,
   approval(ctx: ApprovalContext<Input>) {
     if (ctx.toolInput?.routine.action === "list") {

--- a/apps/portal/src/lib/ai.ts
+++ b/apps/portal/src/lib/ai.ts
@@ -139,6 +139,22 @@ export async function aiSessionRecap(
   });
 }
 
+export async function aiTradePostMortem(
+  snapshot: unknown,
+  paper = false,
+): Promise<string> {
+  const user = JSON.stringify(snapshot);
+  const book = paper
+    ? "One SIMULATED paper trade that just closed (not real funds)"
+    : "One trade that just closed";
+  return complete({
+    system: ANALYST_SYSTEM,
+    user: `${book}. Write a 1-2 sentence post-mortem from the facts only: what happened vs the recorded stop/TP when present, the R-multiple when known, and one concrete observation about the exit. No advice, no new thesis.\n\n${user}`,
+    cacheKey: `postmortem:${paper ? "paper:" : ""}${hash(user)}`,
+    maxTokens: 110,
+  });
+}
+
 export async function aiFundingRead(snapshot: unknown): Promise<string> {
   const user = JSON.stringify(snapshot);
   return complete({

--- a/apps/portal/src/lib/postmortem.test.ts
+++ b/apps/portal/src/lib/postmortem.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  buildClosedTradeReview,
+  clearPostMortems,
+  formatRMultiple,
+  loadPostMortems,
+  recordPostMortem,
+  riskUsd,
+  rMultiple,
+} from "./postmortem";
+
+const STORAGE_KEY = "trader-ralph-terminal/postmortems/v1";
+const storage = new Map<string, string>();
+
+Object.defineProperty(globalThis, "window", {
+  configurable: true,
+  value: {
+    localStorage: {
+      getItem(key: string): string | null {
+        return storage.get(key) ?? null;
+      },
+      setItem(key: string, value: string): void {
+        storage.set(key, value);
+      },
+      removeItem(key: string): void {
+        storage.delete(key);
+      },
+    },
+  },
+});
+
+beforeEach(() => {
+  storage.clear();
+});
+
+describe("rMultiple", () => {
+  test("computes +2R when a long hits 2× the stop distance", () => {
+    // Entry 100, stop 90 → $10 risk/unit. Notional $1000 → size 10 → risk $100.
+    // PnL +$200 → +2R.
+    expect(
+      rMultiple({
+        side: "long",
+        entryPrice: 100,
+        stopLossPrice: 90,
+        notionalUsd: 1000,
+        realizedPnlUsd: 200,
+      }),
+    ).toBeCloseTo(2, 5);
+  });
+
+  test("returns null when stop is missing or on the wrong side of entry", () => {
+    expect(
+      riskUsd({
+        side: "long",
+        entryPrice: 100,
+        stopLossPrice: 110,
+        notionalUsd: 1000,
+      }),
+    ).toBeNull();
+    expect(
+      rMultiple({
+        side: "short",
+        entryPrice: 100,
+        stopLossPrice: null,
+        notionalUsd: 1000,
+        realizedPnlUsd: 50,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("buildClosedTradeReview", () => {
+  test("builds a summary with PnL, R, and exit reason", () => {
+    const review = buildClosedTradeReview({
+      ts: 1,
+      mode: "paper",
+      symbol: "SOL",
+      side: "long",
+      entryPrice: 100,
+      exitPrice: 110,
+      stopLossPrice: 95,
+      notionalUsd: 500,
+      realizedPnlUsd: 50,
+      exitReason: "tp",
+      signature: "paper-event-1",
+    });
+    expect(review.rMultiple).toBeCloseTo(2, 5);
+    expect(review.summary).toContain("SOL long");
+    expect(review.summary).toContain("+2.00R");
+    expect(review.summary).toContain("take profit");
+    expect(formatRMultiple(review.rMultiple)).toBe("+2.00R");
+  });
+});
+
+describe("postmortem storage", () => {
+  test("records and clears reviews", () => {
+    const review = buildClosedTradeReview({
+      ts: 2,
+      mode: "live",
+      symbol: "BTC",
+      side: "short",
+      entryPrice: 100_000,
+      exitPrice: 99_000,
+      stopLossPrice: 101_000,
+      notionalUsd: 10_000,
+      realizedPnlUsd: 100,
+      exitReason: "manual",
+      signature: "sig",
+    });
+    expect(recordPostMortem(review)).toHaveLength(1);
+    expect(loadPostMortems()[0]?.symbol).toBe("BTC");
+    clearPostMortems();
+    expect(storage.has(STORAGE_KEY)).toBe(false);
+    expect(loadPostMortems()).toEqual([]);
+  });
+});

--- a/apps/portal/src/lib/postmortem.ts
+++ b/apps/portal/src/lib/postmortem.ts
@@ -1,0 +1,198 @@
+// Local-first closed-trade post-mortems. Paired with the journal on full
+// closes: facts only (entry/exit/stop/R), no fake fills or invented theses.
+
+const STORAGE_KEY = "trader-ralph-terminal/postmortems/v1";
+const MAX_REVIEWS = 200;
+
+export type PostMortemMode = "live" | "paper";
+export type PostMortemSide = "long" | "short";
+export type PostMortemExitReason = "manual" | "tp" | "sl" | "liq";
+
+export type ClosedTradeReview = {
+  id: string;
+  ts: number;
+  mode: PostMortemMode;
+  venue: "perp" | "spot";
+  symbol: string;
+  side: PostMortemSide;
+  entryPrice: number | null;
+  exitPrice: number | null;
+  stopLossPrice: number | null;
+  takeProfitPrice: number | null;
+  notionalUsd: number | null;
+  realizedPnlUsd: number | null;
+  /** Null when stop was missing or risk distance is zero. */
+  rMultiple: number | null;
+  exitReason: PostMortemExitReason;
+  signature: string;
+  summary: string;
+};
+
+export function riskUsd(input: {
+  side: PostMortemSide;
+  entryPrice: number;
+  stopLossPrice: number;
+  notionalUsd: number;
+}): number | null {
+  if (
+    !(input.entryPrice > 0) ||
+    !(input.stopLossPrice > 0) ||
+    !(input.notionalUsd > 0)
+  ) {
+    return null;
+  }
+  const stopDistance =
+    input.side === "long"
+      ? input.entryPrice - input.stopLossPrice
+      : input.stopLossPrice - input.entryPrice;
+  if (!(stopDistance > 0)) return null;
+  const size = input.notionalUsd / input.entryPrice;
+  const risk = size * stopDistance;
+  return Number.isFinite(risk) && risk > 0 ? risk : null;
+}
+
+export function rMultiple(input: {
+  side: PostMortemSide;
+  entryPrice: number | null;
+  stopLossPrice: number | null;
+  notionalUsd: number | null;
+  realizedPnlUsd: number | null;
+}): number | null {
+  if (
+    input.entryPrice === null ||
+    input.stopLossPrice === null ||
+    input.notionalUsd === null ||
+    input.realizedPnlUsd === null
+  ) {
+    return null;
+  }
+  const risk = riskUsd({
+    side: input.side,
+    entryPrice: input.entryPrice,
+    stopLossPrice: input.stopLossPrice,
+    notionalUsd: input.notionalUsd,
+  });
+  if (risk === null) return null;
+  const value = input.realizedPnlUsd / risk;
+  return Number.isFinite(value) ? value : null;
+}
+
+export function summarizeReview(
+  review: Omit<ClosedTradeReview, "id" | "summary"> & { summary?: string },
+): string {
+  const pnl =
+    review.realizedPnlUsd === null
+      ? "PnL unknown"
+      : `${review.realizedPnlUsd >= 0 ? "+" : "-"}$${Math.abs(review.realizedPnlUsd).toFixed(2)}`;
+  const r =
+    review.rMultiple === null
+      ? "R n/a"
+      : `${review.rMultiple >= 0 ? "+" : ""}${review.rMultiple.toFixed(2)}R`;
+  const reason =
+    review.exitReason === "manual"
+      ? "manual close"
+      : review.exitReason === "tp"
+        ? "take profit"
+        : review.exitReason === "sl"
+          ? "stop loss"
+          : "liquidation";
+  return `${review.symbol} ${review.side} · ${pnl} · ${r} · ${reason}`;
+}
+
+export function buildClosedTradeReview(input: {
+  ts: number;
+  mode: PostMortemMode;
+  venue?: "perp" | "spot";
+  symbol: string;
+  side: PostMortemSide;
+  entryPrice: number | null;
+  exitPrice: number | null;
+  stopLossPrice: number | null;
+  takeProfitPrice?: number | null;
+  notionalUsd: number | null;
+  realizedPnlUsd: number | null;
+  exitReason: PostMortemExitReason;
+  signature: string;
+}): ClosedTradeReview {
+  const r = rMultiple({
+    side: input.side,
+    entryPrice: input.entryPrice,
+    stopLossPrice: input.stopLossPrice,
+    notionalUsd: input.notionalUsd,
+    realizedPnlUsd: input.realizedPnlUsd,
+  });
+  const base = {
+    ts: input.ts,
+    mode: input.mode,
+    venue: input.venue ?? "perp",
+    symbol: input.symbol,
+    side: input.side,
+    entryPrice: input.entryPrice,
+    exitPrice: input.exitPrice,
+    stopLossPrice: input.stopLossPrice,
+    takeProfitPrice: input.takeProfitPrice ?? null,
+    notionalUsd: input.notionalUsd,
+    realizedPnlUsd: input.realizedPnlUsd,
+    rMultiple: r,
+    exitReason: input.exitReason,
+    signature: input.signature,
+  };
+  return {
+    id: `${input.signature}:${input.ts}`,
+    ...base,
+    summary: summarizeReview(base),
+  };
+}
+
+export function loadPostMortems(): ClosedTradeReview[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const data = JSON.parse(raw) as unknown;
+    if (!Array.isArray(data)) return [];
+    return data.flatMap((row) => {
+      if (!row || typeof row !== "object") return [];
+      const candidate = row as Partial<ClosedTradeReview>;
+      if (
+        typeof candidate.ts !== "number" ||
+        typeof candidate.symbol !== "string" ||
+        typeof candidate.summary !== "string" ||
+        typeof candidate.signature !== "string"
+      ) {
+        return [];
+      }
+      if (candidate.mode !== "live" && candidate.mode !== "paper") return [];
+      if (candidate.side !== "long" && candidate.side !== "short") return [];
+      return [candidate as ClosedTradeReview];
+    });
+  } catch {
+    return [];
+  }
+}
+
+export function recordPostMortem(
+  review: ClosedTradeReview,
+): ClosedTradeReview[] {
+  const entries = [...loadPostMortems(), review].slice(-MAX_REVIEWS);
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    // storage unavailable — best-effort
+  }
+  return entries;
+}
+
+export function clearPostMortems(): void {
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+export function formatRMultiple(value: number | null): string {
+  if (value === null) return "R n/a";
+  const abs = Math.abs(value).toFixed(2);
+  return `${value >= 0 ? "+" : "-"}${abs}R`;
+}

--- a/apps/portal/src/lib/terminal/paper-ledger.ts
+++ b/apps/portal/src/lib/terminal/paper-ledger.ts
@@ -115,6 +115,10 @@ export type PaperEvent = {
   leverage: number | null;
   realizedPnlUsd: number;
   signature: string;
+  /** Set on close/tp/sl/liq for post-mortem R math. */
+  entryPrice?: number | null;
+  stopLossPrice?: number | null;
+  takeProfitPrice?: number | null;
 };
 
 export type PaperSpotMarketInput = {
@@ -735,6 +739,9 @@ function closePositionSeed(
       price,
       leverage: null,
       realizedPnlUsd: pnl,
+      entryPrice: position.entryPrice,
+      stopLossPrice: position.stopLossPrice,
+      takeProfitPrice: position.takeProfitPrice,
     },
   };
 }
@@ -1341,6 +1348,9 @@ export function tickPaperLedger(
           price: mid,
           leverage: lev,
           realizedPnlUsd: -margin,
+          entryPrice: position.entryPrice,
+          stopLossPrice: position.stopLossPrice,
+          takeProfitPrice: position.takeProfitPrice,
         });
         continue;
       }

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -31,6 +31,7 @@
     aiFundingRead,
     aiPositionBrief,
     aiSessionRecap,
+    aiTradePostMortem,
     aiParseCommand,
     aiScannerSetups,
     IDLE_READ,
@@ -238,6 +239,15 @@
     recordTrade,
     type JournalEntry,
   } from "$lib/journal";
+  import {
+    buildClosedTradeReview,
+    clearPostMortems,
+    loadPostMortems,
+    recordPostMortem,
+    type ClosedTradeReview,
+    type PostMortemExitReason,
+    type PostMortemSide,
+  } from "$lib/postmortem";
   import {
     cancelTriggerOrder,
     createTriggerOrder,
@@ -829,6 +839,8 @@
   let screenHub: "all" | "crypto" | "equities" | "pre-ipo" = "all";
   // Local-first trade journal + AI desk notes over it.
   let journalEntries: JournalEntry[] = [];
+  let postMortems: ClosedTradeReview[] = [];
+  let postMortemRead: AiRead = IDLE_READ;
   let briefRead: AiRead = IDLE_READ;
   let recapRead: AiRead = IDLE_READ;
   let briefKey = "";
@@ -1994,6 +2006,7 @@
     applyDeepLink(); // ?asset=&venue=&side=… — overrides restored prefs
     alertsStore.load({ trackContext: marketContext });
     journalEntries = loadJournal();
+    postMortems = loadPostMortems();
     loadLayout();
     const panelsWarm = hydrateWidgetCache();
     prefsReady = true;
@@ -3523,6 +3536,11 @@
         event.kind === "spot_buy" ||
         event.kind === "spot_sell" ||
         event.kind === "spot_limit_fill";
+      const isClose =
+        event.kind === "close" ||
+        event.kind === "tp" ||
+        event.kind === "sl" ||
+        event.kind === "liq";
       noteTrade({
         ts: Date.now(),
         mode: "paper",
@@ -3536,10 +3554,7 @@
             : event.kind === "spot_limit_fill"
               ? "limit-sell"
               : "sell"
-          : event.kind === "close" ||
-              event.kind === "tp" ||
-              event.kind === "sl" ||
-              event.kind === "liq"
+          : isClose
             ? "close"
             : event.side === "bid"
               ? "long"
@@ -3549,6 +3564,31 @@
         leverage: event.leverage,
         signature: event.signature,
       });
+      if (isClose) {
+        const exitReason: PostMortemExitReason =
+          event.kind === "tp"
+            ? "tp"
+            : event.kind === "sl"
+              ? "sl"
+              : event.kind === "liq"
+                ? "liq"
+                : "manual";
+        // Close side is the flatten side: ask closes a long, bid closes a short.
+        const side: PostMortemSide = event.side === "ask" ? "long" : "short";
+        noteClosedTrade({
+          mode: "paper",
+          symbol: event.symbol,
+          side,
+          entryPrice: event.entryPrice ?? null,
+          exitPrice: event.price,
+          stopLossPrice: event.stopLossPrice ?? null,
+          takeProfitPrice: event.takeProfitPrice ?? null,
+          notionalUsd: event.notionalUsd,
+          realizedPnlUsd: event.realizedPnlUsd,
+          exitReason,
+          signature: event.signature,
+        });
+      }
       if (event.kind === "tp" || event.kind === "sl" || event.kind === "liq") {
         alertsStore.pushToast({
           ts: Date.now(),
@@ -4038,25 +4078,23 @@
         expectedLiveExecutionEpoch,
         busyKey,
       );
-      {
-        const closing = enrichedPositions.find(
-          (position) => position.symbol === symbol,
-        );
-        track(partial ? "position_partial_close" : "position_closed", {
-          ...marketContext(),
-          closedSymbol: symbol,
-          size,
-          ...(partial ? { fraction } : {}),
-          entryPrice: closing?.entryPrice ?? null,
-          realizedUpnlEst: closing?.unrealizedPnl ?? null,
-          marginUsd: closing?.marginUsd ?? null,
-          roePct:
-            closing?.unrealizedPnl != null && closing?.marginUsd
-              ? (closing.unrealizedPnl / closing.marginUsd) * 100
-              : null,
-          signature: lastTradeSignature,
-        });
-      }
+      const closing = enrichedPositions.find(
+        (position) => position.symbol === symbol,
+      );
+      track(partial ? "position_partial_close" : "position_closed", {
+        ...marketContext(),
+        closedSymbol: symbol,
+        size,
+        ...(partial ? { fraction } : {}),
+        entryPrice: closing?.entryPrice ?? null,
+        realizedUpnlEst: closing?.unrealizedPnl ?? null,
+        marginUsd: closing?.marginUsd ?? null,
+        roePct:
+          closing?.unrealizedPnl != null && closing?.marginUsd
+            ? (closing.unrealizedPnl / closing.marginUsd) * 100
+            : null,
+        signature: lastTradeSignature,
+      });
       noteTrade({
         ts: Date.now(),
         mode: "live",
@@ -4068,6 +4106,23 @@
         leverage: null,
         signature: lastTradeSignature,
       });
+      if (!partial && closing) {
+        noteClosedTrade({
+          mode: "live",
+          symbol,
+          side: size > 0 ? "long" : "short",
+          entryPrice: closing.entryPrice,
+          exitPrice: marketMids[symbol] ?? null,
+          stopLossPrice: closing.stopLossPrice,
+          takeProfitPrice: closing.takeProfitPrice,
+          notionalUsd: marketMids[symbol]
+            ? Math.abs(size) * marketMids[symbol]
+            : closing.positionValue,
+          realizedPnlUsd: closing.unrealizedPnl,
+          exitReason: "manual",
+          signature: lastTradeSignature,
+        });
+      }
       if (partial) {
         // TP/SL are position-level triggers — a partial close leaves them
         // armed on the remainder; say so instead of letting traders wonder.
@@ -4617,6 +4672,21 @@
               : null,
             price: marketMids[position.symbol] ?? null,
             leverage: null,
+            signature: lastTradeSignature,
+          });
+          noteClosedTrade({
+            mode: "live",
+            symbol: position.symbol,
+            side: position.size > 0 ? "long" : "short",
+            entryPrice: position.entryPrice,
+            exitPrice: marketMids[position.symbol] ?? null,
+            stopLossPrice: position.stopLossPrice,
+            takeProfitPrice: position.takeProfitPrice,
+            notionalUsd: marketMids[position.symbol]
+              ? Math.abs(position.size) * marketMids[position.symbol]
+              : position.positionValue,
+            realizedPnlUsd: position.unrealizedPnl,
+            exitReason: "manual",
             signature: lastTradeSignature,
           });
         }
@@ -6031,11 +6101,67 @@
     journalEntries = recordTrade(entry);
   }
 
+  function noteClosedTrade(input: {
+    mode: "live" | "paper";
+    symbol: string;
+    side: PostMortemSide;
+    entryPrice: number | null;
+    exitPrice: number | null;
+    stopLossPrice: number | null;
+    takeProfitPrice: number | null;
+    notionalUsd: number | null;
+    realizedPnlUsd: number | null;
+    exitReason: PostMortemExitReason;
+    signature: string;
+  }): void {
+    const review = buildClosedTradeReview({
+      ts: Date.now(),
+      ...input,
+    });
+    postMortems = recordPostMortem(review);
+    alertsStore.pushToast({
+      ts: Date.now(),
+      title: "Post-mortem",
+      body: review.summary,
+    });
+    void runTradePostMortem(review);
+  }
+
   function wipeJournal(): void {
     clearJournal();
+    clearPostMortems();
     journalEntries = [];
+    postMortems = [];
     recapRead = IDLE_READ;
+    postMortemRead = IDLE_READ;
     recapKey = 0;
+  }
+
+  async function runTradePostMortem(review: ClosedTradeReview): Promise<void> {
+    if (aiDisabled()) return;
+    const snapshot = {
+      symbol: review.symbol,
+      side: review.side,
+      mode: review.mode,
+      entryPrice: review.entryPrice,
+      exitPrice: review.exitPrice,
+      stopLossPrice: review.stopLossPrice,
+      takeProfitPrice: review.takeProfitPrice,
+      realizedPnlUsd: review.realizedPnlUsd,
+      rMultiple: review.rMultiple,
+      exitReason: review.exitReason,
+      summary: review.summary,
+    };
+    postMortemRead = { phase: "loading", text: postMortemRead.text };
+    try {
+      postMortemRead = {
+        phase: "ready",
+        asOf: Date.now(),
+        text: await aiTradePostMortem(snapshot, review.mode === "paper"),
+      };
+    } catch (error) {
+      postMortemRead = { phase: "error", text: "", error: aiErr(error) };
+    }
   }
 
   async function runPositionBrief(): Promise<void> {
@@ -7091,6 +7217,10 @@
             displayTimezone={displayTimezone}
             {journalEntries}
             {journalToday}
+            postMortems={postMortems.filter(
+              (row) => row.mode === (paperMode ? "paper" : "live"),
+            )}
+            postMortemRead={harnessCompact ? IDLE_READ : postMortemRead}
             recapRead={viewRecapRead}
             {sessionPnlUsd}
             onwipe={wipeJournal}

--- a/apps/portal/src/routes/terminal/components/JournalPanel.svelte
+++ b/apps/portal/src/routes/terminal/components/JournalPanel.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
-  import type { AiRead } from "$lib/ai";
+  import { IDLE_READ, type AiRead } from "$lib/ai";
   import { journalToCsv, type JournalEntry } from "$lib/journal";
+  import {
+    formatRMultiple,
+    type ClosedTradeReview,
+  } from "$lib/postmortem";
   import { panelStyle, usePanelLayout } from "$lib/terminal/layout";
   import {
     formatTimeHmInZone,
@@ -13,6 +17,8 @@
   let {
     journalEntries,
     journalToday,
+    postMortems = [],
+    postMortemRead = IDLE_READ,
     recapRead,
     sessionPnlUsd,
     displayTimezone = "UTC",
@@ -20,6 +26,8 @@
   }: {
     journalEntries: JournalEntry[];
     journalToday: JournalEntry[];
+    postMortems?: ClosedTradeReview[];
+    postMortemRead?: AiRead;
     recapRead: AiRead;
     /** Day P&L from the equity baseline — null when no wallet/history. */
     sessionPnlUsd: number | null;
@@ -62,7 +70,7 @@
 >
   <div class="panel-head">
     <DragHead panelId="journal" kicker="JOURNAL" title={`${journalToday.length} today · ${journalEntries.length} total`} />
-    {#if journalEntries.length > 0}
+    {#if journalEntries.length > 0 || postMortems.length > 0}
       <button class="row-action" type="button" onclick={exportJournalCsv}>CSV</button>
       <button class="row-action" type="button" onclick={onwipe}>Clear</button>
     {/if}
@@ -89,6 +97,26 @@
   </div>
   {#if journalToday.length >= 2}
     <AiReadLine read={recapRead} />
+  {/if}
+  {#if postMortems.length > 0}
+    <div class="postmortem-block">
+      <div class="postmortem-kicker">POST-MORTEMS</div>
+      {#if postMortemRead.phase !== "idle"}
+        <AiReadLine read={postMortemRead} />
+      {/if}
+      {#each [...postMortems].reverse().slice(0, 6) as review (review.id)}
+        <div class="postmortem-row">
+          <span class="journal-time">{formatTimeHmInZone(review.ts, displayTimezone)}</span>
+          <span class="journal-sym">{review.symbol}</span>
+          <span
+            class="journal-action"
+            class:positive={review.realizedPnlUsd !== null && review.realizedPnlUsd >= 0}
+            class:negative={review.realizedPnlUsd !== null && review.realizedPnlUsd < 0}
+          >{formatRMultiple(review.rMultiple)}</span>
+          <span class="postmortem-summary">{review.summary}</span>
+        </div>
+      {/each}
+    </div>
   {/if}
   <div class="journal-list">
     {#each [...journalEntries].reverse().slice(0, 12) as entry (entry.ts)}
@@ -136,6 +164,33 @@
   }
   .session-strip .up b { color: var(--up); }
   .session-strip .down b { color: var(--down); }
+  .postmortem-block {
+    padding: 0.4rem 0 0.2rem;
+    border-bottom: 1px solid var(--line-soft);
+  }
+  .postmortem-kicker {
+    font-size: 0.58rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    color: var(--faint);
+    margin-bottom: 0.2rem;
+  }
+  .postmortem-row {
+    display: grid;
+    grid-template-columns: 2.6rem 2.4rem 3.2rem minmax(0, 1fr);
+    gap: 0.45rem;
+    align-items: baseline;
+    padding: 0.28rem 0;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.7rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .postmortem-summary {
+    color: var(--muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
   .journal-list { display: grid; }
   .journal-row {
     display: grid;


### PR DESCRIPTION
## Summary
- Add market_review observe-only routine check: each tick fetches Phoenix candles, drafts bias/range/invalidation plan text into a private alert (never executes).
- Add local closed-trade post-mortems on paper/live closes: R-multiple when stop is known, journal panel section, optional AI critique, toast on close.

## Test plan
- [x] bun run typecheck (0 errors)
- [x] bun run --cwd apps/portal test (577 pass)
- [x] New unit tests: postmortem.test.ts, routine-review.test.ts
- [ ] Ask Eve to review SOL every 15 minutes; alert body contains observe-only draft plan
- [ ] Paper: open long with SL, close/TP/SL shows POST-MORTEMS with R when stop present
- [ ] Live full close records post-mortem; Clear journal wipes post-mortems too

## Validation notes
- Local Windows build hit Vercel adapter symlink EPERM after Vite succeeded; CI is arbiter.
- Targeted biome check on changed TS files is clean.

## Risk
- Routines remain observe-and-alert only (no Mandate / auto-execute).
- Live realized PnL uses pre-close uPnL estimate.

Made with [Cursor](https://cursor.com)