### PR TITLE
feat(terminal): quiet fill sounds and green-day streak flame

### DIFF
--- a/apps/portal/src/lib/postmortem.test.ts
+++ b/apps/portal/src/lib/postmortem.test.ts
@@ -3,6 +3,7 @@ import {
   buildClosedTradeReview,
   clearPostMortems,
   formatRMultiple,
+  greenDayStreak,
   loadPostMortems,
   recordPostMortem,
   riskUsd,
@@ -162,5 +163,73 @@ describe("winRecordUtc", () => {
     ];
     expect(winRecordUtc(rows, now, "paper")).toEqual({ wins: 1, total: 2 });
     expect(winRecordUtc(rows, now, "live")).toBeNull();
+  });
+});
+
+describe("greenDayStreak", () => {
+  test("returns 0 below two consecutive green days", () => {
+    const now = Date.UTC(2026, 6, 21, 12, 0, 0);
+    const one = [
+      buildClosedTradeReview({
+        ts: Date.UTC(2026, 6, 21, 1, 0, 0),
+        mode: "paper",
+        symbol: "SOL",
+        side: "long",
+        entryPrice: 100,
+        exitPrice: 110,
+        stopLossPrice: 95,
+        notionalUsd: 500,
+        realizedPnlUsd: 50,
+        exitReason: "tp",
+        signature: "a",
+      }),
+    ];
+    expect(greenDayStreak(one, now, "paper")).toBe(0);
+  });
+
+  test("counts consecutive green UTC days and hides below 2", () => {
+    const now = Date.UTC(2026, 6, 22, 12, 0, 0);
+    const rows = [
+      buildClosedTradeReview({
+        ts: Date.UTC(2026, 6, 22, 1, 0, 0),
+        mode: "live",
+        symbol: "SOL",
+        side: "long",
+        entryPrice: 100,
+        exitPrice: 110,
+        stopLossPrice: 95,
+        notionalUsd: 500,
+        realizedPnlUsd: 40,
+        exitReason: "tp",
+        signature: "d2",
+      }),
+      buildClosedTradeReview({
+        ts: Date.UTC(2026, 6, 21, 1, 0, 0),
+        mode: "live",
+        symbol: "SOL",
+        side: "long",
+        entryPrice: 100,
+        exitPrice: 105,
+        stopLossPrice: 95,
+        notionalUsd: 500,
+        realizedPnlUsd: 20,
+        exitReason: "tp",
+        signature: "d1",
+      }),
+      buildClosedTradeReview({
+        ts: Date.UTC(2026, 6, 20, 1, 0, 0),
+        mode: "live",
+        symbol: "SOL",
+        side: "long",
+        entryPrice: 100,
+        exitPrice: 90,
+        stopLossPrice: 95,
+        notionalUsd: 500,
+        realizedPnlUsd: -30,
+        exitReason: "sl",
+        signature: "red",
+      }),
+    ];
+    expect(greenDayStreak(rows, now, "live")).toBe(2);
   });
 });

--- a/apps/portal/src/lib/postmortem.ts
+++ b/apps/portal/src/lib/postmortem.ts
@@ -216,3 +216,49 @@ export function winRecordUtc(
   const wins = today.filter((row) => (row.realizedPnlUsd ?? 0) > 0).length;
   return { wins, total: today.length };
 }
