### PR TITLE
feat(terminal): ARMED chip for hotkey trading mode

### DIFF
--- a/apps/portal/src/lib/terminal/prefs.test.ts
+++ b/apps/portal/src/lib/terminal/prefs.test.ts
@@ -152,6 +152,19 @@ describe("parsePrefs", () => {
       ).toBe(expected as number);
     }
   });
+
+  test("accepts hotkeysArmed boolean", () => {
+    expect(
+      parsePrefs(JSON.stringify({ hotkeysArmed: true })).hotkeysArmed,
+    ).toBe(true);
+    expect(
+      parsePrefs(JSON.stringify({ hotkeysArmed: false })).hotkeysArmed,
+    ).toBe(false);
+    expect(
+      parsePrefs(JSON.stringify({ hotkeysArmed: "yes" })).hotkeysArmed,
+    ).toBeUndefined();
+    expect(parsePrefs(JSON.stringify({})).hotkeysArmed).toBeUndefined();
+  });
 });
 
 describe("mergeLayout", () => {

--- a/apps/portal/src/lib/terminal/prefs.ts
+++ b/apps/portal/src/lib/terminal/prefs.ts
@@ -76,6 +76,12 @@ export type TerminalPrefs = {
   orderTemplates: OrderTemplate[];
   /** Quiet fill/TP-SL beeps — default ON unless reduced-motion. */
   fillSounds: boolean;
+  /**
+   * Hotkey trading mode — opt-in ARMED state (default OFF). When armed,
+   * the amber chip shows on the ticket side row; Escape disarms. B/S/M/L
+   * behavior is unchanged either way.
+   */
+  hotkeysArmed: boolean;
 };
 
 export const ORDER_TEMPLATES_CAP = 6;
@@ -262,6 +268,9 @@ export function parsePrefs(raw: string | null): Partial<TerminalPrefs> {
     prefs.orderTemplates = parseOrderTemplates(data.orderTemplates);
   }
   if (typeof data.fillSounds === "boolean") prefs.fillSounds = data.fillSounds;
+  if (typeof data.hotkeysArmed === "boolean") {
+    prefs.hotkeysArmed = data.hotkeysArmed;
+  }
   return prefs;
 }
 
@@ -304,6 +313,7 @@ export function persistPrefs(
   _displayTimezone: DisplayTimezoneId,
   _orderTemplates: OrderTemplate[] = [],
   _fillSounds = true,
+  _hotkeysArmed = false,
 ): void {
   if (typeof window === "undefined") return;
   try {
@@ -334,6 +344,7 @@ export function persistPrefs(
         displayTimezone: _displayTimezone,
         orderTemplates: _orderTemplates.slice(0, ORDER_TEMPLATES_CAP),
         fillSounds: _fillSounds,
+        hotkeysArmed: _hotkeysArmed,
       }),
     );
   } catch {

--- a/apps/portal/src/routes/terminal/+page.svelte
+++ b/apps/portal/src/routes/terminal/+page.svelte
@@ -923,6 +923,7 @@
   let watchlist: string[] = [];
   let orderTemplates: OrderTemplate[] = [];
   let fillSounds = true;
+  let hotkeysArmed = false;
   // Screener controls (persisted; screener panel retired but prefs kept).
   let screenSort: "movers" | "volume" | "cap" = "movers";
   let screenHub: "all" | "crypto" | "equities" | "pre-ipo" = "all";
@@ -1794,6 +1795,7 @@
       displayTimezone,
       orderTemplates,
       fillSounds,
+      hotkeysArmed,
     );
 
   function agentOk(message: string): AgentActionResult {
@@ -6753,6 +6755,9 @@
     } else {
       fillSounds = defaultFillSoundsEnabled();
     }
+    if (prefs.hotkeysArmed !== undefined) {
+      hotkeysArmed = prefs.hotkeysArmed;
+    }
     // Without Privy, live trading is impossible — stay in paper regardless
     // of a previously saved LIVE preference.
     if (!readPrivyConfig().appId) paperMode = true;
@@ -6884,6 +6889,12 @@
       disarmRay();
       return;
     }
