### PR TITLE
feat(terminal): funding countdown, break-even, and one-click reverse

### DIFF
--- a/apps/portal/src/lib/phoenix-trade.ts
+++ b/apps/portal/src/lib/phoenix-trade.ts
@@ -787,6 +787,55 @@ export async function buildPlaceOrderPlan(
   };
 }
 
+/**
+ * One signing ceremony: reduce-only close of the open side, then a fresh
+ * opposite market open at the same base size / margin. Callers must simulate
+ * the concatenated list before broadcast.
+ */
+export async function buildReversePositionPlan(input: {
+  authority: string;
+  position: PhoenixPosition;
+  markPrice: number;
+}): Promise<PlacedOrderPlan> {
+  const { authority, position, markPrice } = input;
+  if (!(Math.abs(position.size) > 0)) {
+    throw new Error("No position to reverse");
+  }
+  if (!(markPrice > 0)) {
+    throw new Error("Mark price unavailable for reverse");
+  }
+  const quantity = Math.abs(position.size);
+  const closeSide: PhoenixSide = position.size > 0 ? "ask" : "bid";
+  const openSide: PhoenixSide = position.size > 0 ? "ask" : "bid";
+  // Close is reduce-only opposite the position; open is the same close-side
+  // direction as a fresh entry (long→short uses ask for both legs).
+  const closePlan = await buildPlaceOrderPlan({
+    authority,
+    symbol: position.symbol,
+    side: closeSide,
+    orderType: "market",
+    quantity,
+    reduceOnly: true,
+  });
+  const marginUsd =
+    position.marginUsd !== null && position.marginUsd > 0
+      ? position.marginUsd
+      : (quantity * markPrice) / 5;
+  const openPlan = await buildPlaceOrderPlan({
+    authority,
+    symbol: position.symbol,
+    side: openSide,
+    orderType: "market",
+    quantity,
+    marginUsd,
+    reduceOnly: false,
+  });
+  return {
+    instructions: [...closePlan.instructions, ...openPlan.instructions],
+    estimatedLiquidationPriceUsd: openPlan.estimatedLiquidationPriceUsd,
+  };
+}
+
 // ── Cancel ────────────────────────────────────────────────────────────
 
 export async function buildCancelAllIxs(

--- a/apps/portal/src/lib/terminal/trade-math.test.ts
+++ b/apps/portal/src/lib/terminal/trade-math.test.ts
@@ -3,12 +3,18 @@ import type { DepthLevel, PhoenixMarketConfig } from "$lib/phoenix-market-data";
 import type { PhoenixOpenOrder, PhoenixPosition } from "$lib/phoenix-trade";
 import {
   buildTradePreview,
+  canAffordReverse,
+  canMoveStopToBreakEven,
   clampLeverage,
   enrichPosition,
   fmtTriggerPrice,
+  formatFundingCountdown,
   liqDistancePct,
   liquidationPriceEstimate,
+  msUntilFundingSettle,
+  nextFundingSettleAt,
   orderCancelKey,
+  positionFundingHoldCostUsd,
   riskNotional,
   SL_CHIP_PCTS,
   TP_CHIP_PCTS,
@@ -465,5 +471,78 @@ describe("liquidationPriceEstimate", () => {
     expect(
       liquidationPriceEstimate(100, 10, Number.POSITIVE_INFINITY, 0.025),
     ).toBeNull();
+  });
+});
+
+describe("funding countdown + hold cost", () => {
+  test("next settle lands on the following UTC 8h bucket", () => {
+    // 2026-08-20T01:00:00.000Z → next is 08:00 UTC
+    const now = Date.UTC(2026, 7, 20, 1, 0, 0);
+    expect(nextFundingSettleAt(now)).toBe(Date.UTC(2026, 7, 20, 8, 0, 0));
+    expect(formatFundingCountdown(msUntilFundingSettle(now))).toBe("in 7h 0m");
+  });
+
+  test("hold cost flips sign for shorts", () => {
+    expect(positionFundingHoldCostUsd(1000, 0.01, "long")).toBeCloseTo(0.1, 8);
+    expect(positionFundingHoldCostUsd(1000, 0.01, "short")).toBeCloseTo(
+      -0.1,
+      8,
+    );
+    expect(positionFundingHoldCostUsd(null, 0.01, "long")).toBeNull();
+  });
+});
+
+describe("break-even gate + reverse affordability", () => {
+  test("BE requires ≥ +0.5R and a protective entry vs mark", () => {
+    // Entry 100, stop 90 → risk $100 on size 10. uPnL +60 → +0.6R.
+    expect(
+      canMoveStopToBreakEven({
+        side: "long",
+        entryPrice: 100,
+        markPrice: 106,
+        stopLossPrice: 90,
+        size: 10,
+        unrealizedPnlUsd: 60,
+      }).ok,
+    ).toBe(true);
+    expect(
+      canMoveStopToBreakEven({
+        side: "long",
+        entryPrice: 100,
+        markPrice: 103,
+        stopLossPrice: 90,
+        size: 10,
+        unrealizedPnlUsd: 30,
+      }).ok,
+    ).toBe(false);
+    expect(
+      canMoveStopToBreakEven({
+        side: "long",
+        entryPrice: 100,
+        markPrice: 106,
+        stopLossPrice: null,
+        size: 10,
+        unrealizedPnlUsd: 60,
+      }).reason,
+    ).toContain("stop");
+  });
+
+  test("reverse affordability uses freed margin + free collateral", () => {
+    expect(
+      canAffordReverse({
+        freeCollateralUsd: 0,
+        marginUsd: 100,
+        unrealizedPnlUsd: 0,
+        notionalUsd: 500,
+      }).ok,
+    ).toBe(true);
+    expect(
+      canAffordReverse({
+        freeCollateralUsd: 10,
+        marginUsd: 100,
+        unrealizedPnlUsd: -50,
+        notionalUsd: 500,
+      }).ok,
+    ).toBe(false);
   });
 });