+
+const UTC_DAY_MS = 24 * 60 * 60 * 1000;
+
+function utcDayStart(ts: number): number {
+  const date = new Date(ts);
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+/**
+ * Consecutive UTC days with positive realized PnL (mode-scoped), ending at
+ * the most recent day that has closes. Empty days break the streak.
+ * Returns 0 when the streak is below 2 (UI hides the flame).
+ */
+export function greenDayStreak(
+  reviews: ClosedTradeReview[],
+  now: number,
+  mode: "live" | "paper",
+): number {
+  const byDay = new Map<number, number>();
+  for (const row of reviews) {
+    if (row.mode !== mode || row.realizedPnlUsd === null) continue;
+    const day = utcDayStart(row.ts);
+    byDay.set(day, (byDay.get(day) ?? 0) + row.realizedPnlUsd);
+  }
+  if (byDay.size === 0) return 0;
+
+  const today = utcDayStart(now);
+  let cursor = today;
+  // If today has no closes yet, start from the most recent prior traded day.
+  if (!byDay.has(cursor)) {
+    const prior = [...byDay.keys()]
+      .filter((day) => day < today)
+      .sort((a, b) => b - a)[0];
+    if (prior === undefined) return 0;
+    cursor = prior;
+  }
+
+  let streak = 0;
+  while (byDay.has(cursor)) {
+    const pnl = byDay.get(cursor) ?? 0;
+    if (!(pnl > 0)) break;
+    streak += 1;
+    cursor -= UTC_DAY_MS;
+  }
+  return streak >= 2 ? streak : 0;
+}

--- a/apps/portal/src/lib/terminal/fill-sounds.test.ts
+++ b/apps/portal/src/lib/terminal/fill-sounds.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from "bun:test";
+import { defaultFillSoundsEnabled, prefersReducedMotion } from "./fill-sounds";
+
+describe("fill sound defaults", () => {
+  test("without window.matchMedia, reduced-motion is false and sounds default on", () => {
+    expect(prefersReducedMotion()).toBe(false);
+    expect(defaultFillSoundsEnabled()).toBe(true);
+  });
+});

--- a/apps/portal/src/lib/terminal/fill-sounds.ts
+++ b/apps/portal/src/lib/terminal/fill-sounds.ts
@@ -1,0 +1,61 @@
+// Quiet Web Audio fill / trigger beeps. No asset files — short oscillators.
+// Respect mute + prefers-reduced-motion at the call site.
+
+let sharedCtx: AudioContext | null = null;
+
+function audioContext(): AudioContext | null {
+  if (typeof window === "undefined") return null;
+  const Ctor =
+    window.AudioContext ??
+    (window as unknown as { webkitAudioContext?: typeof AudioContext })
+      .webkitAudioContext;
+  if (!Ctor) return null;
+  if (!sharedCtx || sharedCtx.state === "closed") {
+    sharedCtx = new Ctor();
+  }
+  return sharedCtx;
+}
+
+function tone(
+  frequency: number,
+  durationMs: number,
+  gain = 0.035,
+  type: OscillatorType = "sine",
+): void {
+  const ctx = audioContext();
+  if (!ctx) return;
+  void ctx.resume().catch(() => {});
+  const now = ctx.currentTime;
+  const osc = ctx.createOscillator();
+  const amp = ctx.createGain();
+  osc.type = type;
+  osc.frequency.value = frequency;
+  amp.gain.setValueAtTime(0, now);
+  amp.gain.linearRampToValueAtTime(gain, now + 0.008);
+  amp.gain.exponentialRampToValueAtTime(0.0001, now + durationMs / 1000);
+  osc.connect(amp);
+  amp.connect(ctx.destination);
+  osc.start(now);
+  osc.stop(now + durationMs / 1000 + 0.02);
+}
+
+/** Soft blip for a fill / open. */
+export function playFillSound(): void {
+  tone(880, 70, 0.03);
+}
+
+/** Slightly brighter blip for TP/SL trigger. */
+export function playTriggerSound(): void {
+  tone(1175, 55, 0.028);
+  window.setTimeout(() => tone(1568, 45, 0.02), 40);
+}
+
+export function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined") return false;
+  if (typeof window.matchMedia !== "function") return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+export function defaultFillSoundsEnabled(): boolean {
+  return !prefersReducedMotion();
+}

--- a/apps/portal/src/lib/terminal/prefs.ts
+++ b/apps/portal/src/lib/terminal/prefs.ts
@@ -74,6 +74,8 @@ export type TerminalPrefs = {
   displayTimezone: DisplayTimezoneId;
   /** Named order templates (max 6) — size/leverage/TP%/SL%. */
   orderTemplates: OrderTemplate[];
+  /** Quiet fill/TP-SL beeps — default ON unless reduced-motion. */
+  fillSounds: boolean;
 };
 
 export const ORDER_TEMPLATES_CAP = 6;
@@ -259,6 +261,7 @@ export function parsePrefs(raw: string | null): Partial<TerminalPrefs> {
   if (data.orderTemplates !== undefined) {
     prefs.orderTemplates = parseOrderTemplates(data.orderTemplates);
   }
+  if (typeof data.fillSounds === "boolean") prefs.fillSounds = data.fillSounds;
   return prefs;
 }
 
@@ -300,6 +303,7 @@ export function persistPrefs(
   _displayCurrency: DisplayCurrencyCode,
   _displayTimezone: DisplayTimezoneId,
   _orderTemplates: OrderTemplate[] = [],
+  _fillSounds = true,
 ): void {
   if (typeof window === "undefined") return;
   try {
@@ -329,6 +333,7 @@ export function persistPrefs(
         displayCurrency: _displayCurrency,
         displayTimezone: _displayTimezone,
         orderTemplates: _orderTemplates.slice(0, ORDER_TEMPLATES_CAP),
+        fillSounds: _fillSounds,
       }),
     );
   } catch {

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -248,10 +248,16 @@
     loadPostMortems,
     recordPostMortem,
     winRecordUtc,
+    greenDayStreak,
     type ClosedTradeReview,
     type PostMortemExitReason,
     type PostMortemSide,
   } from "$lib/postmortem";
