### PR TITLE
fix(terminal): ticket focus trap and session stats rail

### DIFF
--- a/apps/portal/src/lib/journal.test.ts
+++ b/apps/portal/src/lib/journal.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { type JournalEntry, journalToCsv, loadJournal } from "./journal";
+import {
+  entriesTodayUtc,
+  type JournalEntry,
+  journalToCsv,
+  loadJournal,
+  startOfUtcDayMs,
+} from "./journal";
 
 const STORAGE_KEY = "trader-ralph-terminal/journal/v1";
 const storage = new Map<string, string>();
@@ -76,5 +82,19 @@ describe("journalToCsv", () => {
       "time_utc,venue,symbol,action,notional_usd,price,leverage,mode,signature\n" +
         "2026-07-21T12:34:56.000Z,perp,SOL,long,250,172.5,5,paper,abc123",
     );
+  });
+});
+
+describe("entriesTodayUtc", () => {
+  test("uses the UTC day boundary, not local midnight", () => {
+    const now = Date.UTC(2026, 6, 21, 2, 0, 0);
+    expect(startOfUtcDayMs(now)).toBe(Date.UTC(2026, 6, 21, 0, 0, 0));
+    const rows = [
+      { ...entry("live"), ts: Date.UTC(2026, 6, 20, 23, 0, 0), signature: "a" },
+      { ...entry("live"), ts: Date.UTC(2026, 6, 21, 1, 0, 0), signature: "b" },
+    ];
+    expect(entriesTodayUtc(rows, now).map((row) => row.signature)).toEqual([
+      "b",
+    ]);
   });
 });

--- a/apps/portal/src/lib/journal.ts
+++ b/apps/portal/src/lib/journal.ts
@@ -77,6 +77,20 @@ export function entriesToday(
   return entries.filter((entry) => entry.ts >= start.getTime());
 }
 
+/** UTC midnight boundary — used by the market-rail session stats (#545). */
+export function startOfUtcDayMs(now: number): number {
+  const date = new Date(now);
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+export function entriesTodayUtc(
+  entries: JournalEntry[],
+  now: number,
+): JournalEntry[] {
+  const start = startOfUtcDayMs(now);
+  return entries.filter((entry) => entry.ts >= start);
+}
+
 export function journalToCsv(entries: JournalEntry[]): string {
   const header =
     "time_utc,venue,symbol,action,notional_usd,price,leverage,mode,signature";

--- a/apps/portal/src/lib/postmortem.test.ts
+++ b/apps/portal/src/lib/postmortem.test.ts
@@ -7,6 +7,7 @@ import {
   recordPostMortem,
   riskUsd,
   rMultiple,
+  winRecordUtc,
 } from "./postmortem";
 
 const STORAGE_KEY = "trader-ralph-terminal/postmortems/v1";
@@ -112,5 +113,54 @@ describe("postmortem storage", () => {
     clearPostMortems();
     expect(storage.has(STORAGE_KEY)).toBe(false);
     expect(loadPostMortems()).toEqual([]);
+  });
+});
+
+describe("winRecordUtc", () => {
+  test("counts wins from closed reviews with realized PnL on the UTC day", () => {
+    const now = Date.UTC(2026, 6, 21, 15, 0, 0);
+    const rows = [
+      buildClosedTradeReview({
+        ts: Date.UTC(2026, 6, 21, 1, 0, 0),
+        mode: "paper",
+        symbol: "SOL",
+        side: "long",
+        entryPrice: 100,
+        exitPrice: 110,
+        stopLossPrice: 95,
+        notionalUsd: 500,
+        realizedPnlUsd: 50,
+        exitReason: "tp",
+        signature: "w1",
+      }),
+      buildClosedTradeReview({
+        ts: Date.UTC(2026, 6, 21, 2, 0, 0),
+        mode: "paper",
+        symbol: "SOL",
+        side: "long",
+        entryPrice: 100,
+        exitPrice: 90,
+        stopLossPrice: 95,
+        notionalUsd: 500,
+        realizedPnlUsd: -50,
+        exitReason: "sl",
+        signature: "l1",
+      }),
+      buildClosedTradeReview({
+        ts: Date.UTC(2026, 6, 20, 23, 0, 0),
+        mode: "paper",
+        symbol: "SOL",
+        side: "long",
+        entryPrice: 100,
+        exitPrice: 110,
+        stopLossPrice: 95,
+        notionalUsd: 500,
+        realizedPnlUsd: 50,
+        exitReason: "tp",
+        signature: "old",
+      }),
+    ];
+    expect(winRecordUtc(rows, now, "paper")).toEqual({ wins: 1, total: 2 });
+    expect(winRecordUtc(rows, now, "live")).toBeNull();
   });
 });