--- a/apps/portal/src/lib/terminal/trade-math.ts
+++ b/apps/portal/src/lib/terminal/trade-math.ts
@@ -215,3 +215,161 @@ export function tpSlExecutionPrice(
 export function orderCancelKey(order: PhoenixOpenOrder): string {
   return `cancel:${order.symbol}:${order.side}:${order.isStopLoss ? "sl" : order.orderSequenceNumber}`;
 }
+
+/** Phoenix product copy treats funding as an 8h UTC schedule (00/08/16). */
+export const FUNDING_INTERVAL_MS = 8 * 60 * 60 * 1000;
+
+export function nextFundingSettleAt(nowMs: number): number {
+  if (!Number.isFinite(nowMs)) return Number.NaN;
+  return (
+    Math.floor(nowMs / FUNDING_INTERVAL_MS) * FUNDING_INTERVAL_MS +
+    FUNDING_INTERVAL_MS
+  );
+}
+
+export function msUntilFundingSettle(nowMs: number): number | null {
+  const next = nextFundingSettleAt(nowMs);
+  if (!Number.isFinite(next)) return null;
+  return Math.max(0, next - nowMs);
+}
+
+export function formatFundingCountdown(ms: number | null): string {
+  if (ms === null || !Number.isFinite(ms)) return "--";
+  const totalSec = Math.max(0, Math.floor(ms / 1000));
+  const hours = Math.floor(totalSec / 3600);
+  const minutes = Math.floor((totalSec % 3600) / 60);
+  if (hours > 0) return `in ${hours}h ${minutes}m`;
+  return `in ${minutes}m`;
+}
+
+/**
+ * Est. USDC paid (positive) or received (negative) to hold through one
+ * funding window. Longs pay when rate > 0; shorts are the opposite.
+ */
+export function positionFundingHoldCostUsd(
+  notionalUsd: number | null,
+  fundingPct: number | null,
+  side: "long" | "short",
+): number | null {
+  if (
+    notionalUsd === null ||
+    fundingPct === null ||
+    !(notionalUsd > 0) ||
+    !Number.isFinite(fundingPct)
+  ) {
+    return null;
+  }
+  const raw = (fundingPct / 100) * notionalUsd;
+  return side === "long" ? raw : -raw;
+}
+
+/** Open-position R from uPnL vs stop-distance risk. Null without a valid stop. */
+export function unrealizedRMultiple(input: {
+  side: "long" | "short";
+  entryPrice: number | null;
+  stopLossPrice: number | null;
+  size: number;
+  unrealizedPnlUsd: number | null;
+}): number | null {
+  const { entryPrice, stopLossPrice, size, unrealizedPnlUsd } = input;
+  if (
+    entryPrice === null ||
+    stopLossPrice === null ||
+    unrealizedPnlUsd === null ||
+    !(entryPrice > 0) ||
+    !(stopLossPrice > 0) ||
+    !(Math.abs(size) > 0)
+  ) {
+    return null;
+  }
+  const stopDistance =
+    input.side === "long"
+      ? entryPrice - stopLossPrice
+      : stopLossPrice - entryPrice;
+  if (!(stopDistance > 0)) return null;
+  const riskUsd = Math.abs(size) * stopDistance;
+  if (!(riskUsd > 0)) return null;
+  const value = unrealizedPnlUsd / riskUsd;
+  return Number.isFinite(value) ? value : null;
+}
+
+export function canMoveStopToBreakEven(input: {
+  side: "long" | "short";
+  entryPrice: number | null;
+  markPrice: number | null;
+  stopLossPrice: number | null;
+  size: number;
+  unrealizedPnlUsd: number | null;
+  minR?: number;
+}): { ok: boolean; reason: string | null; rMultiple: number | null } {
+  const minR = input.minR ?? 0.5;
+  if (input.entryPrice === null || !(input.entryPrice > 0)) {
+    return { ok: false, reason: "Entry unavailable", rMultiple: null };
+  }
+  if (input.markPrice === null || !(input.markPrice > 0)) {
+    return { ok: false, reason: "Mark unavailable", rMultiple: null };
+  }
+  // SL at entry must still be on the protective side of the mark.
+  const beValid =
+    input.side === "long"
+      ? input.entryPrice < input.markPrice
+      : input.entryPrice > input.markPrice;
+  if (!beValid) {
+    return {
+      ok: false,
+      reason: "Entry is on the wrong side of mark for a stop",
+      rMultiple: null,
+    };
+  }
+  const r = unrealizedRMultiple({
+    side: input.side,
+    entryPrice: input.entryPrice,
+    stopLossPrice: input.stopLossPrice,
+    size: input.size,
+    unrealizedPnlUsd: input.unrealizedPnlUsd,
+  });
+  if (r === null) {
+    return {
+      ok: false,
+      reason: "Set a stop first to measure R",
+      rMultiple: null,
+    };
+  }
+  if (r < minR) {
+    return {
+      ok: false,
+      reason: `Need ≥ +${minR}R (now ${r >= 0 ? "+" : ""}${r.toFixed(2)}R)`,
+      rMultiple: r,
+    };
+  }
+  return { ok: true, reason: null, rMultiple: r };
+}
+
+/** After close frees margin + uPnL, can the same notional flip reopen? */
+export function canAffordReverse(input: {
+  freeCollateralUsd: number;
+  marginUsd: number | null;
+  unrealizedPnlUsd: number | null;
+  notionalUsd: number | null;
+}): { ok: boolean; reason: string | null; needUsd: number | null } {
+  const notional = input.notionalUsd;
+  const margin = input.marginUsd;
+  if (
+    notional === null ||
+    !(notional > 0) ||
+    margin === null ||
+    !(margin > 0)
+  ) {
+    return { ok: false, reason: "Position sizing unavailable", needUsd: null };
+  }
+  const available =
+    input.freeCollateralUsd + margin + (input.unrealizedPnlUsd ?? 0);
+  if (available + 1e-6 < margin) {
+    return {
+      ok: false,
+      reason: `Need $${margin.toFixed(2)} margin after close, have ~$${Math.max(0, available).toFixed(2)}`,
+      needUsd: margin,
+    };
+  }
+  return { ok: true, reason: null, needUsd: margin };
+}

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -9,6 +9,7 @@
   import BookLadder from "./components/BookLadder.svelte";
   import CheatSheetModal from "./components/CheatSheetModal.svelte";
   import ClosePreviewModal from "./components/ClosePreviewModal.svelte";
+  import ReversePreviewModal from "./components/ReversePreviewModal.svelte";
   import CommandPalette from "./components/CommandPalette.svelte";
   import FundingWizard from "./components/FundingWizard.svelte";
   import FundsModal from "./components/FundsModal.svelte";
@@ -279,11 +280,16 @@
     isRecord,
   } from "$lib/utils";
   import {
+    canAffordReverse,
+    canMoveStopToBreakEven,
     clampLeverage,
     enrichPosition,
+    formatFundingCountdown,
     fmtTriggerPrice,
     liqDistancePct,
+    msUntilFundingSettle,
     orderCancelKey,
+    positionFundingHoldCostUsd,
   } from "$lib/terminal/trade-math";
   import { createPerpTicket } from "$lib/terminal/perp-ticket";
   import { createSpotTicket } from "$lib/terminal/spot-ticket";