+  import {
+    defaultFillSoundsEnabled,
+    playFillSound,
+    playTriggerSound,
+  } from "$lib/terminal/fill-sounds";
   import {
     cancelTriggerOrder,
     createTriggerOrder,
@@ -916,6 +922,7 @@
   // Lives in the bottom dock (Positions / Journal / Alerts / Watch).
   let watchlist: string[] = [];
   let orderTemplates: OrderTemplate[] = [];
+  let fillSounds = true;
   // Screener controls (persisted; screener panel retired but prefs kept).
   let screenSort: "movers" | "volume" | "cap" = "movers";
   let screenHub: "all" | "crypto" | "equities" | "pre-ipo" = "all";
@@ -1703,11 +1710,9 @@
     journalTodayUtc.length === 0
       ? null
       : (() => {
-          const win = winRecordUtc(
-            postMortems,
-            nowMs,
-            paperMode ? "paper" : "live",
-          );
+          const mode = paperMode ? "paper" : "live";
+          const win = winRecordUtc(postMortems, nowMs, mode);
+          const streak = greenDayStreak(postMortems, nowMs, mode);
           const dayPnl =
             sessionPnlUsd === null
               ? "--"
@@ -1722,6 +1727,7 @@
                   : "negative",
             win: win ? `${win.wins}/${win.total}` : "--",
             fees: "--",
+            ...(streak >= 2 ? { streak } : {}),
           };
         })();
   $: positionBriefKey = (phoenixTrader?.positions ?? [])
@@ -1787,6 +1793,7 @@
       displayCurrency,
       displayTimezone,
       orderTemplates,
+      fillSounds,
     );
 
   function agentOk(message: string): AgentActionResult {
@@ -3314,6 +3321,7 @@
           leverage: null,
           signature: filled.event.signature,
         });
+        if (fillSounds) playFillSound();
         alertsStore.pushToast({
           ts: Date.now(),
           title: `Paper spot ${$spotSide}`,
@@ -3366,6 +3374,7 @@
         leverage: null,
         signature: spotSignature,
       });
+      if (fillSounds) playFillSound();
       void refreshWalletBalance(address);
       void refreshTokenBalances(address);
       spotTicket.invalidateQuote(); // a late in-flight quote must not re-arm the button
@@ -3676,6 +3685,21 @@
         leverage: event.leverage,
         signature: event.signature,
       });
+      if (
+        fillSounds &&
+        (event.kind === "open" ||
+          event.kind === "limit_fill" ||
+          event.kind === "spot_buy" ||
+          event.kind === "spot_sell" ||
+          event.kind === "spot_limit_fill")
+      ) {
+        playFillSound();
+      } else if (
+        fillSounds &&
+        (event.kind === "tp" || event.kind === "sl")
+      ) {
+        playTriggerSound();
+      }
       if (isClose) {
         const exitReason: PostMortemExitReason =
           event.kind === "tp"
@@ -4104,6 +4128,7 @@
         leverage,
         signature: lastTradeSignature,
       });
+      if (fillSounds) playFillSound();
       tradeOpen = false;
       // Optimistic pending row (from the params in hand) while the lagging
       // indexer catches up; dropped by the burst if it never confirms.
@@ -4835,6 +4860,7 @@
             : null,
         signature: lastTradeSignature,
       });
