### PR TITLE
feat(terminal): named order templates on the ticket

### DIFF
--- a/apps/portal/src/lib/terminal/prefs.test.ts
+++ b/apps/portal/src/lib/terminal/prefs.test.ts
@@ -82,6 +82,36 @@ describe("parsePrefs", () => {
     ).toBeUndefined();
   });
 
+  test("parses order templates with a hard cap of 6", () => {
+    const rows = Array.from({ length: 8 }, (_, i) => ({
+      id: `t${i}`,
+      name: `T${i}`,
+      sizeUsd: 100 + i,
+      leverage: 5,
+      tpPct: 2,
+      slPct: 1,
+    }));
+    const prefs = parsePrefs(JSON.stringify({ orderTemplates: rows }));
+    expect(prefs.orderTemplates).toHaveLength(6);
+    expect(prefs.orderTemplates?.[0]?.name).toBe("T0");
+    expect(
+      parsePrefs(
+        JSON.stringify({
+          orderTemplates: [
+            {
+              id: "x",
+              name: "Bad",
+              sizeUsd: 50,
+              leverage: 3,
+              tpPct: null,
+              slPct: null,
+            },
+          ],
+        }),
+      ).orderTemplates,
+    ).toEqual([]);
+  });
+
   test("rejects out-of-enum values field by field", () => {
     const prefs = parsePrefs(
       JSON.stringify({

--- a/apps/portal/src/lib/terminal/prefs.ts
+++ b/apps/portal/src/lib/terminal/prefs.ts
@@ -72,7 +72,70 @@ export type TerminalPrefs = {
   displayCurrency: DisplayCurrencyCode;
   /** IANA timezone for clocks and journal/tape stamps. */
   displayTimezone: DisplayTimezoneId;
+  /** Named order templates (max 6) — size/leverage/TP%/SL%. */
+  orderTemplates: OrderTemplate[];
 };
+
+export const ORDER_TEMPLATES_CAP = 6;
+export const TICKET_LEVERAGES = [1, 2, 5, 10, 20] as const;
+export type TicketLeverage = (typeof TICKET_LEVERAGES)[number];
+
+export type OrderTemplate = {
+  id: string;
+  name: string;
+  sizeUsd: number;
+  leverage: TicketLeverage;
+  tpPct: number | null;
+  slPct: number | null;
+};
+
+export function parseOrderTemplates(value: unknown): OrderTemplate[] {
+  if (!Array.isArray(value)) return [];
+  const out: OrderTemplate[] = [];
+  for (const row of value) {
+    if (!row || typeof row !== "object") continue;
+    const candidate = row as Record<string, unknown>;
+    const name =
+      typeof candidate.name === "string"
+        ? candidate.name.trim().slice(0, 24)
+        : "";
+    const sizeUsd = Number(candidate.sizeUsd);
+    const leverage = Number(candidate.leverage);
+    const id =
+      typeof candidate.id === "string" && candidate.id
+        ? candidate.id
+        : `t-${out.length}`;
+    if (!name || !(sizeUsd > 0) || !Number.isFinite(sizeUsd)) continue;
+    if (!(TICKET_LEVERAGES as readonly number[]).includes(leverage)) continue;
+    const tpRaw = candidate.tpPct;
+    const slRaw = candidate.slPct;
+    const tpPct =
+      tpRaw === null || tpRaw === undefined
+        ? null
+        : typeof tpRaw === "number" && Number.isFinite(tpRaw) && tpRaw > 0
+          ? tpRaw
+          : null;
+    const slPct =
+      slRaw === null || slRaw === undefined
+        ? null
+        : typeof slRaw === "number" && Number.isFinite(slRaw) && slRaw > 0
+          ? slRaw
+          : null;
+    // Invalid non-null pcts reject the whole template.
+    if (tpRaw !== null && tpRaw !== undefined && tpPct === null) continue;
+    if (slRaw !== null && slRaw !== undefined && slPct === null) continue;
+    out.push({
+      id,
+      name,
+      sizeUsd,
+      leverage: leverage as TicketLeverage,
+      tpPct,
+      slPct,
+    });
+    if (out.length >= ORDER_TEMPLATES_CAP) break;
+  }
+  return out;
+}
 
 /** Rays per symbol — placing a 13th evicts the oldest (FIFO). */
 export const RAYS_PER_SYMBOL_CAP = 12;
@@ -193,6 +256,9 @@ export function parsePrefs(raw: string | null): Partial<TerminalPrefs> {
   if (isValidIanaTimezone(data.displayTimezone)) {
     prefs.displayTimezone = data.displayTimezone;
   }
+  if (data.orderTemplates !== undefined) {
+    prefs.orderTemplates = parseOrderTemplates(data.orderTemplates);
+  }
   return prefs;
 }
 
@@ -233,6 +299,7 @@ export function persistPrefs(
   _paperMode: boolean,
   _displayCurrency: DisplayCurrencyCode,
   _displayTimezone: DisplayTimezoneId,
+  _orderTemplates: OrderTemplate[] = [],
 ): void {
   if (typeof window === "undefined") return;
   try {
@@ -261,6 +328,7 @@ export function persistPrefs(
         paperMode: _paperMode,
         displayCurrency: _displayCurrency,
         displayTimezone: _displayTimezone,
+        orderTemplates: _orderTemplates.slice(0, ORDER_TEMPLATES_CAP),
       }),
     );
   } catch {

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -108,6 +108,7 @@
     persistPrefs,
     PREFS_STORAGE_KEY,
     RAYS_PER_SYMBOL_CAP,
+    type OrderTemplate,
   } from "$lib/terminal/prefs";
   import { isCurrentMarketGeneration } from "$lib/terminal/market-generation";
   import {
@@ -914,6 +915,7 @@
   // Watchlist: starred symbols (uppercase), persisted in prefs.
   // Lives in the bottom dock (Positions / Journal / Alerts / Watch).
   let watchlist: string[] = [];
+  let orderTemplates: OrderTemplate[] = [];
   // Screener controls (persisted; screener panel retired but prefs kept).
   let screenSort: "movers" | "volume" | "cap" = "movers";
   let screenHub: "all" | "crypto" | "equities" | "pre-ipo" = "all";
@@ -1784,6 +1786,7 @@
       paperMode,
       displayCurrency,
       displayTimezone,
+      orderTemplates,
     );
 
   function agentOk(message: string): AgentActionResult {
@@ -6716,6 +6719,9 @@
     } else {
       displayTimezone = detectBrowserTimezone();
     }
+    if (prefs.orderTemplates !== undefined) {
+      orderTemplates = prefs.orderTemplates;
+    }
     // Without Privy, live trading is impossible — stay in paper regardless
     // of a previously saved LIVE preference.
     if (!readPrivyConfig().appId) paperMode = true;
@@ -8061,6 +8067,7 @@
     onmanualsize={() => (sizeSource = "manual")}
     onsizechip={setSizeChip}
     onriskchip={setRiskChip}
+    bind:orderTemplates
   />
 {/snippet}
 

--- a/apps/portal/src/routes/terminal/components/TicketForm.svelte
+++ b/apps/portal/src/routes/terminal/components/TicketForm.svelte
@@ -1,10 +1,17 @@
 <script lang="ts">
   import type { DepthLevel } from "$lib/phoenix-market-data";
   import { bookLevelNotional, formatBookPrice } from "$lib/terminal/book";
-  import type { PerpTicket } from "$lib/terminal/perp-ticket";
-  import { formatGhostSizeLabel } from "$lib/terminal/perp-ticket";
+  import {
+    formatGhostSizeLabel,
+    snapTicketLeverage,
+    type PerpTicket,
+  } from "$lib/terminal/perp-ticket";
   import { ghostFieldPlaceholder } from "$lib/terminal/ghost-field-placeholder";
   import { stepInput } from "$lib/terminal/step-input";
+  import {
+    ORDER_TEMPLATES_CAP,
+    type OrderTemplate,
+  } from "$lib/terminal/prefs";
   import { SL_CHIP_PCTS, TP_CHIP_PCTS, fmtTriggerPrice } from "$lib/terminal/trade-math";
   import {
     formatDisplayMoney,
@@ -76,6 +83,7 @@
     onmanualsize,
     onsizechip,
     onriskchip,
+    orderTemplates = $bindable([] as OrderTemplate[]),
   }: {
     ticket: PerpTicket;
     sizeInput?: HTMLInputElement | null;
@@ -123,6 +131,7 @@
     onmanualsize: () => void;
     onsizechip: (pct: number | "max") => void;
     onriskchip: (pct: number) => void;
+    orderTemplates?: OrderTemplate[];
   } = $props();
 
   const money = (usd: number, digits = 2) =>
@@ -167,6 +176,48 @@
     dismissGhostSl,
     dismissGhostSize,
   } = ticket;
+
+  function applyOrderTemplate(template: OrderTemplate): void {
+    $sizingMode = "usd";
+    $tradeAmount = String(template.sizeUsd);
+    $tradeLeverage = snapTicketLeverage(template.leverage);
+    if (template.tpPct !== null) setTakeProfitPct(template.tpPct);
+    else $tradeTakeProfit = "";
+    if (template.slPct !== null) setStopLossPct(template.slPct);
+    else $tradeStopLoss = "";
+    onmanualsize();
+  }
+
+  function saveOrderTemplate(): void {
+    if (orderTemplates.length >= ORDER_TEMPLATES_CAP) {
+      window.alert(`Max ${ORDER_TEMPLATES_CAP} templates.`);
+      return;
+    }
+    const sizeUsd = Number($tradeAmount);
+    if (!(sizeUsd > 0)) {
+      window.alert("Set a USD size before saving a template.");
+      return;
+    }
+    const name = window.prompt("Template name")?.trim().slice(0, 24);
+    if (!name) return;
+    const leverage = snapTicketLeverage($tradeLeverage) as OrderTemplate["leverage"];
+    orderTemplates = [
+      ...orderTemplates,
+      {
+        id: `t-${Date.now()}`,
+        name,
+        sizeUsd,
+        leverage,
+        tpPct: $tpPct !== null ? Math.abs($tpPct) : null,
+        slPct: $slPct !== null ? Math.abs($slPct) : null,
+      },
+    ];
+  }
+
+  function deleteOrderTemplate(id: string): void {
+    if (!window.confirm("Delete this template?")) return;
+    orderTemplates = orderTemplates.filter((row) => row.id !== id);
+  }
 
   // Telemetry: once per ghost value per field (not per render).
   let shownTpKey = "";
@@ -368,6 +419,33 @@
       <option value={20}>20x</option>
     </select>
   </label>
+  <div class="field template-row">
+    <div class="chip-row" role="group" aria-label="Order templates">
+      {#each orderTemplates as template (template.id)}
+        <button
+          class="pct-chip"
+          type="button"
+          title={`${template.name} · $${formatNumber(template.sizeUsd, 0)} · ${template.leverage}x — double-click to delete`}
+          onclick={() => applyOrderTemplate(template)}
+          ondblclick={(event) => {
+            event.preventDefault();
+            deleteOrderTemplate(template.id);
+          }}
+        >
+          {template.name}
+        </button>
+      {/each}
+      <button
+        class="pct-chip"
+        type="button"
+        disabled={orderTemplates.length >= ORDER_TEMPLATES_CAP}
+        title="Save current size, leverage, and TP/SL % as a template"
+        onclick={saveOrderTemplate}
+      >
+        + Save
+      </button>
+    </div>
+  </div>
   <label>
     Type
     <select bind:value={$tradeType}>
@@ -693,6 +771,10 @@
     display: grid;
     gap: 0.3rem;
     align-content: start;
+  }
+
+  .template-row {
+    grid-column: 1 / -1;
   }
 
   .ghost-input {


### PR DESCRIPTION
## Summary
- Closes #543 — Save current ticket as a named template (max 6) in prefs.
- Chip row under size/leverage applies size, leverage, TP%, SL% without submitting.
- Double-click a chip to delete (confirm).

## Test plan
- [x] bun run typecheck (0)
- [x] bun run --cwd apps/portal test (prefs + suite)
- [ ] Save template from ticket; reload persists
- [ ] Tap chip fills fields only (no submit)
- [ ] 7th save blocked; double-click deletes

## Risk
- window.prompt/confirm for name/delete (MVP; no new modal).

Made with [Cursor](https://cursor.com)