@@ -4516,10 +4522,31 @@
     position: PhoenixPosition;
     fraction: number;
   } | null = null;
+  let reversePreview: PhoenixPosition | null = null;
   $: flattenEstPnl = enrichedPositions.reduce(
     (sum, position) => sum + (position.unrealizedPnl ?? 0),
     0,
   );
+
+  $: fundingHint = (() => {
+    if (tradeMode !== "perps") return "";
+    const countdown = formatFundingCountdown(msUntilFundingSettle(nowMs));
+    const selected = enrichedPositions.find(
+      (position) => position.symbol === selectedSymbol,
+    );
+    if (!selected) return `${countdown} · est --`;
+    const cost = positionFundingHoldCostUsd(
+      selected.positionValue ??
+        (marketMids[selected.symbol] != null
+          ? Math.abs(selected.size) * marketMids[selected.symbol]
+          : null),
+      fundingPercent,
+      selected.size > 0 ? "long" : "short",
+    );
+    if (cost === null) return `${countdown} · est --`;
+    const abs = formatNumber(Math.abs(cost), 2);
+    return `${countdown} · est ${cost >= 0 ? "-" : "+"}$${abs}`;
+  })();
 
   function openClosePreview(position: PhoenixPosition, fraction = 1): void {
     closePreview = { position, fraction };
@@ -4538,6 +4565,184 @@
       preview.position.size,
       preview.position.subaccountIndex,
     );