+      if (fillSounds) playFillSound();
       void burstRefreshPhoenix(preFingerprint);
     } catch (error) {
       const human = humanizeTradeError(error);
@@ -6722,6 +6748,11 @@
     if (prefs.orderTemplates !== undefined) {
       orderTemplates = prefs.orderTemplates;
     }
+    if (prefs.fillSounds !== undefined) {
+      fillSounds = prefs.fillSounds;
+    } else {
+      fillSounds = defaultFillSoundsEnabled();
+    }
     // Without Privy, live trading is impossible — stay in paper regardless
     // of a previously saved LIVE preference.
     if (!readPrivyConfig().appId) paperMode = true;
@@ -7972,6 +8003,7 @@
   currency={displayCurrency}
   timezone={displayTimezone}
   {showLevels}
+  {fillSounds}
   {layoutCustomized}
   onclose={() => (settingsOpen = false)}
   oncurrencychange={(code) => {
@@ -7982,6 +8014,9 @@
   }}
   ontogglelevels={() => {
     showLevels = !showLevels;
+  }}
+  ontogglefillsounds={() => {
+    fillSounds = !fillSounds;
   }}
   onresetlayout={resetLayout}
   onopenshortcuts={() => {

--- a/apps/portal/src/routes/terminal/components/SettingsModal.svelte
+++ b/apps/portal/src/routes/terminal/components/SettingsModal.svelte
@@ -15,24 +15,28 @@ let {
   timezone,
   showLevels = true,
   layoutCustomized = false,
+  fillSounds = true,
   onclose,
   oncurrencychange,
   ontimezonechange,
   ontogglelevels,
   onresetlayout,
   onopenshortcuts,
+  ontogglefillsounds,
 }: {
   open?: boolean;
   currency: DisplayCurrencyCode;
   timezone: DisplayTimezoneId;
   showLevels?: boolean;
   layoutCustomized?: boolean;
+  fillSounds?: boolean;
   onclose: () => void;
   oncurrencychange: (code: DisplayCurrencyCode) => void;
   ontimezonechange: (id: DisplayTimezoneId) => void;
   ontogglelevels: () => void;
   onresetlayout: () => void;
   onopenshortcuts: () => void;
+  ontogglefillsounds: () => void;
 } = $props();
 
 let panel = $state<HTMLDivElement>();
@@ -214,6 +218,21 @@ const timezoneOptions = $derived(timezonesForPicker(timezone));
             {/each}
           </select>
         </label>
+
+        <div class="settings-row">
+          <div class="settings-copy">
+            <strong>Fill sounds</strong>
+            <span>Quiet beep on fills and TP/SL hits</span>
+          </div>
+          <button
+            class="secondary"
+            type="button"
+            aria-pressed={fillSounds}
+            onclick={ontogglefillsounds}
+          >
+            {fillSounds ? "On" : "Muted"}
+          </button>
+        </div>
 
         <div class="settings-row">
           <div class="settings-copy">

--- a/apps/portal/src/routes/terminal/components/TickerRail.svelte
+++ b/apps/portal/src/routes/terminal/components/TickerRail.svelte
@@ -54,6 +54,8 @@
       dayPnlClass: string;
       win: string;
       fees: string;
+      /** Flame when consecutive green days ≥ 2. */
+      streak?: number;
     } | null;
   } = $props();
 
@@ -123,7 +125,15 @@
           />
         {/if}
         {#if sessionStats}
-          <TickerStat label="Day P&L" value={sessionStats.dayPnl} width="5rem" loading={false} valueClass={sessionStats.dayPnlClass} />
+          <TickerStat
+            label="Day P&L"
+            value={sessionStats.streak && sessionStats.streak >= 2
+              ? `${sessionStats.dayPnl} · 🔥${sessionStats.streak}`
+              : sessionStats.dayPnl}
+            width="6.5rem"
+            loading={false}
+            valueClass={sessionStats.dayPnlClass}
+          />
           <TickerStat label="Win" value={sessionStats.win} width="3.5rem" loading={false} />
           <TickerStat label="Fees" value={sessionStats.fees} width="3.5rem" loading={false} />
         {/if}
@@ -186,7 +196,15 @@
         <TickerStat label="24h Vol" value={formatNumber(marketStats?.dayNtlVlm, 0)} width="6.5rem" loading={statsLoading} />
         <TickerStat label="Updated" value={marketFresh} width="4.5rem" loading={updatedLoading} />
         {#if sessionStats}
-          <TickerStat label="Day P&L" value={sessionStats.dayPnl} width="5rem" loading={false} valueClass={sessionStats.dayPnlClass} />
+          <TickerStat
+            label="Day P&L"
+            value={sessionStats.streak && sessionStats.streak >= 2
+              ? `${sessionStats.dayPnl} · 🔥${sessionStats.streak}`
+              : sessionStats.dayPnl}
+            width="6.5rem"
+            loading={false}
+            valueClass={sessionStats.dayPnlClass}
+          />
           <TickerStat label="Win" value={sessionStats.win} width="3.5rem" loading={false} />
           <TickerStat label="Fees" value={sessionStats.fees} width="3.5rem" loading={false} />
         {/if}


### PR DESCRIPTION
## Summary
- Quiet Web Audio fill + TP/SL beeps (default ON; muted in settings; `prefers-reduced-motion` defaults OFF)
- Green-day streak `n` next to DAY P&L when consecutive UTC green days ≥ 2
- Closes #547

## Test plan
- [x] `bun run typecheck`
- [x] unit tests for `greenDayStreak` + fill-sound defaults
- [ ] Terminal: fill a paper order → soft beep; Settings → Mute; TP/SL paper hit → brighter beep
- [ ] After 2+ green journal days → flame next to Day P&L

Made with [Cursor](https://cursor.com)