+    // Hotkey trading mode: Esc clears the ARMED chip (persisted off).
+    if (event.key === "Escape" && hotkeysArmed) {
+      event.stopPropagation();
+      hotkeysArmed = false;
+      return;
+    }
     if (event.key === "Escape") {
       // Modal-priority: if a modal owns this Escape, close only it and leave
       // the side chat — one Escape never doubles as chat-close.
@@ -6983,6 +6994,11 @@
     }
     const tfIndex = PHOENIX_TIMEFRAMES.indexOf(selectedTimeframe);
     switch (event.key.toLowerCase()) {
+      case "a":
+        // Opt-in hotkey trading mode — amber ARMED chip on the ticket.
+        event.preventDefault();
+        hotkeysArmed = !hotkeysArmed;
+        break;
       case "b":
         // In spot mode B/S drive the spot ticket — never a hidden perp order.
         if (tradeMode === "spot") {
@@ -8004,6 +8020,7 @@
   timezone={displayTimezone}
   {showLevels}
   {fillSounds}
+  {hotkeysArmed}
   {layoutCustomized}
   onclose={() => (settingsOpen = false)}
   oncurrencychange={(code) => {
@@ -8017,6 +8034,9 @@
   }}
   ontogglefillsounds={() => {
     fillSounds = !fillSounds;
+  }}
+  ontogglehotkeysarmed={() => {
+    hotkeysArmed = !hotkeysArmed;
   }}
   onresetlayout={resetLayout}
   onopenshortcuts={() => {
@@ -8048,6 +8068,7 @@
     onopenauth={openAuthModal}
     onchip={setSpotAmountChip}
     oncancelorder={cancelSpotLimitOrder}
+    {hotkeysArmed}
   />
 {/snippet}
 
@@ -8103,6 +8124,7 @@
     onsizechip={setSizeChip}
     onriskchip={setRiskChip}
     bind:orderTemplates
+    {hotkeysArmed}
   />
 {/snippet}
 

--- a/apps/portal/src/routes/terminal/components/CheatSheetModal.svelte
+++ b/apps/portal/src/routes/terminal/components/CheatSheetModal.svelte
@@ -27,6 +27,7 @@
         ["/ · ⌘K", "Market and command palette"],
         ["B / S", "Long / Short — flips a live ticket in place"],
         ["M / L", "Ticket order type market / limit"],
+        ["A", "Arm hotkey trading mode (amber chip)"],
         ["C C", "Market-close the selected position (press twice)"],
         ["X X", "Cancel the selected market's orders (press twice)"],
         ["[ ]", "Previous / next timeframe"],
@@ -35,7 +36,7 @@
         ["Alt+Click", "Set price alert at cursor"],
         ["Drag axis", "Scale price/time · double-click resets"],
         ["?", "This sheet"],
-        ["Esc", "Close any overlay"],
+        ["Esc", "Disarm hotkeys / close any overlay"],
       ] as [keys, what] (keys)}
         <div class="cheat-row"><kbd>{keys}</kbd><span>{what}</span></div>
       {/each}

--- a/apps/portal/src/routes/terminal/components/SettingsModal.svelte
+++ b/apps/portal/src/routes/terminal/components/SettingsModal.svelte
@@ -16,6 +16,7 @@ let {
   showLevels = true,
   layoutCustomized = false,
   fillSounds = true,
+  hotkeysArmed = false,
   onclose,
   oncurrencychange,
   ontimezonechange,
@@ -23,6 +24,7 @@ let {
   onresetlayout,
   onopenshortcuts,
   ontogglefillsounds,
+  ontogglehotkeysarmed,
 }: {
   open?: boolean;
   currency: DisplayCurrencyCode;
@@ -30,6 +32,7 @@ let {
   showLevels?: boolean;
   layoutCustomized?: boolean;
   fillSounds?: boolean;
+  hotkeysArmed?: boolean;
   onclose: () => void;
   oncurrencychange: (code: DisplayCurrencyCode) => void;
   ontimezonechange: (id: DisplayTimezoneId) => void;
@@ -37,6 +40,7 @@ let {
   onresetlayout: () => void;
   onopenshortcuts: () => void;
   ontogglefillsounds: () => void;
+  ontogglehotkeysarmed: () => void;
 } = $props();
 
 let panel = $state<HTMLDivElement>();
@@ -231,6 +235,21 @@ const timezoneOptions = $derived(timezonesForPicker(timezone));
             onclick={ontogglefillsounds}
           >
             {fillSounds ? "On" : "Muted"}
+          </button>
+        </div>
+
+        <div class="settings-row">
+          <div class="settings-copy">
+            <strong>Hotkey trading</strong>
+            <span>Show ARMED on the ticket — A arms, Esc disarms. B/S/M/L unchanged.</span>
+          </div>
+          <button
+            class="secondary"
+            type="button"
+            aria-pressed={hotkeysArmed}
+            onclick={ontogglehotkeysarmed}
+          >
+            {hotkeysArmed ? "Armed" : "Off"}
           </button>
         </div>
 

--- a/apps/portal/src/routes/terminal/components/SpotTicketForm.svelte
+++ b/apps/portal/src/routes/terminal/components/SpotTicketForm.svelte
@@ -36,6 +36,7 @@
     onopenauth,
     onchip,
     oncancelorder,
+    hotkeysArmed = false,
   }: {
     ticket: SpotTicket;
     spotAsset: SpotAsset | null;
@@ -61,6 +62,7 @@
     onopenauth: () => void;
     onchip: (pct: number | "max") => void;
     oncancelorder: (orderKey: string) => void | Promise<void>;
+    hotkeysArmed?: boolean;
   } = $props();
 
   // The store bundle is created once by the page and never replaced —
@@ -121,6 +123,9 @@
     >
       Sell
     </button>
+    {#if hotkeysArmed}
+      <span class="armed-chip" role="status" aria-label="Hotkey trading armed">ARMED</span>
+    {/if}
   </div>
 
   <div class="side-toggle" role="group" aria-label="Spot order type">

--- a/apps/portal/src/routes/terminal/components/TicketForm.svelte
+++ b/apps/portal/src/routes/terminal/components/TicketForm.svelte
@@ -84,6 +84,7 @@
     onsizechip,
     onriskchip,
     orderTemplates = $bindable([] as OrderTemplate[]),
+    hotkeysArmed = false,
   }: {
     ticket: PerpTicket;
     sizeInput?: HTMLInputElement | null;
@@ -132,6 +133,8 @@
     onsizechip: (pct: number | "max") => void;
     onriskchip: (pct: number) => void;
     orderTemplates?: OrderTemplate[];
+    /** Amber ARMED chip on the Long/Short row when hotkey trading is armed. */
+    hotkeysArmed?: boolean;
   } = $props();
 
   const money = (usd: number, digits = 2) =>
@@ -331,6 +334,9 @@
 <div class="side-toggle" role="group" aria-label="Side">
   <button class:active={$tradeSide === "buy"} type="button" onclick={() => ($tradeSide = "buy")}>Long</button>
   <button class:active={$tradeSide === "sell"} type="button" onclick={() => ($tradeSide = "sell")}>Short</button>
+  {#if hotkeysArmed}
+    <span class="armed-chip" role="status" aria-label="Hotkey trading armed">ARMED</span>
+  {/if}
 </div>
 
 <div class="ticket-grid-2">

--- a/apps/portal/src/routes/terminal/terminal.css
+++ b/apps/portal/src/routes/terminal/terminal.css
@@ -570,6 +570,27 @@ button.account-row.copyable:hover:not(:disabled) {
   border: 1px solid var(--line);
   border-radius: 0;
   overflow: hidden;
+  position: relative;
+}
+
+/* Hotkey-trading ARMED chip — overlaid on the right end of the side row
+   (mock 07). Visible only while armed; no pulse. */
+.side-toggle .armed-chip {
+  position: absolute;
+  right: 0.4rem;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 1;
+  pointer-events: none;
+  border: 1px solid var(--amber);
+  color: var(--amber);
+  background: var(--surface);
+  font-size: 0.58rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  line-height: 1;
+  padding: 0.22rem 0.38rem;
+  text-transform: uppercase;
 }
 
 .side-toggle button {


### PR DESCRIPTION
## Summary
- Opt-in hotkey trading mode (default off): amber `ARMED` chip on the Long/Short (and spot Buy/Sell) row
- Arm via `A` or Settings; Escape disarms; state persisted in prefs
- B/S/M/L behavior unchanged when disarmed
- Closes #541

## Test plan
- [x] `bun run typecheck`
- [x] prefs unit test for `hotkeysArmed`
- [ ] Press A → chip on ticket; Esc → chip gone; Settings toggle mirrors
- [ ] With mode off, B/S/M/L work exactly as before

Made with [Cursor](https://cursor.com)