+  }
+
+  function openReversePreview(position: PhoenixPosition): void {
+    reversePreview = position;
+  }
+
+  function moveStopToBreakEven(position: PhoenixPosition): void {
+    const mark =
+      marketMids[position.symbol] ??
+      (position.symbol === selectedSymbol ? latestPrice : null);
+    const gate = canMoveStopToBreakEven({
+      side: position.size > 0 ? "long" : "short",
+      entryPrice: position.entryPrice,
+      markPrice: mark,
+      stopLossPrice: position.stopLossPrice,
+      size: position.size,
+      unrealizedPnlUsd: position.unrealizedPnl,
+    });
+    if (!gate.ok || position.entryPrice === null) {
+      phoenixActionError = gate.reason ?? "Break-even unavailable";
+      phoenixActionErrorDetail = "";
+      phoenixActionRetry = null;
+      return;
+    }
+    void submitTpSlDrag(
+      position,
+      "sl",
+      position.entryPrice,
+      position.stopLossPrice ?? position.entryPrice,
+    );
+  }
+
+  async function confirmReversePreview(): Promise<void> {
+    const position = reversePreview;
+    if (!position) return;
+    reversePreview = null;
+    await reversePhoenixPosition(position);
+  }
+
+  async function reversePhoenixPosition(
+    position: PhoenixPosition,
+  ): Promise<void> {
+    const rowKey = `${position.symbol}:${position.subaccountIndex}`;
+    const busyKey = `reverse:${rowKey}`;
+    const mark =
+      marketMids[position.symbol] ??
+      (position.symbol === selectedSymbol ? latestPrice : null);
+    const notional =
+      position.positionValue ??
+      (mark !== null ? Math.abs(position.size) * mark : null);
+    const gate = canAffordReverse({
+      freeCollateralUsd: phoenixCollateral,
+      marginUsd: position.marginUsd,
+      unrealizedPnlUsd: position.unrealizedPnl,
+      notionalUsd: notional,
+    });
+    if (!gate.ok) {
+      phoenixActionError = gate.reason ?? "Reverse unavailable";
+      phoenixActionErrorDetail = "";
+      phoenixActionRetry = null;
+      return;
+    }
+    if (mark === null || !(mark > 0)) {
+      phoenixActionError = "Mark unavailable for reverse";
+      phoenixActionErrorDetail = "";
+      phoenixActionRetry = null;
+      return;
+    }
+
+    if (paperMode) {
+      try {
+        // Opposite market order at 2× notional flips size in one ledger step.
+        const leverage =
+          position.marginUsd && position.marginUsd > 0 && notional
+            ? Math.max(1, notional / position.marginUsd)
+            : 5;
+        const openSide: PhoenixSide = position.size > 0 ? "ask" : "bid";
+        const result = placePaperOrder($paperLedger, {
+          symbol: position.symbol,
+          side: openSide,
+          orderType: "market",
+          notionalUsd: (notional ?? Math.abs(position.size) * mark) * 2,
+          leverage,
+          price: mark,
+          takeProfitPrice: null,
+          stopLossPrice: null,
+          reduceOnly: false,
+        });
+        paperLedger.set(result.ledger);
+        notePaperEvents(result.events);
+        track("position_reversed", {
+          ...marketContext(),
+          symbol: position.symbol,
+          mode: "paper",
+        });
+      } catch (error) {
+        phoenixActionError =
+          error instanceof Error ? error.message : "paper-reverse-failed";
+        phoenixActionErrorDetail = "";
+        phoenixActionRetry = null;
+      }
+      return;
+    }
+
+    if (!phoenixAuthority || phoenixBusyKeys.has(busyKey)) return;
+    const expectedLiveExecutionEpoch = captureLiveExecutionEpoch();
+    setPhoenixBusy(busyKey, true);
+    phoenixActionError = "";
+    phoenixActionErrorDetail = "";
+    phoenixActionRetry = null;
+    const preFingerprint = snapshotFingerprint();
+    const fromSide = position.size > 0 ? "LONG" : "SHORT";
+    const toSide = position.size > 0 ? "SHORT" : "LONG";
+    try {
+      const trade = await tradeModule();
+      const plan = await trade.buildReversePositionPlan({
+        authority: phoenixAuthority,
+        position,
+        markPrice: mark,
+      });
+      lastTradeSignature = await signAndSendPhoenixIxs(
+        plan.instructions,
+        {
+          title: `Reverse ${position.symbol}-PERP`,
+          details: [
+            "Venue: Phoenix Perps",
+            `Close ${fromSide} → open ${toSide}`,
+            `Size: ${formatNumber(Math.abs(position.size), 6)} ${position.symbol}`,
+          ],
+        },
+        expectedLiveExecutionEpoch,
+        busyKey,
+      );
+      track("position_reversed", {
+        ...marketContext(),
+        symbol: position.symbol,
+        mode: "live",
+        signature: lastTradeSignature,
+      });
+      noteTrade({
+        ts: Date.now(),
+        mode: "live",
+        venue: "perp",
+        symbol: position.symbol,
+        action: "close",
+        notionalUsd: notional,
+        price: mark,
+        leverage: null,
+        signature: lastTradeSignature,
+      });
+      noteTrade({
+        ts: Date.now(),
+        mode: "live",
+        venue: "perp",
+        symbol: position.symbol,
+        action: position.size > 0 ? "short" : "long",
+        notionalUsd: notional,
+        price: mark,
+        leverage:
+          position.marginUsd && notional
+            ? Math.round((notional / position.marginUsd) * 10) / 10
+            : null,
+        signature: lastTradeSignature,
+      });
+      void burstRefreshPhoenix(preFingerprint);
+    } catch (error) {
+      const human = humanizeTradeError(error);
+      phoenixActionError = human.text;
+      phoenixActionErrorDetail = human.detail;
+      phoenixActionRetry = human.retriable
+        ? () => void reversePhoenixPosition(position)
+        : null;
+      if (human.confirmUncertain) void burstRefreshPhoenix(preFingerprint);
+      markLastTxFailed(busyKey);
+    } finally {
+      setPhoenixBusy(busyKey, false);
+      clearTxStage(busyKey);
+    }
   }
 
   async function reconnectMarketData(): Promise<void> {
@@ -6585,7 +6790,8 @@
       !settingsOpen &&
       !paletteOpen &&
       !cheatOpen &&
-      !closePreview
+      !closePreview &&
+      !reversePreview
     ) {
       const ticketKey = event.key.toLowerCase();
       if (ticketKey === "b" || ticketKey === "s") {
@@ -6610,7 +6816,8 @@
       settingsOpen ||
       paletteOpen ||
       cheatOpen ||
-      closePreview
+      closePreview ||
+      reversePreview
     ) {
       return;
     }
@@ -6799,6 +7006,7 @@
     ontogglewatch={toggleWatch}
     onopenpalette={openPalette}
     onsectionselect={scrollToSection}
+    {fundingHint}
   />
 
   <!-- Sticky chrome (topbar on desktop + market rail) covers the top of the
@@ -7436,6 +7644,8 @@
       onmarginopen={openMarginAdd}
       onmarginsubmit={(position) => submitMarginAdd(position)}
       onresetpaper={resetPaperAccount}
+      onbreakeven={moveStopToBreakEven}
+      onreverse={openReversePreview}
       {flattenEstPnl}
     />
 {/snippet}
@@ -7496,6 +7706,22 @@
     )}
     onconfirm={confirmClosePreview}
     onclose={() => (closePreview = null)}