--- a/apps/portal/src/lib/postmortem.ts
+++ b/apps/portal/src/lib/postmortem.ts
@@ -196,3 +196,23 @@ export function formatRMultiple(value: number | null): string {
   const abs = Math.abs(value).toFixed(2);
   return `${value >= 0 ? "+" : "-"}${abs}R`;
 }
+
+/** Wins / closed trades for the UTC day — null when no closed reviews with PnL. */
+export function winRecordUtc(
+  reviews: ClosedTradeReview[],
+  now: number,
+  mode: "live" | "paper",
+): { wins: number; total: number } | null {
+  const start = Date.UTC(
+    new Date(now).getUTCFullYear(),
+    new Date(now).getUTCMonth(),
+    new Date(now).getUTCDate(),
+  );
+  const today = reviews.filter(
+    (row) =>
+      row.mode === mode && row.ts >= start && row.realizedPnlUsd !== null,
+  );
+  if (today.length === 0) return null;
+  const wins = today.filter((row) => (row.realizedPnlUsd ?? 0) > 0).length;
+  return { wins, total: today.length };
+}

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -236,6 +236,7 @@
   import {
     clearJournal,
     entriesToday,
+    entriesTodayUtc,
     loadJournal,
     recordTrade,
     type JournalEntry,
@@ -245,6 +246,7 @@
     clearPostMortems,
     loadPostMortems,
     recordPostMortem,
+    winRecordUtc,
     type ClosedTradeReview,
     type PostMortemExitReason,
     type PostMortemSide,
@@ -706,6 +708,78 @@
   $: displayFxRate = rateForCurrency(displayCurrency, fxRates);
   let fundsTab: "receive" | "convert" | "phoenix" = "receive";
   let tradeOpen = false;
+  let tradeModalPanel: HTMLElement | undefined;
+  let tradeModalPreviousFocus: HTMLElement | null = null;
+  let tradeModalWasOpen = false;
+  const tradeFocusableSelector = [
+    "a[href]",
+    "button:not([disabled])",
+    "input:not([disabled])",
+    "select:not([disabled])",
+    "textarea:not([disabled])",
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(", ");
+
+  function tradeModalFocusables(): HTMLElement[] {
+    if (!tradeModalPanel) return [];
+    return Array.from(
+      tradeModalPanel.querySelectorAll<HTMLElement>(tradeFocusableSelector),
+    );
+  }
+
+  function restoreTradeModalFocus(): void {
+    const target = tradeModalPreviousFocus;
+    tradeModalPreviousFocus = null;
+    if (target?.isConnected) target.focus();
+  }
+
+  function trapTradeModalTab(event: KeyboardEvent): void {
+    if (!tradeModalPanel) return;
+    const focusables = tradeModalFocusables();
+    if (focusables.length === 0) {
+      event.preventDefault();
+      tradeModalPanel.focus();
+      return;
+    }
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement;
+    if (!tradeModalPanel.contains(active)) {
+      event.preventDefault();
+      first.focus();
+      return;
+    }
+    if (event.shiftKey && (active === first || active === tradeModalPanel)) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  function pullTradeModalFocus(event: FocusEvent): void {
+    if (!tradeOpen || !tradeModalPanel) return;
+    if (tradeModalPanel.contains(event.target as Node)) return;
+    const [first] = tradeModalFocusables();
+    (first ?? tradeModalPanel).focus();
+  }
+
+  $: if (browser) {
+    if (tradeOpen && !tradeModalWasOpen) {
+      tradeModalWasOpen = true;
+      tradeModalPreviousFocus =
+        document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null;
+      void tick().then(() => {
+        if (tradeOpen) tradeModalPanel?.focus();
+      });
+    } else if (!tradeOpen && tradeModalWasOpen) {
+      tradeModalWasOpen = false;
+      void tick().then(restoreTradeModalFocus);
+    }
+  }
   let pendingBook: { bids: DepthLevel[]; asks: DepthLevel[]; mid: number | null } | null =
     null;
   let bookFrame = 0;
@@ -1620,6 +1694,34 @@
   $: journalToday = entriesToday(journalEntries, Date.now()).filter(
     (entry) => entry.mode === (paperMode ? "paper" : "live"),
   );
+  $: journalTodayUtc = entriesTodayUtc(journalEntries, nowMs).filter(
+    (entry) => entry.mode === (paperMode ? "paper" : "live"),
+  );
+  $: sessionStats =
+    journalTodayUtc.length === 0
+      ? null
+      : (() => {
+          const win = winRecordUtc(
+            postMortems,
+            nowMs,
+            paperMode ? "paper" : "live",
+          );
+          const dayPnl =
+            sessionPnlUsd === null
+              ? "--"
+              : `${sessionPnlUsd >= 0 ? "+" : "-"}$${formatNumber(Math.abs(sessionPnlUsd), 2)}`;
+          return {
+            dayPnl,
+            dayPnlClass:
+              sessionPnlUsd === null
+                ? ""
+                : sessionPnlUsd >= 0
+                  ? "positive"
+                  : "negative",
+            win: win ? `${win.wins}/${win.total}` : "--",
+            fees: "--",
+          };
+        })();
   $: positionBriefKey = (phoenixTrader?.positions ?? [])
     .map((position) => `${position.symbol}:${position.size.toFixed(4)}`)
     .join("|");
@@ -2150,6 +2252,7 @@
       tpslFrame = null;
       posOverlayLines = { entry: null, tp: null, sl: null };
       posOverlayPrices = { entry: null, tp: null, sl: null };
+      if (tradeModalWasOpen) restoreTradeModalFocus();
       lwChart?.remove();
       lwChart = null;
       candleSeries = null;
@@ -6712,6 +6815,10 @@
   }
 
   function onGlobalKeydown(event: KeyboardEvent): void {
+    if (tradeOpen && event.key === "Tab") {
+      trapTradeModalTab(event);
+      return;
+    }
     // A live TP/SL drag owns Escape ahead of everything: cancel the drag
     // (snap back) and swallow — one Escape never doubles as anything else.
     if (event.key === "Escape" && tpslDrag) {
@@ -6914,7 +7021,7 @@
   />
 </svelte:head>
 
-<svelte:window onkeydown={onGlobalKeydown} />
+<svelte:window onkeydown={onGlobalKeydown} onfocusin={pullTradeModalFocus} />
 
 <main
   class="terminal-shell"
@@ -7007,6 +7114,7 @@
     onopenpalette={openPalette}
     onsectionselect={scrollToSection}
     {fundingHint}
+    {sessionStats}
   />
 
   <!-- Sticky chrome (topbar on desktop + market rail) covers the top of the
@@ -7743,13 +7851,21 @@
   <div class="modal-backdrop" role="presentation" onclick={() => (tradeOpen = false)}>
     <!-- Enter from any ticket input submits, gated exactly like the button;
          everything else bubbles so B/S/M/L flip the ticket and Esc closes. -->
-    <section
+    <div
+      bind:this={tradeModalPanel}
       class="modal"
       role="dialog"
       aria-modal="true"
+      aria-label="Trade ticket"
       tabindex="-1"
       onclick={(event) => event.stopPropagation()}
-      onkeydown={onTicketKeydown}
+      onkeydown={(event) => {
+        if (event.key === "Tab") {
+          trapTradeModalTab(event);
+          return;
+        }
+        onTicketKeydown(event);
+      }}
     >
       <div class="panel-head">
         <div>
@@ -7761,7 +7877,7 @@
       <div class="modal-body">
         {@render perpTicketForm()}
       </div>
-    </section>
+    </div>
   </div>
 {/if}
 

--- a/apps/portal/src/routes/terminal/components/TickerRail.svelte
+++ b/apps/portal/src/routes/terminal/components/TickerRail.svelte
@@ -23,6 +23,7 @@
     onopenpalette,
     onsectionselect,
     fundingHint = "",
+    sessionStats = null,
   }: {
     perp: {
       price: number | null;
@@ -47,6 +48,13 @@
     onsectionselect: (id: string) => void;
     /** Preformatted "in 2h 14m · est $0.12" (or "--") for the Funding cell. */
     fundingHint?: string;
+    /** Null when today's journal is empty — hide the three session cells. */
+    sessionStats?: {
+      dayPnl: string;
+      dayPnlClass: string;
+      win: string;
+      fees: string;
+    } | null;
   } = $props();
 
   // Aliases keep the moved markup verbatim against the page's names.
@@ -114,6 +122,11 @@
             valueClass={spotBasisBps >= 0 ? "positive" : "negative"}
           />
         {/if}
+        {#if sessionStats}
+          <TickerStat label="Day P&L" value={sessionStats.dayPnl} width="5rem" loading={false} valueClass={sessionStats.dayPnlClass} />
+          <TickerStat label="Win" value={sessionStats.win} width="3.5rem" loading={false} />
+          <TickerStat label="Fees" value={sessionStats.fees} width="3.5rem" loading={false} />
+        {/if}
       </div>
     {:else}
       <div class="ticker-symbol">
@@ -172,6 +185,11 @@
         <TickerStat label="Open Int" value={formatNumber(marketStats?.openInterest, 0)} width="5rem" loading={statsLoading} />
         <TickerStat label="24h Vol" value={formatNumber(marketStats?.dayNtlVlm, 0)} width="6.5rem" loading={statsLoading} />
         <TickerStat label="Updated" value={marketFresh} width="4.5rem" loading={updatedLoading} />
+        {#if sessionStats}
+          <TickerStat label="Day P&L" value={sessionStats.dayPnl} width="5rem" loading={false} valueClass={sessionStats.dayPnlClass} />
+          <TickerStat label="Win" value={sessionStats.win} width="3.5rem" loading={false} />
+          <TickerStat label="Fees" value={sessionStats.fees} width="3.5rem" loading={false} />
+        {/if}
       </div>
     {/if}
   </div>


### PR DESCRIPTION
## Summary
- Closes #568 — trade-ticket modal takes initial focus, traps Tab/Shift+Tab, pulls focus back in, restores opener on close (PaperFunds pattern).
- Closes #545 — market rail appends Day P&L / Win / Fees when UTC-today journal is non-empty; Fees stays `--` until receipts; Win from post-mortems with realized PnL.

## Test plan
- [x] bun run typecheck (0)
- [x] bun run --cwd apps/portal test (583 pass)
- [ ] Narrow viewport: open trade modal, Tab stays inside dialog (not chart log)
- [ ] Esc closes + focus returns to opener
- [ ] Empty journal: no Day/Win/Fees cells; after a trade, cells appear

## Risk
- WIN uses closed-trade post-mortems (honest when no closes → `--`), not inventing wins from open journal rows.

Made with [Cursor](https://cursor.com)