+  />
+{/if}
+
+{#if reversePreview}
+  <ReversePreviewModal
+    position={reversePreview}
+    mark={marketMids[reversePreview.symbol] ??
+      (reversePreview.symbol === selectedSymbol ? latestPrice : null)}
+    {paperMode}
+    {displayCurrency}
+    fxRate={displayFxRate}
+    busy={phoenixBusyKeys.has(
+      `reverse:${reversePreview.symbol}:${reversePreview.subaccountIndex}`,
+    )}
+    onconfirm={() => void confirmReversePreview()}
+    onclose={() => (reversePreview = null)}
   />
 {/if}
 

--- a/apps/portal/src/routes/terminal/components/PerpDeskPanel.svelte
+++ b/apps/portal/src/routes/terminal/components/PerpDeskPanel.svelte
@@ -8,7 +8,7 @@
   } from "$lib/phoenix-trade";
   import { panelStyle, usePanelLayout } from "$lib/terminal/layout";
   import type { SignalRow } from "$lib/terminal/panels";
-  import { liqDistancePct, orderCancelKey } from "$lib/terminal/trade-math";
+  import { liqDistancePct, orderCancelKey, canAffordReverse, canMoveStopToBreakEven } from "$lib/terminal/trade-math";
   import {
     formatDisplayMoney,
     formatDisplayMoneySigned,
@@ -75,6 +75,8 @@
     onmarginopen,
     onmarginsubmit,
     onresetpaper,
+    onbreakeven,
+    onreverse,
   }: {
     authority: string;
     trader: PhoenixTraderState | null;
@@ -124,6 +126,8 @@
     onmarginopen: (position: PhoenixPosition) => void;
     onmarginsubmit: (position: PhoenixPosition) => void;
     onresetpaper?: () => void;
+    onbreakeven: (position: PhoenixPosition) => void;
+    onreverse: (position: PhoenixPosition) => void;
   } = $props();
 
   const money = (usd: number, digits = 2) =>
@@ -282,6 +286,29 @@
         {@const liqDist = liqDistancePctOf(position)}
         {@const rowKey = `${position.symbol}:${position.subaccountIndex}`}
         {@const closeBusy = busyKeys.has(`close:${rowKey}`)}
+        {@const reverseBusy = busyKeys.has(`reverse:${rowKey}`)}
+        {@const tpslBusy = busyKeys.has(
+          `tpsl:${position.symbol}:${position.subaccountIndex}`,
+        )}
+        {@const mark =
+          marketMids[position.symbol] ??
+          (position.symbol === selectedSymbol ? latestPrice : null)}
+        {@const beGate = canMoveStopToBreakEven({
+          side: position.size > 0 ? "long" : "short",
+          entryPrice: position.entryPrice,
+          markPrice: mark,
+          stopLossPrice: position.stopLossPrice,
+          size: position.size,
+          unrealizedPnlUsd: position.unrealizedPnl,
+        })}
+        {@const reverseGate = canAffordReverse({
+          freeCollateralUsd,
+          marginUsd: position.marginUsd,
+          unrealizedPnlUsd: position.unrealizedPnl,
+          notionalUsd:
+            position.positionValue ??
+            (mark !== null ? Math.abs(position.size) * mark : null),
+        })}
         <div class="pos-card">
           <div class="pos-card-top">
             <span
@@ -368,6 +395,33 @@
                 {pct}%
               </button>
             {/each}
+            <button
+              class="row-action"
+              type="button"
+              disabled={!beGate.ok || tpslBusy || closingKeys.has(rowKey)}
+              title={beGate.reason ?? "Move stop loss to entry (break-even)"}
+              onclick={() => onbreakeven(position)}
+            >
+              BE
+            </button>
+            <button
+              class="row-action"
+              type="button"
+              disabled={
+                !reverseGate.ok ||
+                closeBusy ||
+                reverseBusy ||
+                closingKeys.has(rowKey)
+              }
+              title={
+                reverseGate.reason ??
+                "Close and open the opposite side at the same size"
+              }
+              onclick={() => onreverse(position)}
+            >
+              {#if reverseBusy}<span class="spinner" aria-hidden="true"></span>{/if}
+              Reverse
+            </button>
             <button
               class="row-action"
               type="button"

--- a/apps/portal/src/routes/terminal/components/ReversePreviewModal.svelte
+++ b/apps/portal/src/routes/terminal/components/ReversePreviewModal.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+  import type { PhoenixPosition } from "$lib/phoenix-trade";
+  import {
+    formatDisplayMoney,
+    type DisplayCurrencyCode,
+  } from "$lib/terminal/display-currency";
+  import { formatNumber, formatPrice } from "$lib/utils";
+  import { onMount } from "svelte";
+
+  let {
+    position,
+    mark,
+    paperMode = false,
+    displayCurrency = "USD",
+    fxRate = 1,
+    busy = false,
+    onconfirm,
+    onclose,
+  }: {
+    position: PhoenixPosition;
+    mark: number | null;
+    paperMode?: boolean;
+    displayCurrency?: DisplayCurrencyCode;
+    fxRate?: number;
+    busy?: boolean;
+    onconfirm: () => void;
+    onclose: () => void;
+  } = $props();
+
+  let panel: HTMLElement | undefined = $state();
+
+  const fromSide = $derived(position.size > 0 ? "LONG" : "SHORT");
+  const toSide = $derived(position.size > 0 ? "SHORT" : "LONG");
+  const qty = $derived(Math.abs(position.size));
+  const notional = $derived(
+    position.positionValue ??
+      (mark !== null ? qty * mark : null),
+  );
+
+  onMount(() => {
+    panel?.focus();
+  });
+
+  function onWinKeydown(event: KeyboardEvent): void {
+    if (event.key === "Escape") onclose();
+  }
+
+  function onPanelKeydown(event: KeyboardEvent): void {
+    if (event.key === "Escape") {
+      onclose();
+      return;
+    }
+    event.stopPropagation();
+  }
+</script>
+
+<svelte:window onkeydown={onWinKeydown} />
+
+<div class="modal-backdrop" role="presentation" onclick={() => onclose()}>
+  <div
+    bind:this={panel}
+    class="modal close-preview"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Confirm reverse"
+    tabindex="-1"
+    onclick={(event) => event.stopPropagation()}
+    onkeydown={onPanelKeydown}
+  >
+    <div class="panel-head">
+      <div>
+        <span class="kicker">{paperMode ? "PAPER" : "LIVE"}</span>
+        <h2>Reverse {position.symbol}-PERP</h2>
+      </div>
+      <button class="row-action" type="button" onclick={onclose}>Cancel</button>
+    </div>
+    <div class="body mono">
+      <p>
+        Close <b>{fromSide}</b>
+        {formatNumber(qty, 4)}
+        {#if notional !== null}
+          ({formatDisplayMoney(notional, displayCurrency, fxRate, 2)})
+        {/if}
+      </p>
+      <p>
+        → Open <b>{toSide}</b> same size
+        {#if mark !== null}
+          @ mark {formatPrice(mark)}
+        {/if}
+      </p>
+      <p class="note">
+        One signing ceremony — close + open in a single transaction.
+      </p>
+    </div>
+    <div class="actions">
+      <button
+        class="primary"
+        type="button"
+        disabled={busy}
+        onclick={onconfirm}
+      >
+        {#if busy}Reversing…{:else}Confirm reverse{/if}
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .body {
+    display: grid;
+    gap: 0.45rem;
+    padding: 0.75rem 0;
+    font-size: 0.82rem;
+    color: var(--muted);
+  }
+  .body b { color: var(--ink); font-weight: 700; }
+  .note { color: var(--faint); font-size: 0.72rem; }
+  .actions { display: flex; justify-content: flex-end; }
+  .primary {
+    border: 1px solid var(--ink);
+    background: var(--ink);
+    color: var(--bg);
+    padding: 0.45rem 0.9rem;
+    font-weight: 700;
+    cursor: pointer;
+  }
+  .primary:disabled { opacity: 0.5; cursor: wait; }
+</style>

--- a/apps/portal/src/routes/terminal/components/TickerRail.svelte
+++ b/apps/portal/src/routes/terminal/components/TickerRail.svelte
@@ -22,6 +22,7 @@
     ontogglewatch,
     onopenpalette,
     onsectionselect,
+    fundingHint = "",
   }: {
     perp: {
       price: number | null;
@@ -44,6 +45,8 @@
     ontogglewatch: (symbol: string) => void;
     onopenpalette: () => void;
     onsectionselect: (id: string) => void;
+    /** Preformatted "in 2h 14m · est $0.12" (or "--") for the Funding cell. */
+    fundingHint?: string;
   } = $props();
 
   // Aliases keep the moved markup verbatim against the page's names.
@@ -152,9 +155,10 @@
         <TickerStat
           label="Funding"
           value={formatPercent(fundingPercent)}
-          width="4rem"
+          width="5.5rem"
           loading={statsLoading}
           valueClass={(fundingPercent ?? 0) >= 0 ? "positive" : "negative"}
+          hint={fundingHint}
         />
         {#if perpBasisBps !== null}
           <TickerStat

--- a/apps/portal/src/routes/terminal/components/TickerStat.svelte
+++ b/apps/portal/src/routes/terminal/components/TickerStat.svelte
@@ -7,12 +7,15 @@
     width,
     loading,
     valueClass = "",
+    hint = "",
   }: {
     label: string;
     value: string;
     width: string;
     loading: boolean;
     valueClass?: string;
+    /** Optional second line (e.g. funding countdown + hold cost). */
+    hint?: string;
   } = $props();
 </script>
 
@@ -22,6 +25,9 @@
     <span class="skeleton skel-val" aria-hidden="true"></span>
   {:else}
     <b class={valueClass}>{value}</b>
+    {#if hint}
+      <em class="tk-hint">{hint}</em>
+    {/if}
   {/if}
 </div>
 
@@ -49,6 +55,14 @@
     font-size: 0.78rem;
     font-weight: 600;
     color: var(--ink);
+  }
+
+  .tk-hint {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-variant-numeric: tabular-nums;
+    font-size: 0.58rem;
+    font-style: normal;
+    color: var(--faint);
   }
 
   .skel-val {


### PR DESCRIPTION
## Summary
- Closes #546 — Funding cell shows UTC 8h settle countdown + est. hold cost for the selected position (-- without one).
- Closes #542 — Position row Reverse opens a confirm sheet and flips side in one signing ceremony (concatenated close+open ixs; paper uses one ledger flip).
- Position row BE moves SL to entry via existing TP/SL path, gated until unrealized >= +0.5R (honest disable tooltip when stop/R missing).

## Test plan
- [x] bun run typecheck (0)
- [x] bun run --cwd apps/portal test (581 pass)
- [ ] Perps rail: Funding shows in Xh Ym · est …; no position → est --
- [ ] Paper position with SL and >= +0.5R → BE enabled; moves SL to entry
- [ ] Reverse confirm → opposite side same size; disabled when margin would not fund the flip

## Risk
- Funding schedule assumed UTC 00/08/16 (rate feed has no settle timestamp).
- Live reverse relies on ix concatenation + existing simulation gate.

Made with [Cursor](https://cursor.com)